### PR TITLE
fix: remove duplicate CheckInstallStep mount and .env hot-reload (#41)

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,6 @@ function initializeControllers() {
     require('./Modules/notification-count/init').init(app);
     require('./Modules/notification/sendEmail/init').init(app);
     require('./Modules/trackerUserPermission/init').init(app);
-    require('./Modules/CheckInstallStep/init').init(app);
     require('./Modules/SaasAdmin/init').init(app);
     if(process.env.NODE_ENV === "production") {
         require('./cron.js')
@@ -194,11 +193,6 @@ function initializeControllers() {
     require("./Modules/githubOAuth/init.js").init(app);
     require("./Modules/googleOAuth/init.js").init(app);
 }
-
-// FIRES EVENT WHEN THE ENV IS UPDATED
-fs.watchFile(__dirname+'/.env', () => {
-    initializeControllers();
-})
 
 // SET MIDDLEWARE
 // require('./Config/setMiddleware.js').setMiddlewareWithC(app);


### PR DESCRIPTION
## Summary
Bootstrap was registering duplicate handlers from two paths:

1. **Duplicate `CheckInstallStep` mount** — mounted inside `initializeControllers()` and again unconditionally at the top level. The top-level mount has to stay so the install wizard is reachable before `MONGODB_URL` is configured. Removed the inner mount.

2. **`.env` watcher re-ran init** — `fs.watchFile('/.env')` called `initializeControllers()` on every save, which re-`.init(app)`s ~60 route modules onto the same Express app (no clean way to un-register routes) and spawned another `setInterval` inside `startInterval()`. Removed the watcher; nodemon handles dev reloads and prod env changes require a restart anyway.

After this change `initializeControllers()` is invoked exactly once, from the `MONGODB_URL` startup gate.

## Trade-off
Hot-reload of `.env` no longer takes effect without restarting. This behavior was already broken (it caused the leaks above), so removing it is a correctness fix rather than a feature loss. If hot env reload is wanted later, it should be a separate function that refreshes `config`/`process.env` only — never re-mounts routes.

## Test plan
- [ ] Boot the server, hit a CheckInstallStep route and confirm it responds normally.
- [ ] Boot with `MONGODB_URL` unset, confirm CheckInstallStep is still reachable so the install wizard can run.
- [ ] Edit `.env` while the server runs (without nodemon); confirm the `ACTIVE CONNECTIONS:` log line fires on a single cadence (not stacking).
- [ ] `grep -n "initializeControllers" index.js` shows only the definition and the single startup call.

Closes #41