### PR TITLE
fix: refresh correct lastRequest field on connection reuse (#42)

### DIFF
--- a/middlewares/mongoConnector/helper.js
+++ b/middlewares/mongoConnector/helper.js
@@ -15,7 +15,7 @@ exports.connections = [];
 exports.updateConnectionRecord = (db, conData = {}) => {
     const index = exports.connections.findIndex((x) => x.db === db)
     if (index !== -1) {
-        exports.connections[index].lastRequset = new Date().getTime();
+        exports.connections[index].lastRequest = new Date().getTime();
         // console.log("EXISTING CONNECTION", exports.connections.map((x) => ({ db: x.db, last: x.lastRequest })));
     } else {
         exports.connections.push({ ...conData })


### PR DESCRIPTION
updateConnectionRecord was writing to lastRequset (typo) while the idle-cleanup loop in startInterval reads lastRequest. Active company databases therefore kept the timestamp frozen at createdAt and were eligible for termination after the 30-minute window despite continuous use. Fixed the property name so the update path and the cleanup path reference the same field.

Closes #42

## Pull Request Template Chooser
Please click the link that matches your contribution type to load the correct format. 

> **Note:** Clicking a link will reload this page and clear any text you've already typed here.

- [**Bug Fix**](?expand=1&template=bug_fix.md)
  *Use this for fixing broken logic or UI glitches.*

- [**New Feature**](?expand=1&template=new_feature.md)
  *Use this for adding new functionality or components.*

- [**Refactor**](?expand=1&template=refactor.md)
  *Use this for code cleanup, performance tweaks, or technical debt.*

---
### General Summary
*If you don't want to use a specific template, please provide a brief summary of your changes below.*
