### PR TITLE
feat: allow editing the "Created by" user on a task

### DIFF
--- a/Modules/Tasks/helpers/task_class_Mongo.js
+++ b/Modules/Tasks/helpers/task_class_Mongo.js
@@ -831,6 +831,76 @@ class Task {
         })
     }
 
+    /* -------------- UPDATE TASK LEADER (CREATED BY) FUNCTION FOR TASK -----------------*/
+
+    updateTaskLeader({firebaseObj, projectData, taskData, employeeName, userData, isUpdateTask}) {
+        return new Promise((resolve, reject) => {
+            try {
+                const newLeaderId = firebaseObj && firebaseObj.Task_Leader;
+                if (!newLeaderId) {
+                    reject(new Error("Task_Leader is required"));
+                    return;
+                }
+
+                // SIDE-EFFECTS ONLY (history) — parity with updateAssignee/updateStatus/updatePriority
+                if (isUpdateTask === false) {
+                    const historyObj = {
+                        key: "TaskLeader_Changed",
+                        message: `<b>${userData.Employee_Name}</b> has changed <b>Created by</b> to <b>${employeeName}</b>.`,
+                        sprintId: taskData.sprintId,
+                    };
+                    HandleHistory('task', projectData.CompanyId, projectData._id, taskData._id, historyObj, userData)
+                    .catch((error) => {
+                        logger.error(`ERROR in history: ${error.message}`);
+                    });
+                    resolve({status: true, statusText: "Task leader updated successfully"});
+                    return;
+                }
+
+                // DB-WRITE PATH
+                const findObj = {
+                    type: dbCollections.TASKS,
+                    data: [{ _id: taskData._id }]
+                };
+                MongoDbCrudOpration(projectData.CompanyId, findObj, "findOne").then((response) => {
+                    if (!response) {
+                        throw new Error("Task document does not exist!");
+                    }
+
+                    const mongoUpdateObj = { $set: { Task_Leader: newLeaderId } };
+                    const updateObj = {
+                        type: SCHEMA_TYPE.TASKS,
+                        data: [
+                            { _id: new mongoose.Types.ObjectId(taskData._id) },
+                            mongoUpdateObj,
+                            { returnDocument: "after" }
+                        ]
+                    };
+                    MongoDbCrudOpration(projectData.CompanyId, updateObj, "findOneAndUpdate").then((result) => {
+                        socketEmitter.emit('update', { type: "update", data: result, updatedFields: { Task_Leader: newLeaderId }, module: 'task' });
+                        resolve({status: true, statusText: "Task leader updated successfully"});
+
+                        const historyObj = {
+                            key: "TaskLeader_Changed",
+                            message: `<b>${userData.Employee_Name}</b> has changed <b>Created by</b> to <b>${employeeName}</b>.`,
+                            sprintId: taskData.sprintId,
+                        };
+                        HandleHistory('task', projectData.CompanyId, projectData._id, taskData._id, historyObj, userData)
+                        .catch((error) => {
+                            logger.error(`ERROR in history: ${error.message}`);
+                        });
+                    }).catch((error) => {
+                        reject(error);
+                    });
+                }).catch((error) => {
+                    reject(error);
+                });
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
     /* -------------- (AUTO RUN ON TASK CREATE) UPDATE TASK KEY -----------------*/
     updateTaskKey({companyId, projectCode, projectId, taskId, taskTypeKey, sprintId, mainChat = false,isParentTask=true , indexObj = {}}) {
         return new Promise((resolve, reject) => {

--- a/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
+++ b/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
@@ -54,23 +54,50 @@
             <div class="d-flex task-detail-right-side-label">
                 <h4>{{$t('Comment.created_by')}}</h4>
                 <Skelaton v-if="!task?.Task_Leader && isMainSpinner" style="height: 30px;" class="w-30px border-radius-50-per"/>
-                <div v-else class="d-flex align-items-center">
-                    <UserProfile
-                        :data="{
-                            image: taskLeaderData.Employee_profileImageURL, 
-                            title: taskLeaderData.Employee_Name
-                        }"
-                        :showDot="false"
-                        width="30px"
-                        :thumbnail="'30x30'"
-                    />
-                    <span 
-                        class="black text-ellipsis task-created-by" 
-                        :class="{'font-size-13 font-weight-400' : clientWidth > 767, 'font-size-16' : clientWidth <=767}"
-                        :title="taskLeaderData?.Employee_Name || 'N/A'">
-                        {{ taskLeaderData?.Employee_Name || 'N/A' }}
-                    </span>
-                </div>
+                <template v-else>
+                    <!-- Editable picker — gated by the same permission as Assignee. -->
+                    <div
+                        v-if="checkPermission('task.task_assignee',project?.isGlobalPermission) === true && checkPermission('task.task_list',project?.isGlobalPermission) == true"
+                        class="d-flex align-items-center"
+                    >
+                        <Assignee
+                            :numOfUsers="1"
+                            :users="task.Task_Leader ? [task.Task_Leader] : []"
+                            :addUser="true"
+                            :options="permittedOptions"
+                            @selected="updateTaskLeader($event)"
+                            imageWidth="30px"
+                            :showAddUser="false"
+                            :zIndexAssigne="props.zIndexAssigne"
+                            :isDisplayTeam="false"
+                            :multiSelect="false"
+                        />
+                        <span
+                            class="black text-ellipsis task-created-by ml-5px"
+                            :class="{'font-size-13 font-weight-400' : clientWidth > 767, 'font-size-16' : clientWidth <=767}"
+                            :title="taskLeaderData?.Employee_Name || 'N/A'">
+                            {{ taskLeaderData?.Employee_Name || 'N/A' }}
+                        </span>
+                    </div>
+                    <!-- Read-only display — original behaviour for users without permission. -->
+                    <div v-else class="d-flex align-items-center">
+                        <UserProfile
+                            :data="{
+                                image: taskLeaderData.Employee_profileImageURL,
+                                title: taskLeaderData.Employee_Name
+                            }"
+                            :showDot="false"
+                            width="30px"
+                            :thumbnail="'30x30'"
+                        />
+                        <span
+                            class="black text-ellipsis task-created-by"
+                            :class="{'font-size-13 font-weight-400' : clientWidth > 767, 'font-size-16' : clientWidth <=767}"
+                            :title="taskLeaderData?.Employee_Name || 'N/A'">
+                            {{ taskLeaderData?.Employee_Name || 'N/A' }}
+                        </span>
+                    </div>
+                </template>
             </div>
             <div class="d-flex task-detail-right-side-label" v-if="checkPermission('task.task_priority',project?.isGlobalPermission) !== null && checkApps('Priority')">
                 <h4>{{$t('Projects.priority')}}</h4>
@@ -354,6 +381,44 @@ const updateAssignee = (event, type) =>{
     } catch (error) {
         console.error(error);
         $toast.error(t('Toast.Assignee_not_updated'),{position: 'top-right'});
+    }
+}
+
+const updateTaskLeader = (event) => {
+    try {
+        if (!event || !event.id) return;
+        if (event.id === props.task.Task_Leader) return;
+        const userData = getUserData();
+
+        const updateObject = {
+            Task_Leader: event.id
+        }
+
+        const projectData = {
+            _id: project.value._id,
+            CompanyId: project.value.CompanyId,
+            lastTaskId: project.value.lastTaskId,
+            ProjectName: project.value.ProjectName,
+            ProjectCode: project.value.ProjectCode
+        }
+
+        taskClass.updateTaskLeader({
+            firebaseObj: updateObject,
+            projectData: projectData,
+            taskData: props.task,
+            employeeName: getUser(event.id).Employee_Name,
+            userData
+        })
+        .then(() => {
+            $toast.success(t('Toast.Created_by_updated_successfully'), { position: 'top-right' });
+        })
+        .catch((error) => {
+            console.error("ERROR in updateTaskLeader: ", error);
+            $toast.error(t('Toast.Created_by_not_updated'), { position: 'top-right' });
+        })
+    } catch (error) {
+        console.error(error);
+        $toast.error(t('Toast.Created_by_not_updated'), { position: 'top-right' });
     }
 }
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1707,6 +1707,8 @@ export default {
         "Assignee added successfully": "Assignee added successfully",
         "Assignee removed successfully": "Assignee removed successfully",
         "Assignee not updated": "Assignee not updated",
+        Created_by_updated_successfully: "Created by updated successfully",
+        Created_by_not_updated: "Created by not updated",
         Task_updated_successfully: "Task updated successfully",
         Task_restored_successfully: "Task restored successfully",
         Task_archived_successfully: "Task archived successfully",

--- a/frontend/src/utils/TaskOperations/index.js
+++ b/frontend/src/utils/TaskOperations/index.js
@@ -327,6 +327,58 @@ class Task {
         })
     }
 
+    /* -------------- UPDATE TASK LEADER (CREATED BY) -----------------*/
+
+    updateTaskLeader({ firebaseObj, projectData, taskData, employeeName, userData, isUpdateTask = true }) {
+        return new Promise((resolve, reject) => {
+            try {
+                const newLeaderId = firebaseObj && firebaseObj.Task_Leader;
+                if (!newLeaderId) {
+                    reject({ status: false, error: new Error("Task_Leader is required") });
+                    return;
+                }
+
+                const { sprintId, ProjectID } = taskData;
+
+                // Optimistic UI: mirror what updateAssignee does for AssigneeUserId
+                Store.commit('projectData/mutateUpdateFirebaseTasks', {
+                    snap: null,
+                    op: "modified",
+                    pid: ProjectID,
+                    sprintId,
+                    data: { ...taskData, Task_Leader: newLeaderId },
+                    updatedFields: { ...firebaseObj }
+                });
+
+                apiRequest("patch", env.V2_TASKS, {
+                    action: "updateTaskLeader",
+                    firebaseObj,
+                    projectData,
+                    taskData,
+                    employeeName,
+                    isUpdateTask,
+                    userData: {
+                        "Employee_Name": userData.Employee_Name,
+                        "id": userData.id,
+                        "companyOwnerId": userData.companyOwnerId
+                    }
+                })
+                .then((response) => {
+                    if (response.data.status) {
+                        resolve({ status: true, statusText: "Task leader updated successfully" });
+                    } else {
+                        reject({ status: false, error: response.data.error });
+                    }
+                })
+                .catch((error) => {
+                    reject({ status: false, error: error });
+                });
+            } catch (error) {
+                reject({ status: false, error: error });
+            }
+        });
+    }
+
     /* -------------- UPDATE TASK WATCHER -----------------*/
     updateWatcher({companyId, projectId, sprintId, taskId, userId, add,userData,employeeName, watchers: watchersArr}) {
         return new Promise((resolve,reject) => {


### PR DESCRIPTION
The task sidebar Details panel previously showed Created by (the Task_Leader field) as a read-only user — set once at creation and never changeable. Add an inline picker mirroring the existing Assignee field so the creator can be reassigned.

Changes:
- Backend: new updateTaskLeader action on task_class_Mongo. Validates the new Task_Leader, writes via $set, emits the same socketEmitter.emit('update', { module: 'task', updatedFields }) used by updateAssignee, and logs a TaskLeader_Changed history entry via HandleHistory. Includes the isUpdateTask:false side-effects-only branch for parity with updateStatus / updatePriority.
- Frontend store (TaskOperations): new updateTaskLeader action that optimistically commits the new Task_Leader into the projectData Vuex store, then PATCHes /api/v2/tasks with action 'updateTaskLeader'.
- TaskDetailRightSide.vue: replaced the read-only Created-by block with an Assignee picker (single-select) for users holding the task.task_assignee + task.task_list permissions, preserving the original read-only display as the fallback for users without those permissions. Wired @selected to a new updateTaskLeader() handler with the same toast / error pattern as updateAssignee.
- i18n: added Toast.Created_by_updated_successfully and Toast.Created_by_not_updated to the English locale. The other 10 locales fall back to English via vue-i18n until translators backfill — flagged as a follow-up.

Permission policy: reuses task.task_assignee. Anyone allowed to change the Assignee can also change Created by. No new permission key, no role-permission migration. Backend has no per-field gate, consistent with the existing Assignee / Status / Priority update paths which all trust the frontend permission gate.

## Pull Request Template Chooser
Please click the link that matches your contribution type to load the correct format. 

> **Note:** Clicking a link will reload this page and clear any text you've already typed here.

- [**Bug Fix**](?expand=1&template=bug_fix.md)
  *Use this for fixing broken logic or UI glitches.*

- [**New Feature**](?expand=1&template=new_feature.md)
  *Use this for adding new functionality or components.*

- [**Refactor**](?expand=1&template=refactor.md)
  *Use this for code cleanup, performance tweaks, or technical debt.*

---
### General Summary
*If you don't want to use a specific template, please provide a brief summary of your changes below.*
