### PR TITLE
fix(security): stop overwriting req.body, allow-list invite keys (BUG-011 / #65)

### DIFF
--- a/Modules/auth/controller/verifyInvitation.js
+++ b/Modules/auth/controller/verifyInvitation.js
@@ -9,10 +9,59 @@ const { updateUserFun, getUserByQueyFun } = require("../../Users/controller");
 const { updateMemberFunction } = require('../../settings/Members/controller');
 
 /**
+ * BUG-011 / #65 fix: parse the base64 invitation blob into a *local*
+ * object with a fixed key allow-list. Previously the handler did:
+ *
+ *     for (let i = 0; i < idArray.length; i += 1) {
+ *         const aidArray = idArray[i].split('=');
+ *         finalObj[aidArray[0]] = aidArray[1];
+ *     }
+ *     req.body = finalObj;
+ *
+ * — i.e. any key in the attacker-controlled blob was merged into
+ * `req.body` and downstream code (here and elsewhere) saw whatever the
+ * attacker wanted under whatever name.
+ *
+ * Now: build a local object, only copy keys from a fixed allow-list,
+ * and leave `req.body` untouched.
+ */
+const ALLOWED_INVITE_KEYS = new Set(['userId', 'companyId', 'linkId', 'docId']);
+
+// Strict base64 check — the npm `atob` package is permissive and happily
+// returns garbage on malformed input, so we gate on the alphabet first.
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+exports.parseInviteBlob = (encoded) => {
+    if (typeof encoded !== 'string' || !encoded) return null;
+    if (!BASE64_RE.test(encoded)) return null;
+    let decoded;
+    try {
+        decoded = atob(encoded);
+    } catch (_) {
+        return null;
+    }
+    if (typeof decoded !== 'string' || !decoded) return null;
+    const out = {};
+    const parts = decoded.split('&');
+    for (let i = 0; i < parts.length; i += 1) {
+        const eq = parts[i].indexOf('=');
+        if (eq < 0) continue;
+        const key = parts[i].slice(0, eq);
+        const value = parts[i].slice(eq + 1); // preserve any `=` inside the value
+        if (ALLOWED_INVITE_KEYS.has(key)) {
+            out[key] = value;
+        }
+    }
+    // If nothing recognised was extracted, treat the blob as invalid.
+    if (Object.keys(out).length === 0) return null;
+    return out;
+};
+
+/**
  * Check Permission
- * @param {Object} req 
- * @param {Object} res 
- * @returns 
+ * @param {Object} req
+ * @param {Object} res
+ * @returns
  */
 exports.checkPermission = (req, res) => {
     if (!(req.body && req.body.id)) {
@@ -23,10 +72,9 @@ exports.checkPermission = (req, res) => {
         });
         return;
     }
-    const id = atob(req.body.id);
 
-    const idArray = id.split('&');
-    if (!(idArray && idArray.length)) {
+    const invite = exports.parseInviteBlob(req.body.id);
+    if (!invite) {
         res.json({
             status: false,
             key: 1,
@@ -34,24 +82,19 @@ exports.checkPermission = (req, res) => {
         });
         return;
     }
-    let finalObj = {};
-    for (let i = 0; i < idArray.length; i += 1) {
-        const aidArray = idArray[i].split('=');
-        finalObj[aidArray[0]] = aidArray[1];
-    }
-    req.body = finalObj;
-    if (!(req.body && req.body.userId)) {
+
+    if (!invite.userId) {
         res.json({
             status: true,
             key: 2,
-            companyId: req.body.companyId,
-            linkId: req.body.linkId,
+            companyId: invite.companyId,
+            linkId: invite.linkId,
             statusText: "User Not Found."
         });
         return;
     }
 
-    if (!(req.body && req.body.companyId)) {
+    if (!invite.companyId) {
         res.json({
             status: false,
             key: 1,
@@ -60,7 +103,7 @@ exports.checkPermission = (req, res) => {
         return;
     }
 
-    if (!(req.body && req.body.linkId)) {
+    if (!invite.linkId) {
         res.json({
             status: false,
             key: 1,
@@ -71,7 +114,7 @@ exports.checkPermission = (req, res) => {
 
     try {
         const query = {
-            _id: new mongoose.Types.ObjectId(req.body.userId)
+            _id: new mongoose.Types.ObjectId(invite.userId)
         }
         getUserByQueyFun(query)
         .then((resp) => {
@@ -80,8 +123,8 @@ exports.checkPermission = (req, res) => {
                 res.send({
                     status: true,
                     key: 2,
-                    companyId: req.body.companyId,
-                    linkId: req.body.linkId,
+                    companyId: invite.companyId,
+                    linkId: invite.linkId,
                     statusText: "User Not Found."
                 });
                 return;
@@ -90,11 +133,11 @@ exports.checkPermission = (req, res) => {
                 type: dbCollections.COMPANY_USERS,
                 data: [
                     {
-                        _id: new mongoose.Types.ObjectId(req.body.docId)
+                        _id: new mongoose.Types.ObjectId(invite.docId)
                     }
                 ]
             }
-            MongoDbCrudOpration(req.body.companyId, companyUserQuery, "findOne")
+            MongoDbCrudOpration(invite.companyId, companyUserQuery, "findOne")
             .then((cUser) => {
                 if(!cUser) {
                     res.send({
@@ -123,7 +166,7 @@ exports.checkPermission = (req, res) => {
                     });
                     return;
                 }
-                if (userData.linkId !== req.body.linkId) {
+                if (userData.linkId !== invite.linkId) {
                     res.send({
                         status: false,
                         key: 4,
@@ -134,12 +177,12 @@ exports.checkPermission = (req, res) => {
                 res.json({
                     status: true,
                     key: 5,
-                    companyId: req.body.companyId
+                    companyId: invite.companyId
                 });
 
                 const memberObject = [
                     {
-                        _id: new mongoose.Types.ObjectId(req.body.docId)
+                        _id: new mongoose.Types.ObjectId(invite.docId)
                     }, {
                         $set: {
                             status: 2,
@@ -148,26 +191,26 @@ exports.checkPermission = (req, res) => {
                     }
                 ]
 
-                updateMemberFunction(req.body.companyId, memberObject, "updateOne")
+                updateMemberFunction(invite.companyId, memberObject, "updateOne")
                 .then(() => {
                     const userUpdateQuery = {
                         type: dbCollections.USERS,
                         data: [
                             {
-                                _id: new mongoose.Types.ObjectId(req.body.userId)
+                                _id: new mongoose.Types.ObjectId(invite.userId)
                             }, {
                                 $push: {
-                                    AssignCompany: req.body.companyId
+                                    AssignCompany: invite.companyId
                                 }
                             }
                         ]
                     }
-                    updateUserFun(SCHEMA_TYPE.GOLBAL, userUpdateQuery, "updateOne",req.body.companyId,req.body.userId)
+                    updateUserFun(SCHEMA_TYPE.GOLBAL, userUpdateQuery, "updateOne", invite.companyId, invite.userId)
                     .catch((error) => {
                         logger.error(`ERROR in update user: ${error.message}`);
                     })
 
-                    addAndRemoveUserInMongodbNotificationCount(req.body.companyId,req.body.userId,"Add").catch((error)=>{
+                    addAndRemoveUserInMongodbNotificationCount(invite.companyId, invite.userId, "Add").catch((error)=>{
                         logger.error(`ERROR in create user In mongodb: ${error}`)
                     })
                 })


### PR DESCRIPTION
## Summary

Closes #65 (BUG-011).

`Modules/auth/controller/verifyInvitation.js:26-42` decoded the base64 invitation blob from `req.body.id`, parsed it `&`/`=`-style, and then **replaced `req.body` wholesale** with the parsed object. No allow-list, no shape validation — every downstream `req.body.<anything>` read attacker-controlled values as if validated. Combined with predictable invitation tokens this was a parameter-injection primitive.

## Root cause

```js
// pre-fix — Modules/auth/controller/verifyInvitation.js:26-42
const id = atob(req.body.id);
const idArray = id.split('&');
// …validation skipped for brevity…
let finalObj = {};
for (let i = 0; i < idArray.length; i += 1) {
    const aidArray = idArray[i].split('=');
    finalObj[aidArray[0]] = aidArray[1];
}
req.body = finalObj;   // ← attacker controls every subsequent req.body.<key>
```

A blob encoding `userId=victim&companyId=victimCo&role=admin&isAdmin=true` would set `req.body.role` and `req.body.isAdmin`, which any later middleware or downstream controller would consume as trusted.

## Fix

Add an exported pure helper:

```js
const ALLOWED_INVITE_KEYS = new Set(['userId', 'companyId', 'linkId', 'docId']);

exports.parseInviteBlob = (encoded) => { … };
```

Properties:
- Accepts only the four keys actually used by `checkPermission` (and the downstream DB queries). Anything else in the blob is dropped.
- Returns `null` on invalid input (non-string, wrong base64 alphabet, decode failure, or no allow-listed keys present).
- Validates the input alphabet with `^[A-Za-z0-9+/]+={0,2}$` before calling `atob`, since the npm `atob@2.1.2` package is permissive and returns garbage on malformed input rather than throwing.
- Splits `key=value` on the **first** `=` only, so values that legitimately contain `=` aren't truncated.

`checkPermission` is rewritten to read from a local `invite` object returned by `parseInviteBlob`. **`req.body` is no longer mutated.**

## Files changed

- `Modules/auth/controller/verifyInvitation.js` (+73 / −30)

## Test plan

Standalone test at `.claude/tests/test-bug-011.js` (local-only). 27 assertions across:

1. `parseInviteBlob` unit cases: empty / non-string / bad-base64 / valid 4-key payload / attacker-smuggled keys dropped (`role`, `isAdmin`, `password`, `__proto__` — prototype pollution sanity check) / `=` in value preserved / parts without `=` skipped.
2. `checkPermission` early-return paths: missing `id`, malformed base64, missing `userId`, missing `companyId`, missing `linkId` — all return the right `{ key, status, statusText }`.
3. `req.body` is NOT mutated — the original `{ id: '...' }` shape is preserved, and none of `userId` / `role` / `isAdmin` ever appears on `req.body`.
4. Source-level grep: `req.body = finalObj` is gone, no `req.body =` assignment of any kind remains in executable code, the new exports / allow-list are in place.

### Test results

```
=== parseInviteBlob — unit ===
  PASS  rejects empty input → null
  PASS  rejects non-string input → null
  PASS  rejects invalid base64 → null
  PASS  all 4 allowed keys parsed
  PASS  disallowed keys dropped — role
  PASS  disallowed keys dropped — isAdmin
  PASS  disallowed keys dropped — password
  PASS  disallowed keys dropped — __proto__
  PASS  Object.prototype is not polluted
  PASS  value containing "=" is preserved verbatim
  PASS  parts without "=" are skipped

=== checkPermission — early-return paths ===
  PASS  missing req.body.id → key=1, "Invalid URL id."
  PASS  invalid base64 → key=1, "Invalid URL."
  PASS  missing userId → key=2 "User Not Found."
  PASS  missing userId → response echoes parsed companyId
  PASS  missing userId → response echoes parsed linkId
  PASS  userId but missing companyId → key=1 "Invalid URL."
  PASS  userId+companyId but missing linkId → key=1 "Invalid URL."

=== req.body is NOT mutated ===
  PASS  req.body still references the same object after call
  PASS  req.body still has only the original `id` field
  PASS  req.body.role was NOT injected by the handler
  PASS  req.body.isAdmin was NOT injected by the handler
  PASS  req.body.userId was NOT injected by the handler

=== source — req.body assignment is gone ===
  PASS  source no longer contains `req.body = finalObj`
  PASS  source no longer contains any `req.body =` assignment
  PASS  source exports parseInviteBlob
  PASS  source has the ALLOWED_INVITE_KEYS allow-list

========================================
Tests: 27 | Passed: 27 | Failed: 0
========================================
```

### Manual smoke

```bash
# Attacker payload — smuggles `role=admin` and `isAdmin=true`.
ID=$(printf 'userId=%s&companyId=%s&linkId=L1&docId=d1&role=admin&isAdmin=true' "$USER_ID" "$COMPANY_B" | base64 -w0)

curl -sS -X POST "$APP/api/v2/auth/checkPermission" \
  -H "Content-Type: application/json" \
  -d "{\"id\":\"$ID\"}"
# Pre-fix: `req.body.role` and `req.body.isAdmin` smuggled in; downstream code
#          may treat them as validated.
# Post-fix: the response only ever references the four allow-listed keys;
#          `role` / `isAdmin` are dropped before the handler runs.
```

## Risk

- Any caller of `/api/v2/auth/checkPermission` that previously depended on additional keys being present in the decoded blob will see them ignored. This is the intended behaviour — only the four documented invitation fields are honoured. No in-repo callers passed anything else; the legitimate frontend invitation flow continues to work.