### PR TITLE
fix(security): move Socket.io admin UI creds to env, default-off (BUG-004 / #58)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,16 @@ APPID=""
 MEASUREMENTID=""
 
 # ─────────────────────────────────────────
+# SOCKET.IO ADMIN UI (optional)
+# Leave both blank to disable the admin UI (recommended for production
+# unless you actively need it). Both values must be set to enable.
+# Username is plain text. Password must be a bcrypt hash — generate with:
+#   node -e "console.log(require('bcrypt').hashSync(process.argv[1], 12))" '<your-password>'
+# ─────────────────────────────────────────
+SOCKETIO_ADMIN_USERNAME=""
+SOCKETIO_ADMIN_PASSWORD_HASH=""
+
+# ─────────────────────────────────────────
 # AI
 # ─────────────────────────────────────────
 AI_API_KEY=""

--- a/socket/socketinit.js
+++ b/socket/socketinit.js
@@ -6,10 +6,40 @@ const {companiesSocketHandler} = require('./controller/companiesSocket');
 const {userNotificationCountHandler} = require('./controller/userNotificationCount');
 const { instrument } = require('@socket.io/admin-ui');
 const jwt = require('jsonwebtoken');
+const logger = require('../Config/loggerConfig');
 exports.changeStreams = [];
 const EventEmitter = require('events');
 exports.emitter = new EventEmitter();
 exports.rooms = [];
+
+/**
+ * Build the @socket.io/admin-ui config from env (BUG-004 / #58 fix).
+ *
+ * The previous code hardcoded `username: "alian"` and a committed bcrypt
+ * hash with `mode: "development"` — anyone with the repo could compute the
+ * hash offline (or read it from the source) and reach the admin namespace.
+ *
+ * New behaviour:
+ *   - Both SOCKETIO_ADMIN_USERNAME and SOCKETIO_ADMIN_PASSWORD_HASH must be
+ *     set, non-empty, and non-whitespace. Otherwise the admin UI is
+ *     disabled entirely (default-off).
+ *   - `mode` follows NODE_ENV — "production" enables TLS-only protection
+ *     on the admin namespace.
+ *
+ * Exported for the regression test at .claude/tests/test-bug-004.js.
+ */
+exports.getAdminUiConfig = (env = process.env) => {
+    const username = typeof env.SOCKETIO_ADMIN_USERNAME === 'string'
+        ? env.SOCKETIO_ADMIN_USERNAME.trim() : '';
+    const passwordHash = typeof env.SOCKETIO_ADMIN_PASSWORD_HASH === 'string'
+        ? env.SOCKETIO_ADMIN_PASSWORD_HASH.trim() : '';
+    if (!username || !passwordHash) return null;
+    return {
+        auth: { type: 'basic', username, password: passwordHash },
+        namespaceName: '/admin',
+        mode: env.NODE_ENV === 'production' ? 'production' : 'development',
+    };
+};
 
 exports.initSocket = (server) => {
 
@@ -34,15 +64,13 @@ exports.initSocket = (server) => {
             next();
         });
     });
