### PR TITLE
fix: correct copy-paste error in companyId validation message (BUG-028 / #82)

### DIFF
--- a/Modules/logTime/controllerV2.js
+++ b/Modules/logTime/controllerV2.js
@@ -74,7 +74,8 @@ exports.manualLogTime = async (req, res) => {
     if (!(req.body && req.body.companyId)) {
         res.send({
             status: false,
-            statusText: "ProjectId is required"
+            // BUG-028 / #82 fix: was copy-paste error "ProjectId is required".
+            statusText: "CompanyId is required"
         })
         return;
     }


### PR DESCRIPTION
Closes #82. `Modules/logTime/controllerV2.js:77` returned `"ProjectId is required"` when the missing field was actually `companyId` (copy-paste from adjacent projectId check). One-character user-visible fix.