### PR TITLE
fix(BUG-036): path-traversal-safe loader for SERVICE_FILE

### DIFF
--- a/Config/firebaseConfig.js
+++ b/Config/firebaseConfig.js
@@ -1,8 +1,11 @@
-const path = require('path');
-
 //Initialize Admin
 let admin = null;
 let fcm = null;
+
+// BUG-036 / #90 — share the path-traversal-safe resolver with the
+// installation wizard so both entry points apply the same allow-list
+// (must be inside the project root, must be `.json`, must exist).
+const { resolveServiceFile } = require('../utils/safeServiceFile');
 
 try {
     admin = require("firebase-admin");
@@ -11,7 +14,7 @@ try {
     if (!config.SERVICE_FILE) {
         console.log("Firebase: SERVICE_FILE not configured — push notifications disabled.");
     } else {
-        const serviceFilePath = path.resolve(__dirname, '..', config.SERVICE_FILE);
+        const serviceFilePath = resolveServiceFile(config.SERVICE_FILE);
         const serviceAccount = require(serviceFilePath);
         admin.initializeApp({
             credential: admin.credential.cert(serviceAccount)

--- a/Modules/checkinstallstep/controller.js
+++ b/Modules/checkinstallstep/controller.js
@@ -14,6 +14,8 @@ const pjson = require('../../package.json');
 const { requestHandler } = require('../../Config/config.js');
 const aiModals = require('../../utils/aiModals.json');
 const { makeUniqueId } = require('../../utils/commonFunctions.js');
+// BUG-036 / #90 — path-traversal-safe resolver for the firebase service-account file.
+const { resolveServiceFile } = require('../../utils/safeServiceFile.js');
 
 exports.envVar = {
     "JWT_SECRET": require('crypto').randomBytes(16).toString('hex'),
@@ -257,7 +259,13 @@ exports.checkStorageConnection = (req, cb) => {
 exports.checkFirebaseConnection = async (req, cb) => {
     try {
         const bodyData = req.body;
-        const serviceAccount = require("../"+process.env.SERVICE_FILE);
+        // BUG-036 / #90 fix: was `require("../" + process.env.SERVICE_FILE)`,
+        // which allowed arbitrary JS/JSON inside the repo to be loaded if the
+        // env var was attacker-influenced (e.g. via the installation wizard).
+        // resolveServiceFile() pins the path inside the project root and
+        // requires a `.json` extension so a stray .js file can't be executed.
+        const serviceAccountPath = resolveServiceFile(process.env.SERVICE_FILE);
+        const serviceAccount = require(serviceAccountPath);
         admin1.initializeApp({
             credential: admin1.credential.cert(serviceAccount)
         }, "install-step-firebase"+ new Date().getTime());

--- a/utils/safeServiceFile.js
+++ b/utils/safeServiceFile.js
@@ -1,0 +1,59 @@
+/**
+ * BUG-036 / #90 — safe resolver for the firebase-adminsdk service file.
+ *
+ * `Modules/checkinstallstep/controller.js` did
+ *   `require("../" + process.env.SERVICE_FILE)`
+ * which lets an attacker (or a careless installer wizard input) write
+ * an arbitrary relative path into `SERVICE_FILE` and have Node `require`
+ * any file inside the repo. With `../../etc/passwd`-style payloads the
+ * load fails (because `require` only accepts JS/JSON), but a path that
+ * resolves to a real JS file inside the project still gets executed
+ * with full process privileges.
+ *
+ * This helper:
+ *   * resolves the supplied path against the project root (the parent
+ *     of `Modules/`),
+ *   * confirms the resolved path is still inside the project root
+ *     (no `..` escape),
+ *   * confirms the file extension is `.json` (the Firebase service-
+ *     account file is always JSON; this blocks the "make me execute an
+ *     arbitrary .js" path),
+ *   * confirms the file actually exists.
+ *
+ * If any check fails, it throws — the caller can return a useful
+ * installer-step error instead of letting `require` blow up with a
+ * confusing message (or worse, succeed on the wrong file).
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+exports.resolveServiceFile = function resolveServiceFile(relativePath) {
+    if (typeof relativePath !== 'string' || !relativePath.length) {
+        throw new Error('SERVICE_FILE is not set or is empty.');
+    }
+
+    // Reject absolute paths outright — installer should always point
+    // somewhere inside the deployment.
+    if (path.isAbsolute(relativePath)) {
+        throw new Error('SERVICE_FILE must be a path relative to the project root.');
+    }
+
+    const resolved = path.resolve(PROJECT_ROOT, relativePath);
+    const rootWithSep = PROJECT_ROOT + path.sep;
+    if (resolved !== PROJECT_ROOT && !resolved.startsWith(rootWithSep)) {
+        throw new Error('SERVICE_FILE resolves outside the project root.');
+    }
+
+    if (path.extname(resolved).toLowerCase() !== '.json') {
+        throw new Error('SERVICE_FILE must point to a .json credentials file.');
+    }
+
+    if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+        throw new Error(`SERVICE_FILE not found: ${resolved}`);
+    }
+
+    return resolved;
+};


### PR DESCRIPTION
Fixes #90

## Summary

Two sites loaded the Firebase service-account file via
`require()` with the path coming directly from `process.env.SERVICE_FILE`:

* `Modules/checkinstallstep/controller.js` — `require(\"../\" + process.env.SERVICE_FILE)`
* `Config/firebaseConfig.js` — `require(path.resolve(__dirname, \"..\", config.SERVICE_FILE))`

Either lets an attacker (or a careless installer-wizard input) load
arbitrary JS/JSON inside the repo by stuffing `../`-style paths. A
`.js` file under the repo root would even be executed with full
process privileges.

## What changed

- **`utils/safeServiceFile.js` (new)** — `resolveServiceFile(rel)`:
  - rejects absolute paths,
  - resolves against the project root and verifies the result is
    still inside it (`..`-escape blocked),
  - requires a `.json` extension (Firebase service-account files are
    always JSON; this blocks the arbitrary-`.js` execution path),
  - verifies the file exists.
- **`Modules/checkinstallstep/controller.js`** — replaces the unsafe
  `require(\"../\" + process.env.SERVICE_FILE)` with
  `require(resolveServiceFile(process.env.SERVICE_FILE))`. Resolver
  errors propagate through the existing try/catch, so the installer
  step surfaces a clean error instead of a confusing module-load
  failure.
- **`Config/firebaseConfig.js`** — same swap. Resolver errors land in
  the existing try/catch (push notifications get disabled with a clear
  log message rather than crashing boot).

## Test plan

- [x] resolveServiceFile accepts a valid relative .json inside the
      project root and returns its absolute path.
- [x] Rejects: empty / undefined input, `../../../../etc/passwd`,
      absolute Unix paths, absolute Windows paths, non-.json
      extensions, missing files.
- [x] Confirm both call sites are wired to the new helper and the
      installer no longer uses the legacy unsafe concat.

```
\$ node .claude/tests/test-bug-036.js
PASS: returns absolute path for valid relative .json file inside root
PASS: rejects empty SERVICE_FILE
PASS: rejects undefined SERVICE_FILE
PASS: rejects path-traversal escape (../../../../etc/passwd)
PASS: rejects absolute paths
PASS: rejects Windows-style absolute paths
PASS: rejects non-.json extensions
PASS: rejects missing file
PASS: installer controller uses resolveServiceFile()
PASS: installer no longer uses the unsafe require concat
PASS: firebaseConfig uses resolveServiceFile()

All BUG-036 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)