### PR TITLE
Fix requestedDbs not cleared on failed Mongo connection

### DIFF
--- a/middlewares/mongoConnector/mongoConnection.js
+++ b/middlewares/mongoConnector/mongoConnection.js
@@ -68,13 +68,13 @@ exports.handleConnection = async (companyId) => {
                             .then((conData) => {
                                 // console.log("REQUESTED DB FOUND", db);
                                 updateConnectionRecord(db, conData);
-                                // removeFromArray(db)
+                                removeFromArray(db)
                                 locals = conData.connection
                                 resolve({ status: true, database: locals });
                             })
                             .catch((error) => {
                                 // throw error;
-                                // removeFromArray(db)
+                                removeFromArray(db)
                                 // console.log("REQUESTED DB NOT FOUND", db);
                                 reject({ status: false, statusText: error.message });
                             })
@@ -83,14 +83,14 @@ exports.handleConnection = async (companyId) => {
                     requestedDbs.push(db);
                    createConnection(db)
                         .then((conData) => {
-                            // removeFromArray(db)
+                            removeFromArray(db)
                             // console.log("REQUESTED DB FOUND", db);
                             updateConnectionRecord(db, conData);
                             locals = conData.connection
                             resolve({ status: true, database: locals });
                         })
                         .catch((error) => {
-                            // removeFromArray(db)
+                            removeFromArray(db)
                             // console.log("REQUESTED DB NOT FOUND", db);
                             reject({ status: false, statusText: error.message });
                             // throw error;


### PR DESCRIPTION
## Summary

- Uncomment `removeFromArray(db)` in all `.catch()` handlers where `db` was pushed to `requestedDbs` before calling `createConnection(db)`
- Also call `removeFromArray(db)` on the `.then()` success paths for consistency, so the pending-db marker is always cleaned up regardless of outcome

## Root cause

`requestedDbs` acts as an in-flight guard: a db name is pushed before `createConnection` is called so concurrent requests poll instead of spawning duplicate connections. However, both failure handlers in the `connections.length` and `no connections` branches had `removeFromArray(db)` commented out. A failed connection left the db name in the array permanently, so every subsequent request entered the 60-iteration polling loop and waited up to 60 seconds before eventually retrying.

## Test plan

- [ ] Simulate a Mongo connection failure on a fresh db and confirm the next request retries `createConnection` immediately instead of waiting up to 60 seconds
- [ ] Confirm a successful connection still resolves correctly and the db name is removed from `requestedDbs` after resolution

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)