### PR TITLE
fix(BUG-033): reconcile sprint task counts when secondary writes fail

### DIFF
--- a/Modules/tasks/helpers/mongo_helper.js
+++ b/Modules/tasks/helpers/mongo_helper.js
@@ -12,6 +12,8 @@ const { getCachedCompanyData } = require('../../../utils/planHelper');
 const serviceFun = require("../../serviceFunction");
 const socketEmitter = require('../../../event/socketEventEmitter');
 const { updateCommentCollection, addCommentCollection } = require('../../Comments/controller');
+// BUG-033 / #87 — self-healing reconciliation for sprint task counts.
+const { reconcileSprintTaskCount, scheduleReconciliation } = require('./reconcileTaskCount');
 
 /* ------------- TASK ------------- */
 exports.HandleTask = async (companyId, object, isUpdate, id = null, userData) => {
@@ -316,6 +318,8 @@ exports.convertToSubTaskFunction = (companyId, projectData, sprintId, convertTas
                         }
                         updateSprintFun(incObj).catch((error) => {
                             logger.error(`error in update task count : ${error}`)
+                            // BUG-033 / #87 fix: reconcile drift on count failure.
+                            scheduleReconciliation(companyId, task.sprintId);
                         });
                         const decObj = {
                             body: {
@@ -330,6 +334,8 @@ exports.convertToSubTaskFunction = (companyId, projectData, sprintId, convertTas
                         }
                         updateSprintFun(decObj).catch((error) => {
                             logger.error(`error in update task count : ${error}`)
+                            // BUG-033 / #87 fix: reconcile drift on count failure.
+                            scheduleReconciliation(companyId, convertTask.sprintId);
                         });
                     }
                 }).catch((error) => {
@@ -467,6 +473,11 @@ exports.moveTaskFunction = (companyId, projectData, sprintObj, moveTask, oldSpri
                     }
                     updateSprintFun(incObj).catch((error) => {
                         logger.error(`error in update task count : ${error}`)
+                        // BUG-033 / #87 fix: a failed `$inc` here leaves the
+                        // sprint's denormalised `tasks` count drifted from
+                        // reality. Trigger an off-loop reconciliation that
+                        // recomputes from the tasks collection.
+                        scheduleReconciliation(companyId, sprintObj.id);
                     });
                     const decObj = {
                         body: {
@@ -481,9 +492,18 @@ exports.moveTaskFunction = (companyId, projectData, sprintObj, moveTask, oldSpri
                     }
                     updateSprintFun(decObj).catch((error) => {
                         logger.error(`error in update task count : ${error}`)
+                        // BUG-033 / #87 fix: same drift risk on the source
+                        // sprint when the dec call fails.
+                        scheduleReconciliation(companyId, oldSprintObj.id);
                     });
                 }).catch((error)=>{
                     logger.error(`${error} ERROR IN MONGO QUERY`);
+                    // BUG-033 / #87 fix: the primary findOneAndUpdate above
+                    // marked the source task `deletedStatusKey:1`. If the
+                    // re-insert into the destination sprint fails here we're
+                    // left with both sprints' counts mid-flight. Reconcile
+                    // both ends so the user sees correct numbers.
+                    scheduleReconciliation(companyId, [sprintObj?.id, oldSprintObj?.id]);
                 })
             })
         } catch (error) {
@@ -663,6 +683,8 @@ exports.mergeSubTask = (companyId, subTask, mergeTask, projectData, oldProject) 
                     }
                     updateSprintFun(incCountObj).catch((error) => {
                         logger.error(`error in update task count : ${error}`)
+                        // BUG-033 / #87 fix: reconcile drift on count failure.
+                        scheduleReconciliation(companyId, mergeTask.sprintId);
                     });
                     const decObj = {
                         body: {
@@ -677,6 +699,8 @@ exports.mergeSubTask = (companyId, subTask, mergeTask, projectData, oldProject) 
                     }
                     updateSprintFun(decObj).catch((error) => {
                         logger.error(`error in update task count : ${error}`)
+                        // BUG-033 / #87 fix: reconcile drift on count failure.
+                        scheduleReconciliation(companyId, subTask.sprintId);
                     });
                 }
                 exports.removeCommentCount(companyId,projectData.id,subTask.sprintId,subTask._id).catch((error) => {

--- a/Modules/tasks/helpers/reconcileTaskCount.js
+++ b/Modules/tasks/helpers/reconcileTaskCount.js
@@ -1,0 +1,108 @@
+/**
+ * BUG-033 / #87 — reconciliation helpers for sprint/folder task counts.
+ *
+ * Background: several task mutation flows (moveTaskFunction,
+ * convertToListSubTask, mergeTask, etc.) write a primary update and then
+ * fire one or more secondary `$inc` operations to keep
+ * `sprints.tasks` / `folders.tasks` denormalised counts in sync. Each
+ * secondary op is independent — if it fails, the cached count drifts
+ * away from the actual tasks-collection state and the sidebar shows the
+ * wrong number until manual cleanup.
+ *
+ * Why not real transactions? `MongoDbCrudOpration` is a thin abstraction
+ * that doesn't thread a session through, and Mongo transactions require
+ * a replica-set deployment which AlianHub's self-hosted footprint can't
+ * guarantee. Recomputing from source-of-truth works in every deployment
+ * mode and is idempotent.
+ *
+ * Usage: call `reconcileSprintTaskCount(companyId, sprintId)` from the
+ * `.catch` of a secondary `$inc`. The helper recomputes the canonical
+ * count from the tasks collection (deletedStatusKey ∈ {0, undefined})
+ * and `$set`s it back onto the sprint document.
+ */
+
+const mongoose = require('mongoose');
+const logger = require('../../../Config/loggerConfig');
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+
+function toObjectIdOrNull(id) {
+    if (!id) return null;
+    try {
+        return new mongoose.Types.ObjectId(id);
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Returns the actual number of live tasks belonging to a sprint.
+ * "Live" = `deletedStatusKey` is 0 or unset (consistent with
+ * BUG-032's filter pattern).
+ */
+exports.computeLiveTaskCount = async (companyId, sprintId) => {
+    const sprintObjectId = toObjectIdOrNull(sprintId);
+    if (!sprintObjectId) {
+        throw new Error(`reconcile: invalid sprintId ${sprintId}`);
+    }
+    const query = {
+        type: SCHEMA_TYPE.TASKS,
+        data: [
+            [
+                {
+                    $match: {
+                        sprintId: sprintObjectId,
+                        deletedStatusKey: { $in: [0, undefined] }
+                    }
+                },
+                { $count: 'count' }
+            ]
+        ]
+    };
+    const response = await MongoDbCrudOpration(companyId, query, 'aggregate');
+    return (response && response[0] && response[0].count) || 0;
+};
+
+/**
+ * Recomputes the canonical count and writes it back to the sprint. Safe
+ * to call repeatedly. Resolves to the corrected count (or `null` if the
+ * sprintId is missing/invalid — we never throw, this is best-effort).
+ */
+exports.reconcileSprintTaskCount = async (companyId, sprintId) => {
+    const sprintObjectId = toObjectIdOrNull(sprintId);
+    if (!sprintObjectId) return null;
+    try {
+        const liveCount = await exports.computeLiveTaskCount(companyId, sprintId);
+        const updateObj = {
+            type: SCHEMA_TYPE.SPRINTS,
+            data: [
+                { _id: sprintObjectId },
+                { $set: { tasks: liveCount } },
+                { returnDocument: 'after' }
+            ]
+        };
+        await MongoDbCrudOpration(companyId, updateObj, 'findOneAndUpdate');
+        logger.info(`reconcileSprintTaskCount: sprint=${sprintId} corrected to ${liveCount}`);
+        return liveCount;
+    } catch (error) {
+        logger.error(`reconcileSprintTaskCount failed (sprint=${sprintId}): ${error && error.message ? error.message : error}`);
+        return null;
+    }
+};
+
+/**
+ * Convenience: if a primary task write succeeds but a downstream count
+ * update fails, schedule a reconciliation. Decouples the recovery from
+ * the original error path so the caller doesn't have to chain another
+ * promise.
+ */
+exports.scheduleReconciliation = (companyId, sprintIds) => {
+    const ids = Array.isArray(sprintIds) ? sprintIds : [sprintIds];
+    setImmediate(() => {
+        ids.filter(Boolean).forEach(id => {
+            exports.reconcileSprintTaskCount(companyId, id).catch(err => {
+                logger.error(`scheduleReconciliation outer: ${err && err.message ? err.message : err}`);
+            });
+        });
+    });
+};


### PR DESCRIPTION
Fixes #87

## Summary

The audit (BUG-033) flagged that multi-step task creation has no
transaction, which can leave sprint counts inconsistent if any step
fails. The actual drift risk lives in the **move/convert/merge** task
flows (not `HandleTask` itself), each of which writes a primary
findOneAndUpdate and then fires fire-and-forget `\$inc` calls to keep
the sprint's denormalised `tasks` counter in sync.

A full MongoDB transaction would be the textbook fix, but
`MongoDbCrudOpration` does not thread a session through, and Mongo
transactions require a replica-set deployment that the self-hosted
footprint cannot guarantee. A **self-healing reconcile** is safer and
works in every deployment mode.

## What changed

- **`Modules/tasks/helpers/reconcileTaskCount.js` (new)** — three
  exports:
  - `computeLiveTaskCount(companyId, sprintId)` aggregates the tasks
    collection with `deletedStatusKey ∈ {0, undefined}` (matches
    BUG-032's filter shape).
  - `reconcileSprintTaskCount(...)` writes the recomputed value back
    via `\$set: { tasks }`. Idempotent and best-effort: invalid input
    → null, errors are logged but never rethrown.
  - `scheduleReconciliation(...)` runs the helper off the event loop
    via `setImmediate` so callers don't have to chain another promise.

- **`Modules/tasks/helpers/mongo_helper.js`** — wire
  `scheduleReconciliation` into every `updateSprintFun(...).catch` in
  `moveTaskFunction`, `convertToListSubTask`, and the merge-task flow,
  plus the outer `findOneAndUpdate` catch in `moveTaskFunction` (where
  the source task is already soft-deleted before the destination insert
  fails). On failure the count is recomputed from source-of-truth
  instead of being left drifted.

## Audit accuracy

The audit's pointer (`HandleTask` lines 79–96) was slightly off —
that function only saves the task and fires history hooks, no count
updates. The actual drift risk sits in `moveTaskFunction`,
`convertToListSubTask`, and the merge-task path, which is what the fix
addresses.

## Test plan

- [x] Unit test the new reconcile helper (returns recomputed count,
      uses the right filter shape, handles invalid input).
- [x] Verify `scheduleReconciliation` fans out one reconcile per
      sprintId.

```
\$ node .claude/tests/test-bug-033.js
PASS: computeLiveTaskCount returns the aggregate count
PASS: computeLiveTaskCount issued an aggregate against TASKS
PASS: reconciliation uses the BUG-032 filter shape \`{ \$in: [0, undefined] }\`
PASS: reconcileSprintTaskCount resolves with the corrected count
PASS: reconcileSprintTaskCount issued a findOneAndUpdate against SPRINTS
PASS: reconcileSprintTaskCount \$sets \`tasks: 3\` (the recomputed value)
PASS: reconcileSprintTaskCount returns null for missing sprintId
PASS: no Mongo calls issued for empty sprintId
PASS: scheduleReconciliation runs once per sprintId in the array

All BUG-033 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)