### PR TITLE
fix(stability): align cache set/remove key in MainChats (BUG-020 / #74)

### DIFF
--- a/Modules/MainChats/controller.js
+++ b/Modules/MainChats/controller.js
@@ -4,6 +4,17 @@ const { myCache } = require('../../Config/config');
 const { removeCache } = require("../../utils/commonFunctions");
 const { replaceObjectKey } = require("../Auth/helper");
 const logger = require('../../Config/loggerConfig.js');
+
+// BUG-020 / #74 fix: the cache writer in `getChats` used
+//   `mainChat:${req.headers['companyid']}`
+// while the invalidator in `updateMainChat` built a different key from the
+// updated *document's* _id via `JSON.parse(JSON.stringify(result))?._id`.
+// The two keys never matched, so cache invalidation was a no-op and stale
+// chats stuck around until the 3600s TTL expired. Centralise the key
+// builder so set/remove use the same shape.
+const mainChatCacheKey = (companyId) => `mainChat:${companyId}`;
+exports.mainChatCacheKey = mainChatCacheKey;
+
 exports.getChats = async (req, res) => {
     try {
         const chatsObj = {
@@ -11,8 +22,8 @@ exports.getChats = async (req, res) => {
             data: []
         };
 
-        const mainChatCacheKey = `mainChat:${req.headers['companyid']}`; 
-        let chats = myCache.get(mainChatCacheKey);
+        const cacheKey = mainChatCacheKey(req.headers['companyid']);
+        let chats = myCache.get(cacheKey);
         let isFromCache = true;
         if (!chats) {
             isFromCache = false;
@@ -22,12 +33,12 @@ exports.getChats = async (req, res) => {
                 return res.status(404).json({ message: "Chats not found" });
             }
 
-            myCache.set(mainChatCacheKey, chats, 3600); 
+            myCache.set(cacheKey, chats, 3600);
         }
         if (isFromCache) {
             res.set({
                 'FromCache': 'true',
-                'cacheExpireTime': myCache.getTtl(mainChatCacheKey)
+                'cacheExpireTime': myCache.getTtl(cacheKey)
             });
         }
 
@@ -46,7 +57,11 @@ exports.updateMainChat = (companyId, chatObj) => {
                 data: chatObj
             };
             MongoDbCrudOpration(companyId, objSchema, 'findOneAndUpdate').then((result) => {
-                removeCache(`mainChat:${JSON.parse(JSON.stringify(result))?._id}`, true);
+                // BUG-020 / #74 fix: use the same key the setter uses
+                // (`mainChat:${companyId}`). The old key was built from the
+                // updated document's `_id`, which never matched the setter's
+                // companyId-keyed entry — cache invalidation was a no-op.
+                removeCache(mainChatCacheKey(companyId), true);
                 resolve(result);
             })
             .catch((error) => {


### PR DESCRIPTION
## Summary

Closes #74 (BUG-020).

\`Modules/MainChats/controller.js\` had a cache-key mismatch between writer and invalidator:

| Site | Key built |
| --- | --- |
| \`getChats\` set | \`mainChat:\${req.headers['companyid']}\` |
| \`updateMainChat\` remove | \`mainChat:\${JSON.parse(JSON.stringify(result))?._id}\` |

The setter is keyed by **company id** (from the request header). The invalidator is keyed by the **updated document's _id** (which is the chat-document id — a completely different ObjectId). The two strings never matched, so \`removeCache(...)\` was a silent no-op. Stale chats stayed cached until the 3600s TTL expired.

The audit framed this as \"Mongoose ObjectId stringifies inconsistently\" but the real issue is **wrong key shape** — it was never going to match no matter how it was stringified.

## Fix

Centralise the key shape in a small exported helper so both sites stay in sync:

```js
const mainChatCacheKey = (companyId) => \`mainChat:\${companyId}\`;
exports.mainChatCacheKey = mainChatCacheKey;
```

- \`getChats\`: \`myCache.set(mainChatCacheKey(req.headers['companyid']), ...)\`
- \`updateMainChat\`: \`removeCache(mainChatCacheKey(companyId), true)\`

## Files changed

- \`Modules/MainChats/controller.js\` (+18 / −9)

## Test plan

\`.claude/tests/test-bug-020.js\` (local). Stubs \`MongoDbCrudOpration\`, seeds the cache, runs the update flow, and asserts:

```
=== mainChatCacheKey — shape + parity ===
  PASS  helper is exported
  PASS  helper produces \`mainChat:<companyId>\`

=== updateMainChat invalidates the key the setter wrote ===
  PASS  seed: cache hit before update
  PASS  after update: cache entry for companyId is invalidated
  PASS  companyId-keyed entry is invalidated

=== source — broken JSON.parse(JSON.stringify(...)) pattern is gone ===
  PASS  no executable JSON.parse(JSON.stringify(result))?._id pattern
  PASS  source uses the shared mainChatCacheKey helper

========================================
Tests: 7 | Passed: 7 | Failed: 0
========================================
```

## Risk

- Cache invalidation now actually fires for the right key. Users will see fresh chat list immediately after an update instead of within the next TTL window. Pure improvement.