### PR TITLE
fix(BUG-043): wrap clickable <span>/<img> affordances in real <button>

### DIFF
--- a/frontend/src/components/atom/Attachments/Attachments.vue
+++ b/frontend/src/components/atom/Attachments/Attachments.vue
@@ -21,8 +21,18 @@
                     <Skelaton style="height: 30px;width: 114px;" class="border-radius-6-px mb-5px" />
                 </span>
                 <template v-else>
-                    <span v-if="visibleAttachments.length > 0" class="d-block text-right p-1 blue text-decoration-underline font-weight-500 font-size-14 cursor-pointer"
-                        @click="downloadAllImages()">Download All</span>
+                    <!--
+                        BUG-043 / #97 fix: clickable <span> had no
+                        role/aria-label/keyboard focus. Replace with a
+                        real <button type="button"> so keyboard users can
+                        Tab + Enter to trigger Download All.
+                    -->
+                    <button
+                        v-if="visibleAttachments.length > 0"
+                        type="button"
+                        class="download-all-btn d-block text-right p-1 blue text-decoration-underline font-weight-500 font-size-14 cursor-pointer"
+                        @click="downloadAllImages()"
+                    >Download All</button>
                 </template>
                 <label for="UploadedFile" v-if="permission === true">
                     <div class="cursor-link cursor-pointer" v-if="props.isMainSpinner === true || isLoadingAttachments">
@@ -533,5 +543,23 @@ watch(
     visibility: hidden;
     position: relative;
     margin-left: 10px;
+}
+
+/*
+ * BUG-043 / #97 — the Download All control was a <span> with a click
+ * handler; replaced with a <button>. Strip native button chrome so the
+ * visual result matches the old <span>, but keep focus-visible for
+ * keyboard accessibility.
+ */
+.download-all-btn {
+    background: none;
+    border: 0;
+    font: inherit;
+    color: inherit;
+}
+.download-all-btn:focus-visible {
+    outline: 2px solid #2f3990;
+    outline-offset: 2px;
+    border-radius: 2px;
 }
 </style>

--- a/frontend/src/components/atom/Modal/Modal.vue
+++ b/frontend/src/components/atom/Modal/Modal.vue
@@ -6,7 +6,22 @@
                 <div class="modal-header d-flex align-items-center justify-content-between" :class="headerClasses" v-if="header">
                     <slot name="header">
                         <span>{{title}}</span>
-                        <img v-if="closeIcon" :src="cancelIcon" class="cursor-pointer cancel__icon-img" alt="close" @click.prevent="closeModal()">
+                        <!--
+                            BUG-043 / #97 fix: the close affordance was a bare
+                            <img> with a click handler — no role, no
+                            aria-label, no keyboard focus. Wrap in a real
+                            <button type="button"> so keyboard users can Tab
+                            to it and dismiss the modal with Enter/Space.
+                        -->
+                        <button
+                            v-if="closeIcon"
+                            type="button"
+                            class="cursor-pointer cancel__icon-btn"
+                            :aria-label="$t ? ($t('Projects.close') || 'Close') : 'Close'"
+                            @click.prevent="closeModal()"
+                        >
+                            <img :src="cancelIcon" class="cancel__icon-img" alt="">
+                        </button>
                     </slot>
                 </div>
                 <div class="modal-body" :class="bodyClasses">

--- a/frontend/src/components/atom/Modal/style.css
+++ b/frontend/src/components/atom/Modal/style.css
@@ -77,8 +77,30 @@
     height: 100vh;
 }
 .cancel__icon-img{
-    width: 15px !important; 
+    width: 15px !important;
     height: 15px !important;
+}
+/*
+ * BUG-043 / #97 — the modal close button must look identical to the
+ * old clickable <img>: no chrome, just the icon. Strip native button
+ * styling and let the inner <img> carry the visible size. Preserve
+ * focus visibility so keyboard users can see the focused state.
+ */
+.cancel__icon-btn {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    line-height: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.cancel__icon-btn:focus-visible {
+    outline: 2px solid #2f3990;
+    outline-offset: 2px;
+    border-radius: 2px;
 }
 .setting_task_priority .outline-secondary {
     background: #2f3990 !important;


### PR DESCRIPTION
Fixes #97

## Summary

Two affordances dispatched click handlers on non-semantic elements
(no role, no aria-label, no keyboard focus, no screen-reader
announcement):

- **Modal close icon** — bare `<img @click=\"closeModal()\">`
- **Attachments \"Download All\"** — bare `<span @click=\"downloadAllImages()\">`

Keyboard-only users couldn't reach or activate either.

## What changed

- **`frontend/src/components/atom/Modal/Modal.vue`** — wrap the close
  icon in a `<button type=\"button\" :aria-label=\"...\">` with the
  `<img>` inside as a presentational element (`alt=\"\"`).
- **`frontend/src/components/atom/Modal/style.css`** — add
  `.cancel__icon-btn` rule that strips native button chrome while
  preserving `:focus-visible`.
- **`frontend/src/components/atom/Attachments/Attachments.vue`** —
  replace the `<span @click=\"downloadAllImages()\">` with a
  `<button type=\"button\" class=\"download-all-btn ...\">`, and add a
  matching `.download-all-btn` style rule with `:focus-visible`.

## Out of scope

A few nearby affordances have the same anti-pattern (Attachments'
\"See All\" `<div>`, the help-icon popover, several other clickable
spans across the app). The audit specifically called out the `<span>`
and `<img>` cases above; the rest deserves a sweep PR.

## Test plan

- [x] Modal: source-check that the close affordance is a real
      `<button type=\"button\">` with `aria-label` and `@click=closeModal`,
      and the inner `<img>` no longer carries its own click handler.
- [x] Attachments: source-check that Download All is a
      `<button type=\"button\" class=\"download-all-btn ...\">` with the
      `downloadAllImages()` click handler, and there's no remaining
      `<span @click=downloadAllImages>`.
- [x] Both components carry `:focus-visible` rules so keyboard focus
      is visible.

```
\$ node .claude/tests/test-bug-043.js
PASS: Modal close affordance is a <button type=\"button\"> with @click=closeModal
PASS: Modal close button carries an aria-label
PASS: Modal no longer has a bare <img @click=\"closeModal\"> (handler now on the button)
PASS: modal style.css defines .cancel__icon-btn
PASS: modal style.css preserves :focus-visible for the close button
PASS: download-all-btn appears inside a <button> tag
PASS: download-all-btn carries @click=downloadAllImages()
PASS: download-all-btn declares type=\"button\"
PASS: Attachments no longer has <span @click=downloadAllImages>
PASS: Attachments style defines .download-all-btn
PASS: Attachments style preserves :focus-visible on Download All

All BUG-043 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)