### PR TITLE
fix: validate timeDuration shape before .split(':') (BUG-029 / #83)

### DIFF
--- a/Modules/logTime/controllerV2.js
+++ b/Modules/logTime/controllerV2.js
@@ -159,8 +159,19 @@ exports.manualLogTime = async (req, res) => {
         return;
     }
     const { type = SCHEMA_TYPE.TIMESHEET } = req.body;
-    let diffArr = req.body.timeDuration.split(':');
-    let diffMin = (+diffArr[0]) * 60 + (+diffArr[1]);
+    // BUG-029 / #83 fix: the existing validation at line 53 only blocks
+    // falsy timeDuration. A non-string value (number, array, object) or a
+    // string without a colon (e.g. "1") would crash here with a TypeError
+    // or silently store NaN in the DB. Validate the shape explicitly.
+    if (typeof req.body.timeDuration !== 'string' || !/^\d+:\d+$/.test(req.body.timeDuration)) {
+        res.send({
+            status: false,
+            statusText: "timeDuration must be a string in HH:MM format"
+        });
+        return;
+    }
+    const diffArr = req.body.timeDuration.split(':');
+    const diffMin = (+diffArr[0]) * 60 + (+diffArr[1]);
     let data = {
         ProjectId: req.body.projectId,
         LogStartTime: getTimeStamp(req.body.timeZone, req.body.logTimeDate, req.body.startLogTime),


### PR DESCRIPTION
Closes #83.

Existing validation only blocked falsy `timeDuration`. Non-string values that bypass that check (`[]`, `{}`, numbers) crashed on `.split()` with TypeError; strings without a colon silently stored NaN in Mongo.

Add an explicit `typeof === 'string'` + `/^\d+:\d+$/` shape check before the split. Returns a clean 400 instead of crashing or corrupting data.