### PR TITLE
fix(stability): strict equality on isEmailVerified check (BUG-026 / #80)

### DIFF
--- a/Modules/Users/controller.js
+++ b/Modules/Users/controller.js
@@ -71,7 +71,11 @@ exports.checkUserAndCompany = (req, res) => {
 
     try {
         MongoDbCrudOpration('global', obj, "findOne").then((response)=>{
-            if(response && response.isEmailVerified == false) {
+            // BUG-026 / #80 fix: use strict equality. Pre-fix `== false`
+            // also matched 0, "", null, undefined, NaN — so a user document
+            // missing the field entirely (legacy data) would pass through
+            // the "Email Not Verified" branch unintentionally.
+            if(response && response.isEmailVerified === false) {
                 res.send({
                     status: false,
                     statusText: "Email Not Verified",


### PR DESCRIPTION
Closes #80. Replace loose `== false` with strict `=== false` on the isEmailVerified check in `Modules/Users/controller.js` so legacy documents missing the field aren't misclassified as unverified.

The audit pointed at `Modules/usersModule/...` which no longer exists post the naming-conventions refactor — the actual site is `Modules/Users/controller.js`. Fresh grep shows this was the only `== false` against isEmailVerified.

Test: `.claude/tests/test-bug-026.js` — **2/2 passed**.