### PR TITLE
fix(security): move PRECOMPANYKEY from URL path to header (BUG-008 / #62)

### DIFF
--- a/Modules/common/routes.js
+++ b/Modules/common/routes.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const config =  require('../../Config/config.js');
 const { connections } = require("../../middlewares/mongoConnector/helper.js");
 const commonctrl = require('./controller.js');
+const { requirePresetKey } = require('../../utils/presetKeyAuth.js');
 
 /**
  * Init
@@ -24,17 +25,16 @@ exports.init = (app) => {
     });
 
     // Get Connections
-    app.get("/connections/:id", (req, res) => {
-        if (req.params && req.params.id && req.params.id === config.PRECOMPANYKEY) {
-            const connectionsJSON = connections.map((x) => ({
-                db: x.db,
-                createdAt: new Date(x.createdAt),
-                lastRequest: new Date(x.lastRequest)
-            }))
-            res.json({data: connectionsJSON, total: connectionsJSON.length});
-        } else {
-            res.send('Unauthorized');
-        }
+    // BUG-008 / #62 fix: was `GET /connections/:id` with the PRECOMPANYKEY
+    // secret as a URL path segment. Now POST with the key in the
+    // `x-preset-key` header, constant-time compared by the middleware.
+    app.post("/connections", requirePresetKey, (req, res) => {
+        const connectionsJSON = connections.map((x) => ({
+            db: x.db,
+            createdAt: new Date(x.createdAt),
+            lastRequest: new Date(x.lastRequest)
+        }));
+        res.json({ data: connectionsJSON, total: connectionsJSON.length });
     });
 
     /**

--- a/index.js
+++ b/index.js
@@ -101,14 +101,16 @@ function initializeControllers() {
     startInterval();
     const { currentDirectory } = require(`./common-storage/common-${process.env.STORAGE_TYPE}.js`);
     const { preCompanySetup, } = require("./Modules/Company/controller2.js");
-    app.get("/api/v1/setPresetCompany/:id", (req, res) => {
-        if (req.params && req.params.id && req.params.id === config.PRECOMPANYKEY) {
-            preCompanySetup();
-            res.send('Preset Company Process Start Successful');
-        } else {
-            res.send('Unauthorized');
-        }
-    })
+    const { requirePresetKey } = require("./utils/presetKeyAuth.js");
+    // BUG-008 / #62 fix: was `GET /api/v1/setPresetCompany/:id` with the
+    // PRECOMPANYKEY secret as a URL path segment — that leaked into
+    // reverse-proxy logs, browser history, and Referer headers. Now POST
+    // with the key in the `x-preset-key` header, constant-time compared,
+    // and a proper 401/404 on failure (see utils/presetKeyAuth.js).
+    app.post("/api/v1/setPresetCompany", requirePresetKey, (req, res) => {
+        preCompanySetup();
+        res.status(200).json({ status: true, message: 'Preset Company Process Start Successful' });
+    });
     //IMPORT CUSTOM FILES
     require('./Modules/Auth/init').init(app);
     require('./Modules/notification1/init').init(app);

--- a/utils/presetKeyAuth.js
+++ b/utils/presetKeyAuth.js
@@ -1,0 +1,66 @@
+/**
+ * Preset-key authentication middleware (BUG-008 / #62 fix).
+ *
+ * Two operator endpoints — `/api/v1/setPresetCompany/:id` and
+ * `/connections/:id` — accepted the `PRECOMPANYKEY` secret as a URL path
+ * segment, compared it to `config.PRECOMPANYKEY` with `===`, and returned
+ * a 200 "Unauthorized" body on mismatch. Three problems:
+ *
+ *   1. URL-path secrets leak into reverse-proxy logs, CDN logs, browser
+ *      history, Referer headers, and APM tools. The secret stops being
+ *      a secret the moment it's used.
+ *   2. `===` is not constant-time, so a determined attacker can extract
+ *      the key one character at a time via response timing.
+ *   3. Returning HTTP 200 on auth failure obscures the failure from
+ *      monitoring tools.
+ *
+ * This middleware fixes all three by:
+ *
+ *   - Reading the key from the `x-preset-key` request header (never the
+ *     URL path).
+ *   - Comparing it with `crypto.timingSafeEqual` in constant time.
+ *   - Returning HTTP 401 on missing / wrong key, HTTP 404 when the env
+ *     var is not configured at all (the endpoint is then effectively
+ *     disabled — fail-closed).
+ */
+'use strict';
+
+const crypto = require('crypto');
+
+const PRESET_HEADER = 'x-preset-key';
+
+const constantTimeEqual = (a, b) => {
+    const aBuf = Buffer.from(String(a == null ? '' : a), 'utf-8');
+    const bBuf = Buffer.from(String(b == null ? '' : b), 'utf-8');
+    if (aBuf.length !== bBuf.length) {
+        // Equal-length sham compare so we don't leak the supplied value's
+        // length via fast-fail timing.
+        try {
+            const dummy = Buffer.alloc(bBuf.length, 0);
+            crypto.timingSafeEqual(Buffer.alloc(bBuf.length, 0), dummy);
+        } catch (_) { /* noop */ }
+        return false;
+    }
+    return crypto.timingSafeEqual(aBuf, bBuf);
+};
+
+const requirePresetKey = (req, res, next) => {
+    const configured = process.env.PRECOMPANYKEY || '';
+    if (!configured) {
+        // Endpoint is effectively disabled when PRECOMPANYKEY isn't set —
+        // fail-closed instead of accepting an empty string.
+        return res.status(404).json({ status: false, message: 'Not Found' });
+    }
+    const supplied = req.headers && req.headers[PRESET_HEADER]
+        ? String(req.headers[PRESET_HEADER]) : '';
+    if (!supplied || !constantTimeEqual(supplied, configured)) {
+        return res.status(401).json({ status: false, message: 'Unauthorized' });
+    }
+    return next();
+};
+
+module.exports = {
+    PRESET_HEADER,
+    constantTimeEqual,
+    requirePresetKey,
+};


### PR DESCRIPTION
## Summary

Closes #62 (BUG-008).

Two operator endpoints accepted `PRECOMPANYKEY` as a URL path segment, compared it with `===`, and returned HTTP 200 "Unauthorized" on mismatch. Migrate both to POST with the key in an `x-preset-key` request header, constant-time compared by a shared middleware, with proper 401/404 status codes.

Also surfaces a second occurrence the original bug report didn't flag: `GET /connections/:id` in `Modules/common/routes.js:27-38` uses the exact same vulnerable pattern and is fixed in the same PR.

## Root cause

```js
// index.js:104-111 (pre-fix)
app.get("/api/v1/setPresetCompany/:id", (req, res) => {
    if (req.params && req.params.id && req.params.id === config.PRECOMPANYKEY) {
        preCompanySetup();
        res.send('Preset Company Process Start Successful');
    } else {
        res.send('Unauthorized');
    }
});

// Modules/common/routes.js:27-38 (pre-fix)
app.get("/connections/:id", (req, res) => {
    if (req.params && req.params.id && req.params.id === config.PRECOMPANYKEY) {
        ...
    } else {
        res.send('Unauthorized');
    }
});
```

Three problems:
1. **URL-path secrets leak everywhere.** Reverse proxy access logs, CDN logs, browser history, Referer headers, APM tools — anything that records URL paths records the secret.
2. **`===` is not constant-time.** A patient attacker can recover the key one character at a time from response-timing measurements.
3. **HTTP 200 on auth failure** hides the rejection from monitoring and confuses clients (the body says "Unauthorized" but the status says success).

## Fix

New module `utils/presetKeyAuth.js`:

- `constantTimeEqual(a, b)` — `crypto.timingSafeEqual` with safe handling of `null` / `undefined` / length-mismatched inputs. Always runs an equal-length comparison so the comparison cost doesn't leak the supplied value's length.
- `requirePresetKey(req, res, next)` — Express middleware:
  - Reads the key from the `x-preset-key` header (never the URL).
  - Constant-time compares to `process.env.PRECOMPANYKEY`.
  - Returns **401** on missing or wrong key.
  - Returns **404** when `PRECOMPANYKEY` is not configured at all — fail-closed; the endpoint is effectively disabled.

Both endpoints migrated to:

```js
app.post("/api/v1/setPresetCompany", requirePresetKey, handler);
app.post("/connections",            requirePresetKey, handler);
```

URL paths no longer carry the secret. Methods are POST (state-changing / sensitive). Status codes are correct.

## Files changed

```
A utils/presetKeyAuth.js   (new shared middleware)
M index.js                 (replace the setPresetCompany route)
M Modules/common/routes.js (replace the /connections route)
```

3 files, +87 / −19.

## Test plan

Standalone test at `.claude/tests/test-bug-008.js` (local-only). Boots a tiny Express app with the middleware and exercises:

1. `constantTimeEqual` unit cases (equal / unequal / length-mismatch / null / number coercion).
2. PRECOMPANYKEY unset → 404 (fail-closed) and `next()` not called.
3. PRECOMPANYKEY set, header missing → 401 and `next()` not called.
4. PRECOMPANYKEY set, header wrong → 401 and `next()` not called.
5. PRECOMPANYKEY set, header correct → 200 with `next()` called.
6. Huge wrong header value (1024 chars) → 401, no crash.
7. Empty header value → 401.
8. Source-level: old GET routes are gone from both files; new POST routes exist and reference `requirePresetKey`.

### Test results

```
=== constantTimeEqual — unit ===
  PASS  equal strings → true
  PASS  unequal same-length → false
  PASS  different lengths → false (no throw)
  PASS  empty string vs empty string → true
  PASS  empty vs non-empty → false
  PASS  null vs string → false (no throw)
  PASS  undefined vs string → false (no throw)
  PASS  null vs null → coerced empty → true
  PASS  number vs string of same digits → coerced match

=== PRESET_HEADER constant ===
  PASS  exports the header name

=== requirePresetKey middleware — integration ===
  PASS  PRECOMPANYKEY unset → 404
  PASS  PRECOMPANYKEY unset → next() not called
  PASS  correct key but missing header → 401
  PASS  missing header → next() not called
  PASS  wrong header → 401
  PASS  wrong header → next() not called
  PASS  correct header → 200
  PASS  correct header → next() was called
  PASS  huge wrong header value → 401 (no crash)
  PASS  empty header value → 401

=== source — old GET-with-secret-in-path routes are removed ===
  PASS  index.js no longer registers GET /api/v1/setPresetCompany/:id
  PASS  index.js no longer compares req.params.id to PRECOMPANYKEY
  PASS  index.js registers POST /api/v1/setPresetCompany with requirePresetKey
  PASS  common/routes.js no longer registers GET /connections/:id
  PASS  common/routes.js no longer compares req.params.id to PRECOMPANYKEY
  PASS  common/routes.js registers POST /connections with requirePresetKey

========================================
Tests: 26 | Passed: 26 | Failed: 0
========================================
```

### Manual smoke

```bash
# OLD (vulnerable) — now returns 404
curl -sS -o /dev/null -w "%{http_code}\n" "$APP/api/v1/setPresetCompany/$PRECOMPANYKEY"
# expect: 404

# NEW (correct) — succeeds only with the right header
curl -sS -o /dev/null -w "%{http_code}\n" -X POST \
  -H "x-preset-key: $PRECOMPANYKEY" \
  "$APP/api/v1/setPresetCompany"
# expect: 200

# NEW with wrong key
curl -sS -o /dev/null -w "%{http_code}\n" -X POST \
  -H "x-preset-key: wrong" \
  "$APP/api/v1/setPresetCompany"
# expect: 401

# Same shape for /connections
curl -sS -X POST -H "x-preset-key: $PRECOMPANYKEY" "$APP/connections" | jq .
# expect: { data: [...], total: N }
```

### Deployment notes

- **Rotate `PRECOMPANYKEY` if it has ever traveled in URL paths** — once it's in your reverse-proxy / Render / CDN logs, it should be considered compromised. Generate a new value, set it in the env, then re-deploy.
- **Update any internal runbook / cron / monitoring** that called the old GET endpoint. New shape:

```
POST /api/v1/setPresetCompany
POST /connections
Header: x-preset-key: <PRECOMPANYKEY>
```

## Risk

- Behaviour change: GET on the old paths now returns 404 (was 200 with body 'Unauthorized'). Any caller relying on that quirky 200 will see a 404 — but since the old endpoint required the secret in the URL, any such caller already knew the secret and can be updated to the new POST shape.
- No other callers exist in this repo.