### PR TITLE
fix(stability): add missing else in createProjectFun (BUG-010 / #64)

### DIFF
--- a/Modules/createProject/controller.js
+++ b/Modules/createProject/controller.js
@@ -90,6 +90,19 @@ exports.createProjectFun = async(req, res) => {
                     exports.removeProjectCount(req.body.CompanyId,req.body.isPrivateSpace);
                     res.send({status:false, statusText: error});
                 });
+            } else {
+                // BUG-010 / #64 fix: previously this branch was missing, so
+                // when `checkProjectPlan` resolved with `{status: false}`
+                // (e.g. a future refactor moves a failure path from `reject`
+                // to `resolve`) the request would hang until the proxy timed
+                // out. `checkProjectPlan` increments the project count
+                // before validating limits, so we must also roll the count
+                // back here to mirror the .catch branch below.
+                exports.removeProjectCount(req.body.CompanyId, req.body.isPrivateSpace);
+                res.status(400).send({
+                    status: false,
+                    statusText: (data && data.statusText) || 'Project plan check did not pass.',
+                });
             }
         }).catch((error) => {
             if(error?.countRollBack === false && error.countRollBack !== undefined){


### PR DESCRIPTION
## Summary

Closes #64 (BUG-010).

`Modules/createProject/controller.js:83-93` checked `if (data.status) { … }` on the resolution of `checkProjectPlan` with **no `else` branch**. Today every failure path of `checkProjectPlan` happens to go through `reject`, so the hang isn't reachable in current code — but the handler is one tiny refactor away from a silent hang, and `checkProjectPlan` has already incremented the company's `projectCount` by the time validation runs.

## Root cause

```js
exports.checkProjectPlan(req).then((data) => {
    if (data.status) {
        exports.createProject(req).then((cData) => { ... })
            .catch((error) => {
                exports.removeProjectCount(req.body.CompanyId, req.body.isPrivateSpace);
                res.send({status:false, statusText: error});
            });
    }
    // ← falls off the end with no response when data.status === false
}).catch((error) => { ... })
```

`checkProjectPlan` first runs `updateCompanyFun(...)` which `$inc`s `projectCount.projectCount` and one of `publicCount` / `privateCount`. Validation happens *after* the increment. Every current failure path emits `reject({...})` and routes through the outer `.catch`, which calls `removeProjectCount` to roll back.

If anyone ever changes any of those failure paths from `reject({status:false})` to `resolve({status:false})` — a common refactor when surfacing user-visible reasons — control reaches the `.then`, `if (data.status)` is false, no branch fires, no response is sent, and the speculative count increment is left in place.

## Fix

Add the missing `else` branch, mirroring the rollback the `.catch` branch already performs:

```js
} else {
    exports.removeProjectCount(req.body.CompanyId, req.body.isPrivateSpace);
    res.status(400).send({
        status: false,
        statusText: (data && data.statusText) || 'Project plan check did not pass.',
    });
}
```

## Out of scope

**BUG-009 (#63)** — the `reject(error)` line in the outer `catch` of the same function. Already its own PR (#110). The two fixes touch different regions of the file and merge cleanly together.

## Files changed

- `Modules/createProject/controller.js` (+13)

## Test plan

Standalone test at `.claude/tests/test-bug-010.js` (local-only). Stubs `checkProjectPlan` to resolve with `{status: false}` and asserts:

1. Handler does not hang (`res.send` is called once).
2. Status is 400.
3. Body has `status: false` and the plan-check `statusText`.
4. `removeProjectCount` is called with the right `(companyId, isPrivateSpace)`.

It also re-runs the happy path (`checkProjectPlan` resolves with `{status: true}`) to confirm the existing behaviour didn't regress:

5. `createProject` is invoked.
6. `res.send` fires once with the createProject payload.
7. `removeProjectCount` is NOT called in the happy path.

### Test results

```
=== createProjectFun — checkProjectPlan resolves {status: false} ===
  PASS  createProjectFun does not throw to caller
  PASS  res.send was called exactly once (no hang)
  PASS  res.status was set to 400
  PASS  response body has status: false
  PASS  response body surfaces the plan-check statusText
  PASS  removeProjectCount was called to roll back the speculative count
  PASS  removeProjectCount got the right (companyId, isPrivateSpace)

=== createProjectFun — happy path still works (status: true) ===
  PASS  happy path: createProject was invoked
  PASS  happy path: res.send was called exactly once with the createProject payload
  PASS  happy path: removeProjectCount was NOT called

=== source — else branch is present and rolls back the count ===
  PASS  createProjectFun body contains an else branch on the data.status check
  PASS  else branch calls removeProjectCount
  PASS  else branch sends a 400 response

========================================
Tests: 13 | Passed: 13 | Failed: 0
========================================
```

### Manual smoke

```bash
# Happy path — still returns the created project.
curl -sS -X POST "$APP/api/v2/createProject" \
  -H "Authorization: Bearer $TOKEN" -H "companyid: $COMPANY_A" \
  -H "Content-Type: application/json" \
  -d '{"CompanyId":"'$COMPANY_A'","ProjectName":"qa-bug-010","ProjectCode":"QA10","projectIcon":{}}'
# expect: 200 with new project data.

# Failure path — until a future refactor uses `resolve({status: false})`,
# this still goes through the existing .catch branch which already sends a
# response. The else branch is dead code today, kept for defense-in-depth.
```

## Risk

- The new branch is unreachable from current `checkProjectPlan` behaviour, so this change cannot affect production traffic on its own. Its value is preventing a future regression.
- If a follow-up does start using `resolve({status: false, statusText: '…'})` for user-visible failure reasons, the response shape (`{ status: false, statusText: '…' }`) is consistent with what the `.catch` branch already emits — no client-side changes needed.