### PR TITLE
fix(stability): declare setChat with const (BUG-019 / #73)

### DIFF
--- a/Modules/MainChats/controller.js
+++ b/Modules/MainChats/controller.js
@@ -68,7 +68,12 @@ exports.setChats = async (req, res) => {
             type: SCHEMA_TYPE.TASKS,
             data: query
         };
-        setChat = await MongoDbCrudOpration(req.headers['companyid'], setChatsObj, 'find');
+        // BUG-019 / #73 fix: `setChat = await ...` without a declaration
+        // keyword created an implicit global. In non-strict mode that's a
+        // cross-request leak vector (the global is shared between
+        // concurrent invocations); in strict mode the assignment throws
+        // ReferenceError on first call.
+        const setChat = await MongoDbCrudOpration(req.headers['companyid'], setChatsObj, 'find');
         res.status(200).json(setChat)
     } catch (error) {
         logger.error('Error getting setChats query:', JSON.stringify(error));


### PR DESCRIPTION
## Summary

Closes #73 (BUG-019).

\`Modules/MainChats/controller.js:71\` did \`setChat = await MongoDbCrudOpration(...)\` with no \`const\`/\`let\`/\`var\`. That makes \`setChat\` an **implicit global** on the Node process. Two concurrent requests share the same slot and can clobber each other — the second response can include the first request's data.

Under strict mode the assignment throws \`ReferenceError\`; the file isn't strict today, so the live behaviour is the silent cross-request leak.

## Fix

```diff
-        setChat = await MongoDbCrudOpration(req.headers['companyid'], setChatsObj, 'find');
+        const setChat = await MongoDbCrudOpration(req.headers['companyid'], setChatsObj, 'find');
```

## Files changed

- \`Modules/MainChats/controller.js\` (+7 / −1) — one-line fix plus an explanatory comment.

## Test plan

\`.claude/tests/test-bug-019.js\` (local). Asserts the bare assignment is gone, \`const\` is now present, and requiring the module doesn't leak a \`setChat\` global.

```
=== source — implicit global is gone ===
  PASS  no bare `setChat = await ...` assignment remains
  PASS  setChat is now declared with const

=== module loads without leaking globals ===
  PASS  global.setChat is undefined after require
  PASS  exports.setChats is a function (handler still wired up)

========================================
Tests: 4 | Passed: 4 | Failed: 0
========================================
```

## Risk

- Pure scoping fix. Behaviour identical except no cross-request leak.