### PR TITLE
[AHE-3613] Text spelling errors in common-storage/common-server.js

### DIFF
--- a/common-storage/common-server.js
+++ b/common-storage/common-server.js
@@ -50,32 +50,6 @@ exports.handleCreateCompanyDataStorageFunForUpload = async(bodyData,companyId) =
     })
 }
 
-/**
- * 
- * @param {object} companyId 
- * @param {object} _ 
- * @param {string} fileData 
- * @returns 
- */
-exports.handleChargeebeCreditNotUpload = (companyId,_,fileData,id) => {
-    return new Promise((resolve, reject) => {
-        try {
-            let filePath = `USER_PROFILES/InvoiceAndCreditNotes/CreditNotes/${companyId}/${id}.pdf`;
-            let fullPath = newPath.join(__dirname, '../storage', filePath);
-            fs.writeFile(fullPath, Buffer.from(fileData,'binary'), (error) => {
-                if (error) {
-                    loggerConfig.error(`Credit Note Download Error ${error.message ? error.message : error}`);
-                    return;
-                }
-                resolve()
-            });
-        } catch (error) {
-            loggerConfig.error(`Erro While Uploading Credit Note In STorage: ${error.message ? error.message : error}`);
-            reject(error);
-        }
-    })
-}
-
 exports.handleBucketSizeUpdateCron = () => {
     getBucketSizeStorage();
 }

--- a/common-storage/common-wasabi.js
+++ b/common-storage/common-wasabi.js
@@ -118,36 +118,6 @@ exports.handleCreateCompanyDataStorageFunForUpload = async(bodyData,companyId) =
     })
 }
 
-/**
- * 
- * @param {object} companyId 
- * @param {string} localFilePath 
- * @param {object} filedata
- * @returns 
- */
-exports.handleChargeebeCreditNotUpload = (companyId,localFilePath,filedata,id) => {
-    return new Promise((resolve, reject) => {
-        try {
-            fs.writeFile(localFilePath, Buffer.from(filedata,'binary'), (error) => {
-                if (error) {
-                    loggerConfig.error(`Credit Note Download Error ${error.message ? error.message : error}`);
-                    return;
-                }
-                let path = `InvoiceAndCreditNotes/CreditNotes/${companyId}/${id}.pdf`;
-                uploadFileWasabiPromise(companyId,path,localFilePath, true,localFilePath,'',true).then(()=>{
-                    resolve();
-                }).catch((error)=>{
-                    loggerConfig.error(`Error While Uploading Credit Note In Wasabi: ${error.message ? error.message : error}`);
-                    reject(error);
-                })
-            });
-        } catch (error) {
-            loggerConfig.error(`Error While Uploading Credit Note In Wasabi: ${error.message ? error.message : error}`);
-            reject(error);
-        }
-    })
-}
-
 exports.handleBucketSizeUpdateCron = () => {
     getBucketSize();
 }

--- a/common-storage/common.js
+++ b/common-storage/common.js
@@ -118,36 +118,6 @@ exports.handleCreateCompanyDataStorageFunForUpload = async(bodyData,companyId) =
     })
 }
 
-/**
- * 
- * @param {object} companyId 
- * @param {string} localFilePath 
- * @param {object} filedata
- * @returns 
- */
-exports.handleChargeebeCreditNotUpload = (companyId,localFilePath,filedata,id) => {
-    return new Promise((resolve, reject) => {
-        try {
-            fs.writeFile(localFilePath, Buffer.from(filedata,'binary'), (error) => {
-                if (error) {
-                    loggerConfig.error(`Credit Note Download Error ${error.message ? error.message : error}`);
-                    return;
-                }
-                let path = `InvoiceAndCreditNotes/CreditNotes/${companyId}/${id}.pdf`;
-                uploadFileWasabiPromise(companyId,path,localFilePath, true,localFilePath,'',true).then(()=>{
-                    resolve();
-                }).catch((error)=>{
-                    loggerConfig.error(`Error While Uploading Credit Note In Wasabi: ${error.message ? error.message : error}`);
-                    reject(error);
-                })
-            });
-        } catch (error) {
-            loggerConfig.error(`Error While Uploading Credit Note In Wasabi: ${error.message ? error.message : error}`);
-            reject(error);
-        }
-    })
-}
-
 exports.handleBucketSizeUpdateCron = () => {
     getBucketSize();
 }


### PR DESCRIPTION
#### Task: [AHE-3613](https://alian.alianhub.com/#/6571e7165470e64b12032734/project/6571e7195470e64b120328dd/s/69438c219de8fa67adfb3aa2/696f5ecd2032980a67cd64f1?tab=ProjectListView&detailTab=task-detail-tab)

## Fixed
In this task, the unused handleChargeebeCreditNotUpload function has been removed form below files from `common-storage` folder.
- common-server.js
- common-wasabi.js
- common.js