### PR TITLE
fix(observability): log silently-swallowed fetch failures (BUG-031 / #85)

### DIFF
--- a/Modules/tasks/helpers/handleNotification.js
+++ b/Modules/tasks/helpers/handleNotification.js
@@ -27,6 +27,11 @@ exports.HandleBothNotification = ({ type, companyId, projectId, taskId, folderId
                     }
 
                 }).catch(error => {
+                    // BUG-031 / #85 fix: was a silent `return null` which
+                    // turned every DB failure into "no data" downstream.
+                    // Log so the failure is visible in ops; still return
+                    // null so the notification flow continues (best-effort).
+                    logger.error(`HandleBothNotification: fetchProjectDetailsSingle failed: ${error && error.message ? error.message : error}`);
                     return null
                 })
             }
@@ -37,8 +42,10 @@ exports.HandleBothNotification = ({ type, companyId, projectId, taskId, folderId
                     } else {
                         return null
                     }
-    
+
                 }).catch(error => {
+                    // BUG-031 / #85 fix: same pattern as above.
+                    logger.error(`HandleBothNotification: fetchTaskDetails failed: ${error && error.message ? error.message : error}`);
                     return null
                 })
             }


### PR DESCRIPTION
Closes #85. Two `.catch(error => { return null })` sites turned DB failures into silent 'no data'. Keep best-effort semantics but add Winston `logger.error` so failures are visible in ops.