### PR TITLE
fix(security): tighten + env-configure auth rate limit (BUG-012 / #66)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@ JWT_SECRET="your_jwt_secret_here"         # REQUIRED
 JWT_EXP="24h"
 JWT_ALGORITHM="HS256"
 
+# Login / forgot-password / reset-password rate-limit (per IP).
+# - MAX_ATTEMPTS: failed attempts before the IP is blocked (default 5).
+# - WINDOW_MS:    rolling-window length the attempts are counted in (default 15 min).
+# - BLOCK_MS:     how long the IP stays blocked once tripped (default 30 min).
+AUTH_RATE_LIMIT_MAX_ATTEMPTS="5"
+AUTH_RATE_LIMIT_WINDOW_MS="900000"
+AUTH_RATE_LIMIT_BLOCK_MS="1800000"
+
 # ─────────────────────────────────────────
 # APP URLs
 # ─────────────────────────────────────────

--- a/Modules/auth/helper.js
+++ b/Modules/auth/helper.js
@@ -162,8 +162,31 @@ exports.sendTooManyRequestMail = (ip, data) => {
 }
 
 
+/**
+ * Auth rate-limit configuration (BUG-012 / #66 fix).
+ *
+ * The previous implementation hard-coded 9 attempts inside a 10-minute
+ * window with a 10-minute block — permissive enough to let a patient
+ * attacker grind ~9 attempts per IP per 10 minutes indefinitely. The
+ * variable name (`fiveMinutes`) also disagreed with its value (10 min).
+ *
+ * Move the three knobs to environment variables with safer defaults:
+ *   - AUTH_RATE_LIMIT_MAX_ATTEMPTS    default 5
+ *   - AUTH_RATE_LIMIT_WINDOW_MS       default 15 min
+ *   - AUTH_RATE_LIMIT_BLOCK_MS        default 30 min
+ *
+ * Read at request time so an operator can adjust without restarting.
+ * Exported for the regression test at .claude/tests/test-bug-012.js.
+ */
+exports.getRateLimitConfig = () => ({
+    MAX_ATTEMPTS: Math.max(1, Number(process.env.AUTH_RATE_LIMIT_MAX_ATTEMPTS) || 5),
+    WINDOW_MS: Math.max(1000, Number(process.env.AUTH_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000),
+    BLOCK_MS: Math.max(1000, Number(process.env.AUTH_RATE_LIMIT_BLOCK_MS) || 30 * 60 * 1000),
+});
+
 exports.manageResetAttempt = (ip, data, cb) => {
     try {
+        const { MAX_ATTEMPTS, WINDOW_MS, BLOCK_MS } = exports.getRateLimitConfig();
         const managecount = (attempt) => {
             const now = new Date();
             // Check if the user is blocked
@@ -177,9 +200,9 @@ exports.manageResetAttempt = (ip, data, cb) => {
                 };
             }
 
-            // Reset the attempt count if more than 10 minutes have passed since the first attempt
-            const fiveMinutes = 10 * 60 * 1000;
-            if (now - attempt.firstAttemptTime > fiveMinutes) {
+            // Reset the attempt count if the rolling window has passed
+            // since the first attempt in this series.
+            if (attempt.firstAttemptTime && (now - attempt.firstAttemptTime > WINDOW_MS)) {
                 attempt.attempts = 0;
                 attempt.firstAttemptTime = now;
                 attempt.blockedUntil = null;
@@ -187,8 +210,8 @@ exports.manageResetAttempt = (ip, data, cb) => {
 
             // Increment attempts and check limit
             attempt.attempts += 1;
-            if (attempt.attempts > 9) {
-                attempt.blockedUntil = new Date(now.getTime() + 10 * 60 * 1000); // Block for 10 minutes
+            if (attempt.attempts >= MAX_ATTEMPTS) {
+                attempt.blockedUntil = new Date(now.getTime() + BLOCK_MS);
                 attempt.attempts = 0; // Reset attempt count after blocking
                 attempt.firstAttemptTime = null; // Clear the first attempt time after blocking
             }


### PR DESCRIPTION
## Summary

Closes #66 (BUG-012).

`Modules/auth/helper.js:180-194` hard-coded the auth rate-limit knobs: 9 attempts inside a 10-min window (mislabelled `fiveMinutes` in code), 10-min block. That allowed ~9 attempts per IP per 10 min indefinitely — slow distributed credential stuffing slipped through.

Tighten defaults to **5 / 15 min / 30 min**, lift the three knobs out to env vars, and remove the misleading `fiveMinutes` variable name.

## Root cause

```js
// pre-fix
const fiveMinutes = 10 * 60 * 1000;          // ← name says 5 but value is 10
if (now - attempt.firstAttemptTime > fiveMinutes) {
    attempt.attempts = 0;
    attempt.firstAttemptTime = now;
    attempt.blockedUntil = null;
}
attempt.attempts += 1;
if (attempt.attempts > 9) {                  // ← off-by-one vs the >= we want
    attempt.blockedUntil = new Date(now.getTime() + 10 * 60 * 1000);
    attempt.attempts = 0;
    attempt.firstAttemptTime = null;
}
```

Also: the threshold check used `> 9` so the 10th attempt was the one to trip the block. After blocking, `attempts` was reset to 0, so once the block expired the attacker had a fresh 9-attempt budget. A patient attacker could grind ~54 attempts/hour per IP forever.

## Fix

Exported helper `getRateLimitConfig()` returns:

```js
{
  MAX_ATTEMPTS: Number(process.env.AUTH_RATE_LIMIT_MAX_ATTEMPTS) || 5,
  WINDOW_MS:    Number(process.env.AUTH_RATE_LIMIT_WINDOW_MS)    || 15 * 60 * 1000,
  BLOCK_MS:     Number(process.env.AUTH_RATE_LIMIT_BLOCK_MS)     || 30 * 60 * 1000,
}
```

…clamped to `>= 1` / `>= 1000ms` so a misconfigured `0` falls back to safe values. Read at request time so the env can be tuned without restart.

`manageResetAttempt` now uses these constants:
- threshold check is `attempts >= MAX_ATTEMPTS` (not `> 9`, so the configured number means what it says)
- the misleading `fiveMinutes` variable name is gone

## Out of scope

A future improvement (followup, not this PR) is **exponential backoff** — each consecutive block should double in length so a patient attacker hits 30 min → 1 h → 2 h → … instead of always 30 min. Reasonable next step but a larger change.

Per-account rate limiting on top of per-IP (against credential stuffing rotating IPs) is also a separate concern.

## Files changed

- `Modules/auth/helper.js` (+24 / −5)
- `.env.example` (+12)

## Test plan

Standalone test at `.claude/tests/test-bug-012.js` (local-only). 22 assertions:

1. `getRateLimitConfig()` defaults — 5 / 15 min / 30 min.
2. Env overrides — every var takes precedence over the default.
3. Clamping / safety — zero, non-numeric, and empty values fall back to safe defaults.
4. Source-level grep — the bad `fiveMinutes` variable is gone, the `attempts > 9` literal is gone, the algorithm now references `MAX_ATTEMPTS`/`WINDOW_MS`/`BLOCK_MS`.
5. `.env.example` documents the three new variables.

### Test results

```
=== getRateLimitConfig — defaults ===
  PASS  default MAX_ATTEMPTS is 5 (was 9)
  PASS  default WINDOW_MS is 15 minutes
  PASS  default BLOCK_MS is 30 minutes (was 10 min)

=== getRateLimitConfig — env overrides ===
  PASS  env override on MAX_ATTEMPTS
  PASS  env override on WINDOW_MS
  PASS  env override on BLOCK_MS

=== getRateLimitConfig — clamping / safety ===
  PASS  MAX_ATTEMPTS clamped to >=1 when env is 0
  PASS  WINDOW_MS clamped to >=1000 when env is 0
  PASS  BLOCK_MS clamped to >=1000 when env is 0
  PASS  non-numeric MAX_ATTEMPTS falls back to default 5
  PASS  non-numeric WINDOW_MS falls back to default
  PASS  empty BLOCK_MS falls back to default

=== source — magic numbers replaced with the helper ===
  PASS  no \`fiveMinutes\` variable anywhere (the bad name is gone)
  PASS  no executable \`attempts > 9\` check (old threshold gone)
  PASS  no executable \`10 \* 60 \* 1000\` literal in the attempt logic
  PASS  manageResetAttempt now reads MAX_ATTEMPTS from getRateLimitConfig
  PASS  threshold check uses the MAX_ATTEMPTS variable
  PASS  window check uses WINDOW_MS
  PASS  block-duration uses BLOCK_MS

=== .env.example documents the new vars ===
  PASS  .env.example declares AUTH_RATE_LIMIT_MAX_ATTEMPTS
  PASS  .env.example declares AUTH_RATE_LIMIT_WINDOW_MS
  PASS  .env.example declares AUTH_RATE_LIMIT_BLOCK_MS

========================================
Tests: 22 | Passed: 22 | Failed: 0
========================================
```

### Manual smoke

```bash
# Fire 6 wrong-password attempts from one IP — expect 429 on the 5th.
for i in $(seq 1 6); do
  curl -sS -o /dev/null -w \"%{http_code} \" \
    -X POST \"$APP/api/v2/auth/login\" \
    -H \"Content-Type: application/json\" \
    -d '{\"email\":\"qa@example.com\",\"password\":\"wrong\"}'
done; echo
# expect: 401 401 401 401 429 429   (was 401 x 5 then 429 only on 10th attempt)
```

### Deployment notes

- Defaults are intentionally stricter. If a deployment has high-volume legitimate retry traffic (e.g. an SSO flow probing for an existing account), tune via env:

```env
AUTH_RATE_LIMIT_MAX_ATTEMPTS=10
AUTH_RATE_LIMIT_WINDOW_MS=900000     # 15 min
AUTH_RATE_LIMIT_BLOCK_MS=1800000     # 30 min
```

- Existing `RESET_ATTEMPT` documents in MongoDB are unaffected and will keep working with the new thresholds.

## Risk

- Legitimate users with persistent typos may now get blocked 4× more easily (after 5 wrong attempts instead of 9). The security-alert email already in place (`sendTooManyRequestMail`) notifies the account owner.
- The block is also 3× longer (30 min vs 10), which is the intended deterrent for an attacker but mildly inconvenient for a locked-out legitimate user. They can either wait or reset their password.