### PR TITLE
fix(BUG-035): pin cron jobs to a known timezone

### DIFF
--- a/cron.js
+++ b/cron.js
@@ -4,25 +4,32 @@ const taskIndexRef = require("./Modules/taskIndex/controller");
 const { handleBucketSizeUpdateCron } = require(`./common-storage/common-${process.env.STORAGE_TYPE}.js`);
 const aiRef = require("./Modules/AI/controller")
 
+// BUG-035 / #89 — pin every cron to a known timezone so schedules don't
+// shift when the server's local tz changes (DST transition, container
+// host reboot, base-image swap). The default is UTC because that's the
+// only tz that's stable everywhere; operators can override via
+// CRON_TZ for accounting/billing crons that need calendar-day cuts in
+// a specific region.
+const CRON_TZ = process.env.CRON_TZ || 'UTC';
 
 // // This cron job executes daily at midnight (12 AM) and retrieves the file size from Wasabi storage
-schedule.scheduleJob('0 0 * * *', async () => {
+schedule.scheduleJob({ rule: '0 0 * * *', tz: CRON_TZ }, async () => {
     logger.info(`Enter in schedule job`);
     handleBucketSizeUpdateCron();
 })
 
-schedule.scheduleJob('0 0 * * *', async () => {
+schedule.scheduleJob({ rule: '0 0 * * *', tz: CRON_TZ }, async () => {
     logger.info(`Enter in cleanup trackshot schedule job`);
     cleanUpTrackshot();
 })
 
 // This cron job executes every 1 hour and Make Index for unIndex Task.
-schedule.scheduleJob('0 * * * *', async () => {
+schedule.scheduleJob({ rule: '0 * * * *', tz: CRON_TZ }, async () => {
     logger.info(`[Cron] createUnIndexTask`);
     taskIndexRef.createUnIndexTask();
 })
 
 // // This cron job executes daily at midnight (12 AM) and remove ai request count.
-schedule.scheduleJob('0 0 * * *', async () => {
+schedule.scheduleJob({ rule: '0 0 * * *', tz: CRON_TZ }, async () => {
     aiRef.resetAiRequestCount();
 })


### PR DESCRIPTION
Fixes #89

## Summary

`schedule.scheduleJob('0 0 * * *', …)` resolves the schedule in the
server's local timezone, so DST transitions or a container-host tz
change silently move the wall-clock firing time.

## What changed

- **`cron.js`** — every `scheduleJob` call switched from the bare
  cron-string form to the `{ rule, tz }` object form. The tz defaults
  to UTC (only zone stable everywhere); operators can override via
  `CRON_TZ` env var when they need calendar-day cuts in a specific
  region for accounting/billing.

## Test plan

- [x] Parse `cron.js` source; assert every `scheduleJob` uses the
      object form with a `tz` field, and the legacy bare-string form
      is gone.

```
\$ node .claude/tests/test-bug-035.js
PASS: cron.js reads CRON_TZ from env with UTC default
PASS: at least four scheduleJob calls present (found 4)
PASS: scheduleJob[0] uses { rule: ... } object form
PASS: scheduleJob[0] passes a tz option
PASS: scheduleJob[1] uses { rule: ... } object form
PASS: scheduleJob[1] passes a tz option
PASS: scheduleJob[2] uses { rule: ... } object form
PASS: scheduleJob[2] passes a tz option
PASS: scheduleJob[3] uses { rule: ... } object form
PASS: scheduleJob[3] passes a tz option
PASS: no scheduleJob still uses the bare cron-string form

All BUG-035 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)