### PR TITLE
fix(stability): respond instead of ReferenceError in createProjectFun (BUG-009 / #63)

### DIFF
--- a/Modules/createProject/controller.js
+++ b/Modules/createProject/controller.js
@@ -101,7 +101,16 @@ exports.createProjectFun = async(req, res) => {
             }
         })
     } catch (error) {
-        reject(error)
+        // BUG-009 / #63 fix: `createProjectFun` is `async (req, res)`, not a
+        // `new Promise` constructor body — `reject` is not defined in this
+        // scope. Reaching this branch previously threw a ReferenceError that
+        // masked the real error and left the request hanging until the
+        // client / proxy timed out. Respond with the actual error instead.
+        logger.error(`createProjectFun error: ${error && error.message ? error.message : error}`);
+        res.status(400).send({
+            status: false,
+            statusText: error && error.message ? error.message : error,
+        });
     }
 };
 


### PR DESCRIPTION
## Summary

Closes #63 (BUG-009).

`Modules/createProject/controller.js:104` had `reject(error)` in the outer `catch` block of `createProjectFun`. The function is `async (req, res) => { ... }`, not a `new Promise` constructor body — so `reject` was undefined in that scope. Any synchronous throw upstream of the inner `.then(...).catch(...)` chain threw a `ReferenceError`, masked the original error, and left the response hanging until the client (or upstream proxy) timed out.

## Root cause

```js
exports.createProjectFun = async(req, res) => {
    try {
        exports.checkProjectPlan(req).then((data) => { ... })
            .catch((error) => { ... });
    } catch (error) {
        reject(error)   // ← ReferenceError: reject is not defined
    }
};
```

`reject` lives only inside `new Promise((resolve, reject) => { ... })` bodies. `createProjectFun` is an Express handler, not a Promise body.

## Fix

Replace `reject(error)` with the response shape already used by the inner `.catch` branches (`res.send({ status: false, statusText: ... })`), set HTTP 400, and log the underlying error via the existing Winston `logger`.

```js
} catch (error) {
    logger.error(`createProjectFun error: ${error.message || error}`);
    res.status(400).send({
        status: false,
        statusText: error.message || error,
    });
}
```

The synchronous error path now returns a clean 400 with a useful body instead of dropping into the uncaught-rejection handler.

## Out of scope

**BUG-010 (#64)** — the `if (data.status) { ... }` branch without an `else` that causes the same handler to hang when `checkProjectPlan` *resolves* with `{ status: false }`. That's the next PR in the sequence.

## Files changed

- `Modules/createProject/controller.js` (+10 / −1)

## Test plan

Standalone test at `.claude/tests/test-bug-009.js` (local-only). Stubs `checkProjectPlan` to throw synchronously, invokes `createProjectFun` with a mock `req`/`res`, and asserts that the handler responds correctly without an unhandled ReferenceError.

### Test results

```
=== createProjectFun — synchronous throw in checkProjectPlan ===
  PASS  createProjectFun does not throw to caller (no unhandled ReferenceError)
  PASS  res.send (or res.json) was called exactly once
  PASS  res.status(400) was set
  PASS  response body has status: false
  PASS  response body surfaces the original error message

=== source — `reject(error)` outside Promise scope is removed ===
  PASS  createProjectFun definition still present
  PASS  createProject definition follows after createProjectFun
  PASS  createProjectFun body no longer calls `reject(`
  PASS  createProjectFun body now uses res.status(400).send

========================================
Tests: 9 | Passed: 9 | Failed: 0
========================================
```

### Manual smoke

Pre-fix this curl hung until the proxy timeout:

```bash
# Force a synchronous error by sending no body to the project-create endpoint.
time curl -sS --max-time 5 -o /tmp/cp.json -w "HTTP %{http_code}\n" \
  -X POST "$APP/api/v2/createProject" \
  -H "Authorization: Bearer $TOKEN" -H "companyid: $COMPANY_A" \
  -H "Content-Type: application/json" -d '{}'
# Pre-fix: curl 28 (Operation timed out) after 5s.
# Post-fix: HTTP 400 within ~1s with { "status": false, "statusText": "..." }.
```

## Risk

- The synchronous-error path now returns a real 4xx response, so any client that previously waited for a timeout will see a faster failure. That's the desired behaviour.
- The async-error paths (the inner `.then/.catch` chains) are unchanged — their responses still flow through `res.send({ ... })` as before.