### PR TITLE
fix: repair broken advisory URL in SECURITY.md (#44)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,7 @@ Security fixes are applied on a **best-effort basis**, typically to the latest r
 
 All suspected security vulnerabilities **must be reported via GitHub Security Advisories**.
 
-➡️ Submit a report here:
-`https://github.com/aliansoftwareteam
-AlianHub-Project-Management-System/security/advisories/new`
+➡️ Submit a report here: [Report a vulnerability](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/security/advisories/new)
 
 Please include the following information (all are required):
 


### PR DESCRIPTION
The advisory link was split across two lines and wrapped in a code span, rendering as malformed text rather than a clickable link. Joined the URL and used proper markdown link syntax. Pairs with enabling Private Vulnerability Reporting in repo settings so external reporters can actually submit advisories.

Closes #44

## Pull Request Template Chooser
Please click the link that matches your contribution type to load the correct format. 

> **Note:** Clicking a link will reload this page and clear any text you've already typed here.

- [**Bug Fix**](?expand=1&template=bug_fix.md)
  *Use this for fixing broken logic or UI glitches.*

- [**New Feature**](?expand=1&template=new_feature.md)
  *Use this for adding new functionality or components.*

- [**Refactor**](?expand=1&template=refactor.md)
  *Use this for code cleanup, performance tweaks, or technical debt.*

---
### General Summary
*If you don't want to use a specific template, please provide a brief summary of your changes below.*
