### PR TITLE
fix(stability): replace forEach(async) fire-and-forget pattern (BUG-017 / #71)

### DIFF
--- a/Modules/AI/controller.js
+++ b/Modules/AI/controller.js
@@ -384,15 +384,24 @@ exports.generateWithStream = (axiosData,header,userId,companyId,uniqueUserId,eve
                 .map((chunk) => chunk.replace(/^data: /, '').trim())
                 .filter((chunk) => chunk !== undefined && chunk !== '' && chunk !== '[DONE]')
                 .map((chunk) => JSON.parse(chunk));
-                chunkObjects.forEach(async(chunk) => {
-                    if (chunk.choices && chunk.choices.length > 0 && chunk.choices[0].delta.content){
-                        delayProvider(chunk.choices[0].delta.content,eventId)
-                    }else if(chunk.usage){
-                        const userUpdate = await exports.limitCountUpdate(userId,companyId,chunk.usage.total_tokens);
-                        emitListener(eventId, {step: "COUNT",value : userUpdate});
+                // BUG-017 / #71 fix: this loop has an `await` inside (the
+                // `limitCountUpdate` call) so the previous `.forEach(async ...)`
+                // was fire-and-forget — `resolve(fullText)` ran before the
+                // quota update settled, so quota failures were invisible.
+                // `for ... of` + `await` guarantees the update is fully
+                // applied before we continue.
+                for (const chunk of chunkObjects) {
+                    if (chunk.choices && chunk.choices.length > 0 && chunk.choices[0].delta.content) {
+                        delayProvider(chunk.choices[0].delta.content, eventId);
+                    } else if (chunk.usage) {
+                        const userUpdate = await exports.limitCountUpdate(userId, companyId, chunk.usage.total_tokens);
+                        emitListener(eventId, { step: "COUNT", value: userUpdate });
                     }
-                });
-                chunkObjects.forEach(async(chunk) => {
+                }
+                // BUG-017 / #71 fix: this loop has no `await` inside — just
+                // string concatenation — so the `async` keyword on the
+                // callback was misleading. Plain `forEach` is correct here.
+                chunkObjects.forEach((chunk) => {
                     if (chunk.choices && chunk.choices.length > 0 && chunk.choices[0].delta.content){
                         fullText += chunk.choices[0].delta.content;
                     }

--- a/Modules/projectSetting/controller.js
+++ b/Modules/projectSetting/controller.js
@@ -54,7 +54,10 @@ exports.changeTaskType = async (req, res) => {
             promisesArr.push(
                 new Promise((resolve1, reject1) => {
                     try {
-                        req.body.taskTypeKey.forEach(async(key) => {
+                        // BUG-017 / #71 fix: body has no `await` (it uses
+                        // .then/.catch on MongoDbCrudOpration), so the
+                        // `async` keyword was misleading. Plain forEach.
+                        req.body.taskTypeKey.forEach((key) => {
                             if(key === task.TaskTypeKey){
                                 let newStatus = req.body.oldTaskType.filter((y) => y.key === key)[0]?.convertType;
                                 if(newStatus){
@@ -151,11 +154,16 @@ exports.changeTaskStatus = async (req, res) => {
                 tasks.push(x)
             })
         })
-        tasks.forEach(async(task) => {
+        // BUG-017 / #71 fix: this outer forEach only pushes synchronously
+        // constructed Promise objects, no `await` — drop the `async`.
+        tasks.forEach((task) => {
             promisesArr.push(
                 new Promise((resolve, reject) => {
                     try {
-                        req.body.taskStatusKey.forEach(async(key) => {
+                        // BUG-017 / #71 fix: same shape as the changeTaskType
+                        // version above — inner body uses .then/.catch, no
+                        // `await`, so `async` is misleading.
+                        req.body.taskStatusKey.forEach((key) => {
                             if(key === task.statusKey){
                                 let newStatus = req.body.oldTaskStatus.filter((y) => y.key === key)[0]?.convertStatus;
                                 if(newStatus){

--- a/Modules/storage/server/helpers/bucket.helper.js
+++ b/Modules/storage/server/helpers/bucket.helper.js
@@ -176,28 +176,38 @@ exports.formatBucketSize = (size, unit) => {
     }
 }
 
-async function copyFile(source, destination) {
-    try {
-        await fs.cp(source, destination,(err, data) => {
+// BUG-017 / #71: this helper used `await fs.cp(source, destination, callback)`,
+// but `fs.cp` is callback-style and returns `undefined` — `await undefined`
+// resolves immediately, so the function returned before the copy was done.
+// That made the surrounding `Promise.allSettled(imageArray.map(...))` fix
+// in `uploadIamgesInStorage` toothless on its own. Promisify the callback
+// here so the awaits up the chain actually wait.
+function copyFile(source, destination) {
+    return new Promise((resolve) => {
+        fs.cp(source, destination, (err) => {
             if (err) {
                 loggerConfig.error('Error copying file:', err);
             } else {
                 loggerConfig.info('File copied successfully');
             }
+            resolve();
         });
-    } catch (error) {
-        loggerConfig.error('Error copying file:', error);
-    }
+    });
 }
 exports.uploadIamgesInStorage = (imageArray,companyId) => {
     return new Promise(async (resolve, reject) => {
         try {
-            imageArray.forEach(async(x)=>{
+            // BUG-017 / #71 fix: the previous `imageArray.forEach(async ...)`
+            // didn't wait for the copyFile awaits, so `resolve()` fired
+            // before any file had finished copying. Use `Promise.allSettled`
+            // so independent copies run in parallel and a single failure
+            // doesn't abort the batch.
+            await Promise.allSettled(imageArray.map(async (x) => {
                 const destPath = path.join(__dirname, '../../../../storage', companyId, x.path);
                 const srcPath = path.join(__dirname, '/../../../../wasabiUploadsLocal', x.filePath);
-                await copyFile(srcPath,destPath)
-            });
-            resolve()
+                await copyFile(srcPath, destPath);
+            }));
+            resolve();
         } catch (error) {
             reject(error);
         }

--- a/frontend/src/components/molecules/TaskAudioFiles/TaskAudioFiles.vue
+++ b/frontend/src/components/molecules/TaskAudioFiles/TaskAudioFiles.vue
@@ -348,7 +348,8 @@ const getMongoData = async() => {
             }
         });
         if(arrayData.length > 0) {
-            arrayData.forEach(async(x,index) => {
+            // BUG-017 / #71 fix: body is fully synchronous — drop `async`.
+            arrayData.forEach((x, index) => {
                 let bfileSize = x.mediaSize ? x.mediaSize : 0;
                 let convertedKbSize = parseFloat(parseInt(bfileSize) / Math.pow(1024, 1)).toFixed(2) + 'KB';
                 const fileExt = x.mediaOriginalName.split('.').pop();
@@ -416,12 +417,14 @@ function debouncer(timeout = 1000) {
 const addAttachmentData = () => {
     try {
         let attachmentData = [];
-        props.selectedData.attachments.forEach(async(ele)=>{
+        // BUG-017 / #71 fix: body is fully synchronous — drop `async`.
+        props.selectedData.attachments.forEach((ele) => {
             if(ele.type == 'audio' && audioAttachmentList.value.findIndex((e)=>{return e.id == ele.id}) == -1) {
                 attachmentData.push({...ele,mediaURL:ele.url,mediaName:ele.filename,mediaSize:ele.size,from:'attachment',createdAt:ele.createdAt})
             }
         })
-        attachmentData.forEach(async(x) => {
+        // BUG-017 / #71 fix: body is fully synchronous — drop `async`.
+        attachmentData.forEach((x) => {
             let bfileSize = x.mediaSize ? x.mediaSize : 0;
             let convertedKbSize = parseFloat(parseInt(bfileSize) / Math.pow(1024, 1)).toFixed(2) + 'KB';
             const fileExt = x.mediaName.split('.').pop();

--- a/frontend/src/components/organisms/HourlyMilestone/helper.js
+++ b/frontend/src/components/organisms/HourlyMilestone/helper.js
@@ -191,7 +191,8 @@ export function calendar() {
                                                 let assigneeArray = [];
                                                 allUserData(timeSheet).then((obj)=>{
                                                     if(obj.individualTotals.length > 0){
-                                                        obj.individualTotals.forEach(async (element) => {
+                                                        // BUG-017 / #71 fix: body just does sync array.push.
+                                                        obj.individualTotals.forEach((element) => {
                                                             assigneeArray.push({
                                                                 id:element.user,
                                                                 individualLogTime:element.total

--- a/frontend/src/components/templates/CreateProject/ProjectTaskTypeForm.vue
+++ b/frontend/src/components/templates/CreateProject/ProjectTaskTypeForm.vue
@@ -263,7 +263,9 @@ const { t } = useI18n();
                 return !newTaskTypeData.value.some((y) => y.key === x.key);
             });
             if(notMatchedProjects.length > 0){
-                notMatchedProjects.forEach(async(x) => {
+                // BUG-017 / #71 fix: body uses apiRequest().then().catch(),
+                // no `await`, so the `async` keyword was misleading.
+                notMatchedProjects.forEach((x) => {
                     const searchResult = {
                         $match: {
                             $and:[

--- a/frontend/src/components/templates/CreateProject/TaskStatusForm.vue
+++ b/frontend/src/components/templates/CreateProject/TaskStatusForm.vue
@@ -314,7 +314,9 @@ const { t } = useI18n();
                 return !newStatusData.value.some((y) => y.key === x.key);
             });
             if(notMatchedProjects.length > 0){
-                notMatchedProjects.forEach(async(x) => {
+                // BUG-017 / #71 fix: body uses apiRequest().then().catch(),
+                // no `await`, so the `async` keyword was misleading.
+                notMatchedProjects.forEach((x) => {
                     const searchResult = {
                         $match: {
                             $and:[

--- a/frontend/src/store/ProjectData/actions.js
+++ b/frontend/src/store/ProjectData/actions.js
@@ -203,18 +203,21 @@ export const getPaginatedTasks = ({state, commit}, payload) => {
     
                     // SET CURSOR
                     if(responseData && responseData.length) {
-                        responseData.forEach(async (task) => {
+                        // BUG-017 / #71 fix: body is fully synchronous (Date
+                        // construction + Vuex commit). Drop the unused
+                        // `async` keyword.
+                        responseData.forEach((task) => {
                             const doc = task;
-    
+
                             if(doc.startDate && doc.startDate > 0) {
                                 doc.startDate = new Date(doc.startDate * 1000);
                             }
-    
+
                             if(doc.DueDate && doc.DueDate > 0) {
                                 doc.DueDate = new Date(doc.DueDate * 1000);
                                 // doc.dueDateDeadLine = doc.dueDateDeadLine.map((x) => JSON.parse(x)).map((x) => ({date: new Date(x.date * 1000)}));
                             }
-    
+
                             commit('mutateTypesenseTasks', {found: resCount, nextPage: {[indexKey]: (cursor || 0) + responseData?.length || 0}, pid: pid, sprintId: sprintId, data: {...doc}})
                         })
                     } else {
@@ -258,20 +261,22 @@ export const tabSyncTaskCommit = ({state,commit},payload) => {
         resCount = {[foundKey]: response.data[0]?.count?.[0]?.count || 0}
         // SET CURSOR
         if(responseData && responseData.length) {
-            responseData.forEach(async (task) => {
+            // BUG-017 / #71 fix: body is fully synchronous. Drop the unused
+            // `async` keyword.
+            responseData.forEach((task) => {
                 const doc = task;
-    
+
                 if(doc.favouriteTasks && doc.favouriteTasks.length && typeof doc.favouriteTasks[0] === "string") {
                     doc.favouriteTasks = doc.favouriteTasks.map((x) => ({...x}))
                 }
                 if(doc.startDate && doc.startDate > 0) {
                     doc.startDate = new Date(doc.startDate * 1000);
                 }
-    
+
                 if(doc.DueDate && doc.DueDate > 0) {
                     doc.DueDate = new Date(doc.DueDate * 1000);
                 }
-    
+
                 commit('mutateTypesenseTasks', {found: resCount, nextPage: {[indexKey]: (cursor || 0) + responseData?.length || 0}, pid: pid, sprintId: sprintId, data: {...doc}})
             })
         } else {


### PR DESCRIPTION
## Summary

Closes #71 (BUG-017).

\`array.forEach(async x => { … })\` doesn't wait for the callbacks and silently swallows any rejection. The audit flagged ~14 sites across the codebase. After reading each in context they split into two categories.

## Category B — real concurrency bug (2 sites)

The callback actually had an \`await\` inside, so the loop "completed" before the awaited work did.

### \`Modules/AI/controller.js:387\`

\`await exports.limitCountUpdate(...)\` (quota counter update) was fire-and-forget. \`resolve(fullText)\` then ran before the quota update settled — billing failures were invisible. Replaced with \`for…of\` + \`await\` (serial; at most one chunk has \`usage\` per response so serial is the natural shape).

### \`Modules/storage/server/helpers/bucket.helper.js:195\`

\`await copyFile(...)\` was fire-and-forget, so \`resolve()\` ran before any file had finished copying. Replaced with \`await Promise.allSettled(imageArray.map(async ...))\` so independent copies run in parallel and a single failure doesn't abort the batch.

**Also fixed a latent secondary bug uncovered during the test:** \`copyFile\` itself did \`await fs.cp(source, dest, callback)\`. \`fs.cp\` is callback-style and returns \`undefined\`, so \`await\` resolved immediately and the function returned before the copy started — the surrounding \`Promise.allSettled\` fix would have been toothless without this. Promisified the callback so awaits up the chain actually wait.

## Category A — \`async\` keyword unused (12 sites)

The keyword was misleading but harmless. Dropped it so the pattern is consistent everywhere:

- \`Modules/AI/controller.js:395\` (string concat)
- \`Modules/projectSetting/controller.js:57, 154, 158\` (uses .then chain)
- \`frontend/src/store/ProjectData/actions.js:206, 261\` (Vuex commit)
- \`frontend/src/components/molecules/TaskAudioFiles/TaskAudioFiles.vue:351, :419, :424\`
- \`frontend/src/components/organisms/HourlyMilestone/helper.js:194\`
- \`frontend/src/components/templates/CreateProject/TaskStatusForm.vue:317\`
- \`frontend/src/components/templates/CreateProject/ProjectTaskTypeForm.vue:266\`

## Files changed

```
M Modules/AI/controller.js
M Modules/projectSetting/controller.js
M Modules/storage/server/helpers/bucket.helper.js     (also fixes copyFile)
M frontend/src/store/ProjectData/actions.js
M frontend/src/components/molecules/TaskAudioFiles/TaskAudioFiles.vue
M frontend/src/components/organisms/HourlyMilestone/helper.js
M frontend/src/components/templates/CreateProject/TaskStatusForm.vue
M frontend/src/components/templates/CreateProject/ProjectTaskTypeForm.vue
```

8 files, +75 / −35.

## Test plan

Standalone test at \`.claude/tests/test-bug-017.js\` (local-only). Combines integration test of the Category B \`bucket.helper.js\` fix (stubs \`fs.cp\` and proves all 3 callbacks fire before \`uploadIamgesInStorage\` resolves, with parallelism) with a source-level grep that confirms no \`forEach(async ...)\` remains in executable code across the whole tree.

### Test results

```
=== bucket.helper.js — uploadIamgesInStorage waits for every file copy ===
  PASS  all 3 copyFile calls completed before resolve
  PASS  the function waited (elapsed >= one timer tick)
  PASS  copies ran in parallel (peak in-flight > 1)

=== source — no forEach(async) remains in executable code ===
  PASS  no executable .forEach(async ...) calls remain anywhere

=== source — Category B fixes use proper async patterns ===
  PASS  AI/controller.js: uses for...of with await for chunkObjects
  PASS  bucket.helper.js: uses Promise.allSettled(imageArray.map(...))

========================================
Tests: 6 | Passed: 6 | Failed: 0
========================================
```

### Frontend build

\`npm run build\` in \`frontend/\` compiles cleanly. No new ESLint findings.

## Risk

- Category A changes are pure no-ops semantically (the \`async\` keyword was unused). Zero behaviour change.
- Category B changes fix real ordering bugs:
  - **AI controller**: the resolve of the streaming response now happens AFTER quota updates settle. Adds one DB write of latency per response (which has the \`usage\` chunk). Acceptable for billing-correctness.
  - **bucket.helper**: \`uploadIamgesInStorage\` now waits for all copies before resolving. Callers (e.g. project-creation flows) now have a longer wait, but they were always relying on the copies being done — pre-fix the data was sometimes missing when the next step ran.