### PR TITLE
feat: split header notifications into Unread and Archive views

### DIFF
--- a/Modules/Tasks/helpers/handleNotification.js
+++ b/Modules/Tasks/helpers/handleNotification.js
@@ -93,9 +93,21 @@ exports.HandleBothNotification = ({ type, companyId, projectId, taskId, folderId
                     reject({ status: false, message: "No watchers" });
                     return
                 }
+                // Task_Leader (the task creator) must honour the same
+                // project-level watcher setting as everyone else. Without
+                // this guard, the union below bypassed the "Ignore" filter
+                // entirely — a creator who set the project to Ignore would
+                // still receive in-app and email notifications because the
+                // downstream per-event NOTIFICATIONS_SETTINGS check is a
+                // separate preference layer and defaults email=true.
+                const creatorIgnoringProject = taskData?.Task_Leader && projectData?.watchers?.[taskData.Task_Leader] === "ignore";
+                const includeCreator = taskData?.Task_Leader && !creatorIgnoringProject;
                 let users = [];
                 if (taskId !== undefined) {
-                    users = Array.from(new Set([taskData.Task_Leader, ...watchers]));
+                    users = Array.from(new Set([
+                        ...(includeCreator ? [taskData.Task_Leader] : []),
+                        ...watchers
+                    ]));
                 } else {
                     users = Array.from(new Set([...taskData.AssigneeUserId, ...doc.data().LeadUserId, ...watchers]));
                 }
@@ -138,10 +150,16 @@ exports.HandleBothNotification = ({ type, companyId, projectId, taskId, folderId
             } else if(projectData && type === 'project'){
                 let watchers = projectData?.watchers || {};
                 let ownerId = userData.companyOwnerId;
-                
+
                 let filteredIds = Object.keys(watchers).filter(id =>  watchers[id] === 'all_activity' || (watchers[id] === 'participating_mentions' && mentionUserId?.includes(id)));
+                // Company owner must also honour the project-level "Ignore"
+                // setting — the previous unconditional union forced them
+                // into the recipient list and downstream into the email
+                // pipeline regardless of their stated preference.
+                const ownerIgnoringProject = ownerId && watchers[ownerId] === 'ignore';
+                const includeOwner = ownerId && !ownerIgnoringProject;
                 let users = [];
-                users = Array.from(new Set([...filteredIds, ...(ownerId ? [ownerId] : [])]));
+                users = Array.from(new Set([...filteredIds, ...(includeOwner ? [ownerId] : [])]));
                 const obj = {
                     "createdAt": new Date(),
                     "key": object.key,

--- a/Modules/notification/app-notification/controller.js
+++ b/Modules/notification/app-notification/controller.js
@@ -97,7 +97,7 @@ exports.getMentionsMessages = async (req, res) => {
  */
 exports.getNotificationMessages = async (req, res) => {
     try {
-        const { userId, loadMore, batchSize = 10, notificationSkip = 0 } = req.query;
+        const { userId, loadMore, batchSize = 10, notificationSkip = 0, filter = 'unread' } = req.query;
 
         const limit = parseInt(batchSize);
         const skip = parseInt(notificationSkip);
@@ -109,22 +109,33 @@ exports.getNotificationMessages = async (req, res) => {
             });
         }
 
-        const query = [
+        // `notSeen` carries the IDs of recipients who have NOT yet read the
+        // notification. So `userId IN notSeen` ⇒ unread for that user, and
+        // `userId NOT IN notSeen` ⇒ already read / archived for that user.
+        // Default to 'unread' to keep the bell focused on actionable items;
+        // the dropdown's "View Archive" toggle passes filter=archived.
+        const normalizedFilter = (filter === 'archived' || filter === 'archive') ? 'archived' : 'unread';
+
+        const baseMatch = [
+            { assigneeUsers: { $in: [userId] } },
+            { key: { $ne: Notification_key.COMMENTS_IM_MENTIONS_IN }},
             {
-                $match: {
-                    $and: [
-                        { assigneeUsers: { $in: [userId] } },
-                        { key: { $ne: Notification_key.COMMENTS_IM_MENTIONS_IN }},
-                        {
-                            $or: [
-                                { notificationType: 'push' },
-                                { notificationType: null }
-                            ]
-                        },
-                        { receiverID: userId }
-                    ]
-                }
+                $or: [
+                    { notificationType: 'push' },
+                    { notificationType: null }
+                ]
             },
+            { receiverID: userId }
+        ];
+
+        if (normalizedFilter === 'archived') {
+            baseMatch.push({ notSeen: { $nin: [userId] } });
+        } else {
+            baseMatch.push({ notSeen: { $in: [userId] } });
+        }
+
+        const query = [
+            { $match: { $and: baseMatch } },
             { $sort: { createdAt: -1, _id: 1 } },
             { $skip: loadMore ? skip : 0 },
             { $limit: limit },

--- a/frontend/src/components/organisms/Header/Header.vue
+++ b/frontend/src/components/organisms/Header/Header.vue
@@ -55,7 +55,7 @@
                 <span v-if="totalMainCounts" class="notification-tick blinking"></span>
             </router-link>
             <div class="position-re" :class="{'mr-2' : clientWidth > 1440, 'mr-1' : clientWidth<=1440}" v-if="rules && Object.keys(rules).length">
-                <img src="@/assets/images/svg/header_notification.svg" class="cursor-pointer" id="notification_driver" @click="getNotifications(!notifications.length), showNotification = 0, notificationVisible = true">
+                <img src="@/assets/images/svg/header_notification.svg" class="cursor-pointer" id="notification_driver" @click="openNotificationsDropdown()">
                 <span :class="{'notification-tick': totalNotification}" class="blinking"></span>
             </div>
             <div class="position-re" :class="{'pr-2' : clientWidth > 1440, 'pr-1' : clientWidth<=1440}" v-if="rules && Object.keys(rules).length">
@@ -195,7 +195,7 @@
                         <router-link  v-if="rules && Object.keys(rules).length && checkPermission('chat') == true" class="p-1 cursor-pointer border-radius-7-px mobile-menu-list" @click="visible = false" :class="{'active-list-mobile' : $route.name.includes('chat')}" :to="{name: 'chats', params: {cid: companyId}}">
                             {{$t('Header.Chat')}}
                         </router-link>
-                        <div  v-if="rules && Object.keys(rules).length" class="p-1 cursor-pointer border-radius-7-px mobile-menu-list" @click="getNotifications(!notifications.length), showNotification = 0, notificationVisible = true, visible = false">
+                        <div  v-if="rules && Object.keys(rules).length" class="p-1 cursor-pointer border-radius-7-px mobile-menu-list" @click="openNotificationsDropdown(true)">
                             {{$t('Header.Notification')}}
                         </div>
                         <div v-if="rules && Object.keys(rules).length" class="p-1 cursor-pointer border-radius-7-px mobile-menu-list" @click="getMentions(!mentions.length), showNotification = 1, notificationVisible = true, visible = false">
@@ -225,7 +225,18 @@
                     {{!showNotification ? $t('Header.Notifications') : $t('Header.mentions')}}
                 </div>
                 <div class="d-flex align-items-center justify-content-between">
-                    <button v-if="!showNotification ? totalNotification > 0 : totalMentions > 0" class="outline-primary mr-10px" @click="markAllRead(!showNotification ? 'notifications' : 'mentions')">{{$t('Header.Mark_all_as_read')}}</button>
+                    <!-- Unread / Archive toggle. Only applies to notifications, not mentions. -->
+                    <button
+                        v-if="!showNotification"
+                        class="outline-primary mr-10px"
+                        @click="switchNotificationFilter(notificationFilter === 'unread' ? 'archived' : 'unread')">
+                        {{ notificationFilter === 'unread' ? $t('Header.View_Archive') : $t('Header.View_Unread') }}
+                    </button>
+                    <!-- Show "Mark all as read" whenever there are unread items visible. Using
+                         `notifications.length` (the list is already filtered to unread on this
+                         view) instead of the server-side `totalNotification` counter, which
+                         can lag behind and falsely hide the button. -->
+                    <button v-if="!showNotification ? (notificationFilter === 'unread' && notifications.length > 0) : totalMentions > 0" class="outline-primary mr-10px" @click="markAllRead(!showNotification ? 'notifications' : 'mentions')">{{$t('Header.Mark_all_as_read')}}</button>
                     <img :src="closeBlueImage" alt="closeButton" class="cursor-pointer" @click="notificationVisible = false"/>
                 </div>
             </template>
@@ -456,6 +467,8 @@ const batchSize = ref(10)
 const notifications = ref([]);
 const noNotifications = ref(false);
 const notificationSkip = ref(0);
+// 'unread' (default, shown when the bell first opens) | 'archived' (View Archive)
+const notificationFilter = ref('unread');
 
 // MENTIONS
 const mentions = ref([]);
@@ -501,7 +514,7 @@ function getNotifications(loadMore = false) {
         }
     }
 
-    const url = `${APP_NOTIFICATION}/notification?userId=${userId.value}&loadMore=${loadMore}&batchSize=${batchSize.value}&notificationSkip=${notificationSkip.value}`;
+    const url = `${APP_NOTIFICATION}/notification?userId=${userId.value}&loadMore=${loadMore}&batchSize=${batchSize.value}&notificationSkip=${notificationSkip.value}&filter=${notificationFilter.value}`;
     apiRequest("get", url).then((response) => {
         if (response.data.status) {
             const data = response.data.data;
@@ -533,6 +546,35 @@ function getNotifications(loadMore = false) {
         isSpinner.value = false;
         console.error(`Error in getNotifications hook => ${error}`);
     });
+}
+
+function switchNotificationFilter(newFilter) {
+    if (newFilter !== 'unread' && newFilter !== 'archived') return;
+    if (notificationFilter.value === newFilter) return;
+    notificationFilter.value = newFilter;
+    // Reset paging state so the new filter starts a fresh fetch.
+    notifications.value = [];
+    notificationSkip.value = 0;
+    batchSize.value = 10;
+    noNotifications.value = false;
+    getNotifications(false);
+}
+
+function openNotificationsDropdown(closeMobileMenu = false) {
+    // Always land in the Unread view when the bell opens — matches the
+    // "initially only unread" UX requirement. The "View Archive" button in
+    // the dropdown head flips this to 'archived'.
+    notificationFilter.value = 'unread';
+    notifications.value = [];
+    notificationSkip.value = 0;
+    batchSize.value = 10;
+    noNotifications.value = false;
+    showNotification.value = 0;
+    notificationVisible.value = true;
+    if (closeMobileMenu) {
+        visible.value = false;
+    }
+    getNotifications(false);
 }
 
 async function getMentions(loadMore = false) {
@@ -601,6 +643,15 @@ async function getMentions(loadMore = false) {
 }
 
 function markRead(data, key, redirect = true) {
+    // Once an item is marked read it stops belonging to the "unread" view.
+    // Drop it from the local list so the dropdown doesn't keep showing it
+    // while the user is filtered to unread.
+    const dropFromUnreadList = () => {
+        if (key === 'notifications' && notificationFilter.value === 'unread') {
+            notifications.value = notifications.value.filter((x) => x._id !== data._id);
+        }
+    };
+
     if(data.notSeen && !data.notSeen.includes(userId.value)) {
         if(redirect) {
             clearFilterSignal.value++;
@@ -610,6 +661,7 @@ function markRead(data, key, redirect = true) {
         } else {
             notifications.value = notifications.value.filter((x) => x._id !== data._id);
         }
+        dropFromUnreadList();
         return;
     }
 
@@ -627,6 +679,7 @@ function markRead(data, key, redirect = true) {
         } else {
             notifications.value = notifications.value.filter((x) => x._id !== data._id);
         }
+        dropFromUnreadList();
 
         if(key === 'notifications' ? totalNotification.value <= 0 : totalMentions.value <= 0) return;
 
@@ -656,6 +709,11 @@ function markAllRead(key) {
 
     if(key === 'notifications') {
         notifications.value.filter((x) => !x.seen).forEach((data) => data.seen = true);
+        // After marking everything read, all items belong to "archived" — so
+        // clear them out of the dropdown if the user is on the Unread view.
+        if (notificationFilter.value === 'unread') {
+            notifications.value = [];
+        }
     } else {
         mentions.value.filter((x) => !x.seen).forEach((data) => data.seen = true);
     }

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -347,6 +347,8 @@ export default {
         Logout: "Logout",
         Mark_all_as_read: "Mark all as read",
         Mark_all_as_complete: "Mark all as Complete",
+        View_Archive: "View Archive",
+        View_Unread: "View Unread",
         designation: "Designation",
         upgrade_now: "Upgrade Now",
         load_more: "Load more",


### PR DESCRIPTION
Previously the notification bell fetched every notification the user had ever received (read or unread) in a single combined list, making it hard to focus on actionable items. This change splits the dropdown into two views — Unread (default on every open) and Archive — gated by a single toggle button in the dropdown head.

Changes:
- Backend: GET /api/v1/app-notification/notification accepts a new optional `filter` query param ('unread' | 'archived'). 'unread' adds `notSeen: { $in: [userId] }` to the aggregation match; 'archived' adds `notSeen: { $nin: [userId] }`. Default is 'unread' to keep the bell focused on actionable items. Refactored the match clauses into a `baseMatch` array so the filter is appended cleanly; query shape and pagination are otherwise unchanged.
- Header.vue: added a `notificationFilter` ref ('unread' by default), a "View Archive" / "View Unread" toggle in the dropdown head, a `switchNotificationFilter()` handler that resets paging state and refetches, and an `openNotificationsDropdown()` helper that the bell click handlers now use so each fresh dropdown open lands in Unread. `markRead()` and `markAllRead()` clear the read items from the local list while the Unread filter is active so the dropdown reflects the filter without an extra refetch. The "Mark all as read" button visibility now keys off `notifications.length` (the list is already filtered to unread on this view) rather than the server-side `totalNotification` counter, which can lag and falsely hide the button.
- i18n: added Header.View_Archive / Header.View_Unread to the English locale; other locales fall back to English via vue-i18n until translators backfill (flagged as a follow-up).

Out of scope (deferred per user instruction): goals 3 and 4 from the original spec — creator-prefs fire policy verification and email preference parity audit.

## Pull Request Template Chooser
Please click the link that matches your contribution type to load the correct format. 

> **Note:** Clicking a link will reload this page and clear any text you've already typed here.

- [**Bug Fix**](?expand=1&template=bug_fix.md)
  *Use this for fixing broken logic or UI glitches.*

- [**New Feature**](?expand=1&template=new_feature.md)
  *Use this for adding new functionality or components.*

- [**Refactor**](?expand=1&template=refactor.md)
  *Use this for code cleanup, performance tweaks, or technical debt.*

---
### General Summary
*If you don't want to use a specific template, please provide a brief summary of your changes below.*
