### PR TITLE
fix(stability): guard against missing response.data in sprints (BUG-030 / #84)

### DIFF
--- a/Modules/sprints/controller.js
+++ b/Modules/sprints/controller.js
@@ -41,13 +41,27 @@ exports.updateChannelsCounts = (companyId, private, type) => {
         requestQueue.enqueue(() => {
             updateCompanyFun(SCHEMA_TYPE.GOLBAL,query,"findOneAndUpdate",companyId,true)
             .then((response) => {
+                // BUG-030 / #84 fix: pre-fix code went straight to
+                // `JSON.stringify(response.data)` and then read deeply
+                // nested fields. If response.data was undefined (race
+                // with a newly-created project, or a malformed write)
+                // the chain crashed with TypeError on `data.projectCount.privateChannels`.
+                // Guard against missing layers and resolve(false) (the
+                // "not allowed" outcome) instead of throwing.
+                if (!response || response.data === undefined || response.data === null) {
+                    logger.warn(`checkProjectCount: missing response.data for company ${companyId}`);
+                    resolve(false);
+                    return;
+                }
                 if (response) {
                     const data = JSON.parse(JSON.stringify(response.data));
 
-                    const privateChannels = data.projectCount.privateChannels || 0;
-                    const maxPrivateChannels = data.planFeature.maxPrivateChannels;
-                    const publicChannels = data.projectCount.publicChannels || 0;
-                    const maxPublicChannels = data.planFeature.maxPublicChannels;
+                    const projectCount = data.projectCount || {};
+                    const planFeature = data.planFeature || {};
+                    const privateChannels = projectCount.privateChannels || 0;
+                    const maxPrivateChannels = planFeature.maxPrivateChannels;
+                    const publicChannels = projectCount.publicChannels || 0;
+                    const maxPublicChannels = planFeature.maxPublicChannels;
 
                     if(private) {
                         if(maxPrivateChannels === null) {


### PR DESCRIPTION
Closes #84.

`Modules/sprints/controller.js:45` read deeply nested fields off `response.data` after a JSON round-trip without checking the data was there. If `response.data` was undefined, the next line crashed with TypeError on `data.projectCount.privateChannels`.

Guard up front: resolve(false) (the "not allowed" outcome) when `response.data` is missing, and default the intermediate `projectCount` / `planFeature` objects to `{}` so individual missing fields are merely undefined rather than crashing.

Audit-accuracy: the audit framed this as "JSON.parse throws on undefined" — actually `JSON.parse(JSON.stringify(undefined))` returns undefined silently. The real crash was the property chain on the now-undefined `data`.