### PR TITLE
fix: preserve dataType and options across JWT refresh retry (#38)

### DIFF
--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -184,7 +184,7 @@ export const apiRequest = (type, endPoint, data, dataType, options) => {
                         }else if (err?.response?.data?.isJwtError) {
                             const userId = localStorage.getItem('userId') || "";
                             await getAuth(userId);
-                            apiRequest(type, endPoint, data).then((sData)=>{
+                            apiRequest(type, endPoint, data, dataType, options).then((sData)=>{
                                 resolve(sData);
                             }).catch((err) => {
                                 reject(err);
@@ -234,7 +234,7 @@ export const apiRequestWithoutCompnay = (type, endPoint, data, dataType,options)
                     } else if (err?.response?.data?.isJwtError) {
                         const userId = localStorage.getItem('userId') || "";
                         await getAuth(userId);
-                        apiRequestWithoutCompnay(type, endPoint, data).then((sData)=>{
+                        apiRequestWithoutCompnay(type, endPoint, data, dataType, options).then((sData)=>{
                             resolve(sData);
                         }).catch((err) => {
                             reject(err);


### PR DESCRIPTION
apiRequest and apiRequestWithoutCompnay reconstruct the call after a token refresh using only (type, endPoint, data), dropping dataType and options. Any retry of a multipart upload then runs through the JSON axios instance instead of the form-data instance, and any caller-supplied abort signal or per-request option is lost. Forwarded dataType and options into both retry calls so the replay matches the original.

Closes #38

## Pull Request Template Chooser
Please click the link that matches your contribution type to load the correct format. 

> **Note:** Clicking a link will reload this page and clear any text you've already typed here.

- [**Bug Fix**](?expand=1&template=bug_fix.md)
  *Use this for fixing broken logic or UI glitches.*

- [**New Feature**](?expand=1&template=new_feature.md)
  *Use this for adding new functionality or components.*

- [**Refactor**](?expand=1&template=refactor.md)
  *Use this for code cleanup, performance tweaks, or technical debt.*

---
### General Summary
*If you don't want to use a specific template, please provide a brief summary of your changes below.*
