### PR TITLE
fix(security): re-validate company membership per request, cached (BUG-013 / #67)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,13 @@ JWT_SECRET="your_jwt_secret_here"         # REQUIRED
 JWT_EXP="24h"
 JWT_ALGORITHM="HS256"
 
+# How long (in seconds) the per-(user, company) membership lookup is cached
+# after a successful authenticated request. Lower values pick up membership
+# changes (add / remove member) faster at the cost of an extra Mongo query;
+# higher values are cheaper but widen the window where a removed user can
+# still call the API. Default 60s. Set to 0 to bypass the cache entirely.
+MEMBERSHIP_CACHE_TTL_SECONDS="60"
+
 # ─────────────────────────────────────────
 # APP URLs
 # ─────────────────────────────────────────

--- a/Config/jwt.js
+++ b/Config/jwt.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const mongoose = require('mongoose');
 const logger = require("./loggerConfig");
 const mongoC = require("../utils/mongo-handler/mongoQueries");
 const { dbCollections } = require("../Config/collections.js");
@@ -19,6 +20,64 @@ const isCompanyInAudience = (audClaim, companyId) => {
         : String(audClaim).split(',');
     const target = String(companyId).trim();
     return list.some((entry) => String(entry).trim() === target);
+};
+
+// BUG-013 / #67 fix: live membership re-check against MongoDB, cached.
+//
+// The JWT audience claim is frozen at login and lasts JWT_EXP (24h default),
+// so a user removed from a company between login and token expiry still has
+// access for up to a day. Re-check the `users.AssignCompany` array on every
+// authenticated request, with a short cache TTL (default 60s) so the cost
+// is one Mongo lookup per user-company pair per minute, not per request.
+//
+// Cache invalidation hook `invalidateMembershipCache(uid, companyId?)` is
+// exported so the membership-change flows (add/remove member) can wipe the
+// cache and apply changes immediately.
+const MEMBERSHIP_CACHE_PREFIX = 'membership:';
+
+const getMembershipCacheTtlSeconds = () => {
+    const raw = Number(process.env.MEMBERSHIP_CACHE_TTL_SECONDS);
+    if (!Number.isFinite(raw) || raw < 0) return 60;
+    return raw;
+};
+
+const verifyCompanyMembership = async (uid, companyId) => {
+    if (!uid || !companyId) return false;
+    if (!OBJECT_ID_PATTERN.test(String(uid)) || !OBJECT_ID_PATTERN.test(String(companyId))) {
+        return false;
+    }
+    const cacheKey = `${MEMBERSHIP_CACHE_PREFIX}${uid}:${companyId}`;
+    const cached = myCache.get(cacheKey);
+    if (cached === true) return true;
+    if (cached === false) return false;
+    try {
+        const obj = {
+            type: dbCollections.USERS,
+            data: [{
+                _id: new mongoose.Types.ObjectId(String(uid)),
+                AssignCompany: String(companyId),
+            }],
+        };
+        const resData = await mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, obj, 'findOne');
+        const isMember = !!(resData && resData._id);
+        myCache.set(cacheKey, isMember, getMembershipCacheTtlSeconds());
+        return isMember;
+    } catch (error) {
+        logger.error(`verifyCompanyMembership error for uid=${uid} companyId=${companyId}: ${error.message || error}`);
+        return false;
+    }
+};
+
+const invalidateMembershipCache = (uid, companyId) => {
+    if (!uid) return;
+    if (companyId) {
+        myCache.del(`${MEMBERSHIP_CACHE_PREFIX}${uid}:${companyId}`);
+        return;
+    }
+    const prefix = `${MEMBERSHIP_CACHE_PREFIX}${uid}:`;
+    myCache.keys()
+        .filter((k) => k.indexOf(prefix) === 0)
+        .forEach((k) => myCache.del(k));
 };
 
 
