### PR TITLE
fix(security): remove unauthenticated file-disclosure endpoint (BUG-007 / #61)

### DIFF
--- a/Modules/auth/controller.js
+++ b/Modules/auth/controller.js
@@ -1,6 +1,5 @@
 const mongoC = require("../../utils/mongo-handler/mongoQueries")
 const { dbCollections } = require('../../Config/collections');
-const fs = require("fs");
 const bcrypt = require('bcrypt');
 const config = require("../../Config/config");
 const logger = require("../../Config/loggerConfig");
@@ -105,16 +104,6 @@ exports.addAndRemoveUserInMongodbNotificationCount = (companyId,userId,type) => 
         }
     })
 }
-
-exports.checkAvaibility = (req,res) => {
-    try {
-        let validateFile = fs.readFileSync('./utils/licensesValidate.js', 'utf-8')
-        res.status(200).json({file: validateFile})
-    } catch (error) {
-        res.status(400).json({message: error.message ? error.message : error});
-    }
-}
-
 
 exports.generateTokenV2Fun = (uid, refreshToken, cb) => {
     try {

--- a/Modules/auth/routes.js
+++ b/Modules/auth/routes.js
@@ -6,9 +6,6 @@ exports.init = (app) => {
     app.post('/api/v1/removeUserNotification',  ctrl.removeUserNotification);
 
 
-    app.get("/api/v1/checkAvaibility", ctrl.checkAvaibility);
-    
-
     /**
      * @swagger
      *  components:


### PR DESCRIPTION
## Summary

Closes #61 (BUG-007).

`GET /api/v1/checkAvaibility` was a public, unauthenticated endpoint that read `./utils/licensesValidate.js` via `fs.readFileSync` and returned the file's source in the JSON body. The file is not present in the repository, and `git grep` shows **zero** callers anywhere under `Modules/`, `utils/`, or `frontend/src/`. So it's pure dead code that doubled as a file-disclosure / LFI attack surface.

## Root cause

```js
// Modules/auth/controller.js:109-116 (pre-fix)
exports.checkAvaibility = (req, res) => {
    try {
        let validateFile = fs.readFileSync('./utils/licensesValidate.js', 'utf-8')
        res.status(200).json({file: validateFile})
    } catch (error) {
        res.status(400).json({message: error.message ? error.message : error});
    }
}
```

```js
// Modules/auth/routes.js:9 (pre-fix)
app.get("/api/v1/checkAvaibility", ctrl.checkAvaibility);
```

Today the endpoint returns a 400 (ENOENT) because the file doesn't exist. On any deployment that adds `utils/licensesValidate.js` (likely to support a licensing feature flagged in the bug report), the endpoint would dump the source verbatim to anyone on the internet.

## Fix

- Delete `exports.checkAvaibility` from `Modules/auth/controller.js`.
- Delete the route from `Modules/auth/routes.js`.
- Drop the now-unused `const fs = require("fs")` import from the controller.

No callers, no backward-compat concerns.

## Files changed

```
M Modules/auth/controller.js  (-11)
M Modules/auth/routes.js      (-3)
```

## Test plan

Standalone test at `.claude/tests/test-bug-007.js` (local-only). Asserts:

1. Controller no longer exports `checkAvaibility`.
2. Controller no longer reads `utils/licensesValidate.js`.
3. Controller no longer imports `fs` (it was only used by the removed handler).
4. Route file no longer registers `/api/v1/checkAvaibility`.
5. `git grep` against `Modules/`, `utils/`, `frontend/src/` returns zero matches for both `checkAvaibility` and `licensesValidate`.
6. Controller module still parses and still exports the other surface (`generateTokenV2Fun`, `manageAttempt`).

### Test results

```
=== Modules/auth/controller.js ===
  PASS  exports.checkAvaibility is removed
  PASS  controller no longer reads utils/licensesValidate.js
  PASS  controller no longer imports fs (unused after removal)
  PASS  no fs.readFileSync calls remain in controller

=== Modules/auth/routes.js ===
  PASS  route /api/v1/checkAvaibility is removed

=== repo — no callers / references left behind ===
  PASS  no code under Modules/ utils/ frontend/src/ references checkAvaibility
  PASS  no code under Modules/ utils/ frontend/src/ references licensesValidate

=== Module loads (parse + dependency wiring) ===
  PASS  controller module loads without error
  PASS  controller no longer exports checkAvaibility
  PASS  controller still exports generateTokenV2Fun
  PASS  controller still exports manageAttempt

========================================
Tests: 11 | Passed: 11 | Failed: 0
========================================
```

### Manual smoke

```bash
# BUG-007 attack — was 400 with ENOENT (still leaks file path), or 200 with
# source on any deployment that adds the file. Should now be 404.
curl -sS -o /dev/null -w "%{http_code}\n" "$APP/api/v1/checkAvaibility"
# expect: 404
```

## Risk

- The endpoint had no callers, so removing it cannot regress functionality. Any future caller will hit a 404, which is the desired behaviour.
- If a downstream fork actually relies on this endpoint for a licensing-validation feature, they will see a 404 and can re-add the endpoint **behind authentication** — but that is intentional and the safe default.