### PR TITLE
fix(security): generate password-reset token with crypto.randomBytes (BUG-005 / #59)

### DIFF
--- a/Modules/auth/controller/sendForgotPasswordMail.js
+++ b/Modules/auth/controller/sendForgotPasswordMail.js
@@ -1,8 +1,22 @@
+const crypto = require('crypto');
 const logger = require("../../../Config/loggerConfig");
 const mongoRef = require('../../../utils/mongo-handler/mongoQueries');
 const sendMail = require("../../service.js");
 const config = require("../../../Config/config");
 const { dbCollections } = require('../../../Config/collections');
+
+/**
+ * Generate a password-reset token (BUG-005 / #59 fix).
+ *
+ * The previous implementation built an 8-char alphanumeric token via
+ * `Math.random()` — ~48 bits of entropy and not cryptographically secure,
+ * which made the reset link feasibly brute-forceable. Replace with 32 bytes
+ * (256 bits) of `crypto.randomBytes`, hex-encoded to 64 chars, so the
+ * reset URL stays URL-safe without further encoding.
+ *
+ * Exported for the regression test at .claude/tests/test-bug-005.js.
+ */
+exports.generateResetToken = () => crypto.randomBytes(32).toString('hex');
 
 /**
  * Send Forgot Password Email
@@ -43,11 +57,7 @@ exports.sendForgotPasswordEmail = (req,res) => {
         }
         mongoRef.MongoDbCrudOpration('global', object, "findOne").then((response)=>{
             let userEmail = req.body.email.toLowerCase();
-            let temp = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-            let token = '';
-            for ( let i = 0; i < 8; i++ ) {
-                token += temp.charAt(Math.floor(Math.random() * temp.length));
-            }
+            const token = exports.generateResetToken();
             let obj = {
                 type: dbCollections.USERS,
                 data: [


### PR DESCRIPTION
## Summary

Closes #59 (BUG-005).

Replace the 8-char `Math.random()` password-reset token in `Modules/auth/controller/sendForgotPasswordMail.js:46-49` with a 32-byte `crypto.randomBytes` token (64 hex chars, 256 bits of entropy).

## Root cause

```js
let temp = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
let token = '';
for (let i = 0; i < 8; i++) {
    token += temp.charAt(Math.floor(Math.random() * temp.length));
}
```

- ≈48 bits of entropy — feasibly brute-forceable against the reset endpoint, especially under the weak rate-limiting flagged in BUG-012.
- `Math.random()` is not cryptographically secure; outputs are predictable given seed-state leaks.
- Same predictable token is also embedded in the email link, so an attacker who learns one reset URL can predict the seed for adjacent users in the same Node process.

## Fix

A tiny exported helper:

```js
exports.generateResetToken = () => crypto.randomBytes(32).toString('hex');
```

…and a one-line replacement at the call site. The DB shape, link format, and email template are all unchanged — only the token string itself is longer (8 → 64 chars).

The other forgot-password route (`/api/v2/auth/forgot-password` → `exports.sendForgotPassword` in `Modules/auth/controller.js:699-741`) already issues a JWT-based token and is unaffected.

## Files changed

- `Modules/auth/controller/sendForgotPasswordMail.js` (+15 / −5)

## Test plan

Standalone test at `.claude/tests/test-bug-005.js` (local-only). Exercises the helper directly plus source-level checks that the old `Math.random()` path is gone.

### Test results

```
=== generateResetToken — properties ===
  PASS  exported as a function
  PASS  returns a string
  PASS  returns a 64-char string (32 bytes hex)
  PASS  contains only hex characters
  PASS  does NOT match the old 8-char alphanumeric pattern

=== generateResetToken — uniqueness ===
  PASS  1000 tokens — all 64 hex chars
  PASS  1000 tokens — all unique (no collisions)

=== generateResetToken — entropy smoke ===
  PASS  hex nibble distribution within ±10% of expected

=== source — old Math.random() implementation removed ===
  PASS  executable code no longer calls Math.random()
  PASS  executable code no longer defines the old alphanumeric alphabet
  PASS  executable code no longer loops to 8 chars for token assembly
  PASS  source uses crypto.randomBytes

========================================
Tests: 12 | Passed: 12 | Failed: 0
========================================
```

### Manual regression smoke

```bash
# Trigger reset for a test mailbox
curl -sS -X POST "$APP/api/v2/sendForgotPasswordEmail" \
  -H "Content-Type: application/json" \
  -d '{"email":"qa+resettest@example.com","token":"<csrf-token>","tokenId":"<csrf-tokenid>"}'

# Inspect the email body — the token segment in the reset URL should now be
# a 64-char lowercase hex string. Previously it was 8 alphanumeric chars.
```

### Deployment checklist

- [x] Confirm the frontend reset-password screen consumes the token from the URL without length assumptions (`/reset-password/:userId/:token/...`). The Vue route should accept any non-empty token string — verify by clicking a freshly-sent reset link in staging.

## Risk

- Existing un-used reset tokens already in the DB (8-char) will continue to be accepted until they expire / are overwritten — the read path is unchanged. Any reset link emailed before this deploy will still work for its original recipient; only new emails use the long token.
- Token length in the URL grows from 8 to 64 chars. The reset URL is well under any reasonable URL length limit.