### PR TITLE
fix(BUG-032): consistent soft-delete filtering on list/count endpoints

### DIFF
--- a/Modules/Comments/controller.js
+++ b/Modules/Comments/controller.js
@@ -125,6 +125,12 @@ exports.getPaginatedMessages = async (req, res) => {
             $match: {
                 $and: [
                     { projectId: new mongoose.Types.ObjectId(projectId) },
+                    // BUG-032 / #86 fix: align soft-delete handling with the other
+                    // comment-listing endpoints (searchMessageFromMainChat /
+                    // searchComments). Without this filter, soft-deleted comments
+                    // (isDeleted === true) reappeared in main-chat pagination.
+                    // `$ne: true` keeps documents whose flag is missing/false.
+                    { isDeleted: { $ne: true } },
                     ...(sprintId ? [{ sprintId: new mongoose.Types.ObjectId(sprintId) }] : []),
                     ...(tabLeaveTime ? [{ updatedAt: { $gte: new Date(Number(tabLeaveTime)) } }] : []),
                     ...(!isDefault && mainChat
@@ -193,7 +199,11 @@ exports.searchMessageFromMainChat = async (req, res) => {
                               ]
                           }
                         : {}),
-                    isDeleted: false
+                    // BUG-032 / #86 fix: legacy comments may not have an
+                    // isDeleted field. Using `$ne: true` keeps them in results
+                    // while still excluding soft-deleted ones (consistent with
+                    // searchComments).
+                    isDeleted: { $ne: true }
                 },
                 {},
                 { sort: { createdAt: 1 } },

--- a/Modules/Project/controller/getSprintFolder.js
+++ b/Modules/Project/controller/getSprintFolder.js
@@ -135,11 +135,17 @@ exports.getSprintFolder = async (req,res) => {
 
         if (req.query.collection) {
             if (req.query.collection === 'sprints' || req.query.collection === 'folders') {
-                if (req.query.count) {          
+                if (req.query.count) {
                     let data = [
                         {
                             $match: {
-                                projectId: new mongoose.Types.ObjectId(projectId)
+                                projectId: new mongoose.Types.ObjectId(projectId),
+                                // BUG-032 / #86 fix: count was including
+                                // soft-deleted sprints/folders, which made the
+                                // sidebar counters disagree with the actual
+                                // list (the list-rendering branches below use
+                                // `deletedStatusKey: { $nin: [1] }`).
+                                deletedStatusKey: { $nin: [1] }
                             }
                         },
                     ]

--- a/Modules/tasks/controller/getTabSyncTasks.js
+++ b/Modules/tasks/controller/getTabSyncTasks.js
@@ -105,7 +105,15 @@ exports.getTabSynctTaskWithTable = (companyId,req) => {
                                 $and:[
                                     {ProjectID: {$in : [new mongoose.Types.ObjectId(req.body.pid)]}},
                                     {sprintId: {$eq :new mongoose.Types.ObjectId(req.body.sprintId)}},
-                                    {deletedStatusKey: { $in: [0] }},
+                                    // BUG-032 / #86 fix: was `{ $in: [0] }` which
+                                    // excluded legacy tasks that pre-date the
+                                    // soft-delete field. Tasks where
+                                    // `deletedStatusKey` is unset (undefined)
+                                    // are still active and must be returned —
+                                    // matches the pattern used by getTaskCount
+                                    // (`{$in: [0, 2, undefined]}`) and the
+                                    // sibling getTabSynctTaskWithoutTable.
+                                    {deletedStatusKey: { $in: [0, undefined] }},
                                     {updatedAt: {$gte: new Date(Number(req.body.tabLeaveTime))},}
                                 ]
                             },


### PR DESCRIPTION
Fixes #86

## Summary

Three list-style endpoints either lacked a soft-delete filter or used an
over-narrow form that excluded legacy documents. The audit (BUG-032)
flagged this as "Some queries filter `deletedStatusKey: {$in:[0,undefined]}`,
many `find` calls don't — deleted items appear in list responses."

## What changed

- **`Modules/Comments/controller.js`**
  - `getPaginatedMessages` had no `isDeleted` filter, so soft-deleted
    comments came back in main-chat pagination. Added
    `{ isDeleted: { $ne: true } }` to the `$and` clause.
  - `searchMessageFromMainChat` used `isDeleted: false`, which would also
    drop legacy comments whose flag was never set. Loosened to
    `{ $ne: true }` (matches `searchComments`).

- **`Modules/Project/controller/getSprintFolder.js`**
  - The `count` branch matched only on `projectId`, so the count
    disagreed with the listing branches (which filter
    `deletedStatusKey: { $nin: [1] }`). Aligned the count branch with
    the same filter.

- **`Modules/tasks/controller/getTabSyncTasks.js`**
  - `getTabSynctTaskWithTable` used `{ deletedStatusKey: { $in: [0] } }`,
    which excludes tasks whose flag is `undefined` (legacy or pre-flag
    docs). Switched to `{ $in: [0, undefined] }` so the behaviour
    matches `getTaskCount` and `getTabSynctTaskWithoutTable`.

## Audit accuracy

The audit framing is correct — the inconsistency is real. The fix is
narrowly scoped to the three sites where it changes user-visible
behaviour (a list/count endpoint returning deleted docs). The many other
`deletedStatusKey` references in the codebase are write-paths (setting
the field) or already-correct filters, so I left them alone.

## Test plan

- [x] Stub `MongoDbCrudOpration` and invoke each of the three patched
      controllers; assert the captured filter contains the new clause.
- [x] Verify the test fails against the pre-fix code (manually checked
      the previous filter shapes vs. the assertions).

```
$ node .claude/tests/test-bug-032.js
PASS: Comments.getPaginatedMessages issued an aggregate
PASS: Comments.getPaginatedMessages includes `{ isDeleted: { $ne: true } }`
PASS: Comments.searchMessageFromMainChat issued a find
PASS: Comments.searchMessageFromMainChat uses `\$ne: true` (keeps legacy docs)
PASS: getSprintFolder count branch issued a sprints aggregate
PASS: getSprintFolder count branch filters `deletedStatusKey: { \$nin: [1] }`
PASS: getTabSynctTaskWithTable issued a tasks aggregate
PASS: getTabSynctTaskWithTable still has a deletedStatusKey filter
PASS: getTabSynctTaskWithTable now allows `deletedStatusKey: { \$in: [0, undefined] }` (length >= 2 incl. 0)

All BUG-032 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)