### PR TITLE
fix(security): replace wildcard Socket.io CORS with env allow-list (BUG-003 / #57)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,13 @@ JWT_ALGORITHM="HS256"
 APIURL="http://localhost:4000/"
 WEBURL="http://localhost:4000"
 
+# Optional extra browser origins (comma-separated, no trailing slash) that
+# should be allowed to call the API and open Socket.io connections in
+# addition to WEBURL / APIURL. Use this for multi-domain deployments
+# (e.g. a staging frontend on a separate host). Leave blank in single-
+# domain setups.
+CORS_ORIGINS=""
+
 # ─────────────────────────────────────────
 # STORAGE
 # ─────────────────────────────────────────

--- a/socket/socketinit.js
+++ b/socket/socketinit.js
@@ -6,6 +6,7 @@ const {companiesSocketHandler} = require('./controller/companiesSocket');
 const {userNotificationCountHandler} = require('./controller/userNotificationCount');
 const { instrument } = require('@socket.io/admin-ui');
 const jwt = require('jsonwebtoken');
+const { corsOriginDelegate } = require('../utils/cors.js');
 exports.changeStreams = [];
 const EventEmitter = require('events');
 exports.emitter = new EventEmitter();
@@ -14,8 +15,12 @@ exports.rooms = [];
 exports.initSocket = (server) => {
 
     let io = new Server(server, {
+        // CORS — BUG-003 / #57. Replace `origin: '*'` (which combined with
+        // `credentials: true` let any origin open an authenticated websocket
+        // as the logged-in user) with the same env-driven allow-list used by
+        // the Express HTTP layer (see utils/cors.js).
         cors: {
-            origin: '*',
+            origin: corsOriginDelegate,
             methods: ['GET', 'POST'],
             credentials: true,
         },

--- a/utils/cors.js
+++ b/utils/cors.js
@@ -1,0 +1,65 @@
+/**
+ * CORS allow-list helpers — shared between the Express HTTP layer
+ * (BUG-002 / #56) and the Socket.io transport (BUG-003 / #57).
+ *
+ * Previously both layers accepted `origin: '*'`, which combined with
+ * credentialed cookies and JS-readable tokens opened a CSRF / token-theft
+ * path from any third-party origin. This module builds an allow-list from
+ * environment variables and returns an `origin` callback compatible with
+ * the `cors` middleware shape used by both Express and engine.io.
+ *
+ * Allow-list sources (deduped, trailing slashes stripped):
+ *   - WEBURL          (the configured frontend URL — required in prod)
+ *   - APIURL          (set when the API is hosted on a different domain)
+ *   - CORS_ORIGINS    (optional comma-separated list of extra origins)
+ *
+ * Accepted without lookup:
+ *   - Requests with no Origin header (same-origin, curl, mobile apps)
+ *   - `null` origin (sandboxed iframes, some Electron renderers)
+ *   - `file://...` origins (Electron desktop client)
+ *
+ * The allow-list is rebuilt on every request so operators can update the
+ * env without restarting the process; the cost is a small Set construction
+ * per request, which is negligible compared to JWT verification.
+ */
+'use strict';
+
+const splitAndClean = (raw) => {
+    if (!raw) return [];
+    return String(raw)
+        .split(',')
+        .map((entry) => entry.trim().replace(/\/+$/, ''))
+        .filter(Boolean);
+};
+
+const buildCorsAllowList = (env = process.env) => {
+    const allowed = new Set();
+    splitAndClean(env.WEBURL).forEach((o) => allowed.add(o));
+    splitAndClean(env.APIURL).forEach((o) => allowed.add(o));
+    splitAndClean(env.CORS_ORIGINS).forEach((o) => allowed.add(o));
+    return allowed;
+};
+
+const isOriginAllowed = (origin, allowList) => {
+    if (!origin) return true; // no Origin header
+    if (origin === 'null') return true;
+    if (typeof origin === 'string' && origin.startsWith('file://')) return true;
+    if (typeof origin !== 'string') return false;
+    const normalized = origin.replace(/\/+$/, '');
+    return allowList.has(normalized);
+};
+
+const corsOriginDelegate = (origin, callback) => {
+    const allowList = buildCorsAllowList();
+    if (isOriginAllowed(origin, allowList)) {
+        return callback(null, true);
+    }
+    return callback(new Error(`CORS: origin ${origin} not allowed`));
+};
+
+module.exports = {
+    splitAndClean,
+    buildCorsAllowList,
+    isOriginAllowed,
+    corsOriginDelegate,
+};


### PR DESCRIPTION
## Summary

Closes #57 (BUG-003).

Replace the Socket.io server's `cors: {origin: '*', credentials: true}` config — the worst-of-both combination, which engine.io accepts even though browsers explicitly reject it for fetch/XHR — with the same env-driven allow-list used by the Express HTTP layer (PR #103).

## Root cause

`socket/socketinit.js:17-21` declared:

```js
new Server(server, {
  cors: { origin: '*', methods: ['GET','POST'], credentials: true },
});
```

That lets a malicious page on any origin open an authenticated websocket on behalf of the victim, receive their realtime task/comment/chat stream, and emit events as them.

## Fix

Wire `socket/socketinit.js` to the `corsOriginDelegate` exported from `utils/cors.js`:

```js
cors: {
  origin: corsOriginDelegate,
  methods: ['GET', 'POST'],
  credentials: true,
},
```

Same allow-list rules as the Express layer:
- `WEBURL`, `APIURL`, and an optional comma-separated `CORS_ORIGINS` env entry are accepted (exact match, trim-tolerant, trailing-slash safe).
- Same-origin / no-Origin (curl, native clients) accepted.
- `null` and `file://...` origins accepted (Electron desktop).
- Anything else is rejected by callback — engine.io drops the handshake and omits CORS response headers.

`credentials: true` is kept; with the allow-list now wired in it is safe (each accepted origin is mirrored exactly).

## Relationship to PR #103 (BUG-002)

This PR re-adds `utils/cors.js` and the `CORS_ORIGINS` line in `.env.example` with identical content to PR #103, since each fix branches from `staging` independently per the rollout plan. Git merges identical blobs as a no-op, so order of landing does not matter — whichever PR merges second will see those two paths as already-present and clean.

## Files changed

- `socket/socketinit.js` — wire the delegate, keep credentials.
- `utils/cors.js` — same shared helper as #103 (identical content).
- `.env.example` — same `CORS_ORIGINS` doc as #103.

## Test plan

Standalone Node test harness at `.claude/tests/test-bug-003.js` (kept local, not committed). Boots a real Socket.io server and exercises the engine.io polling handshake with various Origin headers.

### Test results

```
=== Socket.io polling handshake CORS ===
  PASS  WEBURL → ACAO mirrors origin
  PASS  WEBURL → Access-Control-Allow-Credentials: true
  PASS  WEBURL → handshake succeeds (200)
  PASS  APIURL → ACAO mirrors origin
  PASS  APIURL → handshake succeeds
  PASS  CORS_ORIGINS → ACAO mirrors origin
  PASS  evil origin → no ACAO header
  PASS  evil origin → no ACAC header
  PASS  evil origin → handshake NOT succeeded (status != 200)
  PASS  BUG-003 fix: never returns Access-Control-Allow-Origin: *
  PASS  subdomain of WEBURL → rejected
  PASS  substring of WEBURL → rejected
  PASS  file:// origin → handshake succeeds
  PASS  "null" origin → handshake succeeds
  PASS  no Origin → handshake succeeds
  PASS  WEBURL with trailing slash still matches

========================================
Tests: 16 | Passed: 16 | Failed: 0
========================================
```

### Manual regression smoke

```bash
# Allowed origin — handshake succeeds with mirrored ACAO
curl -sSI "$APP/socket.io/?EIO=4&transport=polling" -H "Origin: $WEBURL" | grep -i 'access-control'
# expect: Access-Control-Allow-Origin: <WEBURL>
#         Access-Control-Allow-Credentials: true

# Malicious origin — BUG-003 attack
curl -sSI "$APP/socket.io/?EIO=4&transport=polling" -H "Origin: https://evil.example" | grep -i 'access-control'
# expect: no ACAO / ACAC headers; status != 200

# Electron desktop client
curl -sSI "$APP/socket.io/?EIO=4&transport=polling" -H "Origin: file:///app/index.html" | grep -i 'access-control'
# expect: Access-Control-Allow-Origin: file:///app/index.html
```

### Deployment checklist

- [x] Confirm the frontend's Socket.io client is configured to send the right `withCredentials` / origin (it already is — same domain as REST today).
- [x] If multi-domain, add the realtime client's origin to `CORS_ORIGINS` (comma-separated). Same env var as PR #103.

## Risk

- Any Socket.io client whose Origin is not in the allow-list will be rejected (intended). Native Socket.io clients (no Origin) are unaffected.
- The wildcard `*` is no longer accepted for any origin.