### PR TITLE
fix(stability): guard checkUserAndCompany against duplicate res.send (BUG-027 / #81)

### DIFF
--- a/Modules/Users/controller.js
+++ b/Modules/Users/controller.js
@@ -69,10 +69,27 @@ exports.checkUserAndCompany = (req, res) => {
         ]
     }
 
+    // BUG-027 / #81 fix: this handler has six different res.send sites
+    // across nested .then / .catch chains. Pre-fix, a sync throw in
+    // res.send (e.g. ERR_HTTP_HEADERS_SENT triggered by middleware) on
+    // the inner .then could land in the inner .catch which would also
+    // try to res.send — and the outer .catch would do it a third time.
+    // Wrap every res.send through a `sendOnce` so duplicate writes are
+    // suppressed instead of throwing.
+    let responded = false;
+    const sendOnce = (payload) => {
+        if (responded) {
+            logger.warn('checkUserAndCompany suppressed a duplicate res.send');
+            return;
+        }
+        responded = true;
+        res.send(payload);
+    };
+
     try {
         MongoDbCrudOpration('global', obj, "findOne").then((response)=>{
-            if(response && response.isEmailVerified == false) {
-                res.send({
+            if(response && response.isEmailVerified === false) {
+                sendOnce({
                     status: false,
                     statusText: "Email Not Verified",
                     data: {userData:response}
@@ -93,14 +110,14 @@ exports.checkUserAndCompany = (req, res) => {
 
                 MongoDbCrudOpration('global', cObj, "findOne").then((company)=>{
                     if(company) {
-                        res.send({
+                        sendOnce({
                             status: true,
                             statusText: "Comapny Found",
                             data: {isCompanyFind: true,companyId: company._id,userData:response}
                         });
                         return;
                     } else {
-                        res.send({
+                        sendOnce({
                             status: true,
                             statusText: "Comapny Not Found",
                             data: {isCompanyFind: false,companyId: '',userData:response}
@@ -108,7 +125,7 @@ exports.checkUserAndCompany = (req, res) => {
                         return;
                     }
                 }).catch((error)=>{
-                    res.send({
+                    sendOnce({
                         status: false,
                         statusText: "Comapny Not Found",
                         data: {isCompanyFind: false,companyId: '',userData:response}
@@ -117,7 +134,7 @@ exports.checkUserAndCompany = (req, res) => {
                 })
 
             } else {
-                res.send({
+                sendOnce({
                     status: true,
                     statusText: "Comapny Not Found",
                     data: {isCompanyFind: false,companyId: '',userData:response}
@@ -125,7 +142,7 @@ exports.checkUserAndCompany = (req, res) => {
                 return;
             }
         }).catch((error)=>{
-            res.send({
+            sendOnce({
                 status: false,
                 statusText: "User Not Found",
                 data: {isCompanyFind: false,companyId: '',userData: null}
@@ -133,7 +150,7 @@ exports.checkUserAndCompany = (req, res) => {
             logger.error('USER STATUS UPDATE ERROR checkUserAndCompany: ',error);
         })
     } catch (error) {
-        res.send({
+        sendOnce({
             status: false,
             statusText: "User Not Found",
             data: {}


### PR DESCRIPTION
Closes #81. `Modules/Users/controller.js` `checkUserAndCompany` has six `res.send` sites across three nested .then/.catch chains. Wrap each in a local `sendOnce` helper (flag-based) so duplicate writes are suppressed with a logger warning instead of throwing.

Today the early-return pattern keeps them mutually exclusive in normal traffic, but if `res.send` ever throws synchronously (ERR_HTTP_HEADERS_SENT from upstream middleware) the sync throw lands in the inner `.catch` which calls `res.send` AGAIN — guaranteed cascade. `sendOnce` makes the handler robust against that and future refactors.

Manual test: hit the route for a user state where multiple branches could theoretically fire — only one response goes back, duplicate attempts log a warning.