### PR TITLE
fix(BUG-034): rotate Winston log files

### DIFF
--- a/Config/loggerConfig.js
+++ b/Config/loggerConfig.js
@@ -1,8 +1,37 @@
 const { createLogger, format, transports } = require('winston');
+const DailyRotateFile = require('winston-daily-rotate-file');
 const { combine, timestamp, label, printf } = format;
+
 const myFormat = printf(({ level, message, label, timestamp }) => {
     return `${timestamp} [${label}] ${level}: ${message}`;
 });
+
+// BUG-034 / #88 — rotate log files so they don't grow unbounded and fill
+// disk on long-running deployments. Knobs are environment-tunable so
+// operators can right-size for their disk/retention needs without code
+// changes; the defaults match typical SaaS practice (20MB per file,
+// 14-day retention).
+const LOG_DIR = process.env.LOG_DIR || 'log';
+const LOG_MAX_SIZE = process.env.LOG_MAX_SIZE || '20m';      // per file
+const LOG_MAX_FILES = process.env.LOG_MAX_FILES || '14d';    // retention window
+const LOG_DATE_PATTERN = process.env.LOG_DATE_PATTERN || 'YYYY-MM-DD';
+
+/**
+ * Build a DailyRotateFile transport. `%DATE%` in the filename is
+ * expanded by winston-daily-rotate-file using LOG_DATE_PATTERN.
+ * `zippedArchive: true` gzips rotated files so old logs sit on disk
+ * cheaply.
+ */
+function rotatingTransport(filenameTemplate, level) {
+    return new DailyRotateFile({
+        filename: `${LOG_DIR}/${filenameTemplate}`,
+        datePattern: LOG_DATE_PATTERN,
+        zippedArchive: true,
+        maxSize: LOG_MAX_SIZE,
+        maxFiles: LOG_MAX_FILES,
+        level
+    });
+}
 
 module.exports = createLogger({
     format: combine(
@@ -11,8 +40,11 @@ module.exports = createLogger({
         myFormat
     ),
     transports: [
-        new transports.File({ filename: 'log/track.log', level: 'warn' }),
-        new transports.File({ filename: 'log/error.log', level: 'error' }),
-        new transports.File({ filename: 'log/combined.log', level: 'info' }),
+        // Filenames keep the legacy basenames (`track`, `error`,
+        // `combined`) so existing tail/grep ops continue to find them;
+        // the date suffix is appended by the rotator.
+        rotatingTransport('track-%DATE%.log', 'warn'),
+        rotatingTransport('error-%DATE%.log', 'error'),
+        rotatingTransport('combined-%DATE%.log', 'info'),
     ]
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "swagger-jsdoc": "6.2.8",
         "swagger-ui-express": "5.0.1",
         "ua-parser-js": "2.0.0",
-        "winston": "3.17.0"
+        "winston": "3.17.0",
+        "winston-daily-rotate-file": "^5.0.0"
       },
       "devDependencies": {
         "jest": "^30.4.2"
@@ -5913,6 +5914,15 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -8475,7 +8485,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10664,6 +10673,24 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
       }
     },
     "node_modules/winston-transport": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "swagger-jsdoc": "6.2.8",
     "swagger-ui-express": "5.0.1",
     "ua-parser-js": "2.0.0",
-    "winston": "3.17.0"
+    "winston": "3.17.0",
+    "winston-daily-rotate-file": "^5.0.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Fixes #88

## Summary

`Config/loggerConfig.js` wired three plain `transports.File` instances,
so `log/track.log`, `log/error.log`, and `log/combined.log` grew without
bound. On long-running deployments this eventually fills the disk and
crashes the process.

## What changed

- **`Config/loggerConfig.js`** — each File transport replaced with a
  `winston-daily-rotate-file` (DailyRotateFile) transport.
  - Files split by date (`track-YYYY-MM-DD.log`, etc.) — legacy
    basename preserved as a prefix, so tail/grep / log-aggregator wiring
    keeps working.
  - 20MB per-file cap (`maxSize`) — env-tunable via `LOG_MAX_SIZE`.
  - 14-day retention (`maxFiles`) — env-tunable via `LOG_MAX_FILES`.
  - `zippedArchive: true` gzips rotated files.
  - Levels (`warn`/`error`/`info`) and label format preserved.

- **`package.json` / `package-lock.json`** —
  `winston-daily-rotate-file ^5.0.0` added.

## Test plan

- [x] Introspect the constructed logger — three transports, each a
      DailyRotateFile, each with `maxSize` + `maxFiles`, each targeting
      the legacy basename, each with its original level.

```
\$ node .claude/tests/test-bug-034.js
PASS: logger has three transports
PASS: transport[0] is a DailyRotateFile
PASS: transport[0] has a maxSize cap
PASS: transport[0] has a maxFiles retention window
PASS: transport[1] is a DailyRotateFile
PASS: transport[1] has a maxSize cap
PASS: transport[1] has a maxFiles retention window
PASS: transport[2] is a DailyRotateFile
PASS: transport[2] has a maxSize cap
PASS: transport[2] has a maxFiles retention window
PASS: a transport targets track-*.log
PASS: a transport targets error-*.log
PASS: a transport targets combined-*.log
PASS: warn-level transport present
PASS: error-level transport present
PASS: info-level transport present

All BUG-034 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)