### PR TITLE
fix(stability): surface allSettled rejection reasons (BUG-018 / #72)

### DIFF
--- a/Modules/createProject/controller.js
+++ b/Modules/createProject/controller.js
@@ -610,8 +610,28 @@ exports.createProject = async (req) => {
                         reject({status: false, statusText: err});
                         logger.error(`add create project: ${err}`);
                     });
-                }else{
-                    reject({status: false, statusText: 'error in createProject'});
+                } else {
+                    // BUG-018 / #72 fix: the existing else already rejected
+                    // the outer Promise (so the audit's literal "hangs"
+                    // claim never reproduced — `Promise.allSettled` never
+                    // rejects either, so the outer .then always fires).
+                    // The real bug was that every per-query reason in
+                    // `rejected` was discarded. Surface the actual reasons
+                    // so the caller and the log have something to debug.
+                    const reasons = rejected.map((r, idx) => ({
+                        index: idx,
+                        reason: r && r.reason && r.reason.message
+                            ? r.reason.message
+                            : String(r && r.reason !== undefined ? r.reason : 'unknown'),
+                    }));
+                    logger.error(`createProject prerequisite query failures (${rejected.length}/${results.length}): ${JSON.stringify(reasons)}`);
+                    reject({
+                        status: false,
+                        statusText: 'error in createProject prerequisites',
+                        rejectedCount: rejected.length,
+                        totalCount: results.length,
+                        reasons,
+                    });
                 }
             }).catch((error) => {
                 reject({status: false, statusText: error});


### PR DESCRIPTION
## Summary

Closes #72 (BUG-018).

The audit description for this bug — _\"Promise.allSettled rejection branch never responds, outer Promise stays pending\"_ — turned out to be **inaccurate** in two ways once verified against the audit-time commit (\`26401ba\`):

1. The \`else\` branch on \`if (rejected.length === 0)\` **already existed** and called \`reject({status: false, statusText: 'error in createProject'})\`. The outer Promise did not hang.
2. \`Promise.allSettled\` **never rejects** in the first place — it always resolves with the per-promise outcomes. So even without an else, the surrounding \`.then\` would still fire.

So the literal \"hang\" the audit reported was never reachable. But the file did have **a real-but-different bug** in the same spot: the else body was a generic statusText, with every per-query \`reason\` in the \`rejected\` array discarded. Caller and log learnt nothing about which prerequisite query failed or why.

## Fix

Replace the else's reject body with a structured payload that includes the actual failure information:

```js
} else {
    const reasons = rejected.map((r, idx) => ({
        index: idx,
        reason: r && r.reason && r.reason.message
            ? r.reason.message
            : String(r && r.reason !== undefined ? r.reason : 'unknown'),
    }));
    logger.error(\`createProject prerequisite query failures (...)\`);
    reject({
        status: false,
        statusText: 'error in createProject prerequisites',
        rejectedCount: rejected.length,
        totalCount: results.length,
        reasons,
    });
}
```

The outer Promise's rejection now carries:
- \`rejectedCount\` / \`totalCount\` — quick at-a-glance triage
- \`reasons\` — array of \`{index, reason}\` so the caller can show or log exactly which prerequisite blew up

The same \`reasons\` array is also written via \`logger.error\` for ops visibility.

## Files changed

- \`Modules/createProject/controller.js\` (+22 / −2)

## Test plan

Standalone test at \`.claude/tests/test-bug-018.js\` (local-only). Stubs \`MongoDbCrudOpration\` via \`require.cache\` and drives the five prerequisite Mongo calls into two failure shapes.

### Test results

```
=== createProject — all prerequisites reject → outer rejects with reasons ===
  PASS  createProject rejected (did NOT hang)
  PASS  rejection statusText mentions prerequisites
  PASS  rejection includes rejectedCount = 5
  PASS  rejection includes totalCount = 5
  PASS  rejection includes 5 reasons
  PASS  each reason carries the actual error message

=== createProject — partial rejection (1 of 5) → outer rejects with 1 reason ===
  PASS  partial-rejection: outer rejects
  PASS  partial-rejection: rejectedCount = 1, totalCount = 5
  PASS  partial-rejection: reason text preserved

=== source — else branch surfaces the reasons array ===
  PASS  reject body includes rejectedCount
  PASS  reject body includes totalCount
  PASS  reject body includes a reasons array
  PASS  rejected.map builds a per-failure list
  PASS  logger.error includes the JSON-serialised reasons

========================================
Tests: 14 | Passed: 14 | Failed: 0
========================================
```

## Risk

- The reject path now sends extra fields (\`rejectedCount\`, \`totalCount\`, \`reasons\`). The previous fields (\`status: false\`, \`statusText\`) are preserved (the text changes from \"error in createProject\" to \"error in createProject prerequisites\" — slightly more specific). Callers that only check \`.status\` are unaffected.
- If a caller was log-grepping for the exact previous statusText, they'll need to update the search. There are no such callers in the repo.

## Audit accuracy note

I'm calling out the inaccuracy in the audit description so the bug-report itself can be updated. The audit subagent that scanned this file misread the structure and reported a non-existent hang. The fix here is real, but at a different layer (information disclosure to the caller, not request-lifecycle correctness).