### PR TITLE
fix: clean up close_click IPC listener after each notification (#39)

### DIFF
--- a/time-tracker-app/main/background.js
+++ b/time-tracker-app/main/background.js
@@ -402,12 +402,25 @@ function sendNotification(dataUrl) {
   screenshotNotificationWindow.webContents.on('did-finish-load', () => {
     screenshotNotificationWindow.webContents.send('screenshot-path', dataUrl);
     screenshotNotificationWindow.show();
-    ipcMain.on('close_click', () => {
-      screenshotNotificationWindow.close();
-    });
-    setTimeout(() => {
-      screenshotNotificationWindow.close();
+
+    const notificationWindow = screenshotNotificationWindow;
+    const closeHandler = () => {
+      if (!notificationWindow.isDestroyed()) {
+        notificationWindow.close();
+      }
+    };
+    ipcMain.once('close_click', closeHandler);
+
+    const autoCloseTimer = setTimeout(() => {
+      if (!notificationWindow.isDestroyed()) {
+        notificationWindow.close();
+      }
     }, 10000);
+
+    notificationWindow.once('closed', () => {
+      clearTimeout(autoCloseTimer);
+      ipcMain.removeListener('close_click', closeHandler);
+    });
   });
 
 }


### PR DESCRIPTION
sendNotification() registered a new ipcMain.on('close_click', ...) handler on every screenshot capture and never removed it, so the process accumulated one global IPC listener per screenshot and a single close click eventually fired N stale handlers, each trying to close an already-destroyed BrowserWindow reference.

Switched the registration to ipcMain.once so the happy path (user clicks close) auto-removes the listener. For the auto-timeout path (window closes after 10s without a click) the handler stays registered and would later steal a future notification's close event, so also remove it explicitly when the window emits 'closed'. The timeout id is now tracked and cleared on the same hook so the timer can't fire against a destroyed window. The window reference is captured in a local so each listener targets its own window even if a subsequent sendNotification() reassigns the module-level screenshotNotificationWindow before this listener fires.

Closes #39

## Pull Request Template Chooser
Please click the link that matches your contribution type to load the correct format. 

> **Note:** Clicking a link will reload this page and clear any text you've already typed here.

- [**Bug Fix**](?expand=1&template=bug_fix.md)
  *Use this for fixing broken logic or UI glitches.*

- [**New Feature**](?expand=1&template=new_feature.md)
  *Use this for adding new functionality or components.*

- [**Refactor**](?expand=1&template=refactor.md)
  *Use this for code cleanup, performance tweaks, or technical debt.*

---
### General Summary
*If you don't want to use a specific template, please provide a brief summary of your changes below.*
