### PR TITLE
fix(BUG-038): drop S3 request handler timeout from 5 min to 30 s

### DIFF
--- a/Config/config.js
+++ b/Config/config.js
@@ -55,8 +55,16 @@ module.exports = {
     UNDER_MAINTENANCE: process.env.UNDER_MAINTENANCE,
     myCache: myCache,
     USERPROFILEBUCKET: process.env.USERPROFILEBUCKET,
+    // BUG-038 / #92 — S3 request handler timeouts.
+    // Previously both timeouts were 300_000ms (5 minutes). A hung Wasabi
+    // call would pin the request worker for that long, so a brief
+    // upstream outage saturated the pool and degraded unrelated routes.
+    // Drop to 30s (covers normal multi-MB uploads on slow links but
+    // gives up quickly on truly stuck connections). Env-tunable via
+    // `S3_CONNECTION_TIMEOUT_MS` / `S3_SOCKET_TIMEOUT_MS` for operators
+    // who need a different ceiling (e.g. very large file uploads).
     requestHandler: new NodeHttpHandler({
-        connectionTimeout: 300000, // 5 minutes
-        socketTimeout: 300000, // 5 minutes
+        connectionTimeout: Number(process.env.S3_CONNECTION_TIMEOUT_MS) || 30000,
+        socketTimeout: Number(process.env.S3_SOCKET_TIMEOUT_MS) || 30000,
     })
 }


### PR DESCRIPTION
Fixes #92

## Summary

`Config/config.js` built `requestHandler` with both `connectionTimeout`
and `socketTimeout` set to 300_000 ms (5 minutes). A hung Wasabi call
pinned the request worker for the full five minutes, so a brief
upstream outage was enough to saturate the worker pool and degrade
unrelated routes.

## What changed

- **`Config/config.js`** — defaults drop from 300_000 ms → 30_000 ms
  (30 s). Env-tunable via `S3_CONNECTION_TIMEOUT_MS` /
  `S3_SOCKET_TIMEOUT_MS` for operators who need a different ceiling
  (e.g. very large file uploads from poorly-connected mobile clients).

## Test plan

- [x] Source-grep `Config/config.js`: env hooks present, 30 s default,
      no leftover `300000` literal.
- [x] Load `config.js` with forced env values; confirm `requestHandler`
      accepts numeric env-derived timeouts (the NodeHttpHandler does
      not expose its options through a public getter in v3, so we
      verify by constructing a probe handler with the same args).

```
\$ node .claude/tests/test-bug-038.js
PASS: config.js reads S3_CONNECTION_TIMEOUT_MS from env
PASS: config.js reads S3_SOCKET_TIMEOUT_MS from env
PASS: config.js defaults to 30000ms (30s)
PASS: no remaining hard-coded 300_000ms (5min) timeout
PASS: config exposes requestHandler
PASS: NodeHttpHandler accepts numeric env-derived timeouts

All BUG-038 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)