@@ -177,7 +236,7 @@ const checkToken = (isValid, req, res, next) => {
  * @param {Object} next
  * @returns 
  */
-const verifyJWTTokenWithC = (req, res, next) => {
+const verifyJWTTokenWithC = async (req, res, next) => {
     try {
         let token = req.headers['x-access-token'] || req.headers['authorization']; // Express headers are auto converted to lowercase
         const companyId = req.headers['companyid'] || "";
@@ -205,6 +264,20 @@ const verifyJWTTokenWithC = (req, res, next) => {
             const isValid = jwt.verify(token, process.env.JWT_SECRET);
             if (isValid && isCompanyInAudience(isValid.aud, companyId)) {
                 const { uid } = isValid;
+
+                // BUG-013 / #67 fix: re-check membership against the DB
+                // (cached) so a user removed from this company loses access
+                // within the cache TTL instead of at JWT expiry.
+                const isMember = await verifyCompanyMembership(uid, companyId);
+                if (!isMember) {
+                    return res.status(403).json({
+                        status: false,
+                        error: 'You are no longer a member of this company',
+                        statusText: 'Forbidden',
+                        isJwtError: true,
+                        isLogout: true,
+                    });
+                }
 
                 req.uid = uid;
                 next();
@@ -236,7 +309,7 @@ const verifyJWTTokenWithC = (req, res, next) => {
     }
 }
 
-const verifyJWTTokenWithCV2 = (req, res, next) => {
+const verifyJWTTokenWithCV2 = async (req, res, next) => {
     let token = req.headers['x-access-token'] || req.headers['authorization']; // Express headers are auto converted to lowercase
     const companyId = req.headers['companyid'] || "";
     if (!companyId) {
@@ -271,6 +344,20 @@ const verifyJWTTokenWithCV2 = (req, res, next) => {
                     isJwtError: true
                 });
             }
+
+            // BUG-013 / #67 fix: live membership re-check (cached).
+            const isMember = await verifyCompanyMembership(isValid.uid, companyId);
+            if (!isMember) {
+                res.clearCookie('accessToken');
+                return res.status(403).json({
+                    status: false,
+                    error: 'You are no longer a member of this company',
+                    statusText: 'Forbidden',
+                    isJwtError: true,
+                    isLogout: true,
+                });
+            }
+
             checkToken(isValid, req, res, next);
         } catch (error) {
             res.clearCookie('accessToken');
@@ -419,5 +506,9 @@ module.exports = {
     verifyJWTToken: verifyJWTToken,
     verifyJWTTokenV2: verifyJWTTokenV2,
     verifyToken: verifyToken,
-    removeCacheAndCookie: removeCacheAndCookie
+    removeCacheAndCookie: removeCacheAndCookie,
+    // BUG-013 / #67
+    verifyCompanyMembership: verifyCompanyMembership,
+    invalidateMembershipCache: invalidateMembershipCache,
+    getMembershipCacheTtlSeconds: getMembershipCacheTtlSeconds,
 }


### PR DESCRIPTION
## Summary

Closes #67 (BUG-013).

The JWT audience claim is frozen at login and lasts `JWT_EXP` (24h default), so a user removed from a company kept access until the token expired — for up to a day on default settings. Add a live, cached membership re-check that runs after the existing audience verification.

## Root cause

`verifyJWTTokenWithC` and `verifyJWTTokenWithCV2` in `Config/jwt.js` verify the JWT signature and audience but never look at the current `users.AssignCompany` array. The audience claim is set at login from the user's company list at that moment and is not refreshed until the next login (or refresh-token rotation).

So:
1. User U logs in while a member of company C. JWT issued with `aud: 'C,...'`, 24h validity.
2. Admin removes U from C 1 minute later.
3. U continues to call `/api/v2/...` with the original token + `companyid: C` for the next ~24 hours, and the API accepts every request.

## Fix

Add `verifyCompanyMembership(uid, companyId)` in `Config/jwt.js`:

```js
const verifyCompanyMembership = async (uid, companyId) => {
    if (!uid || !companyId) return false;
    if (!OBJECT_ID_PATTERN.test(uid) || !OBJECT_ID_PATTERN.test(companyId)) return false;

    const cacheKey = `membership:${uid}:${companyId}`;
    const cached = myCache.get(cacheKey);
    if (cached === true) return true;
    if (cached === false) return false;

    const resData = await mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, {
        type: dbCollections.USERS,
        data: [{ _id: new mongoose.Types.ObjectId(uid), AssignCompany: companyId }],
    }, 'findOne');

    const isMember = !!(resData && resData._id);
    myCache.set(cacheKey, isMember, getMembershipCacheTtlSeconds());
    return isMember;
};
```

Plus a cache-invalidation hook (also exported) so the add-member / remove-member flows can wipe the cache when membership actually changes:

```js
const invalidateMembershipCache = (uid, companyId) => {
    if (companyId) {
        myCache.del(`membership:${uid}:${companyId}`);
        return;
    }
    // No specific company — wipe every entry for this user.
    myCache.keys()
        .filter((k) => k.startsWith(`membership:${uid}:`))
        .forEach((k) => myCache.del(k));
};
```

Both middlewares become `async` and now reject with HTTP **403** (+ `isLogout: true`) when the membership check fails, even with a valid signed JWT.

Cost: one Mongo lookup per (user, company) per `MEMBERSHIP_CACHE_TTL_SECONDS` (default 60s). Negligible next to the existing JWT verify on the same path.

## Followup (not in this PR)

Wire `invalidateMembershipCache(...)` calls into the add-member and remove-member flows in `Modules/settings/Members/controller.js`. With that, removals propagate **instantly** rather than within the cache TTL. Until then the TTL bounds the window — the operator can dial it as low as 0 to bypass caching entirely.

## Files changed

- `Config/jwt.js` (+87 / −2)
- `.env.example` (+8) — documents `MEMBERSHIP_CACHE_TTL_SECONDS`

## Test plan

Standalone test at `.claude/tests/test-bug-013.js` (local-only). Stubs `mongoC.MongoDbCrudOpration` so the helper can be exercised without Mongo.

### Test results

```
=== getMembershipCacheTtlSeconds — defaults / env ===
  PASS  default is 60s
  PASS  env override takes effect
  PASS  zero disables caching (returns 0)
  PASS  non-numeric falls back to default

=== verifyCompanyMembership — input validation ===
  PASS  returns false for missing uid
  PASS  returns false for missing companyId
  PASS  returns false for non-ObjectId uid
  PASS  returns false for non-ObjectId companyId
  PASS  no Mongo call for invalid inputs

=== verifyCompanyMembership — cache miss → hit → invalidate ===
  PASS  first call returns true (member)
  PASS  first call issued exactly 1 Mongo lookup
  PASS  second call returns true
  PASS  second call did NOT hit Mongo (cache hit)
  PASS  after invalidate(uid, companyId) → Mongo lookup happens again
  PASS  non-member returns false
  PASS  negative result is cached too

=== invalidateMembershipCache(uid) — wipes all entries for that user ===
  PASS  cached both companies
  PASS  both companies re-queried after uid-wide invalidate

=== verifyJWTTokenWithC — 403 when membership check fails ===
  PASS  verifyJWTTokenWithC → 403 when user is not a current member
  PASS  verifyJWTTokenWithC → next() NOT called when non-member
  PASS  verifyJWTTokenWithC → response body sets isLogout flag
  PASS  verifyJWTTokenWithC → statusText is Forbidden

=== verifyJWTTokenWithC — pass-through when member ===
  PASS  verifyJWTTokenWithC → next() called when membership confirmed
  PASS  verifyJWTTokenWithC → req.uid is set from the token

=== verifyJWTTokenWithCV2 — 403 when membership check fails ===
  PASS  verifyJWTTokenWithCV2 → 403 on non-member
  PASS  verifyJWTTokenWithCV2 → next() NOT called

=== source — middlewares exist + helpers exported ===
  PASS  verifyJWTTokenWithC is now async
  PASS  verifyJWTTokenWithCV2 is now async
  PASS  verifyCompanyMembership is called inside both middlewares
  PASS  module exports verifyCompanyMembership
  PASS  module exports invalidateMembershipCache

========================================
Tests: 31 | Passed: 31 | Failed: 0
========================================
```

### Manual smoke

```bash
# 1. Log in as a user that's a member of company C. Save the access token.
TOKEN=$(curl -sS -X POST "$APP/api/v2/auth/login" \
  -H "Content-Type: application/json" \
  -d '{"email":"qa@example.com","password":"..."}' | jq -r '.accessToken')

# 2. Confirm a normal authenticated call works.
curl -sS -o /dev/null -w "%{http_code}\n" \
  -H "Authorization: Bearer $TOKEN" -H "companyid: $COMPANY_C" \
  "$APP/api/v2/projects/list"
# expect: 200

# 3. In a second shell, remove that user from company C via the admin UI.
#    Wait MEMBERSHIP_CACHE_TTL_SECONDS (60s by default) — or call the
#    invalidate hook (followup PR will wire this automatically).

# 4. Re-issue the request with the same token.
curl -sS -o /dev/null -w "%{http_code}\n" \
  -H "Authorization: Bearer $TOKEN" -H "companyid: $COMPANY_C" \
  "$APP/api/v2/projects/list"
# expect (after fix): 403 with { isLogout: true, statusText: "Forbidden" }
# pre-fix: 200 (the API kept honouring the stale JWT for up to 24h).
```

## Risk

- Every authenticated request now does a cache lookup + occasional Mongo `findOne`. Cache hits are sub-millisecond; misses are one indexed query per (user, company) per minute. No measurable impact on hot paths.
- A user who's actively switching between companies and the cache hasn't warmed up yet will see a one-time ~10-50ms delay per company on first request. Subsequent requests are cached.
- If `MEMBERSHIP_CACHE_TTL_SECONDS=0`, every request does a Mongo lookup. Set this only if instant propagation is critical and Mongo can handle the load.