### PR TITLE
Bug Fix: Guard removeChat against expired AI chat cache

### DIFF
--- a/Modules/AI/helper.js
+++ b/Modules/AI/helper.js
@@ -44,5 +44,8 @@ exports.deleteChat = (chatId) => {
 }
 
 exports.removeChat = (chatId) => {
-    requestedPrompts[chatId].chats.splice(requestedPrompts[chatId].chats.length -1,1);
+    const user = requestedPrompts[chatId];
+    if (user && user.chats.length > 0) {
+        user.chats.splice(user.chats.length - 1, 1);
+    }
 }


### PR DESCRIPTION
# Bug Fix

## Bug Summary
`removeChat` in the AI helper assumes the cached prompt entry exists, so AI regenerate after the 10-minute cache expiry throws and surfaces as an internal error instead of the controlled `time out` response.

Closes: #43


## Problem Description
What was going wrong?

- **Actual behavior:** When a user triggered AI regenerate after the cached chat history had expired, `Modules/AI/controller.js#generatePromptChat` called `removeChat(req.body.uniqueUserId)` unconditionally. `removeChat` then dereferenced `requestedPrompts[chatId].chats` on `undefined`, throwing a `TypeError`. The controller's `try/catch` returned `{status: false, statusText: <Error>}` — an internal error path rather than the existing `time out` response.
- **Affected components:** `Modules/AI/helper.js`, `Modules/AI/controller.js` (regenerate path), surfaced through `frontend/src/components/molecules/HubAiSidebar/HubAiSidebar.vue`'s `sendMessageToAi(true)`.
- **Severity:** medium — user-facing failure on a shipped regenerate action.


## Steps to Reproduce
1. Open the AI sidebar and generate at least one response.
2. Leave the conversation idle for >10 minutes (cache expiry interval in `Modules/AI/helper.js`).
3. Click regenerate from the sidebar.
4. Observe the backend hits the unguarded `removeChat` path and the response carries an Error instead of `{status: false, statusText: 'time out'}`.


## Expected Behavior
Regenerating after cache expiry returns the existing controlled timeout response (`{status: false, statusText: 'time out'}`) and the helper does not throw.


## Solution Description
Guard `removeChat` against a missing cache entry:

```js
exports.removeChat = (chatId) => {
    const user = requestedPrompts[chatId];
    if (user && user.chats.length > 0) {
        user.chats.splice(user.chats.length - 1, 1);
    }
}
```

- **Root cause:** A process-wide cache (`requestedPrompts`) is actively expired after 10 minutes of inactivity, but `removeChat` had no existence check.
- **Why this fix works:** With `removeChat` made safe, the existing flow in `generatePromptChat` already handles the rest. `getChat()` returns `[]` when the entry is missing (helper.js:38), so the existing condition `getChat(...).length > 0` falls through to `res.send({status: false, statusText: 'time out'})` at controller.js:119 — exactly the controlled timeout path the issue's acceptance criteria require.
- **Alternatives considered:** Adding an explicit early-return in `generatePromptChat` for the regenerate-when-missing case. Rejected as redundant — the existing `time out` branch already covers it once `removeChat` is guarded, keeping the change minimal.


## Testing Done
Select all that apply:

- [ ] Unit tests added
- [ ] Existing tests updated
- [x] Manual testing
- [ ] Regression test added

The repository currently has no test runner (`package.json` `test` script is a placeholder), so no automated test was added. Verification steps:
1. Reviewed `Modules/AI/helper.js` cache lifecycle — expiry sweep at 60s interval, deletion after 10 min idle.
2. Walked the `generatePromptChat` regenerate path with the patched `removeChat`: cache-missing → no throw → `getChat()` returns `[]` → controller returns `{status: false, statusText: 'time out'}`.
3. Confirmed the cache-present regenerate path is unchanged: `user.chats.length > 0` still trims the last entry exactly as before.


## Impact Analysis
- [x] Affects only this module
- [ ] Affects multiple modules
- [x] Potential side effects considered

Behavior is unchanged when the cache is populated (length > 0). The only behavioral change is the missing-cache branch, which previously threw and now no-ops — pairing cleanly with the existing `time out` controller response.


## Backward Compatibility
- [x] No breaking changes
- [ ] Potential impact (explain)


## Preflight Checklist
> **Required before submitting this Pull Request**

- [x] I have read and understood the **[Contributing Guidelines](../../CONTRIBUTING.md)** for this project.
- [x] I agree to follow the **[Code of Conduct](../../CODE_OF_CONDUCT.md)** that this project adheres to.
- [x] This PR is submitted against the correct base branch.
- [x] The scope of this PR is clearly defined and limited.
- [x] I have performed a self-review of my changes.


## Additional Context
Diff is one file, 4 insertions / 1 deletion. The frontend already ships the regenerate action in `HubAiSidebar.vue`, so this is a user-visible fix.