-    instrument(io, {
-        auth: {
-            type: "basic",
-            username: "alian",
-            password: "$2a$12$HHemhzmTrC8Dmf2Gd9v/Teo9oiCxfYJb.St3HKMBx1L3wJmZLeX5u"
-        }, 
-        namespaceName: '/admin', 
-        mode: "development"
-    });
+    const adminUiConfig = exports.getAdminUiConfig();
+    if (adminUiConfig) {
+        instrument(io, adminUiConfig);
+        logger.info(`Socket.io admin UI enabled at /admin (mode=${adminUiConfig.mode})`);
+    } else {
+        logger.info('Socket.io admin UI disabled — set SOCKETIO_ADMIN_USERNAME and SOCKETIO_ADMIN_PASSWORD_HASH to enable.');
+    }
 
     userNamespace.on('connection', (socket) => {
         const {userRole} = socket.handshake.query;


### PR DESCRIPTION
## Summary

Closes #58 (BUG-004).

Remove the hardcoded Socket.io admin-UI credentials and shipped `mode: "development"` from `socket/socketinit.js:37-45`. The admin UI is now disabled by default and only enabled when both env-supplied credentials are present; in production deployments it runs in `mode: "production"`.

## Root cause

The previous code:

```js
instrument(io, {
  auth: { type: "basic", username: "alian", password: "$2a$12$HHe..." },
  namespaceName: '/admin',
  mode: "development",
});
```

- Username and bcrypt hash were committed to source, so anyone with repo read access could log in to the deployed admin UI.
- `mode: "development"` disabled TLS-only protection on the admin namespace.

## Fix

New exported helper `getAdminUiConfig(env)`:

- Reads `SOCKETIO_ADMIN_USERNAME` and `SOCKETIO_ADMIN_PASSWORD_HASH` from env. Returns `null` if either is missing, empty, or whitespace — in that case `instrument()` is skipped and the admin namespace is not registered.
- When both are set, returns the config with `mode` driven by `NODE_ENV`. `production` → `production` (TLS-only); anything else → `development` (fail-closed default for unrecognised values).
- The helper is `exports.getAdminUiConfig` so the regression test can exercise it directly without spinning up `@socket.io/admin-ui`.

`.env.example` documents both variables with a one-liner for generating a bcrypt hash.

## Files changed

- `socket/socketinit.js` — new helper, replace hardcoded `instrument()` call (+39 / −9).
- `.env.example` — document the two new env vars (+8).

## Test plan

Standalone test at `.claude/tests/test-bug-004.js` (local-only). Covers the helper directly plus source-level checks that the leaked credentials are gone.

### Test results

```
=== getAdminUiConfig — disabled paths ===
  PASS  null when env is empty
  PASS  null when only username set
  PASS  null when only password hash set
  PASS  null when username is whitespace
  PASS  null when password hash is whitespace
  PASS  null when username is empty string
  PASS  null when both env values are wrong types

=== getAdminUiConfig — enabled paths ===
  PASS  returns object when both set
  PASS  auth.type is "basic"
  PASS  auth.username comes from env, NOT "alian"
  PASS  auth.password (hash) comes from env, NOT the committed hash
  PASS  namespaceName is /admin
  PASS  mode defaults to "development" when NODE_ENV not set
  PASS  mode is "production" when NODE_ENV=production
  PASS  mode is "development" when NODE_ENV=development
  PASS  mode is "development" for unrecognised NODE_ENV (fail-closed)

=== source — old hardcoded credentials removed ===
  PASS  executable code no longer contains username: "alian"
  PASS  source no longer contains the leaked bcrypt hash anywhere
  PASS  executable code no longer hardcodes mode: "development" in the instrument call
  PASS  source reads SOCKETIO_ADMIN_USERNAME from env
  PASS  source reads SOCKETIO_ADMIN_PASSWORD_HASH from env

=== .env.example documents the new vars ===
  PASS  .env.example declares SOCKETIO_ADMIN_USERNAME
  PASS  .env.example declares SOCKETIO_ADMIN_PASSWORD_HASH
  PASS  .env.example defaults SOCKETIO_ADMIN_USERNAME to empty (admin UI off by default)
  PASS  .env.example defaults SOCKETIO_ADMIN_PASSWORD_HASH to empty

========================================
Tests: 25 | Passed: 25 | Failed: 0
========================================
```

### Manual regression smoke

```bash
# Admin UI disabled by default — namespace not registered.
# Previously the polling handshake returned 200; now it should not.
curl -sS -o /dev/null -w "%{http_code}\n" "$APP/socket.io/admin/?EIO=4&transport=polling"
# expect: not 200 (404 or transport error)

# Enable per deployment by setting env:
#   SOCKETIO_ADMIN_USERNAME=admin
#   SOCKETIO_ADMIN_PASSWORD_HASH=$(node -e "console.log(require('bcrypt').hashSync(process.argv[1], 12))" '<password>')
# Then restart and confirm /admin works only with that password.
```

### Deployment checklist

- [x] **Rotate compromised credentials.** The previously hardcoded bcrypt hash is now public in git history. Anyone with the old cleartext password (or who cracks the hash offline) could log into the admin UI of every existing deployment until either the env-driven config is set OR the deployment redeploys with the admin UI disabled.
- [x] If you don't actively use the admin UI, leave both env vars blank in production — the safest setting.
- [x] If you do use it, generate a strong bcrypt hash and set both `SOCKETIO_ADMIN_USERNAME` and `SOCKETIO_ADMIN_PASSWORD_HASH`. Make sure `NODE_ENV=production` is set so the admin namespace runs in TLS-only mode.

## Risk

- The admin UI is **off by default** after this change. Any deployment that relied on the hardcoded `alian` credentials will lose admin-UI access on next deploy. This is the intended outcome — anyone with the old cleartext should not be assumed to be authorised.
- Operators who genuinely need the admin UI must add the two env vars before deploying.