### PR TITLE
refactor(projects): split Projects.vue and Task.vue mega-components (#167)

### DIFF
--- a/frontend/src/components/organisms/Task/Task.vue
+++ b/frontend/src/components/organisms/Task/Task.vue
@@ -17,7 +17,7 @@
                     <img v-if="!data.isParentTask" :src="lastChild ? pointer : extendedPointer" alt="" class="align-self-baseline parent__task-lastchild parent__task-image">
 
                     <!-- INVENTORY -->
-                    <img v-if="task.deletedStatusKey === 2" :src="inventoryIcon" alt="inventory" class="ml-5px" />
+                    <img v-if="task.deletedStatusKey === 2" :src="inventoryIcon" alt="inventory" class="ml-5px"/>
                     <img v-if="task.deletedStatusKey === 1" :src="deleteIcon" alt="delete" class="ml-5px">
 
                     <!-- TASK STATUS -->
@@ -46,7 +46,7 @@
                     <div @click="!showArchiveVar ? toggleTaskDetail(task) : ''" class="task_name_wrapper task_Name ml-6px">
                         <!-- TASK NAME -->
                         <span v-if="!editTaskName" class="text-ellipsis d-inline-block edit__taskname" :title="task.TaskName">
-                            {{task.TaskName}}
+                            {{ task.TaskName }}
                         </span>
                         <InputText
                             v-else
@@ -58,18 +58,18 @@
                             height="30px"
                             :isOutline="false"
                             @blur="editTaskName = false;"
-                            @enter="editTaskName = false, updateTaskName()"
+                            @enter="editTaskName = false, updateTaskName(taskName)"
                         />
                         <!-- Tagchips -->
                         <template v-if="checkApps('tags') && clientWidth > 768">
                             <div v-for="(item, index) in tagChipArray" :key="index" @click.stop="">
                                 <div v-if="(index < chipCount)" class="tagList">
-                                    <TagChip  :data="item" :isBorder="false"  :ids="ids" :tagsArray="projectData.tagsArray" :prjectGlobalPermission='projectData?.isGlobalPermission' :taskId="task._id" :sprintId="task.sprintId" :taskName="task.TaskName"/>
+                                    <TagChip :data="item" :isBorder="false" :ids="ids" :tagsArray="projectData.tagsArray" :prjectGlobalPermission='projectData?.isGlobalPermission' :taskId="task._id" :sprintId="task.sprintId" :taskName="task.TaskName"/>
                                 </div>
                                 <div v-if="index == chipCount" class="tagcount" @click="openDropDwon()"> +{{tagChipArray.length - chipCount}} </div>
                             </div>
                             <div v-if="(task.tagsArray && task.tagsArray.length > chipCount ) && checkPermission('task.task_tag',projectData?.isGlobalPermission) !== null">
-                                <CreateTagPopup ref="openDrop"  :task="data" @send:tagChipArray="(val)=>tagChipArray = val" @send:ids="(val)=>ids = val" :project="projectData" :chipCount="chipCount" :isTaskList="true" />
+                                <CreateTagPopup ref="openDrop" :task="data" @send:tagChipArray="(val)=>tagChipArray = val" @send:ids="(val)=>ids = val" :project="projectData" :chipCount="chipCount" :isTaskList="true"/>
                             </div>
                         </template>
                         <template v-if="clientWidth > 768">
@@ -95,12 +95,10 @@
                                 <img :src="editing" alt="editing" class="task-options-image">
                             </div>
                             <div v-if="(!task?.tagsArray || (task.tagsArray && task.tagsArray.length < 3 )) && checkPermission('task.task_tag',projectData?.isGlobalPermission) === true">
-                                <CreateTagPopup ref="openDrop" :task="data" @send:dropvisible="(val) => dropVisible = val" @send:tagChipArray="(val)=>tagChipArray = val" @send:ids="(val)=>ids = val" :project="projectData" :chipCount="chipCount" :isTaskList="true" />
+                                <CreateTagPopup ref="openDrop" :task="data" @send:dropvisible="(val) => dropVisible = val" @send:tagChipArray="(val)=>tagChipArray = val" @send:ids="(val)=>ids = val" :project="projectData" :chipCount="chipCount" :isTaskList="true"/>
                             </div>
-                            <!-- Tag List -->
                         </div>
                     </div>
-                    <!-- <img :src="clockBlue" alt="clockBlue"> -->
                     <div id="modelListComponent" class="groupdFileOption sticky_options" v-if="!projectData?.deletedStatusKey && clientWidth <= 768">
                         <div class="d-flex align-items-center task-options-image img__parent-task ml-5px p3x-5px" v-if="data?.isParentTask && ((showArchiveVar || searchedTask) ? data?.subtaskArray?.length : data?.subTasks)" :style="`min-width: ${myParentCounts ? '64px' : ''}`">
                             <img :src="subTaskImage" alt="subTaskImage" class="mr-2px">
@@ -109,94 +107,24 @@
                                 {{myParentCounts > 99 ? "+99" : myParentCounts}}
                             </div>
                         </div>
-                        <DropDown :title="task.TaskName" v-if="showArchiveVar ? task.deletedStatusKey === 2 : task.deletedStatusKey === 0">
-                            <template #button>
-                                <img :ref="task._id+'options'" :src="horizontalDots" alt="horizontalDots" id="taskquickmenudriver">
-                            </template>
-    
-                            <template #options>
-                                <div id="taskquickmenu_driver">
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),copyTaskLink()" v-if="!showArchiveVar">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="linkIcon" alt="inventoryIcon">
-                                            <span>{{$t('ProjectDetails.copy_task_link')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),copyTaskKey()" v-if="!showArchiveVar">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="splitScreen" alt="inventoryIcon">
-                                            <span>{{$t('ProjectDetails.copy_task_key')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="(task.queueListArray == undefined || (task.queueListArray && task.queueListArray.indexOf(userId) == -1)) && (task.AssigneeUserId && task.AssigneeUserId.indexOf(userId) !== -1) && !showArchiveVar && checkPermission('task.queue_list',projectData.isGlobalPermission) == true" @click="$refs[task._id+`options`].click(),addToQueue('add')">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="cancelIcon" alt="addIcon">
-                                            <span>{{$t('ProjectDetails.add_que_list')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="(task.queueListArray && task.queueListArray.indexOf(userId) !== -1) && (task.AssigneeUserId && task.AssigneeUserId.indexOf(userId) !== -1) && !showArchiveVar && checkPermission('task.queue_list',projectData.isGlobalPermission) == true" @click="$refs[task._id+`options`].click(),addToQueue('remove')">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="cancelIcon" alt="addIcon">
-                                            <span>{{$t('ProjectDetails.remove_from_queue_list')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="(task.deletedStatusKey === undefined || task.deletedStatusKey === 0) && !showArchiveVar && checkPermission('task.task_archive',projectData.isGlobalPermission) == true" @click="$refs[task._id+`options`].click(), showSidebar = true, archive = true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="inventoryIcon" alt="inventoryIcon">
-                                            <span>{{$t('Projects.archive')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="task.deletedStatusKey === 2" @click="$refs[task._id+`options`].click(), updateTask(0)">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="inventoryIcon" alt="restoreInventoryIcon">
-                                            <span>{{$t('Projects.restore')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(), showSidebar = true, archive = false" v-if="checkPermission('task.task_delete',projectData.isGlobalPermission) == true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="deleteIcon" alt="deleteIcon">
-                                            <span>{{$t('Projects.delete')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),convertToSubTask()" v-if="checkPermission('task.sub_task_create',projectData.isGlobalPermission) === true && !showArchiveVar && task.isParentTask && checkPermission('task.task_convert_to_subtask',projectData.isGlobalPermission) === true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="subTaskIcon" alt="deleteIcon">
-                                            <span>{{$t('ProjectDetails.convert_subtask')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),convertToList()" v-if="checkPermission('project.project_sprint_create',projectData.isGlobalPermission) === true && !showArchiveVar && checkPermission('task.task_convert_to_list',projectData.isGlobalPermission) === true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="combinedIcon" />
-                                            <span>{{$t('ProjectDetails.convert_list')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),duplicateTask()" v-if="!showArchiveVar && checkPermission('task.task_duplicate',projectData.isGlobalPermission) === true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="copyIcon" class="copyIcon"/>
-                                            <span>{{$t('Projects.duplicate')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),moveTask()" v-if="!showArchiveVar && checkPermission('task.task_move',projectData.isGlobalPermission) == true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="moveIcon" />
-                                            <span>{{$t('ProjectDetails.move')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),mergeTask()" v-if="!showArchiveVar && checkPermission('task.task_merge',projectData.isGlobalPermission) == true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="mergeIcon" />
-                                            <span>{{$t('ProjectDetails.merge')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),convertToTask()" v-if="task.isParentTask === false && checkPermission('task.task_create',projectData.isGlobalPermission) === true && checkPermission('task.convert_to_task',projectData.isGlobalPermission) === true && !showArchiveVar">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="mergeIcon" />
-                                            <span>{{$t('ProjectDetails.convert_task')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                </div>
-                            </template>
-                        </DropDown>
+                        <TaskQuickMenu
+                            :task="task"
+                            :projectData="projectData"
+                            :showArchiveVar="showArchiveVar"
+                            :userId="userId"
+                            @copyLink="copyTaskLink"
+                            @copyKey="copyTaskKey"
+                            @queue="(action) => addToQueue(action)"
+                            @confirmArchive="showSidebar = true, archive = true"
+                            @restore="updateTask(0, archive)"
+                            @confirmDelete="showSidebar = true, archive = false"
+                            @convertToSubTask="convertToSubTask"
+                            @convertToList="convertToList"
+                            @duplicate="duplicateTask"
+                            @move="moveTask"
+                            @merge="mergeTask"
+                            @convertToTask="convertToTask"
+                        />
                     </div>
                 </div>
             </div>
@@ -221,8 +149,8 @@
                             :num-of-users="2"
                             imageWidth="30px"
                             :addUser="!showArchiveVar"
-                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event)"
-                            @removed="changeAssignee('remove', $event)"
+                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event, assigneeInProgress)"
+                            @removed="changeAssignee('remove', $event, assigneeInProgress)"
                             :isDisplayTeam="true"
                             :multiSelect="checkApps('MultipleAssignees')"
                         />
@@ -233,8 +161,8 @@
                             :num-of-users="2"
                             imageWidth="30px"
                             :addUser="!showArchiveVar"
-                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event)"
-                            @removed="changeAssignee('remove', $event)"
+                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event, assigneeInProgress)"
+                            @removed="changeAssignee('remove', $event, assigneeInProgress)"
                             :isDisplayTeam="true"
                             :multiSelect="checkApps('MultipleAssignees')"
                         />
@@ -253,7 +181,7 @@
                         />
                         <template v-else>
                             <span v-if="task.DueDate">{{convertDateFormat(task.DueDate,'',{showDayName:false})}}</span>
-                            <span v-else>{{$t('ProjectDetails.no_due_date')}}</span>
+                            <span v-else>{{ $t('ProjectDetails.no_due_date') }}</span>
                         </template>
                     </span>
 
@@ -270,7 +198,7 @@
                     <span class="key-new task_right" v-if="projectData.viewColumn?.find((x)=> x.key === 'TaskKey')?.show">
                         {{task.TaskKey}}
                     </span>
-                    
+
                     <!-- Created Date -->
                     <span class="key-new task_right" v-if="projectData.viewColumn?.find((x)=> x.key === 'created_date')?.show">
                         {{convertDateFormat(task.createdAt,'',{showDayName: false})}}
@@ -286,101 +214,31 @@
                         />
                     </span>
                     <template v-if="projectData?.viewColumn && projectData?.viewColumn.length && isCustomFields()">
-                        <CustomFieldListViewColumnComponent 
+                        <CustomFieldListViewColumnComponent
                             :projectData="projectData"
                             :task="task"
                         />
                     </template>
                     <!-- OPTIONS -->
                     <div id="modelListComponent" class="groupdFileOption sticky_options" v-if="!projectData?.deletedStatusKey">
-                        <DropDown :title="task.TaskName" v-if="showArchiveVar ? task.deletedStatusKey === 2 : task.deletedStatusKey === 0">
-                            <template #button>
-                                <img :ref="task._id+'options'" :src="horizontalDots" alt="horizontalDots" id="taskquickmenudriver">
-                            </template>
-
-                            <template #options>
-                                <div id="taskquickmenu_driver">
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),copyTaskLink()" v-if="!showArchiveVar">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="linkIcon" alt="inventoryIcon">
-                                            <span>{{$t('ProjectDetails.copy_task_link')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),copyTaskKey()" v-if="!showArchiveVar">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="splitScreen" alt="inventoryIcon">
-                                            <span>{{$t('ProjectDetails.copy_task_key')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="(task.queueListArray == undefined || (task.queueListArray && task.queueListArray.indexOf(userId) == -1)) && (task.AssigneeUserId && task.AssigneeUserId.indexOf(userId) !== -1) && !showArchiveVar && checkPermission('task.queue_list',projectData.isGlobalPermission) == true" @click="$refs[task._id+`options`].click(),addToQueue('add')">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="cancelIcon" alt="addIcon">
-                                            <span>{{$t('ProjectDetails.add_que_list')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="(task.queueListArray && task.queueListArray.indexOf(userId) !== -1) && (task.AssigneeUserId && task.AssigneeUserId.indexOf(userId) !== -1) && !showArchiveVar && checkPermission('task.queue_list',projectData.isGlobalPermission) == true" @click="$refs[task._id+`options`].click(),addToQueue('remove')">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="cancelIcon" alt="addIcon">
-                                            <span>{{$t('ProjectDetails.remove_from_queue_list')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="(task.deletedStatusKey === undefined || task.deletedStatusKey === 0) && !showArchiveVar && checkPermission('task.task_archive',projectData.isGlobalPermission) == true" @click="$refs[task._id+`options`].click(), showSidebar = true, archive = true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="inventoryIcon" alt="inventoryIcon">
-                                            <span>{{$t('Projects.archive')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption v-if="task.deletedStatusKey === 2" @click="$refs[task._id+`options`].click(), updateTask(0)">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="inventoryIcon" alt="restoreInventoryIcon">
-                                            <span>{{$t('Projects.restore')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(), showSidebar = true, archive = false" v-if="checkPermission('task.task_delete',projectData.isGlobalPermission) == true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="deleteIcon" alt="deleteIcon">
-                                            <span>{{$t('Projects.delete')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),convertToSubTask()" v-if="checkPermission('task.sub_task_create',projectData.isGlobalPermission) === true && !showArchiveVar && task.isParentTask && checkPermission('task.task_convert_to_subtask',projectData.isGlobalPermission) === true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="subTaskIcon" alt="deleteIcon">
-                                            <span>{{$t('ProjectDetails.convert_subtask')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),convertToList()" v-if="checkPermission('project.project_sprint_create',projectData.isGlobalPermission) === true && !showArchiveVar && checkPermission('task.task_convert_to_list',projectData.isGlobalPermission) === true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="combinedIcon" />
-                                            <span>{{$t('ProjectDetails.convert_list')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),duplicateTask()" v-if="!showArchiveVar && checkPermission('task.task_duplicate',projectData.isGlobalPermission) === true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="copyIcon" class="copyIcon"/>
-                                            <span>{{$t('Projects.duplicate')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),moveTask()" v-if="!showArchiveVar && checkPermission('task.task_move',projectData.isGlobalPermission) == true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="moveIcon" />
-                                            <span>{{$t('ProjectDetails.move')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),mergeTask()" v-if="!showArchiveVar && checkPermission('task.task_merge',projectData.isGlobalPermission) == true">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="mergeIcon" />
-                                            <span>{{$t('ProjectDetails.merge')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                    <DropDownOption @click="$refs[task._id+`options`].click(),convertToTask()" v-if="task.isParentTask === false && checkPermission('task.task_create',projectData.isGlobalPermission) === true && checkPermission('task.convert_to_task',projectData.isGlobalPermission) === true && !showArchiveVar">
-                                        <div class="d-flex align-items-center task_desc_icon">
-                                            <img :src="mergeIcon" />
-                                            <span>{{$t('ProjectDetails.convert_task')}}</span>
-                                        </div>
-                                    </DropDownOption>
-                                </div>
-                            </template>
-                        </DropDown>
+                        <TaskQuickMenu
+                            :task="task"
+                            :projectData="projectData"
+                            :showArchiveVar="showArchiveVar"
+                            :userId="userId"
+                            @copyLink="copyTaskLink"
+                            @copyKey="copyTaskKey"
+                            @queue="(action) => addToQueue(action)"
+                            @confirmArchive="showSidebar = true, archive = true"
+                            @restore="updateTask(0, archive)"
+                            @confirmDelete="showSidebar = true, archive = false"
+                            @convertToSubTask="convertToSubTask"
+                            @convertToList="convertToList"
+                            @duplicate="duplicateTask"
+                            @move="moveTask"
+                            @merge="mergeTask"
+                            @convertToTask="convertToTask"
+                        />
                     </div>
                 </div>
             </div>
@@ -392,625 +250,291 @@
             :confirmationString="`${archive ? 'archive' : 'delete'}`"
             :acceptButtonClass="archive ? 'btn-primary': 'btn-danger'"
             :acceptButton="`${archive ? $t('Projects.archive') : $t('Projects.delete')}`"
-            @confirm="updateTask(), showSidebar = false"
+            @confirm="updateTask(null, archive), showSidebar = false"
         />
-        <ConvertToSubTaskSidebar v-if="openConvertSubTaskSidebar === true" :closeSideBar="openConvertSubTaskSidebar"  
-            @isConvertSubtaskOPen="(val) => {sidebarOPen(val)}" :isMoveTask="openMoveSidebar" :openMoveSubTask="openMoveSubTask" 
+        <ConvertToSubTaskSidebar v-if="openConvertSubTaskSidebar === true" :closeSideBar="openConvertSubTaskSidebar"
+            @isConvertSubtaskOPen="(val) => {sidebarOPen(val)}" :isMoveTask="openMoveSidebar" :openMoveSubTask="openMoveSubTask"
             :isMergeTask="openMergeTask" :isDuplicate="duplicateTaskSidebar" :task="task" :isConvertTask="openConvertToTask" :isOpenSubTask="openSubTaskSideabr" :item="item"/>
-        <ConvertToList v-if="converrtToListSidebar === true" :openSidebar="converrtToListSidebar" @closeSidebar="(val) => {converrtToListSidebar = val}" :task="task" />
+        <ConvertToList v-if="converrtToListSidebar === true" :openSidebar="converrtToListSidebar" @closeSidebar="(val) => {converrtToListSidebar = val}" :task="task"/>
     </div>
 </template>
 
 <script setup>
-// PACKAGES
-import { ref, watch, defineProps, inject, defineEmits, defineComponent, computed, onMounted } from "vue"
+import { ref, watch, defineProps, inject, defineEmits, defineComponent, computed, onMounted } from 'vue';
 
-// COMPONENTS
-import DropDown from '@/components/molecules/DropDown/DropDown.vue'
-import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue'
-import Assignee from "@/components/molecules/Assignee/Assignee.vue"
-import InputText from "@/components/atom/InputText/InputText.vue"
-import Priority from "@/components/molecules/PriorityCompo/PriorityComp.vue"
-import TaskStatus from "@/components/atom/TaskStatus/TaskStatus.vue"
-import ProjectTaskType from "@/components/atom/TaskTypeSelection/TaskTypeSelection.vue"
+import Assignee from '@/components/molecules/Assignee/Assignee.vue';
+import InputText from '@/components/atom/InputText/InputText.vue';
+import Priority from '@/components/molecules/PriorityCompo/PriorityComp.vue';
+import TaskStatus from '@/components/atom/TaskStatus/TaskStatus.vue';
+import ProjectTaskType from '@/components/atom/TaskTypeSelection/TaskTypeSelection.vue';
 import DueDateCompo from '@/components/molecules/DueDateCompo/DueDateCompo.vue';
-import ConfirmationSidebar from "@/components/molecules/ConfirmationSidebar/ConfirmationSidebar.vue"
-import CreateTagPopup from "@/components/molecules/TagList/CreateTagPopup.vue";
+import ConfirmationSidebar from '@/components/molecules/ConfirmationSidebar/ConfirmationSidebar.vue';
+import CreateTagPopup from '@/components/molecules/TagList/CreateTagPopup.vue';
 import TagChip from '@/components/atom/TagChip/TagChip.vue';
 import ConvertToSubTaskSidebar from '@/components/molecules/ConvertToSubTaskSidebar/ConvertToSubTaskSidebar.vue';
 import ConvertToList from '@/components/molecules/ConvertToList/ConvertToList.vue';
-// UTILS
-import taskClass from "@/utils/TaskOperations";
-import { useConvertDate, useCustomComposable, useGetterFunctions } from "@/composable";
-import { useStore } from "vuex";
-import { useToast } from "vue-toast-notification"
-import { useRouter, useRoute } from "vue-router"
-import { useUpdateTasks } from "@/views/Projects/helper"
-import {customField} from '../../../plugins/customFieldView/helper.js';
-import { useI18n } from "vue-i18n";
-const { t } = useI18n();
 
-const {isCustomFields} = customField();
-const dropVisible = ref(false)
+import TaskQuickMenu from './components/TaskQuickMenu.vue';
+import { useTaskActions } from './composables/useTaskActions';
+import { useTaskMutations } from './composables/useTaskMutations';
+
+import { useConvertDate, useCustomComposable } from '@/composable';
+import { useStore } from 'vuex';
+import { customField } from '../../../plugins/customFieldView/helper.js';
+
+const { isCustomFields } = customField();
+const dropVisible = ref(false);
 const clientWidth = inject('$clientWidth');
-const projectRef = inject("selectedProject");
+const projectRef = inject('selectedProject');
 const userId = inject('$userId');
-const {getUser} = useGetterFunctions();
-const {getters,commit} = useStore();
-const companyId = inject("$companyId");
+const { getters } = useStore();
 const searchedTask = inject('searchedTask');
-const {convertDateFormat} = useConvertDate();
-const {checkPermission, checkApps} = useCustomComposable();
-const showArchiveVar = inject("showArchived");
-const $toast = useToast()
-const router = useRouter()
-const tagChipArray = ref()
-const ids = ref()
-const openConvertSubTaskSidebar = ref(false);
-const converrtToListSidebar = ref(false);
-const openMoveSubTask = ref(false);
-const openMoveSidebar = ref(false);
-const openMergeTask = ref(false);
-const duplicateTaskSidebar = ref(false);
-const route = useRoute();
-const chipCount = ref(2)
-const openSubTaskSideabr = ref(false);
-const {updateTaskByGroup} = useUpdateTasks();
+const { convertDateFormat } = useConvertDate();
+const { checkPermission, checkApps } = useCustomComposable();
+const showArchiveVar = inject('showArchived');
+const tagChipArray = ref();
+const ids = ref();
+const chipCount = ref(2);
 
 // IMAGES
-const dragIcon = require("@/assets/images/svg/move_table_icon.svg");
-const triangleBlack = require("@/assets/images/svg/triangleBlack.svg");
-const horizontalDots = require("@/assets/images/svg/horizontalDots.svg");
-const inventoryIcon = require("@/assets/images/inventory_2.png");
-const deleteIcon = require("@/assets/images/DeleteIcon.png");
-const addlistCheklistPlus = require("@/assets/images/svg/addlistCheklistPlus.svg");
-const addlistChecklist = require("@/assets/images/svg/addlistChecklist.svg");
-const editing = require("@/assets/images/editing.png");
-const subTaskImage = require("@/assets/images/subtask2.png");
-const pointer = require("@/assets/images/svg/pointer.svg");
-const extendedPointer = require("@/assets/images/svg/pointer_extended.svg");
-const chatIcon = require("@/assets/images/svg/ChatIcon.svg");
-const linkIcon = require("@/assets/images/png/link.png");
-const splitScreen = require("@/assets/images/png/splitscreen.png");
-const subTaskIcon = require("@/assets/images/png/subTaskIcon.png");
-const moveIcon = require("@/assets/images/png/moveIcon.png");
-const mergeIcon = require("@/assets/images/png/mergeIcon.png");
-const combinedIcon = require("@/assets/images/png/Combined_shape.png");
-const copyIcon = require("@/assets/images/copy.png");
-const cancelIcon = require("@/assets/images/svg/arrow_circle_up.svg");
-// const clockBlue = require("@/assets/images/svg/clock_timer_svg.svg");
+const dragIcon = require('@/assets/images/svg/move_table_icon.svg');
+const triangleBlack = require('@/assets/images/svg/triangleBlack.svg');
+const inventoryIcon = require('@/assets/images/inventory_2.png');
+const deleteIcon = require('@/assets/images/DeleteIcon.png');
+const addlistCheklistPlus = require('@/assets/images/svg/addlistCheklistPlus.svg');
+const addlistChecklist = require('@/assets/images/svg/addlistChecklist.svg');
+const editing = require('@/assets/images/editing.png');
+const subTaskImage = require('@/assets/images/subtask2.png');
+const pointer = require('@/assets/images/svg/pointer.svg');
+const extendedPointer = require('@/assets/images/svg/pointer_extended.svg');
+const chatIcon = require('@/assets/images/svg/ChatIcon.svg');
 
 // EMITS
-const emit = defineEmits(["toggle", "createTask"]);
+const emit = defineEmits(['toggle', 'createTask']);
 
-// COMPONENT
-defineComponent({
-    name: "Task-Component",
-
-    components: {
-        DropDown,
-        DropDownOption,
-        Assignee,
-        // InputText,
-        Priority,
-        TaskStatus,
-        DueDateCompo,
-        ConfirmationSidebar,
-        ProjectTaskType
-    }
-})
+defineComponent({ name: 'Task-Component' });
 
 const props = defineProps({
-    data: {
-        type: Object,
-        default: null
-    },
-    lastChild: {
-        type: Boolean,
-        default: false
-    },
-    parentAssignee: {
-        type: Array,
-        default: () => []
-    },
-    item: {
-        type: Object,
-        default: () => {}
-    },
-    projectObject: {
-        type: Object,
-        default: () => {}
-    }
-})
+    data: { type: Object, default: null },
+    lastChild: { type: Boolean, default: false },
+    parentAssignee: { type: Array, default: () => [] },
+    // Note: defaults must be undefined/null (not {}). The projectData computed
+    // below treats truthy projectObject as authoritative and falls back to
+    // injected `selectedProject` otherwise; an empty-object default would skip
+    // the fallback and crash on `projectData.value.taskStatusData.find(...)`.
+    item: { type: Object, default: null },
+    projectObject: { type: Object, default: null },
+});
 
 const showSidebar = ref(false);
 const archive = ref(false);
-const openDrop = ref()
+const openDrop = ref();
 
 const openDropDwon = () => {
-    if(checkPermission('task.task_tag',projectData.value?.isGlobalPermission) == true) {
-        openDrop.value.sendMethod()
+    if (checkPermission('task.task_tag', projectData.value?.isGlobalPermission) == true) {
+        openDrop.value.sendMethod();
     }
-}
+};
 
 const customFieldList = computed(() => (getters['settings/finalCustomFields'] && getters['settings/finalCustomFields'].length) ? JSON.parse(JSON.stringify(getters['settings/finalCustomFields'])) : []);
 
-const companyUsers = computed(() => getters["settings/companyUsers"]?.map((x) => x.userId))
+const companyUsers = computed(() => getters['settings/companyUsers']?.map((x) => x.userId));
 
 const projectData = computed(() => {
-    if(props.projectObject) {
+    if (props.projectObject) {
         return props.projectObject;
     } else {
         return projectRef.value;
     }
-})
+});
 
-const companyOwner = computed(() => {
-    return getters["settings/companyOwnerDetail"];
-})
 const sideScrollWidth = ref(769);
 const task = ref(props.data);
-const toggleTaskDetail = inject('toggleTaskDetail')
-const statusSearch = ref("");
+const toggleTaskDetail = inject('toggleTaskDetail');
+const statusSearch = ref('');
 const taskName = ref(props.data.TaskName);
 const editTaskName = ref(false);
-const openConvertToTask = ref(false)
 const assigneeInProgress = ref({});
 
-const dueDate = computed(() => props.data.DueDate)
+const dueDate = computed(() => props.data.DueDate);
 
-const projectStatus = computed(() => {
-    return projectData.value.taskStatusData.filter((x) => x.name?.toLowerCase().includes(statusSearch.value.toLowerCase()))
-})
-const projectTaskType = computed(() => {
-    return projectData.value.taskTypeCounts;
-})
-
-const taskStatus = computed(() => {
-    return projectData.value.taskStatusData.find((x) => x.key === task.value.statusKey)
-})
-const taskType = computed(() => {
-    return projectData.value.taskTypeCounts.find((x) => x.key === task.value.TaskTypeKey)
-})
+const projectStatus = computed(() => projectData.value.taskStatusData.filter((x) => x.name?.toLowerCase().includes(statusSearch.value.toLowerCase())));
+const projectTaskType = computed(() => projectData.value.taskTypeCounts);
+const taskStatus = computed(() => projectData.value.taskStatusData.find((x) => x.key === task.value.statusKey));
+const taskType = computed(() => projectData.value.taskTypeCounts.find((x) => x.key === task.value.TaskTypeKey));
 
 const sprintData = computed(() => {
     let sprintData = false;
     if (projectData.value && props.data) {
-        sprintData = props.data.folderObjId ? projectData.value?.sprintsfolders?.[props.data.folderObjId]?.sprintsObj?.[props.data.sprintId] : projectData.value?.sprintsObj?.[props.data.sprintId]
+        sprintData = props.data.folderObjId ? projectData.value?.sprintsfolders?.[props.data.folderObjId]?.sprintsObj?.[props.data.sprintId] : projectData.value?.sprintsObj?.[props.data.sprintId];
     }
-
     return sprintData || null;
-})
+});
+
 const permittedOptions = computed(() => {
     let users = [];
-    if(sprintData.value) {
-        if(props.data.isParentTask) {
-            if(sprintData.value?.private) {
+    if (sprintData.value) {
+        if (props.data.isParentTask) {
+            if (sprintData.value?.private) {
                 users = sprintData.value?.AssigneeUserId || [];
             } else {
-                if(projectData.value?.isPrivateSpace) {
-                    users = projectData.value?.AssigneeUserId || [];
-                } else {
-                    users = companyUsers.value;
-                }
+                users = projectData.value?.isPrivateSpace ? (projectData.value?.AssigneeUserId || []) : companyUsers.value;
             }
         } else {
-            if(sprintData.value?.private) {
-                users = props.parentAssignee.filter((x) => sprintData.value?.AssigneeUserId?.includes(x))
-            } else {
-                users = props.parentAssignee
-            }
+            users = sprintData.value?.private
+                ? props.parentAssignee.filter((x) => sprintData.value?.AssigneeUserId?.includes(x))
+                : props.parentAssignee;
         }
     }
 
-    if(projectData.value?.isPrivateSpace) {
+    if (projectData.value?.isPrivateSpace) {
         users = users.filter((x) => projectData.value?.AssigneeUserId.includes(x));
         return Array.from(new Set([...users, ...(props.data?.AssigneeUserId || [])]));
-    } else {
-        return users;
     }
-})
+    return users;
+});
+
 const nonPermittedOptions = computed(() => {
     let users = [];
-    if(sprintData.value) {
-        if(props.data.isParentTask) {
-            if(sprintData.value?.private) {
+    if (sprintData.value) {
+        if (props.data.isParentTask) {
+            if (sprintData.value?.private) {
                 users = (sprintData.value?.AssigneeUserId || []).filter((x) => x === userId.value);
             } else {
-                if(projectData.value?.isPrivateSpace) {
-                    users = (projectData.value?.AssigneeUserId || []).filter((x) => x === userId.value);
-                } else {
-                    users = [userId.value];
-                }
+                users = projectData.value?.isPrivateSpace
+                    ? (projectData.value?.AssigneeUserId || []).filter((x) => x === userId.value)
+                    : [userId.value];
             }
         } else {
-            users = (props.parentAssignee || [])?.filter((x) => x === userId.value)
-            if(sprintData.value?.private) {
-                users = users.filter((x) => sprintData.value?.AssigneeUserId?.includes(x))
+            users = (props.parentAssignee || [])?.filter((x) => x === userId.value);
+            if (sprintData.value?.private) {
+                users = users.filter((x) => sprintData.value?.AssigneeUserId?.includes(x));
             }
         }
     }
-    if(projectData.value?.isPrivateSpace) {
+    if (projectData.value?.isPrivateSpace) {
         users = users.filter((x) => projectData.value?.AssigneeUserId.includes(x));
-        return users;
-    } else {
-        return users;
     }
-})
+    return users;
+});
 
 watch(() => props.data, (newVal, oldVal) => {
-    if(JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
+    if (JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
         task.value = newVal;
         manageCustomField(customFieldList.value);
     }
 });
 
 watch(() => projectData.value?.viewColumn?.length, (newVal, oldVal) => {
-    if(JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
+    if (JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
         manageCustomField(customFieldList.value);
     }
 });
 watch(() => getters['settings/finalCustomFields'], (newVal) => {
     manageCustomField(newVal);
-},{deep:true});
+}, { deep: true });
 
-//onMounted
-
-const taskCollapsed = inject("taskCollapsed");
+const taskCollapsed = inject('taskCollapsed');
 onMounted(() => {
-    if(taskCollapsed.value !== undefined && !taskCollapsed.value) {
-        emit("toggle");
+    if (taskCollapsed.value !== undefined && !taskCollapsed.value) {
+        emit('toggle');
     }
     manageCustomField(customFieldList.value);
-})
+});
 
-function getUserData() {
-    const user = getUser(userId.value);
-    const userData = {
-        id: user.id,
-        Employee_Name: user.Employee_Name,
-        companyOwnerId: companyOwner.value.userId,
-    }
+// MUTATIONS
+const { updateTask, updateTaskName, changeStatus, changeTaskType, changeAssignee, updateDueDate, updatePriority } = useTaskMutations({ projectData, task, props });
 
-    return userData;
-}
-
-function changeRoute() {
-    const paramsObj = {
-        cid: companyId.value,
-        id: projectData.value._id,
-        sprintId: task.value.sprintId,
-        taskId: task.value._id
-    }
-
-    if(task.value.folderObjId) {
-        paramsObj.folderId = task.value.folderObjId;
-    }
-    router.push({
-        name: task.value.folderObjId? 'ProjectFolderSprintTask' : 'ProjectSprintTask',
-        params: paramsObj,
-        query: {...route.query, detailTab: "comment"}
-    })
-}
-
-function updateTask(value = null) {
-    const deletedStatusKey = value !== null ? value : archive.value ? 2 : 1;
-    const userData = getUserData();
-    const project = {
-        _id: projectData.value._id,
-        CompanyId: projectData.value.CompanyId,
-        lastTaskId: projectData.value.lastTaskId,
-        ProjectName: projectData.value.ProjectName,
-        ProjectCode: projectData.value.ProjectCode
-    }
-    taskClass.updateArchiveDelete({
-        companyId: companyId.value,
-        projectData: project,
-        sprintId: task.value.sprintId,
-        task: task.value,
-        folderId : task.value.folderObjId ? task.value.folderObjId : '',
-        userData,
-        deletedStatusKey,
-    })
-    .then((res) => {
-        let sprint = {};
-        if(task.value.folderObjId){
-            sprint = projectData.value.sprintsfolders[task.value.folderObjId].sprintsObj[task.value.sprintId];
-        }
-        else{
-            sprint = projectData.value.sprintsObj[task.value.sprintId];
-        }
-        sprint.tasks = sprint.tasks - (task.value.isParentTask ? ((task.value.subTasks || 0) + 1) : 1)
-        commit("projectData/mutateSprints",{op:'modified',data:{...sprint}});
-        if(res.status) {
-            $toast.success(t(`Toast.Task_${value !== null ? 'restored' : archive.value ? 'archived' : 'deleted'}_successfully`), { position: "top-right" })
-        }
-    })
-    .catch((err) => {
-        console.error(err);
-    })
-}
-
-// UPDATE TASK NAME
-function updateTaskName() {
-    if(taskName.value.trim().length < 3 || taskName.value.trim().length > 250) return;
-
-    const userData = getUserData();
-
-    const firebaseObj = {
-        'TaskName': taskName.value
-    }
-    let obj = {
-        'previousTaskName': props.data.TaskName,
-        'userName' : userData.Employee_Name
-    }
-    const project = {
-        _id: projectData.value._id,
-        CompanyId: projectData.value.CompanyId,
-        lastTaskId: projectData.value.lastTaskId,
-        ProjectName: projectData.value.ProjectName,
-        ProjectCode: projectData.value.ProjectCode
-    }
-
-    taskClass.updateTaskName({firebaseObj, projectData: project, taskData: props.data, obj, userData})
-    .then(() => {
-        $toast.success(t(`Toast.Task_name_updated_successfully`), {position: "top-right"})
-    })
-    .catch((err) => {
-        console.error(err);
-    })
-}
-
-// CHANGE STATUS
-function changeStatus(status) {
-    const statusIndex = projectData.value.taskStatusData.findIndex((x) => x.key === props.data.statusKey);
-    if(statusIndex === -1) return;
-    updateTaskByGroup(props.data, status, 0);
-}
-function changeTaskType(status) {
-    const statusIndex = projectData.value.taskTypeCounts.findIndex((x) => x.key === props.data.TaskTypeKey);
-    if(statusIndex === -1) return;
-    updateTaskByGroup(props.data, status, 4);
-}
-
-// CHANGE ASSIGNEE
-function changeAssignee(type, value) {
-    if(!value?.id) return;
-    if(assigneeInProgress.value[value?.id] && assigneeInProgress.value[value?.id] === type) return;
-    assigneeInProgress.value[value?.id] = type;
-
-    const userData = getUserData();
-
-    let operation = ""
-
-    if(type === "add") {
-        operation = "assigneeAdd"
-    } else if(type === 'remove') {
-        operation = "assigneRemove"
-    } else if(type === 'replace') {
-        operation = "replace"
-    }
-
-    let updateObject = {
-        AssigneeUserId : value.id
-    }
-
-    const project = {
-        _id: projectData.value._id,
-        CompanyId: projectData.value.CompanyId,
-        lastTaskId: projectData.value.lastTaskId,
-        ProjectName: projectData.value.ProjectName,
-        ProjectCode: projectData.value.ProjectCode
-    }
-
-    taskClass.updateAssignee({
-        firebaseObj: updateObject,
-        projectData: project,
-        taskData: props.data,
-        employeeName: getUser(value.id).Employee_Name,
-        type: operation,
-        userData
-    })
-    .then(() => {
-        if(operation === "assigneRemove"){
-           let index = task.value.AssigneeUserId.findIndex((x) => x === value.id);
-            task.value.AssigneeUserId.splice(index,1);
-            commit("projectData/mutateSearchTask", {op:"modified", data: [task.value]});
-        }
-        delete assigneeInProgress.value[value?.id];
-        $toast.success(t(`Toast.Assignee ${type === "add" || type === "replace" ? 'added' : 'removed'} successfully`), {position: "top-right"})
-    })
-    .catch((error) => {
-        delete assigneeInProgress.value[value?.id];
-        console.error("ERROR in changeAssignee: ", error);
-    })
-}
-
-// CHANGE DUE DATE
-const updateDueDate = (event) => {
-    try {
-        if(!event?.dateVal) return;
-        updateTaskByGroup(props.data, {seconds: new Date(event.dateVal).getTime()/1000}, 3);
-    } catch (error) {
-        console.error("ERROR in updateDueDate: ", error);
-    }
-}
-
-// CHANGE PRIORITY
-function updatePriority(val = null) {
-    if(!val) return;
-    updateTaskByGroup(props.data, val, 2);
-}
+// ACTIONS
+const {
+    openConvertSubTaskSidebar,
+    converrtToListSidebar,
+    openMoveSubTask,
+    openMoveSidebar,
+    openMergeTask,
+    duplicateTaskSidebar,
+    openSubTaskSideabr,
+    openConvertToTask,
+    changeRoute,
+    copyTaskLink,
+    copyTaskKey,
+    convertToSubTask,
+    sidebarOPen,
+    convertToList,
+    moveTask,
+    mergeTask,
+    duplicateTask,
+    convertToTask,
+    addToQueue,
+} = useTaskActions({ projectData, task, props });
 
 const myCounts = computed(() => {
     let total = 0;
-
-    if(getters["users/myCounts"]?.data?.[`task_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`]) {
-        total += getters["users/myCounts"]?.data?.[`task_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`] || 0
+    if (getters['users/myCounts']?.data?.[`task_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`]) {
+        total += getters['users/myCounts']?.data?.[`task_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`] || 0;
     }
-
     return total;
-})
+});
 const myParentCounts = computed(() => {
     let total = 0;
-
-    if(getters["users/myCounts"]?.data?.[`parentTask_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`]) {
-        total += getters["users/myCounts"]?.data?.[`parentTask_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`] || 0
+    if (getters['users/myCounts']?.data?.[`parentTask_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`]) {
+        total += getters['users/myCounts']?.data?.[`parentTask_${projectData.value._id}_${task.value.sprintId}_${task.value._id}_comments`] || 0;
     }
-
     return total;
-})
-
-// COPY TASK LINK
-const copyTaskLink = () => {
- let path;
-        let navigation = window.location.href;
-        let modifiedUrl;
-        let newnavigation = navigation.replace(/\?tab.*$/, '');
-
-        if (route.name === "Project") {
-        if (task.value.folderObjId) {
-            modifiedUrl = newnavigation.slice(0, -2);
-            path = `${modifiedUrl}/fs/${task.value.folderObjId}/${task.value.sprintId}/${task.value._id}`;
-        } else {
-            modifiedUrl = newnavigation.slice(0, -2);
-            path = `${modifiedUrl}/s/${task.value.sprintId}/${task.value._id}`;
-        }
-        }
-        if (route.name === "ProjectSprint" || route.name === "ProjectFolderSprint") {
-            path = `${newnavigation}/${task.value._id}`;
-        }
-        if (route.name === "ProjectFolder") {
-            modifiedUrl = newnavigation.replace(/\/f(.*)/, '');
-            path = `${modifiedUrl}/fs/${task.value.folderObjId}/${task.value.sprintId}/${task.value._id}`;
-        }
-        
-        const tabParamIndex = navigation.indexOf('?tab');
-        if (tabParamIndex !== -1) {
-            const tabParam = navigation.slice(tabParamIndex);
-            path += tabParam;
-        }
-
-        navigator.clipboard.writeText(path);
-        $toast.success(t("Toast.Link_is_Copied_to_clipboard"), { position: 'top-right' });
-}
-// COPY TASK KEY
-const copyTaskKey = () => {
-    navigator.clipboard.writeText(task.value.TaskKey);
-    $toast.success(t("Toast.Task_Key_is_Copied_to_clipboard"),{position: 'top-right'});
-}
-const convertToSubTask = () => {
-    openConvertSubTaskSidebar.value = true;
-    openSubTaskSideabr.value = true;
-}
-const sidebarOPen = (val) => {
-    openConvertSubTaskSidebar.value = val;
-    openMoveSubTask.value = false;
-    openMoveSidebar.value = false;
-    duplicateTaskSidebar.value = false;
-    openConvertToTask.value = false;
-    openMergeTask.value = false;
-    converrtToListSidebar.value = false;
-    openSubTaskSideabr.value = false;
-}
-const convertToList = () => {
-    converrtToListSidebar.value = true;
-}
-const moveTask = () => {
-    if(props.data.isParentTask === true){
-        openMoveSidebar.value = true;
-    }else if(props.data.isParentTask === false){
-        openMoveSubTask.value = true;
-    }
-    openConvertSubTaskSidebar.value = true;
-}
-const mergeTask= () => {
-    openConvertSubTaskSidebar.value = true;
-    openMergeTask.value = true;
-}
-const duplicateTask = () => {
-    openConvertSubTaskSidebar.value = true;
-    duplicateTaskSidebar.value = true;
-}
-
-const convertToTask = () => {
-    openConvertToTask.value = true;
-    openConvertSubTaskSidebar.value = true;
-}
-const addToQueue = (action) => {
-    try {
-        taskClass.updateQueueList({CompanyId:projectData.value.CompanyId, projectId:projectData.value._id, sprintId:props.data.sprintId, taskId:props.data._id,userId:userId.value,actionType:action, queueListArray: props.data.queueListArray})
-            .then(() => {
-                $toast.success(t(`Toast.Queue list ${action == 'add' ? 'added' : 'removed'} successfully`),{position: 'top-right'});
-            })
-            .catch((error) => {
-                console.error("ERROR in update addToQueue: ", error);
-                $toast.error(t('Toast.Queue_list_not_updated'),{position: 'top-right'});
-            })
-    } catch (error) {
-        console.error("ERROR in update addToQueue: ", error);
-    }
-};
-
+});
 
 const manageCustomField = (data) => {
     if (!(data && data.length)) {
         return;
     }
-    if(projectData.value?.viewColumn && projectData.value?.viewColumn.length){
+    if (projectData.value?.viewColumn && projectData.value?.viewColumn.length) {
         let count = 0;
-        let countFunction = (element) => {
-            if(count >= projectData.value?.viewColumn.length){
+        const countFunction = (element) => {
+            if (count >= projectData.value?.viewColumn.length) {
                 return;
-            }else{
-                let checkCustom = customFieldList.value.find((x)=> (x._id === element.key) && (x?.isDelete) && (x?.type === 'task') && (x?.global || x?.projectId.includes(task?.value?.ProjectID)));
-                if (checkCustom && Object.keys(checkCustom).length) {
-                    if(task.value.customField?.[element.key]){
-                        if(checkCustom.fieldType === 'phone'){
-                            task.value.customField[element.key] = {
-                                ...checkCustom,
-                                taskId:task.value._id,
-                                fieldValue:task.value.customField[element.key].fieldValue,
-                                fieldCode:task.value.customField[element.key].fieldCode,
-                                fieldFlag:task.value.customField[element.key].fieldFlag,
-                                fieldPattern:task.value.customField[element.key].fieldPattern
-                            }
-                        }else{
-                            task.value.customField[element.key] = {
-                                ...checkCustom,
-                                taskId:task.value._id,
-                                fieldValue:task.value.customField[element.key].fieldValue
-                            }
-                        }
-                        count ++;
-                        countFunction(projectData.value.viewColumn[count]);
-                    }else{
-                        delete checkCustom?.fieldPattern;
-                        delete checkCustom?.fieldValue;
-                        delete checkCustom?.fieldCode;
-                        delete checkCustom?.fieldFlag;
-                        checkCustom.taskId = task.value._id;
-                        let newObject = {
-                            [element.key]:checkCustom
+            }
+            const checkCustom = customFieldList.value.find((x) => (x._id === element.key) && (x?.isDelete) && (x?.type === 'task') && (x?.global || x?.projectId.includes(task?.value?.ProjectID)));
+            if (checkCustom && Object.keys(checkCustom).length) {
+                if (task.value.customField?.[element.key]) {
+                    if (checkCustom.fieldType === 'phone') {
+                        task.value.customField[element.key] = {
+                            ...checkCustom,
+                            taskId: task.value._id,
+                            fieldValue: task.value.customField[element.key].fieldValue,
+                            fieldCode: task.value.customField[element.key].fieldCode,
+                            fieldFlag: task.value.customField[element.key].fieldFlag,
+                            fieldPattern: task.value.customField[element.key].fieldPattern,
                         };
-                        task.value.customField = {
-                            ...task.value.customField,
-                            ...newObject
-                        }
-                        count ++;
-                        countFunction(projectData.value.viewColumn[count]);
+                    } else {
+                        task.value.customField[element.key] = {
+                            ...checkCustom,
+                            taskId: task.value._id,
+                            fieldValue: task.value.customField[element.key].fieldValue,
+                        };
                     }
-                }else{
-                    count ++;
+                    count++;
+                    countFunction(projectData.value.viewColumn[count]);
+                } else {
+                    delete checkCustom?.fieldPattern;
+                    delete checkCustom?.fieldValue;
+                    delete checkCustom?.fieldCode;
+                    delete checkCustom?.fieldFlag;
+                    checkCustom.taskId = task.value._id;
+                    const newObject = { [element.key]: checkCustom };
+                    task.value.customField = { ...task.value.customField, ...newObject };
+                    count++;
                     countFunction(projectData.value.viewColumn[count]);
                 }
+            } else {
+                count++;
+                countFunction(projectData.value.viewColumn[count]);
             }
-        }
-        countFunction(projectData.value.viewColumn[count])
+        };
+        countFunction(projectData.value.viewColumn[count]);
     }
 };
 </script>
 
 <style src="./style.css">
-    
+
 </style>

--- a/frontend/src/components/organisms/Task/components/TaskQuickMenu.vue
+++ b/frontend/src/components/organisms/Task/components/TaskQuickMenu.vue
@@ -1,0 +1,142 @@
+<template>
+    <DropDown :title="task.TaskName" v-if="showArchiveVar ? task.deletedStatusKey === 2 : task.deletedStatusKey === 0">
+        <template #button>
+            <img :ref="task._id+'options'" :src="horizontalDots" alt="horizontalDots" id="taskquickmenudriver">
+        </template>
+        <template #options>
+            <div id="taskquickmenu_driver">
+                <DropDownOption @click="closeAnd($emit('copyLink'))" v-if="!showArchiveVar">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="linkIcon" alt="inventoryIcon">
+                        <span>{{ $t('ProjectDetails.copy_task_link') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('copyKey'))" v-if="!showArchiveVar">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="splitScreen" alt="inventoryIcon">
+                        <span>{{ $t('ProjectDetails.copy_task_key') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption v-if="(task.queueListArray == undefined || (task.queueListArray && task.queueListArray.indexOf(userId) == -1)) && (task.AssigneeUserId && task.AssigneeUserId.indexOf(userId) !== -1) && !showArchiveVar && checkPermission('task.queue_list',projectData.isGlobalPermission) == true" @click="closeAnd($emit('queue', 'add'))">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="cancelIcon" alt="addIcon">
+                        <span>{{ $t('ProjectDetails.add_que_list') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption v-if="(task.queueListArray && task.queueListArray.indexOf(userId) !== -1) && (task.AssigneeUserId && task.AssigneeUserId.indexOf(userId) !== -1) && !showArchiveVar && checkPermission('task.queue_list',projectData.isGlobalPermission) == true" @click="closeAnd($emit('queue', 'remove'))">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="cancelIcon" alt="addIcon">
+                        <span>{{ $t('ProjectDetails.remove_from_queue_list') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption v-if="(task.deletedStatusKey === undefined || task.deletedStatusKey === 0) && !showArchiveVar && checkPermission('task.task_archive',projectData.isGlobalPermission) == true" @click="closeAnd($emit('confirmArchive'))">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="inventoryIcon" alt="inventoryIcon">
+                        <span>{{ $t('Projects.archive') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption v-if="task.deletedStatusKey === 2" @click="closeAnd($emit('restore'))">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="inventoryIcon" alt="restoreInventoryIcon">
+                        <span>{{ $t('Projects.restore') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('confirmDelete'))" v-if="checkPermission('task.task_delete',projectData.isGlobalPermission) == true">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="deleteIcon" alt="deleteIcon">
+                        <span>{{ $t('Projects.delete') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('convertToSubTask'))" v-if="checkPermission('task.sub_task_create',projectData.isGlobalPermission) === true && !showArchiveVar && task.isParentTask && checkPermission('task.task_convert_to_subtask',projectData.isGlobalPermission) === true">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="subTaskIcon" alt="deleteIcon">
+                        <span>{{ $t('ProjectDetails.convert_subtask') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('convertToList'))" v-if="checkPermission('project.project_sprint_create',projectData.isGlobalPermission) === true && !showArchiveVar && checkPermission('task.task_convert_to_list',projectData.isGlobalPermission) === true">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="combinedIcon"/>
+                        <span>{{ $t('ProjectDetails.convert_list') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('duplicate'))" v-if="!showArchiveVar && checkPermission('task.task_duplicate',projectData.isGlobalPermission) === true">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="copyIcon" class="copyIcon"/>
+                        <span>{{ $t('Projects.duplicate') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('move'))" v-if="!showArchiveVar && checkPermission('task.task_move',projectData.isGlobalPermission) == true">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="moveIcon"/>
+                        <span>{{ $t('ProjectDetails.move') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('merge'))" v-if="!showArchiveVar && checkPermission('task.task_merge',projectData.isGlobalPermission) == true">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="mergeIcon"/>
+                        <span>{{ $t('ProjectDetails.merge') }}</span>
+                    </div>
+                </DropDownOption>
+                <DropDownOption @click="closeAnd($emit('convertToTask'))" v-if="task.isParentTask === false && checkPermission('task.task_create',projectData.isGlobalPermission) === true && checkPermission('task.convert_to_task',projectData.isGlobalPermission) === true && !showArchiveVar">
+                    <div class="d-flex align-items-center task_desc_icon">
+                        <img :src="mergeIcon"/>
+                        <span>{{ $t('ProjectDetails.convert_task') }}</span>
+                    </div>
+                </DropDownOption>
+            </div>
+        </template>
+    </DropDown>
+</template>
+
+<script setup>
+import { getCurrentInstance, defineProps, defineEmits } from 'vue';
+import DropDown from '@/components/molecules/DropDown/DropDown.vue';
+import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue';
+import { useCustomComposable } from '@/composable';
+
+const { checkPermission } = useCustomComposable();
+
+const props = defineProps({
+    task: { type: Object, required: true },
+    projectData: { type: Object, required: true },
+    showArchiveVar: { type: Boolean, default: false },
+    userId: { type: String, default: '' },
+});
+
+defineEmits([
+    'copyLink',
+    'copyKey',
+    'queue',
+    'confirmArchive',
+    'restore',
+    'confirmDelete',
+    'convertToSubTask',
+    'convertToList',
+    'duplicate',
+    'move',
+    'merge',
+    'convertToTask',
+]);
+
+const instance = getCurrentInstance();
+
+function closeAnd() {
+    // Close the menu by clicking the trigger ref (kept for parity with original `$refs[task._id+'options'].click()`)
+    const ref = instance?.proxy?.$refs?.[props.task._id + 'options'];
+    if (ref && typeof ref.click === 'function') {
+        ref.click();
+    }
+}
+
+const horizontalDots = require('@/assets/images/svg/horizontalDots.svg');
+const inventoryIcon = require('@/assets/images/inventory_2.png');
+const deleteIcon = require('@/assets/images/DeleteIcon.png');
+const linkIcon = require('@/assets/images/png/link.png');
+const splitScreen = require('@/assets/images/png/splitscreen.png');
+const subTaskIcon = require('@/assets/images/png/subTaskIcon.png');
+const moveIcon = require('@/assets/images/png/moveIcon.png');
+const mergeIcon = require('@/assets/images/png/mergeIcon.png');
+const combinedIcon = require('@/assets/images/png/Combined_shape.png');
+const copyIcon = require('@/assets/images/copy.png');
+const cancelIcon = require('@/assets/images/svg/arrow_circle_up.svg');
+</script>

--- a/frontend/src/components/organisms/Task/composables/useTaskActions.js
+++ b/frontend/src/components/organisms/Task/composables/useTaskActions.js
@@ -1,0 +1,164 @@
+import { ref, inject } from 'vue';
+import { useToast } from 'vue-toast-notification';
+import { useI18n } from 'vue-i18n';
+import { useRouter, useRoute } from 'vue-router';
+import taskClass from '@/utils/TaskOperations';
+
+export function useTaskActions({ projectData, task, props }) {
+    const $toast = useToast();
+    const { t } = useI18n();
+    const router = useRouter();
+    const route = useRoute();
+
+    const userId = inject('$userId');
+    const companyId = inject('$companyId');
+
+    const openConvertSubTaskSidebar = ref(false);
+    const converrtToListSidebar = ref(false);
+    const openMoveSubTask = ref(false);
+    const openMoveSidebar = ref(false);
+    const openMergeTask = ref(false);
+    const duplicateTaskSidebar = ref(false);
+    const openSubTaskSideabr = ref(false);
+    const openConvertToTask = ref(false);
+
+    function changeRoute() {
+        const paramsObj = {
+            cid: companyId.value,
+            id: projectData.value._id,
+            sprintId: task.value.sprintId,
+            taskId: task.value._id,
+        };
+        if (task.value.folderObjId) paramsObj.folderId = task.value.folderObjId;
+        router.push({
+            name: task.value.folderObjId ? 'ProjectFolderSprintTask' : 'ProjectSprintTask',
+            params: paramsObj,
+            query: { ...route.query, detailTab: 'comment' },
+        });
+    }
+
+    const copyTaskLink = () => {
+        let path;
+        const navigation = window.location.href;
+        let modifiedUrl;
+        const newnavigation = navigation.replace(/\?tab.*$/, '');
+
+        if (route.name === 'Project') {
+            if (task.value.folderObjId) {
+                modifiedUrl = newnavigation.slice(0, -2);
+                path = `${modifiedUrl}/fs/${task.value.folderObjId}/${task.value.sprintId}/${task.value._id}`;
+            } else {
+                modifiedUrl = newnavigation.slice(0, -2);
+                path = `${modifiedUrl}/s/${task.value.sprintId}/${task.value._id}`;
+            }
+        }
+        if (route.name === 'ProjectSprint' || route.name === 'ProjectFolderSprint') {
+            path = `${newnavigation}/${task.value._id}`;
+        }
+        if (route.name === 'ProjectFolder') {
+            modifiedUrl = newnavigation.replace(/\/f(.*)/, '');
+            path = `${modifiedUrl}/fs/${task.value.folderObjId}/${task.value.sprintId}/${task.value._id}`;
+        }
+
+        const tabParamIndex = navigation.indexOf('?tab');
+        if (tabParamIndex !== -1) {
+            const tabParam = navigation.slice(tabParamIndex);
+            path += tabParam;
+        }
+
+        navigator.clipboard.writeText(path);
+        $toast.success(t('Toast.Link_is_Copied_to_clipboard'), { position: 'top-right' });
+    };
+
+    const copyTaskKey = () => {
+        navigator.clipboard.writeText(task.value.TaskKey);
+        $toast.success(t('Toast.Task_Key_is_Copied_to_clipboard'), { position: 'top-right' });
+    };
+
+    const convertToSubTask = () => {
+        openConvertSubTaskSidebar.value = true;
+        openSubTaskSideabr.value = true;
+    };
+
+    const sidebarOPen = (val) => {
+        openConvertSubTaskSidebar.value = val;
+        openMoveSubTask.value = false;
+        openMoveSidebar.value = false;
+        duplicateTaskSidebar.value = false;
+        openConvertToTask.value = false;
+        openMergeTask.value = false;
+        converrtToListSidebar.value = false;
+        openSubTaskSideabr.value = false;
+    };
+
+    const convertToList = () => {
+        converrtToListSidebar.value = true;
+    };
+
+    const moveTask = () => {
+        if (props.data.isParentTask === true) {
+            openMoveSidebar.value = true;
+        } else if (props.data.isParentTask === false) {
+            openMoveSubTask.value = true;
+        }
+        openConvertSubTaskSidebar.value = true;
+    };
+
+    const mergeTask = () => {
+        openConvertSubTaskSidebar.value = true;
+        openMergeTask.value = true;
+    };
+
+    const duplicateTask = () => {
+        openConvertSubTaskSidebar.value = true;
+        duplicateTaskSidebar.value = true;
+    };
+
+    const convertToTask = () => {
+        openConvertToTask.value = true;
+        openConvertSubTaskSidebar.value = true;
+    };
+
+    const addToQueue = (action) => {
+        try {
+            taskClass.updateQueueList({
+                CompanyId: projectData.value.CompanyId,
+                projectId: projectData.value._id,
+                sprintId: props.data.sprintId,
+                taskId: props.data._id,
+                userId: userId.value,
+                actionType: action,
+                queueListArray: props.data.queueListArray,
+            }).then(() => {
+                $toast.success(t(`Toast.Queue list ${action == 'add' ? 'added' : 'removed'} successfully`), { position: 'top-right' });
+            }).catch((error) => {
+                console.error('ERROR in update addToQueue: ', error);
+                $toast.error(t('Toast.Queue_list_not_updated'), { position: 'top-right' });
+            });
+        } catch (error) {
+            console.error('ERROR in update addToQueue: ', error);
+        }
+    };
+
+    return {
+        openConvertSubTaskSidebar,
+        converrtToListSidebar,
+        openMoveSubTask,
+        openMoveSidebar,
+        openMergeTask,
+        duplicateTaskSidebar,
+        openSubTaskSideabr,
+        openConvertToTask,
+        changeRoute,
+        copyTaskLink,
+        copyTaskKey,
+        convertToSubTask,
+        sidebarOPen,
+        convertToList,
+        moveTask,
+        mergeTask,
+        duplicateTask,
+        convertToTask,
+        addToQueue,
+    };
+}

--- a/frontend/src/components/organisms/Task/composables/useTaskMutations.js
+++ b/frontend/src/components/organisms/Task/composables/useTaskMutations.js
@@ -1,0 +1,159 @@
+import { inject } from 'vue';
+import { useStore } from 'vuex';
+import { useToast } from 'vue-toast-notification';
+import { useI18n } from 'vue-i18n';
+import { useGetterFunctions } from '@/composable';
+import { useUpdateTasks } from '@/views/Projects/helper';
+import taskClass from '@/utils/TaskOperations';
+
+export function useTaskMutations({ projectData, task, props }) {
+    const { commit, getters } = useStore();
+    const $toast = useToast();
+    const { t } = useI18n();
+    const { getUser } = useGetterFunctions();
+    const { updateTaskByGroup } = useUpdateTasks();
+
+    const userId = inject('$userId');
+    const companyId = inject('$companyId');
+
+    const companyOwner = () => getters['settings/companyOwnerDetail'];
+
+    function getUserData() {
+        const user = getUser(userId.value);
+        return {
+            id: user.id,
+            Employee_Name: user.Employee_Name,
+            companyOwnerId: companyOwner().userId,
+        };
+    }
+
+    function getProjectStub() {
+        return {
+            _id: projectData.value._id,
+            CompanyId: projectData.value.CompanyId,
+            lastTaskId: projectData.value.lastTaskId,
+            ProjectName: projectData.value.ProjectName,
+            ProjectCode: projectData.value.ProjectCode,
+        };
+    }
+
+    function updateTask(value = null, archiveFlag) {
+        const deletedStatusKey = value !== null ? value : archiveFlag ? 2 : 1;
+        const userData = getUserData();
+
+        taskClass.updateArchiveDelete({
+            companyId: companyId.value,
+            projectData: getProjectStub(),
+            sprintId: task.value.sprintId,
+            task: task.value,
+            folderId: task.value.folderObjId ? task.value.folderObjId : '',
+            userData,
+            deletedStatusKey,
+        }).then((res) => {
+            let sprint = {};
+            if (task.value.folderObjId) {
+                sprint = projectData.value.sprintsfolders[task.value.folderObjId].sprintsObj[task.value.sprintId];
+            } else {
+                sprint = projectData.value.sprintsObj[task.value.sprintId];
+            }
+            sprint.tasks = sprint.tasks - (task.value.isParentTask ? ((task.value.subTasks || 0) + 1) : 1);
+            commit('projectData/mutateSprints', { op: 'modified', data: { ...sprint } });
+            if (res.status) {
+                $toast.success(t(`Toast.Task_${value !== null ? 'restored' : archiveFlag ? 'archived' : 'deleted'}_successfully`), { position: 'top-right' });
+            }
+        }).catch((err) => {
+            console.error(err);
+        });
+    }
+
+    function updateTaskName(taskName) {
+        if (taskName.trim().length < 3 || taskName.trim().length > 250) return;
+
+        const userData = getUserData();
+
+        const firebaseObj = { TaskName: taskName };
+        const obj = {
+            previousTaskName: props.data.TaskName,
+            userName: userData.Employee_Name,
+        };
+
+        taskClass.updateTaskName({ firebaseObj, projectData: getProjectStub(), taskData: props.data, obj, userData })
+            .then(() => {
+                $toast.success(t('Toast.Task_name_updated_successfully'), { position: 'top-right' });
+            })
+            .catch((err) => {
+                console.error(err);
+            });
+    }
+
+    function changeStatus(status) {
+        const statusIndex = projectData.value.taskStatusData.findIndex((x) => x.key === props.data.statusKey);
+        if (statusIndex === -1) return;
+        updateTaskByGroup(props.data, status, 0);
+    }
+    function changeTaskType(status) {
+        const statusIndex = projectData.value.taskTypeCounts.findIndex((x) => x.key === props.data.TaskTypeKey);
+        if (statusIndex === -1) return;
+        updateTaskByGroup(props.data, status, 4);
+    }
+
+    function changeAssignee(type, value, assigneeInProgress) {
+        if (!value?.id) return;
+        if (assigneeInProgress.value[value?.id] && assigneeInProgress.value[value?.id] === type) return;
+        assigneeInProgress.value[value?.id] = type;
+
+        const userData = getUserData();
+
+        let operation = '';
+        if (type === 'add') operation = 'assigneeAdd';
+        else if (type === 'remove') operation = 'assigneRemove';
+        else if (type === 'replace') operation = 'replace';
+
+        const updateObject = { AssigneeUserId: value.id };
+
+        taskClass.updateAssignee({
+            firebaseObj: updateObject,
+            projectData: getProjectStub(),
+            taskData: props.data,
+            employeeName: getUser(value.id).Employee_Name,
+            type: operation,
+            userData,
+        }).then(() => {
+            if (operation === 'assigneRemove') {
+                const index = task.value.AssigneeUserId.findIndex((x) => x === value.id);
+                task.value.AssigneeUserId.splice(index, 1);
+                commit('projectData/mutateSearchTask', { op: 'modified', data: [task.value] });
+            }
+            delete assigneeInProgress.value[value?.id];
+            $toast.success(t(`Toast.Assignee ${type === 'add' || type === 'replace' ? 'added' : 'removed'} successfully`), { position: 'top-right' });
+        }).catch((error) => {
+            delete assigneeInProgress.value[value?.id];
+            console.error('ERROR in changeAssignee: ', error);
+        });
+    }
+
+    const updateDueDate = (event) => {
+        try {
+            if (!event?.dateVal) return;
+            updateTaskByGroup(props.data, { seconds: new Date(event.dateVal).getTime() / 1000 }, 3);
+        } catch (error) {
+            console.error('ERROR in updateDueDate: ', error);
+        }
+    };
+
+    function updatePriority(val = null) {
+        if (!val) return;
+        updateTaskByGroup(props.data, val, 2);
+    }
+
+    return {
+        getUserData,
+        updateTask,
+        updateTaskName,
+        changeStatus,
+        changeTaskType,
+        changeAssignee,
+        updateDueDate,
+        updatePriority,
+    };
+}

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -45,7 +45,7 @@
                                                 {{ projectData?.ProjectName }}
                                             </span>
                                         </template>
-                                        <div v-else class="position-re project-titlerename-input ml-10px mr-5px" :class="{'list-type-error': projectName.error }" >
+                                        <div v-else class="position-re project-titlerename-input ml-10px mr-5px" :class="{'list-type-error': projectName.error }">
                                             <input
                                                 type="text"
                                                 class="form-control project__name-input"
@@ -64,7 +64,7 @@
                                                 'type':projectName.type,
                                                 'event':$event.event})"
                                             />
-                                            <div class="red position-ab z-index-1 font-size-11 text-nowrap project__name-error">{{projectName.error}}</div>
+                                            <div class="red position-ab z-index-1 font-size-11 text-nowrap project__name-error">{{ projectName.error }}</div>
                                         </div>
 
                                         <div v-if="clientWidth <= 767" class="d-flex align-items-center">
@@ -81,14 +81,14 @@
                                                         class="d-flex align-items-center text-nowrap border-top-radius-10-px cursor-pointer h-100"
                                                         :ref="projectView"
                                                     >
-                                                    <img :src="publicIcon"  v-if="!projectData.isPrivateSpace" class="pr-10px vertical-middle"   alt="public-folder"/>
+                                                        <img :src="publicIcon" v-if="!projectData.isPrivateSpace" class="pr-10px vertical-middle" alt="public-folder"/>
                                                         <span class="font-size-14 text-ellipsis d-inline-block gray81 project__requirement">
-                                                            <img :src="activeTab !== 'EmbedView' 
-                                                                    ? projectComponentsIcons(projectData?.ProjectRequiredComponent?.find(x => x.keyName === activeTab)?.keyName)?.icon 
-                                                                    : projectComponentsIcons(projectData?.ProjectRequiredComponent?.find(x => x.name === embedViewName)?.type)?.icon"  alt="list" class="mr-5px">
+                                                            <img :src="activeTab !== 'EmbedView'
+                                                                    ? projectComponentsIcons(projectData?.ProjectRequiredComponent?.find(x => x.keyName === activeTab)?.keyName)?.icon
+                                                                    : projectComponentsIcons(projectData?.ProjectRequiredComponent?.find(x => x.name === embedViewName)?.type)?.icon" alt="list" class="mr-5px">
                                                             {{activeTab !== 'EmbedView' ? projectData?.ProjectRequiredComponent?.find(x => x.keyName === activeTab)?.name || "N/A" : embedViewName || "N/A"}}
                                                         </span>
-                                                        <img :src="listDropIcon" alt="ListDropIcon" :style="[{marginLeft : clientWidth <=375 ? '2px' : '10px'}]" />
+                                                        <img :src="listDropIcon" alt="ListDropIcon" :style="[{marginLeft : clientWidth <=375 ? '2px' : '10px'}]"/>
                                                     </div>
                                                 </template>
                                                 <template #options>
@@ -102,46 +102,46 @@
                                                                 <span class="d-flex align-items-center justify-content-center border-radius-6-px mr-20px bg-white border-gray view__activeproject-name">
                                                                     <img :src="view?.keyName ? activeTab === view.keyName ? projectComponentsIcons(view?.keyName)?.activeIcon || '' : projectComponentsIcons(view?.keyName)?.icon || '' : icons?.[view?.type] || ''" alt="view.icon" class="mr-0">
                                                                 </span>
-                                                                <span class="font-size-16 font-weight-500 text-ellipsis d-inline-block gray81 mw-66"  @click="handleViewName(view.name)">{{$t(`ViewList.${view.name}`)}}</span>
+                                                                <span class="font-size-16 font-weight-500 text-ellipsis d-inline-block gray81 mw-66" @click="handleViewName(view.name)">{{ $t(`ViewList.${view.name}`) }}</span>
                                                             </div>
-                                                            <span v-if="view.setAsDefault" class="mobile-defaultview-text font-size-12 font-weight-400 darkblue"><img class="list_make_as_defaultimg" :src="viewDefaultIcon" />
-                                                                {{$t('Projects.default_view')}}
+                                                            <span v-if="view.setAsDefault" class="mobile-defaultview-text font-size-12 font-weight-400 darkblue"><img class="list_make_as_defaultimg" :src="viewDefaultIcon"/>
+                                                                {{ $t('Projects.default_view') }}
                                                             </span>
                                                             <img class="ml-20px activeTab-tick" v-if="activeTab === view.keyName" :src="viewDefaultActive"/>
                                                         </div>
                                                     </DropDownOption>
                                                     <DropDownOption class="position-sti border d-flex justify-content-center addview__dropdown" @click="$refs[projectView].click(), $refs.all_views_dd.click()">
                                                         <div class="blue font-size-18 font-weight-700">
-                                                            + {{$t('Projects.add_view')}}
+                                                            + {{ $t('Projects.add_view') }}
                                                         </div>
                                                     </DropDownOption>
                                                 </template>
                                             </DropDown>
                                         </div>
                                     </div>
-                                <div class="key-wapper" v-if="clientWidth > 767">
-                                    <span class="text-ellipsis border-left font-size-13 text-uppercase key-text pl-11px pr-10px GunPowder"  :title="projectData.ProjectCode">
-                                        {{ projectData?.ProjectCode }}
-                                    </span>
+                                    <div class="key-wapper" v-if="clientWidth > 767">
+                                        <span class="text-ellipsis border-left font-size-13 text-uppercase key-text pl-11px pr-10px GunPowder" :title="projectData.ProjectCode">
+                                            {{ projectData?.ProjectCode }}
+                                        </span>
+                                    </div>
+                                    <img :src="publicFolder" class="vertical-middle" alt="public-folder" v-if="clientWidth > 767 && !projectData.isPrivateSpace"/>
                                 </div>
-                                <img :src="publicFolder" class="vertical-middle" alt="public-folder" v-if="clientWidth > 767 && !projectData.isPrivateSpace"/>
-                                </div>
-                            <div class="list-head-mid h-100" :class="{'desktop-view' : clientWidth > 767}" id="projectview_driver">
-                                <template v-if="clientWidth > 765">
-                                    <div class="d-flex align-items-center overflow-x-auto style-scroll view_list_scroll h-100">
-                                        <ViewsList
-                                            v-for="(view, index) in (viewsListArray)"
-                                            :key="view._id"
-                                            :id="view.keyName"
-                                            :item="view"
-                                            :active="activeTab === view.keyName"
-                                            :firstChild="index === 0"
-                                            :isDeleteDisabled="viewsListArray.length == 1"
-                                            :commentCount="view.keyName === 'Comments' ? myCounts?.[`project_${projectData._id}_comments`] || 0 : 0"
-                                            @click="activeTab = view.keyName,$router.replace({query: {tab: view.keyName}})"
-                                        />
-                                        <div class="project__requirementcomponent-wrapper" v-if="projectData?.ProjectRequiredComponent && (embedViews).length">
-                                        <DropDown :bodyClass="{'dropdown-width':true}" @isVisible="(val)=> !val? (renameValue = {name:'',id:''}) :''">
+                                <div class="list-head-mid h-100" :class="{'desktop-view' : clientWidth > 767}" id="projectview_driver">
+                                    <template v-if="clientWidth > 765">
+                                        <div class="d-flex align-items-center overflow-x-auto style-scroll view_list_scroll h-100">
+                                            <ViewsList
+                                                v-for="(view, index) in (viewsListArray)"
+                                                :key="view._id"
+                                                :id="view.keyName"
+                                                :item="view"
+                                                :active="activeTab === view.keyName"
+                                                :firstChild="index === 0"
+                                                :isDeleteDisabled="viewsListArray.length == 1"
+                                                :commentCount="view.keyName === 'Comments' ? myCounts?.[`project_${projectData._id}_comments`] || 0 : 0"
+                                                @click="activeTab = view.keyName,$router.replace({query: {tab: view.keyName}})"
+                                            />
+                                            <div class="project__requirementcomponent-wrapper" v-if="projectData?.ProjectRequiredComponent && (embedViews).length">
+                                                <DropDown :bodyClass="{'dropdown-width':true}" @isVisible="(val)=> !val? (renameValue = {name:'',id:''}) :''">
                                                     <template #button>
                                                         <div class="d-flex p9x-13px" ref="project_tabs_components" :class="{'bg-light-gray':activeTab == 'EmbedView'}">
                                                             <img :src="!selectedEmbedView ? icons[embedViews[0].type] : icons[selectedEmbedView.type]" alt="" class="list_make_as_defaultimg">
@@ -154,55 +154,47 @@
                                                     </template>
                                                     <template #options>
                                                         <template v-for="(element, index) in (embedViews)" :key="index">
-                                                        <div class="cursor-pointer d-flex embed-option justify-content-between"   @click="openEmbedView(element),$refs['project_tabs_components'].click()">
-                                                            <div class="align-items-center d-flex" v-if="element.id != renameValue.id">
-                                                                <img class="embed_view_dropdown mr-10-px" :src="icons[element.type]" alt="">
-                                                                <span class="d-block text-ellipsis embeded__element-name" :title="element.name">{{element.name}}</span>
-                                                            </div>
-                                                            <div v-if="element.id == renameValue.id" @click.stop="">
-                                                                    <InputText  v-model="renameValue.name"  :inputId="renameValue.id" :isDirectFocus="true" ></InputText>
-                                                            </div>
-                                                            <div v-if="element.id != renameValue.id" class="d-flex align-items-center p5x-0px" @click.stop="">
-                                                                <img :src="require('@/assets/images/svg/active-pin.svg')" v-if="element?.isPin && element.isPin"  class="ml-10px active__pin-img">
-                                                                <span class="notification-tick blinking position-sti ml-7px" v-if="element?.isPrivate"></span>                  
-                                                                <DropDown :id="Uid">
-                                                                        <template #button>         
-                                                                            <img :src="threedots" :ref="Uid" class="vertical-middle" />
+                                                            <div class="cursor-pointer d-flex embed-option justify-content-between" @click="openEmbedView(element),$refs['project_tabs_components'].click()">
+                                                                <div class="align-items-center d-flex" v-if="element.id != renameValue.id">
+                                                                    <img class="embed_view_dropdown mr-10-px" :src="icons[element.type]" alt="">
+                                                                    <span class="d-block text-ellipsis embeded__element-name" :title="element.name">{{ element.name }}</span>
+                                                                </div>
+                                                                <div v-if="element.id == renameValue.id" @click.stop="">
+                                                                    <InputText v-model="renameValue.name" :inputId="renameValue.id" :isDirectFocus="true"></InputText>
+                                                                </div>
+                                                                <div v-if="element.id != renameValue.id" class="d-flex align-items-center p5x-0px" @click.stop="">
+                                                                    <img :src="require('@/assets/images/svg/active-pin.svg')" v-if="element?.isPin && element.isPin" class="ml-10px active__pin-img">
+                                                                    <span class="notification-tick blinking position-sti ml-7px" v-if="element?.isPrivate"></span>
+                                                                    <DropDown :id="Uid">
+                                                                        <template #button>
+                                                                            <img :src="threedots" :ref="Uid" class="vertical-middle"/>
                                                                         </template>
                                                                         <template #options>
-                                                                                    <div class="">
-                                                                                        <ul class="p-0 m-0 justify-content-start cursor-pointer">
-                                                                                            <li class="embed-edit-options" @click.stop="renameValue = {name:element.name,id:element.id}">
-                                                                                                <img :src="renameImage" class="inner-tagedit-list-item embed__options"/>
-                                                                                                <span>{{$t('Projects.rename')}}</span>
-                                                                                            </li>
-                                                                                            <li v-if="false" class="embed-edit-options" @click="$refs[Uid][index].click()">
-                                                                                                <img :src="pin" class="inner-tagedit-list-item embed__options" />
-                                                                                                <span>{{$t('Projects.pin')}}</span>
-                                                                                            </li>
-                                                                                            <li v-if="false" class="embed-edit-options" @click="$refs[Uid][index].click()">
-                                                                                                <img :src="code" class="inner-tagedit-list-item embed__options" >
-                                                                                                <span>{{$t('Projects.edit_code')}}</span>
-                                                                                            </li>
-                                                                                            <li class="embed-edit-options" @click="copyToClipboard(element.id),$refs[Uid][index].click()">
-                                                                                                <img :src="copy" class="inner-tagedit-list-item embed__options" >
-                                                                                                <span>{{$t('Projects.copy_link')}}</span>
-                                                                                            </li> 
-                                                                                            <li class="embed-edit-options cursor-pointer" @click.stop="openDelete = {flag:true,data:element},$refs[Uid][index].click(),$refs.project_tabs_components.click()">
-                                                                                                <img :src="deleteImage" class="inner-tagedit-list-item embed__options"/>
-                                                                                                <span class="red">{{$t('Projects.delete')}}</span>
-                                                                                            </li>
-                                                                                        </ul>
-                                                                                    </div>
+                                                                            <div>
+                                                                                <ul class="p-0 m-0 justify-content-start cursor-pointer">
+                                                                                    <li class="embed-edit-options" @click.stop="renameValue = {name:element.name,id:element.id}">
+                                                                                        <img :src="renameImage" class="inner-tagedit-list-item embed__options"/>
+                                                                                        <span>{{ $t('Projects.rename') }}</span>
+                                                                                    </li>
+                                                                                    <li class="embed-edit-options" @click="copyToClipboard(element.id),$refs[Uid][index].click()">
+                                                                                        <img :src="copy" class="inner-tagedit-list-item embed__options">
+                                                                                        <span>{{ $t('Projects.copy_link') }}</span>
+                                                                                    </li>
+                                                                                    <li class="embed-edit-options cursor-pointer" @click.stop="openDelete = {flag:true,data:element},$refs[Uid][index].click(),$refs.project_tabs_components.click()">
+                                                                                        <img :src="deleteImage" class="inner-tagedit-list-item embed__options"/>
+                                                                                        <span class="red">{{ $t('Projects.delete') }}</span>
+                                                                                    </li>
+                                                                                </ul>
+                                                                            </div>
                                                                         </template>
-                                                            </DropDown>
+                                                                    </DropDown>
+                                                                </div>
+                                                                <div v-if="element.id == renameValue.id" class="d-flex align-items-center p5x-0px ml-5px">
+                                                                    <img :src="saveImage" class="save__cancel-img" @click.stop="() => { editViewName(element)}">
+                                                                    <img :src="cancelImage" class="save__cancel-img ml-5px" @click.stop="renameValue = {name:'',id:''}">
+                                                                </div>
                                                             </div>
-                                                            <div v-if="element.id == renameValue.id" class="d-flex align-items-center p5x-0px ml-5px" >
-                                                                <img :src="saveImage" class="save__cancel-img"  @click.stop="() => { editViewName(element)}">
-                                                                <img :src="cancelImage" class="save__cancel-img ml-5px" @click.stop="renameValue = {name:'',id:''} ">
-                                                            </div>
-                                                        </div>
-                                                    </template>
+                                                        </template>
                                                     </template>
                                                 </DropDown>
 
@@ -213,208 +205,45 @@
                                                     acceptButtonClass="btn-danger"
                                                     @confirm="() => deleteEmbedView()"
                                                     :acceptButton="$t('Projects.delete')"
-                                                    >
+                                                >
                                                     <template #body>
                                                         <div></div>
                                                     </template>
                                                 </ConfirmationSidebar>
+                                            </div>
                                         </div>
-                                    </div>
-                                    <div
-                                        class="d-flex align-items-center text-nowrap border-top-radius-10-px cursor-pointer view-list-wrapper h-100"
-                                    >
-                                    <DropDown v-if="checkPermission('project.view_list',projectData.isGlobalPermission) === true" maxHeight="80vh" :bodyClass="{'embed__dropdown':true}" id="embeddropdown" >
-                                        <template #button>
-                                        <div ref="embeddropdown" id="embeddropdown_button" class="d-flex  align-items-center justify-content-center font-size-14 view-list-title p0x-10px">
-                                            <img :src="addIcon" alt="addIcon" class="mr-10px">
-                                            <span>{{$t('Projects.view')}}</span>
-                                        </div>
-                                        </template>
-                                        <template #options>
-                                            <ViewsDropdown :projectData="projectData" @closeDropdown="$refs['embeddropdown'].click()" :tourId="'projectviewlist_driver'"/>
-                                        </template>
-                                    </DropDown>
-
-                                    </div>
-                                </template>
-                            </div>
-                            </div>
-                            <div class="list-head-right">
-                                <ul class="d-flex align-items-center m-0">
-                                    <li v-if="clientWidth > 767">
-                                        <img @click="open('filesLinks')" id="projectviewfiles_driver" :src="fileLinks" class="cursor-pointer"/>
-                                    </li>
-                                    <li class="ml-10px"  v-if="clientWidth > 767" :class="clientWidth>767 ? 'mr-10px' : 'm-0'">
-                                        <img @click="open('audio')" id="projectviewaudio_driver" :src="audio" alt="audio" class="cursor-pointer"/>
-                                    </li>
-                                    <li v-if="clientWidth > 767">
-                                        <div class="position-re">
-                                            <a href.prevent="#" @click="openProjectWatcher = true" class="d-flex align-items-center justify-content-center border border-radius-5-px open__watcher cursor-pointer">
-                                                <img id="projectviewwatch_driver" :src="eyeIcon">
-                                            </a>
-                                            <span class="sprint-watcher-count">{{ Object.keys(projectData?.watchers || {})?.length || 0 }}</span>
-                                        </div>
-                                    </li>
-                                    <li :style="[{marginLeft : clientWidth > 767 ? '1rem' : '20px'}]" class="audio-list-wrapper" >
-                                        <DropDown maxHeight="64dvh" class="audio_dropdown" :bodyClass="{'assigneelist-audiofile-dropdown' : true}"  >
-                                            <template #head v-if="clientWidth<=767">
-                                                <div class="mobiledropdown-projecttitleimage-wrapper">
-                                                    <span v-if="projectData?.projectIcon && projectData?.projectIcon.type === 'color'" class="d-flex align-items-center justify-content-center ml-9px" :class="{'inital-box' : clientWidth > 767 , 'project-firtsleeter-box' : clientWidth <=767}" :style="[{'background-color': projectData?.projectIcon.data}]">{{ projectData?.ProjectName.charAt(0).toUpperCase()}}</span>
-                                                    <template v-else-if="projectData?.projectIcon && projectData?.projectIcon?.type === 'image'">
-                                                        <WasabiImage thumbnail="60x60" class="profile-sm-square mobile-projectlist-icon" v-if="!projectData.projectIcon.data.includes('http')" :data="{url: projectData.projectIcon.data, filename: projectData.projectIcon.data.split('/').pop(), extension: projectData.projectIcon.data.split('/').pop().split('.').pop()}"/>
-                                                        <img v-else class="profile-sm-square mobile-projectlist-icon" :src="projectData.projectIcon.data" alt=""/>
-                                                    </template>
-                                                    <div class="list-text-wrapper">
-                                                    <span v-if="!editProject2" class="text-ellipsis font-weight-bold text-capitalize black list-view-header-title ml-12px"  @dblclick="projectName.value = projectData?.ProjectName, editProject = true" :title="projectData.ProjectName">
-                                                        {{ projectData?.ProjectName }} 
-                                                    </span>
-                                                    <!-- <span v-if="editProject2 ">
-                                                        <input
-                                                            type="text"
-                                                            class="form-control"
-                                                            v-model.trim="projectName.value"
-                                                            placeholder="Project name"
-                                                            style="height: 20px;"
-                                                            :maxLength="250"
-                                                            :minLength="3"
-                                                            :isOutline="false"
-                                                            :isDirectFocus="true"
-                                                            @blur="editProject2 = false"
-                                                            :style="{borderColor: !projectName.error.length ? '#cecece' : 'red'}"
-                                                            @keypress.enter="projectName.value !== projectData?.ProjectName ? updateProjectName() : editProject2 = false"
-                                                            @keyup="checkErrors({'field':projectName,
-                                                            'name':projectName.name,
-                                                            'validations':projectName.rules,
-                                                            'type':projectName.type,
-                                                            'event':$event.event})"
-                                                        />
-                                                        <div class="red position-ab z-index-1 font-size-11 text-nowrap" style="bottom: -10px; left: 0px;">{{projectName.error}}</div>
-                                                    </span> -->
-                                                </div>
-                                                </div>
-                                            </template>
-                                            <template #button>
-                                                <button class="cursor-pointer dot-btn border-0" :ref="`projectdd_${projectData._id || ''}`">
-                                                    <img :src="clientWidth > 767 ? horizontalDots : horizontalDotsMobile" id="projectoptions_driver" />
-                                                </button>
-                                            </template>
-                                            <template #options>
-                                                <!-- <DropDownOption @click="toggleShowAllTasks(!projectData?.showAllTasks)" v-if="false">
-                                                    <div class="d-flex justify-content-between w-100">
-                                                        <span>Show all Tasks</span>
-                                                        <Toggle :modelValue="projectData?.showAllTasks" @click="toggleShowAllTasks(!projectData?.showAllTasks)" class="filter-toggle" width="20"/>
+                                        <div class="d-flex align-items-center text-nowrap border-top-radius-10-px cursor-pointer view-list-wrapper h-100">
+                                            <DropDown v-if="checkPermission('project.view_list',projectData.isGlobalPermission) === true" maxHeight="80vh" :bodyClass="{'embed__dropdown':true}" id="embeddropdown">
+                                                <template #button>
+                                                    <div ref="embeddropdown" id="embeddropdown_button" class="d-flex align-items-center justify-content-center font-size-14 view-list-title p0x-10px">
+                                                        <img :src="addIcon" alt="addIcon" class="mr-10px">
+                                                        <span>{{ $t('Projects.view') }}</span>
                                                     </div>
-                                                </DropDownOption> -->
-                                                <div id="projectoptionslist_driver">
-                                                    <DropDownOption v-if="projectData?.isPrivateSpace && clientWidth<=767" class="border-bottom mb-20px">
-                                                        <Assignee
-                                                            class="assignee-data ml-15px"
-                                                            :users="projectData.AssigneeUserId"
-                                                            :options="[...users.map((x) => x._id), ...teams.map((x) => 'tId_'+x._id)]"
-                                                            :imageWidth="clientWidth>1024 ? '30px' : '25px'"
-                                                            :num-of-users="clientWidth>1024 ? 4 : 2"
-                                                            :addUser="checkPermission('project.project_assignee',projectData.isGlobalPermission) === true"
-                                                            :showAddUser="true"
-                                                            @selected="changeAssignee('add', $event)"
-                                                            @removed="changeAssignee('remove', $event)"
-                                                            :isDisplayTeam="true"
-                                                            :z-index-assigne="8"
-                                                        />
-                                                    </DropDownOption>
-                                                    <template v-if="clientWidth<=767" >
-                                                        <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(), openProjectWatcher = true">
-                                                            <div :style="[{padding : clientWidth <= 767 ? '10px 0px !important' : '3.5px 10px !important'}]"  class="d-flex align-items-center">
-                                                                <div class="position-re mr-15px">
-                                                                    <div class="d-flex align-items-center justify-content-center border border-radius-5-px open__watcher">
-                                                                        <img :src="eyeIcon">
-                                                                    </div>
-                                                                    <span class="sprint-watcher-count">{{ Object.keys(projectData?.watchers || {})?.length || 0 }}</span>
-                                                                </div>
-                                                                <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.watchers')}}</span>
-                                                            </div>
-                                                        </DropDownOption>
-                                                        <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(), open('filesLinks')" >
-                                                            <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                                <div class="d-flex align-items-center">
-                                                                    <img :src="fileLink" class="mr-20px" />
-                                                                </div>
-                                                                <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.files_links')}}</span>
-                                                            </div>
-                                                        </DropDownOption>
-                                                        <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(), open('audio')" class="border-bottom pb-20px">
-                                                            <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                                <div class="d-flex align-items-center">
-                                                                    <img :src="audioLinkMobile" class="mr-20px" />
-                                                                </div>
-                                                                <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.audio_files')}}</span>
-                                                            </div>
-                                                        </DropDownOption>
-                                                    </template>
-                                                    <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(),openPermissionSidebar()" v-if="checkPermission('settings.settings_security_permissions') !== null">
-                                                        <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                            <div class="d-flex align-items-center">
-                                                                <img :src="lockIcon" alt="lockIcon" class="mr-20px">
-                                                            </div>
-                                                            <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.project_permissions')}}</span>
-                                                        </div>
-                                                    </DropDownOption>
-                                                    <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(), projectName.value = projectData?.ProjectName, editProject = true" v-if="checkPermission('project.project_name_edit',projectData.isGlobalPermission) === true">
-                                                        <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                            <div class="d-flex align-items-center">
-                                                                <img :src="listIcon" alt="listIcon" class="mr-20px">
-                                                            </div>
-                                                            <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.rename')}}</span>
-                                                        </div>
-                                                    </DropDownOption>
-                                                    <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(), showColorAvatar = true, assignAvatarData({id: projectData._id, name: projectData.ProjectName, icon: projectData?.projectIcon})" v-if="checkPermission('project.project_create',projectData.isGlobalPermission) === true">
-                                                        <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                            <div class="d-flex align-items-center">
-                                                                <img :src="colorPalletIcon" alt="colorPalletIcon" class="mr-20px">
-                                                            </div>
-                                                            <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.color_avatar')}}</span>
-                                                        </div>
-                                                    </DropDownOption>
-                                                    <DropDownOption v-if="false">
-                                                        <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                            <div class="d-flex align-items-center">
-                                                                <img :src="copyIcon" alt="copyIcon" class="mr-20px">
-                                                            </div>
-                                                            <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.duplicate')}}</span>
-                                                        </div>
-                                                    </DropDownOption>
-                                                    <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(), showSidebar = true, archive=0" v-if="checkPermission('project.project_close',projectData.isGlobalPermission) === true">
-                                                        <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                            <div class="d-flex align-items-center">
-                                                                <img :src="cancelIcon" alt="cancelIcon" class="mr-20px">
-                                                            </div>
-                                                            <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.close_project')}}</span>
-                                                        </div>
-                                                    </DropDownOption>
-                                                    <!-- <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(), showSidebar = true,archive=1">
-                                                        <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                            <div class="d-flex align-items-center">
-                                                                <img :src="inventoryIcon" alt="inventoryIcon" class="mr-20px">
-                                                            </div>
-                                                            <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.archive')}}</span>ee
-                                                        </div>
-                                                    </DropDownOption> -->
-                                                    <DropDownOption  v-if="checkPermission('project.project_delete',projectData.isGlobalPermission) === true" @click="$refs[`projectdd_${projectData._id || ''}`].click(), showSidebar = true,archive=2">
-                                                        <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
-                                                            <div class="d-flex align-items-center">
-                                                                <img :src="deleteIcon" alt="deleteIcon" class="mr-20px">
-                                                            </div>
-                                                            <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{$t('Projects.delete')}}</span>
-                                                        </div>
-                                                    </DropDownOption>
-                                                </div>
-                                            </template>
-                                        </DropDown>
-                                    </li>
-                                </ul>
+                                                </template>
+                                                <template #options>
+                                                    <ViewsDropdown :projectData="projectData" @closeDropdown="$refs['embeddropdown'].click()" :tourId="'projectviewlist_driver'"/>
+                                                </template>
+                                            </DropDown>
+                                        </div>
+                                    </template>
+                                </div>
                             </div>
+                            <ProjectActionsBar
+                                :projectData="projectData"
+                                :clientWidth="clientWidth"
+                                :users="users"
+                                :teams="teams"
+                                @openSidebar="open"
+                                @openWatcher="openProjectWatcher = true"
+                                @changeAssignee="(type, $event) => changeAssignee(type, $event)"
+                                @openPermissionSidebar="openPermissionSidebar"
+                                @startEditName="projectName.value = projectData?.ProjectName; editProject = true"
+                                @openColorAvatar="showColorAvatar = true; assignAvatarData({id: projectData._id, name: projectData.ProjectName, icon: projectData?.projectIcon})"
+                                @archiveProject="(val) => { showSidebar = true; archive = val }"
+                            />
                         </div>
                         <div v-if="showLoader" class="d-flex box-shadow-6 position-fi z-index-10 right-22px bottom-22px bg-white p-10px border-radius-5-px align-items-center">
-                            <div class="progress-container d-flex align-items-center position-re ">
+                            <div class="progress-container d-flex align-items-center position-re">
                                 <div class="progress-circle" :style="circleStyle">
                                     <span class="progress-text">{{ currentProgress }}%</span>
                                 </div>
@@ -435,173 +264,42 @@
                             ]"
                             :style="{height: clientWidth > 767 ? 'calc(100% - 48px)' : 'calc(100% - 62px)'}"
                         >
-                            <div class="task-assigneesearch-groupbywrapper" :class="{'overflow-auto' : clientWidth <=767}">
-                                <div class="d-flex align-items-center justify-content-between flex-wrap task-filtersearchassignee-wrapper" :class="{'w-545' : clientWidth <=767 }" v-if="['ProjectListView', 'Calendar', 'ProjectKanban','TableView'].includes(activeTab)">
-                                    <div class="d-flex align-items-center justify-content-start task-filtersearch" :class="[{ 'mb-10px': clientWidth <= 767 }]" :style="{width: (clientWidth <= 767 ? '100%' : '')}" v-if="!showArchived">
-                                        <TaskFilter :projectData="projectData" @apply="applyFilter" @clear="clearFilter" v-if="Object.keys(projectData).length > 0"/>
-                                        <div class="position-re task-fitler-search"  id="projectviewfiltersearch_driver">
-                                            <input type="text" :placeHolder="$t('PlaceHolder.search')" class="form-control" :style="{width: (clientWidth > 1025 ? '392px' : '90%')}" v-model="taskSearch">
-                                            <DropDown title="Search In" id="searchfilterdropdownoptions_driver" class="position-ab dropdown-image-horizontal" :bodyClass="{'search__in-dropdown' : true}">
-                                                <template #head>
-                                                    <h4 class="black font-size-13 font-weight-500 p-10px m-0 search__in" :class="{'border-bottom': clientWidth > 767}">
-                                                        {{$t('Projects.search_in')}}
-                                                    </h4>
-                                                </template>
-                                                <template #button>
-                                                    <img :src="horizontalDots" alt="horizontalDots" class="vertical-middle" id="searchfilterdropdown_driver">    
-                                                </template>
-                                                <template #options>
-                                                    <DropDownOption @click="taskDescriptionSearch || taskKeySearch ? taskNameSearch = !taskNameSearch : ''" class="task-serachstatus-dropdown border-radius-4-px">
-                                                        <span class="project-mobile-desc mr-10px">{{$t('Projects.task_name')}}</span>
-                                                        <Toggle  width="20" v-model="taskNameSearch" :disabled="taskNameSearch && !taskDescriptionSearch && !taskKeySearch" @change="searchMongoDB()"/>
-                                                    </DropDownOption>
-                                                    <DropDownOption @click="taskKeySearch = !taskKeySearch" class="task-serachstatus-dropdown border-radius-4-px">
-                                                        <span class="project-mobile-desc mr-10px">{{$t('Projects.task_key')}}</span>
-                                                        <Toggle width="20" v-model="taskKeySearch" @change="toggleSearch(),searchMongoDB()"/>
-                                                    </DropDownOption>
-                                                    <DropDownOption @click="taskDescriptionSearch = !taskDescriptionSearch" class="task-serachstatus-dropdown border-radius-4-px">
-                                                        <span class="project-mobile-desc mr-10px">{{$t('ProjectDetails.description')}}</span>
-                                                        <Toggle width="20" v-model="taskDescriptionSearch" @change="toggleSearch(),searchMongoDB()"/>
-                                                    </DropDownOption>
-                                                </template>
-                                            </DropDown>
-                                        </div>
-                                        <Assignee
-                                            :tourId="'projectviewassignee_driver'"
-                                            v-if="clientWidth> 767 && projectData?.isPrivateSpace"
-                                            class="assignee-data ml-15px"
-                                            :users="projectData.AssigneeUserId"
-                                            :options="[...users.map((x) => x._id), ...teams.map((x) => 'tId_'+x._id)]"
-                                            :imageWidth="clientWidth>1024 ? '30px' : '25px'"
-                                            :num-of-users="clientWidth>1024 ? 4 : 2"
-                                            :showAddUser="true"
-                                            :addUser="checkPermission('project.project_assignee',projectData.isGlobalPermission) === true"
-                                            @selected="changeAssignee('add', $event)"
-                                            @removed="changeAssignee('remove', $event)"
-                                            :isDisplayTeam="true"
-                                        />
-                                    </div>
-                                    <div v-if="['ProjectListView', 'ProjectKanban','TableView'].includes(activeTab)" class="d-flex align-items-center justify-content-end task-filter-assignee overflow-auto style-scroll" :style="`${showArchived ? 'width: 100%;' : ''}`" :class="clientWidth <= 767 ? 'justify-content-start' : ''">
-                                        <template v-if="!showArchived">
-                                            <button class="text-nowrap btn ai_button mr-1 cursor-pointer" @click="openAiSidebar = true" v-if="checkApps('AI',projectData) && checkPermission('artificial_intelligence',projectData?.isGlobalPermission) === true">
-                                                <img src="@/assets/images/svg/ai_image_white.svg" class="mr-10-px"/>
-                                                <span>{{$t('AI.write_with_ai')}}</span>
-                                            </button>
-                                            <DropDown id="group_by" class="mr-1 group_by">
-                                                <template #button>
-                                                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="group_by_status" @click="currentActive='group'">
-                                                        <div class="group-by-dropdown" :class = "{'active' : clientWidth <= 767 && currentActive == 'group' }">
-                                                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{$t('Projects.group_by')}} : </strong> <span :style="{color: (clientWidth <= 767 ? '#535358' : '#818181')}" :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}">{{$t(`Projects.${groupByOptions.find(x => x.id === groupBy).label}`)}}</span>
-                                                        </div>
-                                                    </button>
-                                                </template>
-                                                <template #options>
-                                                    <DropDownOption v-for="item in groupByOptions" :key="item.id" @click="groupBy = item.id,$refs.group_by_status.click(item)" :class="{'bg-light-gray' : item.id === groupBy}">
-                                                        <div>
-                                                            <img :src="item.image" :alt="item.label" class="pr-10px">
-                                                            <span :class="{'purple' : item.id === groupBy}">{{$t(`Projects.${item.label}`)}}</span>
-                                                        </div>
-                                                    </DropDownOption>
-                                                </template>
-                                            </DropDown>
-                                            <DropDown class="mr-1 group_by" v-if="activeTab === 'ProjectListView'">
-                                                <template #button>
-                                                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="expand_collapse" @click="currentActive='subtask'">
-                                                        <div class="group-by-dropdown current__dropdown" :class = "{'active' : clientWidth <= 767 && currentActive == 'subtask' }">
-                                                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{$t('Projects.subtask')}}: </strong> <span :style="{color: (clientWidth <= 767 ? '#535358' : '#818181')}" :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}"> {{collapsed ? $t('Projects.collapsed') : $t('Projects.expanded')}}</span>
-                                                        </div>
-                                                    </button>
-                                                </template>
-                                                <template #options>
-                                                    <DropDownOption @click="collapsed = false, $refs.expand_collapse.click()" :class="{'bg-light-gray' : !collapsed}">
-                                                        <span :class="{'purple' : !collapsed}">{{$t('Projects.expanded')}}</span>
-                                                    </DropDownOption>
-                                                    <DropDownOption @click="collapsed = true, $refs.expand_collapse.click()" :class="{'bg-light-gray' : collapsed}">
-                                                        <span :class="{'purple' : collapsed}">{{$t('Projects.collapsed')}}</span>
-                                                    </DropDownOption>
-                                                </template>
-                                            </DropDown>
-                                            <div class="mr-1 border-groupBy border-radius-6-px d-flex align-items-center assignee-filter manage__filter-users">
-                                                <div
-                                                    @click="manageFilterUsers(userId)"
-                                                    :class="{'bg-white' : filterUsers.includes(userId)}"
-                                                    class="border-radius-6-px border-right-radius-0 border-right cursor-pointer assignee-user font-size-12 font-weight-400 p7x-5px"
-                                                >
-                                                    <img :src="filterUsers.includes(userId) ? activeUserIcon : userIcon" alt="user icon" class="vertical-middle">
-                                                    <span class="font-size-12 font-weight-400 ml-7px"> {{$t('Projects.me')}} </span>
-                                                </div>
-                                                <div
-                                                    v-if="projectData?.isGlobalPermission === false  ? checkPermission('task.show_tasks',projectData.isGlobalPermission) === 2 || checkPermission('task.show_tasks',projectData.isGlobalPermission) === true : true"
-                                                    @click="userSidebar = !userSidebar"
-                                                    class="border-radius-6-px border-left-radius-0 cursor-pointer assignee-status p4x-5px"
-                                                    :class="{'bg-white blue' : filterUsers.length && filterUsers.filter((x) => x !== userId).length}"
-                                                >
-                                                    <img :src="filterUsers.length && filterUsers.filter((x) => x !== userId).length ? activeGroupIcon : groupIcon" alt="user icon">
-                                                    <span class="font-size-12 font-weight-400 ml-10px"> {{filterUsers.length && filterUsers.filter((x) => x !== userId).length ? `(${filterUsers.filter((x) => x !== userId).length})` : $t('ProjectDetails.assignee')}}</span>
-                                                </div>
-                                            </div>
-                                        </template>
-                                        <button class="archived-btn font-weight-400 d-flex align-items-center justify-content-between" :style="{color: (clientWidth <= 767 ? '#535358' : '')}" :class="{'outline-primary show-archived-active': showArchived, 'outline-secondary': !showArchived, 'border-radius-6-px font-size-14' : clientWidth <=767 , 'border-0 font-size-13' : clientWidth > 767 }">
-                                            <template v-if="showArchived">
-                                                <span class="font-weight-bold font-size-16 dark-gray">
-                                                    {{$t('ProjectSlider.archived_list')}}
-                                                </span>
-                                                <span v-if="!showArchivedProjects" @click="showArchived = false">
-                                                    {{$t('ProjectSlider.hide_archive')}}
-                                                </span>
-                                            </template>
-                                            <template v-else>
-                                                <span @click="showArchived = true" class="text-nowrap">
-                                                    {{$t('ProjectSlider.show_archive')}}
-                                                </span>
-                                            </template>
-                                        </button>
-                                    </div>
-                                    <div v-if="['Calendar'].includes(activeTab)" class="d-flex align-items-center justify-content-end task-filter-assignee style-scroll" :class="clientWidth <= 767 ? 'justify-content-start' : ''">
-                                        <div class="mr-1 border-groupBy border-radius-6-px d-flex align-items-center assignee-filter manage__filter-users">
-                                            <div
-                                                @click="manageFilterUsers(userId)"
-                                                :class="{'bg-white' : filterUsers.includes(userId)}"
-                                                class="border-radius-6-px border-right-radius-0 border-right cursor-pointer assignee-user font-size-12 font-weight-400 p7x-5px"
-                                            >
-                                                <img :src="filterUsers.includes(userId) ? activeUserIcon : userIcon" alt="user icon" class="vertical-middle">
-                                                <span class="font-size-12 font-weight-400 ml-7px">{{ $t('Projects.me') }} </span>
-                                            </div>
-                                            <div
-                                                v-if="projectData?.isGlobalPermission === false  ? checkPermission('task.show_tasks',projectData.isGlobalPermission) === 2 || checkPermission('task.show_tasks',projectData.isGlobalPermission) === true : true"
-                                                @click="userSidebar = !userSidebar"
-                                                class="border-radius-6-px border-left-radius-0 cursor-pointer assignee-status p4x-5px"
-                                                :class="{'bg-white blue' : filterUsers.length && filterUsers.filter((x) => x !== userId).length}"
-                                            >
-                                                <img :src="filterUsers.length && filterUsers.filter((x) => x !== userId).length ? activeGroupIcon : groupIcon" alt="user icon">
-                                                <span class="font-size-12 font-weight-400 ml-10px"> {{filterUsers.length && filterUsers.filter((x) => x !== userId).length ? `(${filterUsers.filter((x) => x !== userId).length})` : $t('ProjectDetails.assignee')}}</span>
-                                            </div>
-                                        </div>
-                                        <div class="d-flex align-items-center assignee-filter">
-                                            <div class="mr-1 group_by monthly-calendar monthly-calendar-view" @click="calendartoggle = true,rangeObjectFRun(calendarDate ? new Date(calenderSelectDate) : new Date())">
-                                                {{ calendarDate ? calendarDate : new Date().toLocaleString('default', { month: 'long', year: 'numeric' }) }}
-                                                <MonthlyCalendarMilestone
-                                                    v-if="calendartoggle"
-                                                    :rangeObject="rangeObject"
-                                                    :startDate="calendarDate ? new Date(calenderSelectDate) : new Date()"
-                                                    @startEndDate="handleStartEndDate"
-                                                />
-                                            </div>
-                                            <div class="mr-1 group_by d-flex">
-                                                <button type="button" title="Previous month" class="calendar-button" @click="prevMonth()">
-                                                    <span class="fc-icon fc-icon-chevron-left"></span>
-                                                </button>
-                                                <button type="button" title="Next month" class="calendar-button" @click="nextMonth()">
-                                                    <span class="fc-icon fc-icon-chevron-right"></span>
-                                                </button>
-                                            </div>
-                                            <div class="mr-1 group_by">
-                                                <button type="button" title="This month" class="calendar-button calendar-currentday-text" @click="defaultMonth()">{{ $t('Home.Today') }}</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <ProjectFiltersToolbar
+                                :activeTab="activeTab"
+                                :projectData="projectData"
+                                :clientWidth="clientWidth"
+                                :showArchived="showArchived"
+                                :showArchivedProjects="showArchivedProjects"
+                                v-model:taskSearch="taskSearch"
+                                v-model:taskNameSearch="taskNameSearch"
+                                v-model:taskKeySearch="taskKeySearch"
+                                v-model:taskDescriptionSearch="taskDescriptionSearch"
+                                :filterUsers="filterUsers"
+                                v-model:userSidebar="userSidebar"
+                                v-model:collapsed="collapsed"
+                                v-model:groupBy="groupBy"
+                                :groupByOptions="groupByOptions"
+                                :users="users"
+                                :teams="teams"
+                                :userId="userId"
+                                :calendartoggle="calendartoggle"
+                                :calendarDate="calendarDate"
+                                :calenderSelectDate="calenderSelectDate"
+                                :rangeObject="rangeObject"
+                                @applyFilter="applyFilter"
+                                @clearFilter="clearFilter"
+                                @search="searchMongoDB"
+                                @toggleSearch="toggleSearch"
+                                @manageFilterUsers="manageFilterUsers"
+                                @changeAssignee="(type, $event) => changeAssignee(type, $event)"
+                                @openAi="openAiSidebar = true"
+                                @update:showArchived="(v) => showArchived = v"
+                                @openCalendar="calendartoggle = true; rangeObjectFRun(calendarDate ? new Date(calenderSelectDate) : new Date())"
+                                @handleStartEndDate="handleStartEndDate"
+                                @prevMonth="prevMonth"
+                                @nextMonth="nextMonth"
+                                @defaultMonth="defaultMonth"
+                            />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
                                 :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView'}]"
@@ -625,8 +323,8 @@
                                 :activeTab="activeTab"
                                 :sprintLoading="sprintLoading"
                                 :commentType="'project'"
-                                />
-                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription" />
+                            />
+                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
                         </div>
                         <div class="position-ab z-index-1 p-5px border-radius-5-px text-center p0x-15px archived_wrapper" v-if="projectData?.deletedStatusKey === 2">
                             <div>
@@ -652,75 +350,36 @@
                         />
                     </div>
 
-                    <Sidebar
-                        :value="filterUsers.map((x) => ({value: x}))"
-                        :multiSelect="true"
-                        :enableSearch="true"
-                        :options="assigneeFilterOptions"
-                        v-model:visible="userSidebar"
-                        :title="$t('Projects.list_of_user')"
-                        @selected="manageFilterUsers($event.value)"
-                        @itemClicked="manageFilterUsers($event.value)"
-                        @removed="manageFilterUsers($event.value)"
-                        @clear="filterUsers = [], manageFilterUsers()"
+                    <ProjectSidebars
+                        :filterUsers="filterUsers"
+                        :assigneeFilterOptions="assigneeFilterOptions"
+                        v-model:userSidebar="userSidebar"
+                        v-model:isSidebar="isSidebar"
+                        :sidebarTitle="sidebarTitle"
+                        v-model:showColorAvatar="showColorAvatar"
+                        :savingAvatar="savingAvatar"
+                        :formData="formData"
+                        :projectData="projectData"
+                        :clientWidth="clientWidth"
+                        @manageFilterUsers="manageFilterUsers"
+                        @clearFilterUsers="filterUsers = []; manageFilterUsers()"
+                        @resetFormData="resetFormData"
+                        @saveAvatar="saveProjectAvatar"
+                        @updateFormData="(v) => formData.projectProfileField = v"
+                        @updateImage="updateImageValue"
                     />
-                    <Sidebar
-                        className="task-sub-sidebar"
-                        v-model:visible="isSidebar"
-                        :title="$t(`${sidebarTitle}`)"
-                        width="358px"
-                        :top="clientWidth <= 767 ? '0px' : '46px'"
-                    >
-                        <template #body>
-                            <FileAndLinks
-                                v-if="sidebarTitle === $t('Projects.Files_&_Links')"
-                                :attachments="projectData.attachments"
-                                :description=" projectData.description"
-                                @closeSidebar="(val) => isSidebar = val"
-                                :handleType="'project'"
-                                :selectedData="projectData"
-                            />
-                            <TaskAudioFiles
-                                v-else-if="sidebarTitle === $t('Projects.audio_files')"
-                                :key="`${projectData?._id}` + 'audiofiles'"
-                                :fromWhich="'project'"
-                                :selectedData="projectData"
-                            />
-                        </template>
-                    </Sidebar>
-                    <Sidebar
-                        v-model:visible="showColorAvatar"
-                        width="607px"
-                        :title="$t('Projects.change_color')"
-                        @update:visible="resetFormData()"
-                    >
-                        <template #head-right>
-                            <div>
-                                <button class="btn-primary p0x-10px" @click="saveProjectAvatar()">{{ $t('Projects.save') }}</button>
-                                <button class="outline-secondary p0x-10px ml-10px" @click="showColorAvatar = false">{{ $t('Projects.cancel') }}</button>
-                            </div>
-                        </template>
-                        <template #body>
-                            <div class="bg-white p-1 m-1 border-radius-8-px">
-                                <div v-if="savingAvatar" class="bg-blue position-ab z-index-1 h-100 w-100 saving__avtar-div">
-                                    <SpinnerComp :isSpinner="true"/>
-                                </div>
-                                <ProjectProfileForm v-model="formData.projectProfileField" :name="{value: formData.projectName} || {value: 'N/A'}" @update:image="(ele)=>{updateImageValue(ele)}"/>
-                            </div>
-                        </template>
-                    </Sidebar>
                 </template>
                 <template v-else>
                     <template v-if="projectData?.isRestrict === true">
                         <div class="section-right bg-white" :class="[{'position-re': projectData?.isRestrict === true}]">
-                        <UpgradYourPlanComponent
-                            v-if="projectData?.isRestrict === true"
-                            :buttonText="$t('Upgrades.upgrade_your_plan')"
-                            :lastTitle="$t('Upgrades.to_unlcok_project')"
-                            :secondTitle="$t('Upgrades.unlimited')"
-                            :firstTitle="$t('Upgrades.upgrade_to')"
-                            :message="$t('Upgrades.the_feature_not_available')"
-                        />
+                            <UpgradYourPlanComponent
+                                v-if="projectData?.isRestrict === true"
+                                :buttonText="$t('Upgrades.upgrade_your_plan')"
+                                :lastTitle="$t('Upgrades.to_unlcok_project')"
+                                :secondTitle="$t('Upgrades.unlimited')"
+                                :firstTitle="$t('Upgrades.upgrade_to')"
+                                :message="$t('Upgrades.the_feature_not_available')"
+                            />
                         </div>
                     </template>
                     <div v-else class="d-flex bg-light-gray align-items-center justify-content-center w-100 h-100">
@@ -729,83 +388,41 @@
                 </template>
             </template>
             <template v-else>
-                <div class="bg-light-gray d-flex align-items-center justify-content-center flex-column w-100 h-100">
-                    <img :src="noProjectsIcon" alt="noProjectsIcon">
-                    <template v-if="!showArchivedProjects">
-                        <h2>{{$t('ProjectSlider.you_dont')}}</h2>
-                        <div v-if="checkPermission('project.project_list',projectData.isGlobalPermission) === true && checkPermission('project.project_create',projectData.isGlobalPermission) === true && !isFilterHasData">
-                            <button class="outline-primary ml-1 font-size-16 p0x-13px" @click="openSidebar()">+ {{$t('ProjectSlider.new_project')}}</button>
-                            <button v-if="currentCompany?.planFeature?.aiPermission" class="btn btn-primary ml-1 font-size-16 p0x-13px" @click="openAiCreator()">✨ Create with AI</button>
-                        </div>
-                    </template>
-                    <template v-else>
-                        <h2>{{$t('ProjectSlider.no_archived')}}</h2>
-                        <button class="outline-primary" @click="handleUnarchived()">{{$t('ProjectSlider.hide_archive')}}</button>
-                    </template>
-                </div>
+                <ProjectEmptyState
+                    :showArchivedProjects="showArchivedProjects"
+                    :canCreate="checkPermission('project.project_list',projectData.isGlobalPermission) === true && checkPermission('project.project_create',projectData.isGlobalPermission) === true"
+                    :isFilterHasData="isFilterHasData"
+                    :currentCompany="currentCompany"
+                    @createProject="openSidebar"
+                    @createAiProject="openAiCreator"
+                    @hideArchive="handleUnarchived"
+                />
             </template>
         </template>
 
-        <!-- PROJECT VIEWS DD -->
-        <DropDown title="All Views" :ref="projectAddView" :bodyClass="{'viewlist-mobile-dropdown-new' : true}" maxHeight="unset" v-if="clientWidth <= 768">
-            <template #button>
-                <span ref="all_views_dd"></span>
-            </template>
-            <template #options>
-                <div>
-                    <ViewsDropdown @handleCloseDropdown="$refs.all_views_dd.click()" :projectData="projectData"/>
-                </div>
-            </template>
-        </DropDown>
-
-        <ProjectWatcher
-            v-model:openSidebar="openProjectWatcher"
-            :watchers="projectData?.watchers"
-            :options="projectData?.isPrivateSpace ? projectData?.AssigneeUserId : users.map((x) => x._id)"
-            :projectId="projectData?._id || ''"
-        />
-        <ConfirmationSidebar
-            v-model="showSidebar"
-            :title="`${archive === 0 ? $t('Projects.close') : archive === 1 ? $t('Projects.archive') : $t('Projects.delete')}`"
-            :message="archive === 0 ? $t('conformationmsg.archive0mesg') : archive === 1 ? $t('conformationmsg.archive'): $t('conformationmsg.delete')"
-            :confirmationString="`${archive === 0 ? 'close' : archive === 1 ? 'archive' : 'delete'}`"
-            :acceptButtonClass="archive === 1 ? 'btn-primary': 'btn-danger'"
-            :acceptButton="`${archive === 0 ? $t('Projects.close') : archive === 1 ? $t('Projects.archive') : $t('Projects.delete')}`"
-            @confirm="updateProject()"
+        <ProjectBottomModals
+            :clientWidth="clientWidth"
+            :projectAddView="projectAddView"
+            :projectData="projectData"
+            :users="users"
+            v-model:openProjectWatcher="openProjectWatcher"
+            v-model:showSidebar="showSidebar"
+            :archive="archive"
             :showSpinner="showSpinner"
+            :isActiveCreateSidebar="isActiveCreateSidebar"
+            :isAdvanceFilterApplied="isAdvanceFilterApplied"
+            :isActiveAiCreator="isActiveAiCreator"
+            v-model:permissionSidebar="permissionSidebar"
+            :showDriverSidebar="showDriverSidebar"
+            :openAiSidebar="openAiSidebar"
+            @confirmArchive="updateProject()"
+            @closeCreateSidebar="closeSidebar"
+            @closeAiCreator="isActiveAiCreator = false"
+            @aiProjectCreated="onAiProjectCreated"
+            @tourModalAccept="currentVideoUrl == 0 ? updateTourStatusInUser('isProjectAndNavbarTour') : ''"
+            @tourModalClose="closeModal"
+            @closeAiSidebar="openAiSidebar = false"
         />
-        <CreateProjectSidebar v-if="isActiveCreateSidebar" :isAdvanceFilterApplied='isAdvanceFilterApplied' :isActiveCreateSidebar="isActiveCreateSidebar" @click:closeSidebar="closeSidebar" @closeSidebar="closeSidebar"/>
-        <AiProjectCreator v-if="isActiveAiCreator" :visible="isActiveAiCreator" @close="isActiveAiCreator = false" @created="onAiProjectCreated"/>
-        <ProjectPermission v-if="permissionSidebar" @isClose="(val) => {permissionSidebar = !val}" :projectData="projectData"></ProjectPermission>
-        <ConfirmModal
-            className="projecttourend_driver_modal"
-            :modelValue="showDriverSidebar"
-            :acceptButtonText="$t('Tour.watch_video')"
-            :cancelButtonText="$t('Projects.cancel')"
-            :header="false"
-            :cancelButton='false'
-            :showCloseIcon="false"
-            :footer="false"
-            @accept="currentVideoUrl == 0 ? updateTourStatusInUser('isProjectAndNavbarTour'):''"
-            @close="closeModal, currentVideoUrl == 0 ? updateTourStatusInUser('isProjectAndNavbarTour'):''"
-        >
-            <template #body>
-                <div class="d-flex flex-column justify-content-center align-items-center position-re">
-                    <div class="position-ab tourendmodal__close_button">
-                        <img :src="cancelIconForTour" class="cursor-pointer cancel__icon-img tourendmodal__close_img" alt="close" @click.prevent="closeModal()">
-                    </div>
-                    <div>
-                        <img :src="tourModalImage" alt="tourmodalimage">
-                    </div>
-                    <div class="text-center">
-                        <h1>{{$t('Tour.tour_completed')}}</h1>
-                        <!-- <div class="mb-20px tourendmodal__description">{{$t('Tour.do_you_have_any')}}</div> -->
-                        <!-- <button class="btn-primary tourendmodal__watch_button font-size-16" @click="currentVideoUrl == 0 ? updateTourStatusInUser('isProjectAndNavbarTour'):'',openVideo()">Watch Video</button> -->
-                    </div>
-                </div>
-            </template>
-        </ConfirmModal>
-        <AISidebar v-if="openAiSidebar" @closeAi="openAiSidebar = false"></AISidebar>
     </div>
     <div v-else class="d-flex align-items-center justify-content-center w-100 h-100">
         <img :src="accessDenied" alt="accessDenied">
@@ -814,1744 +431,756 @@
 
 <script setup>
 // PACKAGES
-import { computed, defineComponent, inject, onMounted, provide, ref, watch,onUnmounted, nextTick } from 'vue'
-import isEqual from "lodash/isEqual"
+import { computed, defineComponent, inject, onMounted, provide, ref, watch, onUnmounted, nextTick } from 'vue';
+import isEqual from 'lodash/isEqual';
 import { useStore } from 'vuex';
 import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 import { useCustomComposable, useGetterFunctions } from '@/composable';
 import { useValidation } from '@/composable/Validation';
-import ConfirmationSidebar from "@/components/molecules/ConfirmationSidebar/ConfirmationSidebar.vue"
-import {deleteView , editView} from '@/components/molecules/EmbedView/helper.js'
-import { deletePrivateView ,editPrivateName} from '@/components/molecules/ProjectViews/helper.js'
-import { calendar } from '@/components/organisms/HourlyMilestone/helper.js';
 import { projectComponentsIcons } from '@/composable/commonFunction';
-import { EditProjectName } from '@/utils/NotificationTemplate';
 
 // COMPONENTS
-import ProjectWatcher from "@/components/organisms/ProjectWatcher/ProjectWatcher.vue"
-import CreateProjectSidebar from '@/components/organisms/CreateProject/CreateProjectSidebar.vue'
-import AiProjectCreator from '@/components/organisms/AiProjectCreator/AiProjectCreator.vue'
-import ProjectProfileForm from '@/components/templates/CreateProject/ProjectProfileForm.vue';
-import WasabiImage from "@/components/atom/WasabiIamgeCompp/WasabiIamgeCompp.vue";
-import SpinnerComp from "@/components/atom/SpinnerComp/SpinnerComp.vue";
-import ProjectListing from './ProjectsListing/ProjectListing.vue'
-import TableViewComp from "@/views/Projects/TableView/TableView.vue"
-import EmbedViewItem from '@/components/molecules/EmbedView/EmbedViewItem.vue'
-import ViewsDropdown from '@/components/molecules/ProjectViews/ViewsDropdown.vue'
-import MonthlyCalendarMilestone from '@/components/atom/MonthlyCalendarMilestone/MonthlyCalendarMilestone.vue';
-import ProjectPermission from '@/components/atom/ProjectPermission/ProjectPermission.vue';
+import ConfirmationSidebar from '@/components/molecules/ConfirmationSidebar/ConfirmationSidebar.vue';
+import WasabiImage from '@/components/atom/WasabiIamgeCompp/WasabiIamgeCompp.vue';
+import ProjectListing from './ProjectsListing/ProjectListing.vue';
+import ViewsDropdown from '@/components/molecules/ProjectViews/ViewsDropdown.vue';
 import UpgradYourPlanComponent from '@/components/atom/UpgradYourPlanComponent/UpgradYourPlanComponent.vue';
-import AISidebar from '@/components/molecules/AISidebar/AISidebar.vue';
-// VIEWS
-import ProjectListView from './ListView/ListView.vue'
-import Comments from "@/views/Projects/Comments/Comments.vue"
-import ActivityLog from "@/views/Projects/ActivityLog/ActivityLog.vue"
-import WorkloadView from "@/views/Projects/WorkloadView/WorkloadView.vue"
-import BoardView from '@/views/Projects/Kanban/BoardView.vue';
-import ProjectDetail from "@/views/Projects/ProjectDetail/ProjectDetail.vue"
-import ProjectDetailRightSide from '@/components/organisms/ProjectDetailRightSide/ProjectDetailRightSide.vue'
-import NotFound from '../NotFound.vue'
-import Sidebar from "@/components/molecules/Sidebar/Sidebar.vue"
-import DropDown from '@/components/molecules/DropDown/DropDown.vue'
-import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue'
-import TaskDetail from '@/views/TaskDetail/TaskDetail.vue'
-import Assignee from "@/components/molecules/Assignee/Assignee.vue"
-import ViewsList from "@/components/atom/ViewsList/ViewsList.vue"
-import InputText from "@/components/atom/InputText/InputText.vue"
-import { useToast } from 'vue-toast-notification';
-import { projectAssignee, projectAssigneeRemove } from '@/utils/NotificationTemplate';
-import Toggle from '@/components/atom/Toggle/Toggle.vue'
-import FileAndLinks from '@/components/molecules/FileAndLinks/FileAndLinks.vue'
-import TaskAudioFiles from '@/components/molecules/TaskAudioFiles/TaskAudioFiles.vue'
-import TaskFilter from '@/components/molecules/TaskFilter/TaskFilter.vue'
+import ProjectDetailRightSide from '@/components/organisms/ProjectDetailRightSide/ProjectDetailRightSide.vue';
+import DropDown from '@/components/molecules/DropDown/DropDown.vue';
+import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue';
+import TaskDetail from '@/views/TaskDetail/TaskDetail.vue';
+import ViewsList from '@/components/atom/ViewsList/ViewsList.vue';
+import InputText from '@/components/atom/InputText/InputText.vue';
+
+// VIEWS (async-loaded so each tab pulls its own chunk on demand)
+import { defineAsyncComponent } from 'vue';
+const ProjectListView = defineAsyncComponent(() => import(/* webpackChunkName: "project-list-view" */ './ListView/ListView.vue'));
+const Comments = defineAsyncComponent(() => import(/* webpackChunkName: "project-comments" */ '@/views/Projects/Comments/Comments.vue'));
+const ActivityLog = defineAsyncComponent(() => import(/* webpackChunkName: "project-activity-log" */ '@/views/Projects/ActivityLog/ActivityLog.vue'));
+const WorkloadView = defineAsyncComponent(() => import(/* webpackChunkName: "project-workload" */ '@/views/Projects/WorkloadView/WorkloadView.vue'));
+const BoardView = defineAsyncComponent(() => import(/* webpackChunkName: "project-kanban" */ '@/views/Projects/Kanban/BoardView.vue'));
+const ProjectDetail = defineAsyncComponent(() => import(/* webpackChunkName: "project-detail" */ '@/views/Projects/ProjectDetail/ProjectDetail.vue'));
+const TableViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-table-view" */ '@/views/Projects/TableView/TableView.vue'));
+const EmbedViewItem = defineAsyncComponent(() => import(/* webpackChunkName: "embed-view" */ '@/components/molecules/EmbedView/EmbedViewItem.vue'));
+import NotFound from '../NotFound.vue';
+
+// EXTRACTED PIECES
+import ProjectActionsBar from './components/ProjectActionsBar.vue';
+import ProjectFiltersToolbar from './components/ProjectFiltersToolbar.vue';
+import ProjectSidebars from './components/ProjectSidebars.vue';
+import ProjectBottomModals from './components/ProjectBottomModals.vue';
+import ProjectEmptyState from './components/ProjectEmptyState.vue';
+import { useProjectCalendar } from './composables/useProjectCalendar';
+import { useProjectRules } from './composables/useProjectRules';
+import { useProjectNameEdit } from './composables/useProjectNameEdit';
+import { useProjectAssignee } from './composables/useProjectAssignee';
+import { useEmbedViews } from './composables/useEmbedViews';
+import { useProjectLifecycle } from './composables/useProjectLifecycle';
+import { useProjectAvatar } from './composables/useProjectAvatar';
+import { useProjectSearch } from './composables/useProjectSearch';
+import { useProjectTour } from './composables/useProjectTour';
+
 import { useProjectsHelper } from './helper';
-import { useProjects } from '@/composable/projects';
-import { useHistoryNotification } from '@/composable';
-import * as env from '@/config/env';
-import { apiRequest, apiRequestWithoutCompnay } from '../../services';
-const {addHistory, addNotification} = useHistoryNotification();
-import {storageQueryBuilder,generateFileName} from '@/utils/storageQueryBuild.js';
-import { useI18n } from "vue-i18n";
-const { t } = useI18n();
 
 // UTILS
-const  { checkErrors , checkAllFields } = useValidation();
-const $toast = useToast();
-const {projects, filteredProjects, dispatchProjects} = useProjectsHelper();
+const { checkErrors } = useValidation();
+const { t } = useI18n();
+const { projects, filteredProjects, dispatchProjects } = useProjectsHelper();
 const showArchivedProjects = ref(false);
 const isAdvanceFilterApplied = ref(false);
 const isFilterHasData = ref(false);
 const sprintLoading = ref(false);
-const showSpinner = ref(false);
-const previewImage = ref(null);
-const {markFavourite} = useProjects();
-const { calendarRange} = calendar();
-provide("showArchivedProjects", showArchivedProjects);
-import ConfirmModal from '@/components/atom/Modal/Modal.vue';
-const cancelIconForTour = require("@/assets/images/cancel_icon.png");
-const tourModalImage = require("@/assets/images/tourmodalimage.png");
+provide('showArchivedProjects', showArchivedProjects);
 
-// 1 for Project and 2 for Task
-const currentVideoUrl = ref(0)
-const embeddropdown = ref(null);
+const currentVideoUrl = ref(0);
 const openAiSidebar = ref(false);
 const showDriverSidebar = ref(false);
 const skipWatcher = ref(false);
-const mainTour = inject("$mainTour");
-const socket = inject("$socket");
-import { tourHepler } from "@/components/organisms/Tour/helper";
-const { startProjectTour } = tourHepler();
+const socket = inject('$socket');
 
-// IMAGES
-const eyeIcon = require('@/assets/images/svg/PriorityIcon/watchProjectEye.svg');
-const accessDenied = require("@/assets/images/access_denied_img.png");
-const listDropIcon = require("@/assets/images/svg/list_view_dropicon.svg");
-const publicIcon = require("@/assets/images/svg/public_folder.svg");
-// const listViewIcon = require("@/assets/images/svg/listViewSvg.svg");
-const noProjectsIcon = require("@/assets/images/svg/No-Search-Result.svg");
-const horizontalDots = require("@/assets/images/svg/horizontalDots.svg");
-const horizontalDotsMobile = require("@/assets/images/svg/threedot_mobile_list.svg");
-const addIcon = require("@/assets/images/Shape 614.png");
-const activeUserIcon = require("@/assets/images/peopleBlue.png");
-const userIcon = require("@/assets/images/peopleGray.png");
-const activeGroupIcon = require("@/assets/images/peopleBlue.png");
-const groupIcon = require("@/assets/images/peopleGray.png");
-const lockIcon = require("@/assets/images/lock.png");
-const listIcon = require("@/assets/images/svg/edit_rename_icon.svg");
-const colorPalletIcon = require("@/assets/images/svg/palette.svg");
-const copyIcon = require("@/assets/images/svg/content_copy.svg");
-const cancelIcon = require("@/assets/images/svg/cancel.svg");
-const deleteIcon = require("@/assets/images/svg/Delete_Icon.svg");
-const publicFolder = require("@/assets/images/public_folder.png");
-const fileLinks = require("@/assets/images/svg/Fileslinks.svg");
-const whiteDownArrow = require('@/assets/images/svg/embed_drop_arrow.svg')
-const deleteImage = require('@/assets/images/svg/delete-red.svg')
-const renameImage = require('@/assets/images/svg/rename.svg')
-const saveImage = require("@/assets/images/save.png")
-const cancelImage = require("@/assets/images/svg/deletered.svg")
-const threedots = require("@/assets/images/svg/tagdots.svg")
-const pin = require("@/assets/images/svg/pin.svg")
-const code = require("@/assets/images/svg/code.svg")
-const copy = require("@/assets/images/svg/copy-link.svg")
+defineComponent({
+    name: 'Projects-Page',
+});
 
+// Reactive Variables to show the progress of the tasks being imported
+const progress = ref(0);
+const showLoader = ref(false);
 
-    defineComponent({
-        name: "Projects-Page",
+provide('progress', progress);
+provide('showLoader', showLoader);
 
-        components: {
-            ProjectListing,
-            ProjectListView,
-            Comments,
-            ActivityLog,
-            ProjectDetail,
-            Sidebar,
-            DropDown,
-            DropDownOption,
-            TaskDetail,
-            Assignee,
-            ViewsList,
-            NotFound,
-            ProjectDetailRightSide,
-            InputText,
-            Toggle,
-            TaskFilter,
-            SpinnerComp,
-            EmbedViewItem
-        }
-    })
+const currentProgress = ref(0);
 
-    // Reactive Variables to show the progress of the tasks being imported
-    const progress = ref(0);
-    const showLoader = ref(false);
+const circleStyle = computed(() => ({
+    background: `conic-gradient(#4caf50 0% ${currentProgress.value}%, #ddd ${currentProgress.value}% 100%)`,
+}));
 
-    provide('progress', progress);
-    provide('showLoader', showLoader);
+watch(progress, (newVal) => {
+    animateProgress(newVal);
+});
 
-    const currentProgress = ref(0);
-
-    const circleStyle = computed(() => {
-        return {
-            background: `conic-gradient(#4caf50 0% ${currentProgress.value}%, #ddd ${currentProgress.value}% 100%)`
-        };
-    });
-
-    // Watch progress value and animate changes
-    watch(progress, (newVal) => {
-        animateProgress(newVal);
-    });
-
-    function animateProgress(target) {
-        let step = () => {
-            if (currentProgress.value < target) {
-                currentProgress.value++;
-                requestAnimationFrame(step);
-            } else if (currentProgress.value === 100) {
-                setTimeout(() => {
-                    currentProgress.value = 0;
-                    progress.value = 0;
-                    showLoader.value = false;
-                }, 1200);
-            }    
-        };
-        requestAnimationFrame(step);
-    }
-
-    const {getters, commit, dispatch} = useStore();
-
-    const companyUserDetail = computed(() => getters['settings/companyUserDetail'])
-    const myCounts = computed(() => getters["users/myCounts"]?.data || {})
-
-    const editProject2 = ref(false)
-    const archive = ref(0)
-    const userId = inject("$userId");
-    const showSidebar = ref(false);
-    const isVisible = ref(true);
-    const isVisibleProjectDetial = ref(true);
-    const openProjectWatcher = ref(false);
-
-    const isActiveCreateSidebar = ref(false);
-    const savingAvatar = ref(false);
-    const showColorAvatar = ref(false);
-    const calendartoggle = ref(false);
-    const rangeObject = ref({});
-    const calendarDate = ref('')
-    const calenderSelectDate = ref(0)
-    const permissionSidebar = ref(false);
-    const projectSearchText = ref("");
-    // const isSprintLoad = ref(false);
-    // const folderSprintsData = ref({})
-    const prevMonth = () => {
-        if (!calendarDate.value) {
-            const now = new Date();
-            const nextDate = now.setMonth(now.getMonth() - 1, 1);
-            calenderSelectDate.value = nextDate;
-            calendarDate.value = new Date(nextDate).toLocaleString('default', { month: 'long', year: 'numeric' });
-        } else {
-            const now = new Date(calenderSelectDate.value);
-            const nextDate = now.setMonth(now.getMonth() - 1, 1);
-            calenderSelectDate.value = nextDate;
-            calendarDate.value = new Date(nextDate).toLocaleString('default', { month: 'long', year: 'numeric' });
-        }
-    }
-    const nextMonth = () => {
-        if (!calendarDate.value) {
-            const now = new Date();
-            const nextDate = now.setMonth(now.getMonth() + 1, 1);
-            calenderSelectDate.value = nextDate;
-            calendarDate.value = new Date(nextDate).toLocaleString('default', { month: 'long', year: 'numeric' });
-        } else {
-            const now = new Date(calenderSelectDate.value);
-            const nextDate = now.setMonth(now.getMonth() + 1, 1);
-            calenderSelectDate.value = nextDate;
-            calendarDate.value = new Date(nextDate).toLocaleString('default', { month: 'long', year: 'numeric' });
-        }
-    }
-    const defaultMonth = () => {
-        if (calendarDate.value) {
-            calendarDate.value = ''
-            calenderSelectDate.value = 0
-        }
-    }
-    const handleStartEndDate = (value) => {
-        calendartoggle.value = false;
-        const startEndObj = value;
-        const getYear = new Date(startEndObj.start).getFullYear();
-        const getMonth = new Date(startEndObj.start);
-        const month = getMonth.toLocaleString('default', { month: 'short' });
-        const tmpValue = JSON.parse(JSON.stringify(value));
-        rangeObject.value.monthValueRange = `${getYear}`;
-        rangeObject.value.selectedmonth = `${month}`;
-        rangeObject.value.rangeValueMonthly = rangeObject.value.monthlyOrweeklyRangesValue[`${getYear}`];
-        calenderSelectDate.value = new Date(tmpValue.start).getTime();
-        calendarDate.value = new Date(tmpValue.start).toLocaleString('default', { month: 'long', year: 'numeric' });
-    }
-    const rangeObjectFRun = (value) => {
-        const startEndObj = value;
-        const getYear = new Date(startEndObj).getFullYear();
-        const getMonth = new Date(startEndObj);
-        const month = getMonth.toLocaleString('default', { month: 'short' });
-        rangeObject.value.monthValueRange = `${getYear}`;
-        rangeObject.value.selectedmonth = `${month}`;
-        rangeObject.value.rangeValueMonthly = rangeObject.value.monthlyOrweeklyRangesValue[`${getYear}`];
-    }
-    const handleClickOutside = (event) => {
-        if(calendartoggle.value && !event.target.closest('.monthly-calendar')) {
-            calendartoggle.value = false;
+function animateProgress(target) {
+    const step = () => {
+        if (currentProgress.value < target) {
+            currentProgress.value++;
+            requestAnimationFrame(step);
+        } else if (currentProgress.value === 100) {
+            setTimeout(() => {
+                currentProgress.value = 0;
+                progress.value = 0;
+                showLoader.value = false;
+            }, 1200);
         }
     };
-    const formData = ref({
-        projectName: "",
-        projectId: "",
-        projectProfileField:{
-            selectedColor : {
-                value: "",
-                rules:
-                "required",
-                name: "selectedColor",
-                error: "",
-            },
-            uploadedImage : {
-                value: "",
-                rules:
-                "required",
-                name: "Choose an Image to Upload",
-                error: "",
-            },
-            previewImage : {
-                value: "",
-                rules:
-                "required",
-                name: "previewImage",
-                error: "",
-            }
-        }
-    })
-    const resetFormData = () => {
-        formData.value = {
-            projectName: "",
-            projectId: "",
-            projectProfileField:{
-                selectedColor : {
-                    value: "",
-                    rules:
-                    "required",
-                    name: "selectedColor",
-                    error: "",
-                },
-                uploadedImage : {
-                    value: "",
-                    rules:
-                    "required",
-                    name: "Choose an Image to Upload",
-                    error: "",
-                },
-                previewImage : {
-                    value: "",
-                    rules:
-                    "required",
-                    name: "previewImage",
-                    error: "",
-                }
-            }
-        }
-    }
-    const openSidebar = () => {
-        isActiveCreateSidebar.value = true;
-    }
-    function closeSidebar(value){
-        isActiveCreateSidebar.value = value;
-    }
-    const isActiveAiCreator = ref(false);
-    const currentCompany = computed(() => getters['settings/selectedCompany']);
-    const openAiCreator = () => {
-        isActiveAiCreator.value = true;
-    }
-    function onAiProjectCreated({ projectId }) {
-        // The project-list socket pipeline doesn't fan out an 'insert' event
-        // for new projects, so we re-fetch the project list ourselves so the
-        // new project shows up immediately without a page reload.
-        try {
-            dispatch('projectData/setProjects', { roleType: 'currentUser' });
-        } catch (_e) { /* ignore */ }
-        if (projectId) {
-            try {
-                const cid = (currentCompany.value && currentCompany.value._id) || route.params.cid;
-                router.push({ name: 'Project', params: { cid, id: projectId } });
-            } catch (_e) { /* ignore */ }
-        }
-        isActiveAiCreator.value = false;
-    }
+    requestAnimationFrame(step);
+}
 
-    const assigneeInProgress = ref({});
-    const visible = ref(false);
-    const filterFavorites = ref(localStorage.getItem('favoriteFilter') == 'true');
-    const activeTab = ref("ProjectListView");
-    const clientWidth = inject("$clientWidth");
-    const route = useRoute();
-    const router = useRouter();
-    const responseWidth = 1300;
-    const sidebarArrowIcon = require("@/assets/images/svg/sidebarclose_arrow.svg");
-    const projectStar = require("@/assets/images/svg/start13.svg");
-    const blankStar = require("@/assets/images/svg/blankStar.svg");
-    const audio = require("@/assets/images/svg/Voice_Record.svg");
-    const fileLink = require("@/assets/images/svg/Files_links.svg");
-    const audioLinkMobile = require("@/assets/images/svg/AudioLink.svg");
-    const viewDefaultIcon = require("@/assets/images/svg/list_home_icon.svg");
-    const viewDefaultActive = require("@/assets/images/svg/blue_tick.svg");
-    const projectList = ref()
+const { getters, commit, dispatch } = useStore();
 
-    const companyId = inject("$companyId");
-    const {debounce, checkPermission ,makeUniqueId,checkApps,sanitizeInput} = useCustomComposable()
-    const {getUser} = useGetterFunctions();
-    const renameValue = ref('')
-    const openDelete = ref({flag:false,data:''})
-    const taskNameSearch = ref(true)
-    const taskKeySearch = ref(false)
-    const taskDescriptionSearch = ref(false)
+const companyUserDetail = computed(() => getters['settings/companyUserDetail']);
+const myCounts = computed(() => getters['users/myCounts']?.data || {});
 
-    // const projects = ref([]);
-    const projectData = ref({});
-    const showArchived = ref(false);
-    const taskSearch = ref("");
-    const filterUsers = ref([]);
-    const assigneeFilterOptions = ref([]);
-    const userSidebar = ref(false);
-    const collapsed = ref(true);
-    const filterQuery = ref({});
-    const currentActive = ref('');
-    const embedViews = ref([])
-    const Uid = ref('embed'+ makeUniqueId(6));
-    // const prevDateVal = ref(false);
-    const isRuleData = ref(false)
-    const rulePermission = ref(true)
+const userId = inject('$userId');
+// template ref: bound via ref="embeddropdown" in the View list DropDown,
+// accessed via $refs in @closeDropdown handler.
+// eslint-disable-next-line no-unused-vars
+const embeddropdown = ref(null);
+const isVisible = ref(true);
+const isVisibleProjectDetial = ref(true);
+// `visible` was a separate ref in the original (initialized false) and
+// mutated by clientWidth watcher / onMounted / open('searchIcon') /
+// handleUnarchived. Kept separate from `isVisible` to preserve original
+// behavior (the template binds isVisible, not visible).
+const visible = ref(false);
+const openProjectWatcher = ref(false);
 
-    const selectedEmbedView = ref('');
-    const projectView = ref(`projectView${makeUniqueId(6)}`);
-    const projectAddView = ref(`projectAddView${makeUniqueId(6)}`);
-    const embedViewName = ref('');
+const isActiveCreateSidebar = ref(false);
+const permissionSidebar = ref(false);
+const projectSearchText = ref('');
 
-    const showTasks = computed(() => checkPermission("task.show_tasks", projectData.value.isGlobalPermission, {gettersVal: getters}))
-    const projectDetailPermission = computed(() => checkPermission("project.project_details", projectData.value.isGlobalPermission, {gettersVal: getters}))
-    provide("taskCollapsed", collapsed)
-    const icons = ref({
-        Anything_url:require("@/assets/images/svg/anything.svg") ,
-        Anything_html:require("@/assets/images/svg/anything.svg"), 
-        Docs : require("@/assets/images/svg/Googledocs.svg") ,
-        Sheets : require("@/assets/images/svg/googlesheets.svg"),
-        Youtube : require("@/assets/images/svg/Youtube.svg"),
-        Figma : require("@/assets/images/svg/figma.svg")
-    })
-    const groupBy = ref(0);
-    const groupByOptions = ref([
-        {
-            label: "status",
-            image: require("@/assets/images/groupbySattus.png"),
-            id: 0,
-        },
-        // {
-        //     label: "Assignee",
-        //     image: require("@/assets/images/peopleGray.png"),
-        //     id: 1,
-        // },
-        {
-            label: "priority",
-            image: require("@/assets/images/groupbyFlag.png"),
-            id: 2,
-        },
-        {
-            label: "due_date",
-            image: require("@/assets/images/calendar_month.png"),
-            id: 3
-        }
-    ])
+const filterFavorites = ref(localStorage.getItem('favoriteFilter') == 'true');
+const clientWidth = inject('$clientWidth');
+const route = useRoute();
+const router = useRouter();
+const responseWidth = 1300;
+const sidebarArrowIcon = require('@/assets/images/svg/sidebarclose_arrow.svg');
+const projectStar = require('@/assets/images/svg/start13.svg');
+const blankStar = require('@/assets/images/svg/blankStar.svg');
+const viewDefaultIcon = require('@/assets/images/svg/list_home_icon.svg');
+const viewDefaultActive = require('@/assets/images/svg/blue_tick.svg');
+const projectList = ref();
 
-    const companyOwner = computed(() => getters["settings/companyOwnerDetail"])
+const companyId = inject('$companyId');
+const { checkPermission, makeUniqueId } = useCustomComposable();
+const { getUser } = useGetterFunctions();
 
-    const editProject = ref(false);
-    const projectName = ref({
-        value: "",
-        rules:
-        "required | min: 3",
-        name: "name",
-        error: "",
-    });
+// IMAGES
+const accessDenied = require('@/assets/images/access_denied_img.png');
+const listDropIcon = require('@/assets/images/svg/list_view_dropicon.svg');
+const publicIcon = require('@/assets/images/svg/public_folder.svg');
+const addIcon = require('@/assets/images/Shape 614.png');
+const publicFolder = require('@/assets/images/public_folder.png');
+const whiteDownArrow = require('@/assets/images/svg/embed_drop_arrow.svg');
+const deleteImage = require('@/assets/images/svg/delete-red.svg');
+const renameImage = require('@/assets/images/svg/rename.svg');
+const saveImage = require('@/assets/images/save.png');
+const cancelImage = require('@/assets/images/svg/deletered.svg');
+const threedots = require('@/assets/images/svg/tagdots.svg');
+const copy = require('@/assets/images/svg/copy-link.svg');
 
-    const searchTask = ref(false);
-    const loadingProjects = ref(false);
-    provide("searchedTask", searchTask)
-    provide("showArchived", showArchived)
-    provide("selectedProject", projectData)
+const projectData = ref({});
+const showArchived = ref(false);
+const assigneeFilterOptions = ref([]);
 
-    provide("isSupport", ref(false));
+// COMPOSABLES
+const { calendartoggle, rangeObject, calendarDate, calenderSelectDate, prevMonth, nextMonth, defaultMonth, handleStartEndDate, rangeObjectFRun, calendarDateChange } = useProjectCalendar();
+const { isRuleData, rulePermission, getProjectRule } = useProjectRules();
+const { editProject, projectName, updateProjectName } = useProjectNameEdit(projectData);
+const { changeAssignee } = useProjectAssignee(projectData);
+const { archive, showSidebar, showSpinner, updateProject, markProjectFavourite } = useProjectLifecycle(projectData);
+const { showColorAvatar, savingAvatar, formData, resetFormData, assignAvatarData, updateImageValue, saveProjectAvatar } = useProjectAvatar(projectData);
+const { taskSearch, taskNameSearch, taskKeySearch, taskDescriptionSearch, filterUsers, searchTask, collapsed, groupBy, userSidebar, resetFilters, toggleSearch, searchMongoDB, manageFilterUsers, applyFilter, clearFilter } = useProjectSearch(projectData, showArchived);
+const { runProjectStartupTours, hanldeBlankProjectTour, hanldeProjectTaktypeTour, hanldeProjectLastStep } = useProjectTour();
 
-    const companyUserData = computed(()=> { return getters['settings/companyUsers']} )
-    const companyUser = ref('')
-    const viewsListArray = ref([])
+const Uid = ref('embed' + makeUniqueId(6));
+const renameValue = ref('');
+const openDelete = ref({ flag: false, data: '' });
+const selectedEmbedView = ref('');
+const embedViewName = ref('');
+const activeTab = ref('ProjectListView');
+const embedViews = ref([]);
+const projectView = ref(`projectView${makeUniqueId(6)}`);
+const projectAddView = ref(`projectAddView${makeUniqueId(6)}`);
+const companyUserData = computed(() => getters['settings/companyUsers']);
+const companyUser = ref('');
+const viewsListArray = ref([]);
+const loadingProjects = ref(false);
 
-    function resetFilters() {
-        if(!showArchivedProjects.value) {
+const { copyToClipboard, editViewName, deleteEmbedView } = useEmbedViews(projectData, embedViews, companyUser, renameValue, openDelete, selectedEmbedView);
+// openEmbedView lives in the parent because it mutates activeTab/selectedEmbedView refs owned here
+const openEmbedView = (item) => {
+    embedViewName.value = item?.name;
+    activeTab.value = 'EmbedView';
+    router.replace({ query: { tab: 'EmbedView', eid: item.id } });
+    selectedEmbedView.value = item;
+};
+
+provide('taskCollapsed', collapsed);
+provide('searchedTask', searchTask);
+provide('showArchived', showArchived);
+provide('selectedProject', projectData);
+provide('isSupport', ref(false));
+
+const icons = ref({
+    Anything_url: require('@/assets/images/svg/anything.svg'),
+    Anything_html: require('@/assets/images/svg/anything.svg'),
+    Docs: require('@/assets/images/svg/Googledocs.svg'),
+    Sheets: require('@/assets/images/svg/googlesheets.svg'),
+    Youtube: require('@/assets/images/svg/Youtube.svg'),
+    Figma: require('@/assets/images/svg/figma.svg'),
+});
+const groupByOptions = ref([
+    { label: 'status', image: require('@/assets/images/groupbySattus.png'), id: 0 },
+    { label: 'priority', image: require('@/assets/images/groupbyFlag.png'), id: 2 },
+    { label: 'due_date', image: require('@/assets/images/calendar_month.png'), id: 3 },
+]);
+
+const projectDetailPermission = computed(() => checkPermission('project.project_details', projectData.value.isGlobalPermission, { gettersVal: getters }));
+
+watch(projectData, (newVal, oldVal) => {
+    if (newVal._id != oldVal._id) {
+        const data = newVal;
+        getProjectRule(data);
+        selectedEmbedView.value = !(route?.query?.eid) ? '' : embedViews.value.filter((item) => item.id == route.query.eid)[0];
+        if (!showArchivedProjects.value) {
             showArchived.value = false;
         }
-        groupBy.value = 0;
-        filterUsers.value = [];
-        searchTask.value = false;
-        filterQuery.value = '';
-        collapsed.value = true;
+        resetFilters();
     }
-    function calendarDateChange(status, key) {
-        if (key === "calendar" && status) {
-            defaultMonth()
-        }
-        // if (status) {
-        //     defaultMonth()
-        // }
+    getChange();
+});
+
+watch(() => companyUserData, () => {
+    getChange();
+}, { deep: true });
+
+watch(route, (newVal) => {
+    if (newVal.query.tab === 'comment') {
+        activeTab.value = `Comments`;
     }
-    watch(projectData,(newVal,oldVal) => {
-        if(newVal._id != oldVal._id){
-            const data = newVal;
-            getProjectRule(data);
-            selectedEmbedView.value = !(route?.query?.eid) ?  '' : embedViews.value.filter((item) => item.id == route.query.eid)[0];
-            resetFilters();
-        }
-        getChange()
-    })
-    watch(() => companyUserData ,() => {
-        getChange()
-    },{deep:true})
+});
 
-    watch(route, (newVal) => {
-        if(newVal.query.tab === 'comment') {
-            activeTab.value = `Comments`
-        }
-    })
+watch(() => projectDetailPermission.value, () => {
+    getChange();
+});
 
-    watch(() => projectDetailPermission.value, () => {
-        getChange()
-    })
-
-    watch(activeTab, (newVal, oldVal) => {
-        if(newVal !== oldVal) {
-            document.getElementById(activeTab.value)?.scrollIntoView();
-        }
-    })
-
-    watch(
-        [() => embedViews.value, () => projectData.value, () => route],
-        ([newEmbedView, newProject, newRoute], [, oldProject, ]) => {
-            if (newRoute.query.tab === 'EmbedView') {
-                if (!newEmbedView.length && isEqual(newProject._id, oldProject._id)) {
-                    activeTab.value = 'ProjectListView';
-                    router.replace({ query: { tab: 'ProjectListView' } });
-                } else if (newEmbedView.length) {
-                    if (newEmbedView[0].id === route.query.eid) {
-                        selectedEmbedView.value = newEmbedView[0];
-                    } else {
-                        selectedEmbedView.value = newEmbedView.find(item => item.id === route.query.eid) || newEmbedView[0];
-                    }
-
-                    nextTick(() => {
-                        loadingProjects.value = false;
-                    });
-                }
-            }
-        }
-    );
-
-    watch(clientWidth, () => {
-        if(clientWidth.value < 765) {
-            if(visible.value) {
-                visible.value = false;
-            }
-        }
-    })
-
-    function resetProjectName() {
-        projectName.value.value = "";
-        projectName.value.error = "";
+watch(activeTab, (newVal, oldVal) => {
+    if (newVal !== oldVal) {
+        document.getElementById(activeTab.value)?.scrollIntoView();
     }
+});
 
-    const openEmbedView = (item) => {
-        embedViewName.value = item?.name;
-        activeTab.value = 'EmbedView'
-        router.replace({query: {tab: 'EmbedView' ,eid:item.id}})
-        selectedEmbedView.value = item
-    }
-
-
-    const getChange  = () => {
-        companyUser.value = (companyUserData.value.filter((item) => userId.value == item.userId))[0]
-        let userTabs = (companyUser.value?.ProjectRequiredComponent) ? ((Object.entries(companyUser.value?.ProjectRequiredComponent)).map((element) => {return {uniqueId:element[0] , ...element[1]}} )).filter((item) => item.projectId === projectData.value._id ) : []
-        let Tabs2 = projectData.value.ProjectRequiredComponent?.filter((item) =>  item._id.length > 6 )
-        let ids = projectData.value.ProjectRequiredComponent?.map((item) =>  item._id)
-        viewsListArray.value = [...(userTabs.filter((element) => element.id.length > 6 && (!ids.includes(element.id)) )) , ...Tabs2].sort((a,b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin&&b.isPin) ? 1 : -1))))
-        embedViews.value = ([...projectData.value.ProjectRequiredComponent.filter((item) => item._id.length == 6) , ...(userTabs.filter((element) => element.id.length == 6)) ].sort((a,b) => (a.name.toLowerCase() < b.name.toLowerCase()) ? -1 : ((b.name.toLowerCase() < a.name.toLowerCase()) ? 1 : 0))).sort((a,b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))))
-        if(projectDetailPermission.value === null){
-            viewsListArray.value = viewsListArray.value.filter((item) => item.keyName !== 'ProjectDetail');
-        }
-    }
-
-    const editViewName = (element) => {
-        const user = getUser(userId.value);
-        const userData = {
-            id: user.id,
-            Employee_Name: user.Employee_Name,
-            companyOwnerId: companyOwner.value.userId
-        }
-
-        if(renameValue.value.name.trim() == element.name.trim())
-        {
-            renameValue.value = {name:'',id:''}
-            return
-        }
-        if(!renameValue.value.name.trim())
-        {
-            $toast.error(t('Toast.View_name_is_required'),{position:'top-right'})
-            return 
-        }
-        if((renameValue.value.name.trim().length) < 3)
-        {
-            $toast.error(t('Toast.name_should_be_at_least_3_characters_long'),{position:'top-right'})
-            return 
-        }
-        let duplicate = (embedViews.value.filter((item) => item.id !== element.id && item.name.trim() === renameValue.value.name.trim() ))
-            if( duplicate.length ){
-            $toast.error(t('Toast.View_name_already_exists'),{position:'top-right'})
-            return
-        }
-        if(element.isPrivate)
-        {
-        editPrivateName({cid:companyId.value , uid: companyUser.value._id, uniqueId: element.id},element,renameValue.value.name.trim())
-        }
-        else
-        {
-            editView({cid:companyId.value , pid:projectData.value._id} , element , renameValue.value.name.trim(),'name').then((res)=>{
-                commit('projectData/projectLocalUpdate', {itemData: res.data,projectId: projectData.value._id,key:"ProjectView",subKey:"edit",userId: ''});
-            }).catch((error)=>{
-                console.error(error);
-            })
-            if(selectedEmbedView.value.id == element.id){
-                selectedEmbedView.value.name = renameValue.value.name
-            }
-        }     
-        let historyObj = 
-            {
-            'message': `<b>${userData.Employee_Name}</b> has changed the  <b> Embed View name </b> as <b> ${renameValue.value.name.trim()} </b>  from <b>${element?.name} </b>`,
-            'key' : 'Project_Name',
-            }
-        apiRequest("post", env.HANDLE_HISTORY, {
-            "type": 'project',
-            "companyId": companyId.value,
-            "projectId": projectData.value._id,
-            "taskId": null,
-            "object": historyObj,
-            "userData": userData
-        })
-        .catch((error) => {
-            console.error("ERROR in update project history: ", error);
-        })
-        renameValue.value = {name:'',id:''}
-
-    }
-
-    const deleteEmbedView = () => {
-        const user = getUser(userId.value);
-        const userData = {
-            id: user.id,
-            Employee_Name: user.Employee_Name,
-            companyOwnerId: companyOwner.value.userId
-        }
-        let historyObj = {
-            'message': `<b> ${userData.Employee_Name} </b> has deleted the  <b> Embed View ${openDelete.value.data.name} </b>`,
-            'key' : 'Project_Name',
-        }
-
-        if(openDelete.value.data.isPrivate) {
-            deletePrivateView({ cid: companyId.value, uid: companyUser.value._id, uniqueId: openDelete.value.data.id}).then(() => {
-                $toast.success(t('Toast.View_Deleted_Successfully'),{position:'top-right'}) 
-            })
-            .catch((err) => {
-                console.error(err.statusText) 
-            })
-            openDelete.value.flag = false 
-            apiRequest("post", env.HANDLE_HISTORY, {
-                "type": 'project',
-                "companyId": companyId.value,
-                "projectId": projectData.value._id,
-                "taskId": null,
-                "object": historyObj,
-                "userData": userData
-            })
-            .catch((error) => {
-                console.error("ERROR in update project history: ", error);
-            })
-            return;
-        }
-
-        deleteView({ cid: companyId.value, pid: projectData.value._id }, openDelete.value.data).then((res)=>{
-            commit('projectData/projectLocalUpdate', {itemData: res.data,projectId: projectData.value._id,key:"ProjectView",subKey:"delete",userId: ''});
-        })
-        .catch((err) => {
-            console.error(err.statusText)
-        })
-        openDelete.value.flag = false
-        apiRequest("post", env.HANDLE_HISTORY, {
-            "type": 'project',
-            "companyId": companyId.value,
-            "projectId": projectData.value._id,
-            "taskId": null,
-            "object": historyObj,
-            "userData": userData
-        })
-        .catch((error) => {
-            console.error("ERROR in update project history: ", error);
-        })
-        $toast.success(t('Toast.View_Deleted_Successfully'),{position:'top-right'}) 
-    }
-
-    const copyToClipboard = (id) => {
-        let link = window.location.href.split('?')[0]
-        link = link+`?tab=EmbedView&eid=${id}`
-        navigator.clipboard.writeText(link)
-        $toast.success(t('Toast.Link_copied_to_clipboard_successfully'),{position:'top-right'})
-    }
-
-    function updateProjectName() {
-        checkAllFields({projectName: projectName.value})
-        .then(async (valid) =>{
-            const prevName = sanitizeInput(projectData.value.ProjectName);
-            const newName = sanitizeInput(projectName.value.value);
-            if(valid) {
-                editProject.value = false;
-                editProject2.value = false;
-                try {
-                    const updateObj = { ProjectName: projectName.value.value };
-                    await apiRequest("put",`/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`,{updateObject: updateObj});
-                    $toast.success(t('Toast.Project_name_updated_successfully'), {position: 'top-right'});
-                    const user = getUser(userId.value);
-                    const userData = {
-                        id: user.id,
-                        Employee_Name: user.Employee_Name,
-                        companyOwnerId: companyOwner.value.userId
-                    }
-
-                     // Call history API
-                    const axiosData = {
-                        "type": "project",
-                        "companyId": companyId.value,
-                        "projectId": projectData.value._id,
-                        "taskId": null,
-                        "object": {
-                            "sprintId": null,
-                            "key": "Project_Name",
-                            "message": `<b>${userData.Employee_Name}</b> has changed the name of <b>${prevName}</b> to <b>${newName}</b>`
-                        },
-                        "userData": userData
-                    };
-                    apiRequest("post", env.HANDLE_HISTORY, axiosData).then((result) => {
-                        if(result.data.status) {
-                            console.info(result.data.statusText)
-                        }
-                    });
-                    let updatedPr = {...projectData.value,ProjectName: projectName.value.value}
-                    commit('projectData/projectLocalUpdate', {itemData: updatedPr,key:"ProjectName",subKey:"",userId: userId.value});
-                    let notifyObj = {
-                        TaskName: newName,
-                        previousTaskName: prevName
-                    }
-                    let notificationObject = {
-                        message: EditProjectName(notifyObj),
-                        key: "project_name",
-                    };
-                    
-                    apiRequest("post", env.HANDLE_NOTIFICATION, {
-                        type: 'project',
-                        companyId: companyId.value,
-                        projectId: projectData.value._id,
-                        object: notificationObject,
-                        userData: userData,
-                        changeType:'name',
-                        changeData: notifyObj
-                    })
-                    .catch((error) => {
-                        console.error("ERROR in update notification", error);
-                    })
-                    resetProjectName();
-                } catch (error) {
-                    console.error(error);
-                }
-            }
-        })
-        .catch((error) => {
-            console.error("ERROR in validation: ", error);
-        })
-    }
-
-    function toggleSearch() {
-        if(taskDescriptionSearch.value === false && taskKeySearch.value === false) {
-            taskNameSearch.value = true
-        }
-    }
-
-    function searchMongoDB() {
-        if(!taskSearch.value.trim().length && !filterUsers.value.length && !showArchived.value && !Object.keys(filterQuery.value).length) {
-            commit("projectData/mutateSearchTask", {data:[],op: "added"})
-            searchTask.value = false;
-            return;
-        }
-
-        let query_by = {};
-        let searchStr = taskSearch.value ? taskSearch.value.toString(): "";
-        let andOr = '$or';
-        query_by[andOr] = [];
-        if(taskNameSearch.value) {
-            query_by[andOr].push({'TaskName':{ $regex: searchStr, $options: 'i' }});
-        }
-        if(taskKeySearch.value) {
-            query_by[andOr].push({'TaskKey':{ $regex: searchStr, $options: 'i' }});
-        }
-        if(taskDescriptionSearch.value) {
-            query_by[andOr].push({'rawDescription':{ $regex: searchStr, $options: 'i' }});
-        }
-        searchTask.value = true;
-        const query = [
-            {
-                $match: {
-                    $and: [
-                        {
-                            $and:[
-                                {ProjectID: {objId: {$in : [projectData.value._id]}}},
-                                { deletedStatusKey: { $in: [showArchived.value ? 2 : 0] } }
-                            ]
-                        },
-                    ]
-                }
-            }
-        ];
-
-        if (filterQuery.value) {
-            query[0].$match.$and.push(filterQuery.value);
-        }
-
-        if (searchStr && searchStr.length) {
-            query[0].$match.$and.push(query_by);
-        }
-
-        if (filterUsers.value && filterUsers.value.length > 0) {
-            query[0].$match.$and.push({ AssigneeUserId: { $in: filterUsers.value } });
-        }
-
-        if ((showTasks.value === 1)) {
-            query[0].$match.$and.push({ AssigneeUserId: { $in: [userId.value] } });
-        }
-
-        dispatch("projectData/searchTask",
-            {query: query, showArchived: showArchived.value}
-        )
-        .catch((error) => {
-            console.error("ERROR in search tasks: ", error);
-        })
-    }
-
-    function manageFilterUsers(userId = null) {
-        if(userId) {
-            if(filterUsers.value.includes(userId)) {
-                filterUsers.value = filterUsers.value.filter((x) => x !== userId);
+watch([() => embedViews.value, () => projectData.value, () => route], ([newEmbedView, newProject, newRoute], [, oldProject]) => {
+    if (newRoute.query.tab === 'EmbedView') {
+        if (!newEmbedView.length && isEqual(newProject._id, oldProject._id)) {
+            activeTab.value = 'ProjectListView';
+            router.replace({ query: { tab: 'ProjectListView' } });
+        } else if (newEmbedView.length) {
+            if (newEmbedView[0].id === route.query.eid) {
+                selectedEmbedView.value = newEmbedView[0];
             } else {
-                filterUsers.value.push(userId);
+                selectedEmbedView.value = newEmbedView.find((item) => item.id === route.query.eid) || newEmbedView[0];
             }
+
+            nextTick(() => {
+                loadingProjects.value = false;
+            });
         }
-
-        searchMongoDB()
     }
+});
 
-    watch(taskSearch, debounce(() => {
-        searchMongoDB()
-    },1000))
-
-    watch([projectData, showArchived],() => {
-        searchMongoDB()
-    })
-
-    const sprints = ref([]);
-
-    function checkSprint(sprintData) {
-        let addSprint = false;
-        if(!showArchived.value) {
-            addSprint = (sprintData?.deletedStatusKey === 0 || sprintData?.deletedStatusKey === undefined) && sprintData._id;
-        } else {
-            addSprint = (sprintData?.deletedStatusKey === 2) && sprintData._id;
-            if(!addSprint && getters["projectData/searchedTasks"]?.length) {
-                addSprint = getters["projectData/searchedTasks"].filter((task) => task.sprintId === sprintData.id).length
-            }
+watch(clientWidth, () => {
+    if (clientWidth.value < 765) {
+        if (visible.value) {
+            visible.value = false;
         }
-
-        return addSprint;
     }
+});
 
-    async function assignProjects(data = []) {
-        await filteredProjects(JSON.parse(JSON.stringify(data)), showArchivedProjects.value, filterFavorites.value)
-
-        nextTick(() => {
-            loadingProjects.value = false;
-        })
-    }
-
-
-    watch(showArchivedProjects, (newVal, oldVal) => {
-        if(newVal !== oldVal && projectData.value && Object.keys(projectData.value)?.length) {
-            loadingProjects.value = true;
-        }
-    })
-
-    // GET FILTERED PROJECTS, FOLDERS & SPRINTS
-    watch([() => getters["projectData/projects"], showArchivedProjects, route, filterFavorites], ([data]) => {
-        localStorage.setItem('favoriteFilter', filterFavorites.value)
-        if(data.data && data.data.length) {
-            assignProjects(data.data);
-        } else if(showArchivedProjects.value) {
-            loadingProjects.value = false;
-        } 
-    },{deep: true})
-
-    function tourHandler(key,isDirectTour=false) {
+const isActiveAiCreator = ref(false);
+const currentCompany = computed(() => getters['settings/selectedCompany']);
+const openSidebar = () => {
+    isActiveCreateSidebar.value = true;
+};
+function closeSidebar(value) {
+    isActiveCreateSidebar.value = value;
+}
+const openAiCreator = () => {
+    isActiveAiCreator.value = true;
+};
+function onAiProjectCreated({ projectId }) {
+    try {
+        dispatch('projectData/setProjects', { roleType: 'currentUser' });
+    } catch (_e) { /* ignore */ }
+    if (projectId) {
         try {
-            if(!isDirectTour) {
-                mainTour.value.handleTour(key);
-            } else {
-                startProjectTour(key)
-            }
-        } catch (error) {
-            console.error("ER: ", error);
+            const cid = (currentCompany.value && currentCompany.value._id) || route.params.cid;
+            router.push({ name: 'Project', params: { cid, id: projectId } });
+        } catch (_e) { /* ignore */ }
+    }
+    isActiveAiCreator.value = false;
+}
+
+const getChange = () => {
+    companyUser.value = (companyUserData.value.filter((item) => userId.value == item.userId))[0];
+    const userTabs = (companyUser.value?.ProjectRequiredComponent)
+        ? (Object.entries(companyUser.value?.ProjectRequiredComponent)).map((element) => ({ uniqueId: element[0], ...element[1] })).filter((item) => item.projectId === projectData.value._id)
+        : [];
+    const Tabs2 = projectData.value.ProjectRequiredComponent?.filter((item) => item._id.length > 6);
+    const ids = projectData.value.ProjectRequiredComponent?.map((item) => item._id);
+    viewsListArray.value = [...(userTabs.filter((element) => element.id.length > 6 && (!ids.includes(element.id)))), ...Tabs2].sort((a, b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))));
+    embedViews.value = ([...projectData.value.ProjectRequiredComponent.filter((item) => item._id.length == 6), ...(userTabs.filter((element) => element.id.length == 6))].sort((a, b) => (a.name.toLowerCase() < b.name.toLowerCase()) ? -1 : ((b.name.toLowerCase() < a.name.toLowerCase()) ? 1 : 0))).sort((a, b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))));
+    if (projectDetailPermission.value === null) {
+        viewsListArray.value = viewsListArray.value.filter((item) => item.keyName !== 'ProjectDetail');
+    }
+};
+
+function checkSprint(sprintData) {
+    let addSprint = false;
+    if (!showArchived.value) {
+        addSprint = (sprintData?.deletedStatusKey === 0 || sprintData?.deletedStatusKey === undefined) && sprintData._id;
+    } else {
+        addSprint = (sprintData?.deletedStatusKey === 2) && sprintData._id;
+        if (!addSprint && getters['projectData/searchedTasks']?.length) {
+            addSprint = getters['projectData/searchedTasks'].filter((task) => task.sprintId === sprintData.id).length;
         }
     }
- 
-    onMounted(() => {
-        if(clientWidth.value <= 1300){
-            visible.value = true;
-            projectList.value.toggleSidebar(true)
-        }
+
+    return addSprint;
+}
+
+async function assignProjects(data = []) {
+    await filteredProjects(JSON.parse(JSON.stringify(data)), showArchivedProjects.value, filterFavorites.value);
+    nextTick(() => {
+        loadingProjects.value = false;
+    });
+}
+
+watch(showArchivedProjects, (newVal, oldVal) => {
+    if (newVal !== oldVal && projectData.value && Object.keys(projectData.value)?.length) {
         loadingProjects.value = true;
-        dispatchProjects()
+    }
+});
+
+watch([() => getters['projectData/projects'], showArchivedProjects, route, filterFavorites], ([data]) => {
+    localStorage.setItem('favoriteFilter', filterFavorites.value);
+    if (data.data && data.data.length) {
+        assignProjects(data.data);
+    } else if (showArchivedProjects.value) {
+        loadingProjects.value = false;
+    }
+}, { deep: true });
+
+onMounted(() => {
+    if (clientWidth.value <= 1300) {
+        visible.value = true;
+        projectList.value.toggleSidebar(true);
+    }
+    loadingProjects.value = true;
+    dispatchProjects()
         .then(() => {
             nextTick(() => {
-                if(getters["projectData/projects"] && getters["projectData/projects"]?.data?.length) {
-                    if(!route.query?.tab) {
-                        if(route.params.id) {
-                            let index = projects.value.findIndex((e)=>e._id === route.params.id);
-                            if(index!== -1) {
-                                let viewFind = projects.value[index].ProjectRequiredComponent?.find((e) => e.setAsDefault) || projects.value[index].ProjectRequiredComponent?.find((e) => e.viewStatus) || projects.value[index].ProjectRequiredComponent[0];
-                                router.replace({query: {tab: (viewFind ? viewFind?.keyName :"ProjectListView"),...route.query}});
+                if (getters['projectData/projects'] && getters['projectData/projects']?.data?.length) {
+                    if (!route.query?.tab) {
+                        if (route.params.id) {
+                            const index = projects.value.findIndex((e) => e._id === route.params.id);
+                            if (index !== -1) {
+                                const viewFind = projects.value[index].ProjectRequiredComponent?.find((e) => e.setAsDefault) || projects.value[index].ProjectRequiredComponent?.find((e) => e.viewStatus) || projects.value[index].ProjectRequiredComponent[0];
+                                router.replace({ query: { tab: (viewFind ? viewFind?.keyName : 'ProjectListView'), ...route.query } });
                             }
                         } else {
-                            let viewFind = projects.value[0]?.ProjectRequiredComponent?.find((e) => e.setAsDefault) || projects.value[0]?.ProjectRequiredComponent?.find((e) => e.viewStatus) || projects.value[0]?.ProjectRequiredComponent[0];
-                            router.replace({query: {tab: (viewFind ? viewFind?.keyName :"ProjectListView"),...route.query}})
+                            const viewFind = projects.value[0]?.ProjectRequiredComponent?.find((e) => e.setAsDefault) || projects.value[0]?.ProjectRequiredComponent?.find((e) => e.viewStatus) || projects.value[0]?.ProjectRequiredComponent[0];
+                            router.replace({ query: { tab: (viewFind ? viewFind?.keyName : 'ProjectListView'), ...route.query } });
                         }
                     }
                 }
                 loadingProjects.value = false;
-            })
+            });
         })
         .catch((error) => {
             nextTick(() => {
                 loadingProjects.value = false;
-            })
-            console.error("ERROR: in set projects: ", error);
-        })
-        if(getters["projectData/projects"] && getters["projectData/projects"]?.data?.length) {
-            assignProjects(getters["projectData/projects"].data);
-        }
-        calendarRange(new Date('01-jan-1970'),[],'Monthly',true,new Date('31-dec-2100')).then((value)=>{
-            rangeObject.value = value
+            });
+            console.error('ERROR: in set projects: ', error);
         });
-        document.body.addEventListener('click', handleClickOutside);
-        companyUserData.value = computed(()=> { return getters['settings/companyUsers']} )
-        setTimeout(()=>{
-            if(companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
-                if(getUser(userId.value)?.tourStatus?.isProjectAndNavbarTour == undefined || getUser(userId.value)?.tourStatus?.isProjectAndNavbarTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
-                    if(clientWidth.value > 767) {
-                        tourHandler('isProjectAndNavbarTour')
-                    }
-                } else {
-                    // Project Views
-                    if(companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
-                        if(getUser(userId.value)?.tourStatus?.isProjectViewTour == undefined || getUser(userId.value)?.tourStatus?.isProjectViewTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
-                            if(clientWidth.value > 767) {
-                                if(projects.value.length) {
-                                    tourHandler('isProjectViewTour');
-                                }
-                            }
-                        }
-                    }
-
-                    //Project List Left Views
-                    if(companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
-                        if(getUser(userId.value)?.tourStatus?.isProjectLeftViewTour == undefined || getUser(userId.value)?.tourStatus?.isProjectLeftViewTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
-                            if(clientWidth.value > 1300) {
-                                tourHandler('isProjectLeftViewTour');
-                            }
-                        }
-                    }
-                }
-                // if(getUser(userId.value)?.tourStatus?.isTaskTour == undefined || getUser(userId.value)?.tourStatus?.isTaskTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
-                //     secondTour.value.drive()
-                // }
-            }
-        },1500)
-    })
-    onUnmounted(() => {
-        socket.value.emit('getRoomList', socket.value.id, (rooms) => {
-            let currentSocketRooms = rooms.find((x)=> x.includes(socket.value.id) && x.includes('project_sprint_'))
-            if (currentSocketRooms) {
-                socket.value.emit('leaveProjectSprintForTask', currentSocketRooms);    
-                let sprintId = currentSocketRooms.split('**')[0].split("_").pop()
-                commit("projectData/setGetPaginatedTasksPayload",{data:{projectData,pid:projectData.value._id},op: 'remove'});
-                commit("projectData/setGetTableTaskPayload",{data:{sprintId,pid:projectData.value._id},op: 'remove'});
-                const events = ['taskInsert', 'taskUpdate', 'taskDelete', 'taskReplace'];
-                events.forEach(event => {
-                    socket.value.off(event);
-                });
-            }
-        })
-        document.body.removeEventListener('click', handleClickOutside);
-    });
- 
-    // UPDATE PROJECT DATA ON UPDATES IN DATABASE
-    watch([projects, route], () => {
-        if(projects.value && route?.params?.id && projectData.value && Object.keys(projectData.value).length) {
-            if(route.params.id !== projectData.value._id){
-                searchMongoDB();
-            }
-
-            if(projects.value && projects.value.length) {
-                let index = projects.value.findIndex((x) => x._id == projectData.value._id);
-                if(index !== -1) {
-                    projectData.value = projects.value[index] || {}
-                }
-                else{
-                    projectData.value = projects.value[0] || {};
-                }
-            }
+    if (getters['projectData/projects'] && getters['projectData/projects']?.data?.length) {
+        assignProjects(getters['projectData/projects'].data);
+    }
+    setTimeout(() => {
+        runProjectStartupTours(projects.value.length);
+    }, 1500);
+});
+onUnmounted(() => {
+    socket.value.emit('getRoomList', socket.value.id, (rooms) => {
+        const currentSocketRooms = rooms.find((x) => x.includes(socket.value.id) && x.includes('project_sprint_'));
+        if (currentSocketRooms) {
+            socket.value.emit('leaveProjectSprintForTask', currentSocketRooms);
+            const sprintId = currentSocketRooms.split('**')[0].split('_').pop();
+            commit('projectData/setGetPaginatedTasksPayload', { data: { projectData, pid: projectData.value._id }, op: 'remove' });
+            commit('projectData/setGetTableTaskPayload', { data: { sprintId, pid: projectData.value._id }, op: 'remove' });
+            const events = ['taskInsert', 'taskUpdate', 'taskDelete', 'taskReplace'];
+            events.forEach((event) => {
+                socket.value.off(event);
+            });
         }
-    })
+    });
+});
 
-    watch(route, () => {
-        if(projects.value && route?.params?.id && projectData.value && Object.keys(projectData.value).length && route.params.id !== projectData.value._id) {
-            let index = projects.value.findIndex((x) => x._id == route.params.id)
-            if(index !== -1) {
+// UPDATE PROJECT DATA ON UPDATES IN DATABASE
+watch([projects, route], () => {
+    if (projects.value && route?.params?.id && projectData.value && Object.keys(projectData.value).length) {
+        if (route.params.id !== projectData.value._id) {
+            searchMongoDB();
+        }
+
+        if (projects.value && projects.value.length) {
+            const index = projects.value.findIndex((x) => x._id == projectData.value._id);
+            if (index !== -1) {
                 projectData.value = projects.value[index] || {};
             } else {
-                router.replace({name: "Project", params: {cid: route.params?.cid, id: route.params?.id}, query: {...route.query}})
                 projectData.value = projects.value[0] || {};
             }
         }
-    })
+    }
+});
 
-    // UPDATE/FILTER SPRINTS ARRAY FOR LISTING
-    watch([projectData, route, () => getters["projectData/searchedTasks"]], () => {
-        if (skipWatcher.value) return;
-        if(!route.name.toLowerCase().includes("project")) return;
-        let tmp = sprints.value;
-        if(!projectData.value || !Object.keys(projectData.value).length) return;
-        let projectId = route.params?.id ? route.params.id : projectData.value._id
-        let project;
-        if (projectSearchText.value === '') {
-            project = getters["projectData/projects"]?.data?.find((x) => x._id === projectId) || null;
+watch(route, () => {
+    if (projects.value && route?.params?.id && projectData.value && Object.keys(projectData.value).length && route.params.id !== projectData.value._id) {
+        const index = projects.value.findIndex((x) => x._id == route.params.id);
+        if (index !== -1) {
+            projectData.value = projects.value[index] || {};
         } else {
-            project = getters["projectData/searchedProjects"]?.find((x) => x._id === projectId) || null;
+            router.replace({ name: 'Project', params: { cid: route.params?.cid, id: route.params?.id }, query: { ...route.query } });
+            projectData.value = projects.value[0] || {};
         }
-        
-        if(!project) return;
+    }
+});
 
-        try {
-            if(route.name === "Projects" || route.name === "Project") {
-                tmp = project?.sprintsObj && Object.values(project?.sprintsObj).length ? Object.values(project.sprintsObj).filter((x) => checkSprint(x)) : [];
-                Object.values(project.sprintsfolders || {}).forEach((value) => {
-                    try {
-                        if(showArchived.value && value?.deletedStatusKey === 2) {
-                            tmp.push({
-                                name: value.name,
-                                id: value.folderId,
-                                isExpanded: false,
-                                items: [],
-                                archivedSprintList: value.sprintsObj || {},
-                                deletedStatusKey: 2,
-                                isFolder: true
-                            })
-                        } else if(showArchived.value && !value?.deletedStatusKey){
-                            tmp = [
-                                ...tmp,
-                                ...(Object.values(value?.sprintsObj || {})?.length ? Object.values(value.sprintsObj || {}).filter((x) => checkSprint(x)) : [])
-                            ]
-                        } else if(!showArchived.value && !value?.deletedStatusKey){
-                            tmp = [
-                                ...tmp,
-                                ...(Object.values(value?.sprintsObj || {})?.length ? Object.values(value?.sprintsObj || {}).filter((x) => checkSprint(x)) : [])
-                            ]
-                        }
-                    } catch (error) {
-                        console.error("ERROR: ", error, value);
+const sprints = ref([]);
+
+// UPDATE/FILTER SPRINTS ARRAY FOR LISTING
+watch([projectData, route, () => getters['projectData/searchedTasks']], () => {
+    if (skipWatcher.value) return;
+    if (!route.name.toLowerCase().includes('project')) return;
+    let tmp = sprints.value;
+    if (!projectData.value || !Object.keys(projectData.value).length) return;
+    const projectId = route.params?.id ? route.params.id : projectData.value._id;
+    let project;
+    if (projectSearchText.value === '') {
+        project = getters['projectData/projects']?.data?.find((x) => x._id === projectId) || null;
+    } else {
+        project = getters['projectData/searchedProjects']?.find((x) => x._id === projectId) || null;
+    }
+
+    if (!project) return;
+
+    try {
+        if (route.name === 'Projects' || route.name === 'Project') {
+            tmp = project?.sprintsObj && Object.values(project?.sprintsObj).length ? Object.values(project.sprintsObj).filter((x) => checkSprint(x)) : [];
+            Object.values(project.sprintsfolders || {}).forEach((value) => {
+                try {
+                    if (showArchived.value && value?.deletedStatusKey === 2) {
+                        tmp.push({
+                            name: value.name,
+                            id: value.folderId,
+                            isExpanded: false,
+                            items: [],
+                            archivedSprintList: value.sprintsObj || {},
+                            deletedStatusKey: 2,
+                            isFolder: true,
+                        });
+                    } else if (showArchived.value && !value?.deletedStatusKey) {
+                        tmp = [
+                            ...tmp,
+                            ...(Object.values(value?.sprintsObj || {})?.length ? Object.values(value.sprintsObj || {}).filter((x) => checkSprint(x)) : []),
+                        ];
+                    } else if (!showArchived.value && !value?.deletedStatusKey) {
+                        tmp = [
+                            ...tmp,
+                            ...(Object.values(value?.sprintsObj || {})?.length ? Object.values(value?.sprintsObj || {}).filter((x) => checkSprint(x)) : []),
+                        ];
                     }
-                })
-            } else if(route.name.includes("ProjectFolder")) {
-                if(route.params.sprintId && !project?.sprintsfolders?.[route.params.folderId]?.deletedStatusKey) {
-                    const sprintIndex = Object.values(project?.sprintsfolders?.[route.params.folderId]?.sprintsObj || {})?.findIndex((x) => x.id === route.params.sprintId);
-                    if(sprintIndex !== -1) {
-                        tmp = [Object.values(project.sprintsfolders[route.params.folderId].sprintsObj)[sprintIndex]]
+                } catch (error) {
+                    console.error('ERROR: ', error, value);
+                }
+            });
+        } else if (route.name.includes('ProjectFolder')) {
+            if (route.params.sprintId && !project?.sprintsfolders?.[route.params.folderId]?.deletedStatusKey) {
+                const sprintIndex = Object.values(project?.sprintsfolders?.[route.params.folderId]?.sprintsObj || {})?.findIndex((x) => x.id === route.params.sprintId);
+                if (sprintIndex !== -1) {
+                    tmp = [Object.values(project.sprintsfolders[route.params.folderId].sprintsObj)[sprintIndex]];
+                } else {
+                    tmp = [];
+                }
+            } else {
+                if (project.sprintsfolders?.[route.params.folderId]?.deletedStatusKey === 2) {
+                    if (showArchived.value) {
+                        const val = project.sprintsfolders?.[route.params.folderId];
+                        tmp = [{
+                            name: val.name,
+                            id: val.folderId,
+                            isExpanded: false,
+                            archivedSprintList: project?.sprintsfolders?.[route.params.folderId]?.sprintsObj || {},
+                            items: [],
+                            deletedStatusKey: 2,
+                            isFolder: true,
+                        }];
                     } else {
                         tmp = [];
                     }
                 } else {
-                    if(project.sprintsfolders?.[route.params.folderId]?.deletedStatusKey === 2) {
-                        if(showArchived.value) {
-                            let val = project.sprintsfolders?.[route.params.folderId]
-                            tmp = [{
-                                name: val.name,
-                                id: val.folderId,
-                                isExpanded: false,
-                                archivedSprintList: project?.sprintsfolders?.[route.params.folderId]?.sprintsObj || {},
-                                items: [],
-                                deletedStatusKey: 2,
-                                isFolder: true,
-                            }];
-                        } else {
-                            tmp = [];
-                        }
-                    } else {
-                        tmp = Object.values(project.sprintsfolders[route.params.folderId]?.sprintsObj || {})?.length ? Object.values(project.sprintsfolders[route.params.folderId].sprintsObj).filter((x) => checkSprint(x)) : [];
-                    }
-                }
-            } else if(route.name.includes("ProjectSprint")){
-                const sprintsArray = Object.values(project?.sprintsObj || {});
-                const sprintIndex = sprintsArray.findIndex((x) => x.id === route.params.sprintId && (!showArchived.value ? (x?.deletedStatusKey === 0 || x?.deletedStatusKey === undefined) : true));
-                if((companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2) || (sprintIndex !== -1 && (!sprintsArray[sprintIndex]?.private || sprintsArray[sprintIndex]?.AssigneeUserId?.includes(userId.value)))) {
-                    tmp = sprintIndex !== -1 ? [sprintsArray[sprintIndex]] : [];
-                } else {
-                    tmp = [];
+                    tmp = Object.values(project.sprintsfolders[route.params.folderId]?.sprintsObj || {})?.length ? Object.values(project.sprintsfolders[route.params.folderId].sprintsObj).filter((x) => checkSprint(x)) : [];
                 }
             }
-        } catch (error) {
-            console.error(error,"Error")
-        }
-
-
-        if(companyUserDetail.value.roleType !== 1 && companyUserDetail.value.roleType !== 2) {
-            tmp = tmp.filter((x) => {
-                return !x?.private || x?.AssigneeUserId?.includes(userId.value)
-            })
-        }
-
-        tmp = tmp.sort((a, b) => a?.createdAt?.seconds > b?.createdAt?.seconds ? -1 : 1);
-
-        if(searchTask.value) {
-            if(getters["projectData/searchedTasks"]?.length) {
-                if(showArchived.value) {
-                    tmp = tmp?.filter((x) => getters["projectData/searchedTasks"].filter((y) => y.sprintId === x.id || x.isFolder === true || x.deletedStatusKey === 2).length) || [];
-                } else {
-                    tmp = tmp?.filter((x) => getters["projectData/searchedTasks"].filter((y) => y.sprintId === x.id || x.isFolder === true).length) || [];
-                }
+        } else if (route.name.includes('ProjectSprint')) {
+            const sprintsArray = Object.values(project?.sprintsObj || {});
+            const sprintIndex = sprintsArray.findIndex((x) => x.id === route.params.sprintId && (!showArchived.value ? (x?.deletedStatusKey === 0 || x?.deletedStatusKey === undefined) : true));
+            if ((companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2) || (sprintIndex !== -1 && (!sprintsArray[sprintIndex]?.private || sprintsArray[sprintIndex]?.AssigneeUserId?.includes(userId.value)))) {
+                tmp = sprintIndex !== -1 ? [sprintsArray[sprintIndex]] : [];
             } else {
-                tmp = tmp?.filter((x) => x.isFolder || x.deletedStatusKey === 2);
+                tmp = [];
             }
         }
+    } catch (error) {
+        console.error(error, 'Error');
+    }
 
-        tmp = tmp.filter((x) => x && x?.deletedStatusKey !== 1)
-        tmp = tmp?.filter((x) => (showArchived.value ? (x?.deletedStatusKey === 2 || x.archiveTaskCount) : !x?.deletedStatusKey))
+    if (companyUserDetail.value.roleType !== 1 && companyUserDetail.value.roleType !== 2) {
+        tmp = tmp.filter((x) => !x?.private || x?.AssigneeUserId?.includes(userId.value));
+    }
 
-        // CONDITION TO REDIRECT TO THE PROJECT IF REQUESTED SPRINT NOT FOUND
-        if(!tmp.length && !showArchived.value) {
-            if(route.params?.cid && route.params?.id === project.id && ["ProjectListView", "ProjectKanban", "Calendar", "TableView"].includes(route.params?.tab || "")) {
-                let tab = route.query?.tab;
-                if(!project?.ProjectRequiredComponent?.find((x) => x.keyName === route.query?.tab)) {
-                    let viewFind = project?.ProjectRequiredComponent?.find((e) => e.setAsDefault) || project?.ProjectRequiredComponent?.find((e) => e.viewStatus) || project?.ProjectRequiredComponent[0];
-                    tab = viewFind ? viewFind?.keyName :"ProjectListView";
-                }
-                if(route.params?.id) {
-                    router.replace({name: "Project", params: {cid: route.params?.cid, id: route.params?.id}, query: {...route.query, tab}})
-                } else {
-                    router.replace({name: "Projects", params: {cid: route.params?.cid}, query: {...route.query, tab}})
-                }
-            }
-        }
-        if(!isEqual(tmp, sprints.value)) {
-            sprints.value = tmp;
-        }
+    tmp = tmp.sort((a, b) => a?.createdAt?.seconds > b?.createdAt?.seconds ? -1 : 1);
 
-        // REOPEN LIST VIEW
-        if(project && project?.ProjectRequiredComponent?.length) {
-            if((route.query && route.query.tab && (project?.ProjectRequiredComponent.filter((x) => x.keyName === route.query.tab || x.id != route.query.eid).length)) || route.query.tab == 'EmbedView' ) {
-                activeTab.value = route.query.tab;
+    if (searchTask.value) {
+        if (getters['projectData/searchedTasks']?.length) {
+            if (showArchived.value) {
+                tmp = tmp?.filter((x) => getters['projectData/searchedTasks'].filter((y) => y.sprintId === x.id || x.isFolder === true || x.deletedStatusKey === 2).length) || [];
             } else {
-                activeTab.value = route.query.tab ? route.query.tab :'ProjectListView';
+                tmp = tmp?.filter((x) => getters['projectData/searchedTasks'].filter((y) => y.sprintId === x.id || x.isFolder === true).length) || [];
             }
         } else {
-            activeTab.value = "ProjectListView";
+            tmp = tmp?.filter((x) => x.isFolder || x.deletedStatusKey === 2);
         }
+    }
 
-        assigneeFilterOptions.value = [];
-        let usersArr = [];
-        if(project.isPrivateSpace) {
-            usersArr = project.AssigneeUserId;
+    tmp = tmp.filter((x) => x && x?.deletedStatusKey !== 1);
+    tmp = tmp?.filter((x) => (showArchived.value ? (x?.deletedStatusKey === 2 || x.archiveTaskCount) : !x?.deletedStatusKey));
+
+    if (!tmp.length && !showArchived.value) {
+        if (route.params?.cid && route.params?.id === project.id && ['ProjectListView', 'ProjectKanban', 'Calendar', 'TableView'].includes(route.params?.tab || '')) {
+            let tab = route.query?.tab;
+            if (!project?.ProjectRequiredComponent?.find((x) => x.keyName === route.query?.tab)) {
+                const viewFind = project?.ProjectRequiredComponent?.find((e) => e.setAsDefault) || project?.ProjectRequiredComponent?.find((e) => e.viewStatus) || project?.ProjectRequiredComponent[0];
+                tab = viewFind ? viewFind?.keyName : 'ProjectListView';
+            }
+            if (route.params?.id) {
+                router.replace({ name: 'Project', params: { cid: route.params?.cid, id: route.params?.id }, query: { ...route.query, tab } });
+            } else {
+                router.replace({ name: 'Projects', params: { cid: route.params?.cid }, query: { ...route.query, tab } });
+            }
+        }
+    }
+    if (!isEqual(tmp, sprints.value)) {
+        sprints.value = tmp;
+    }
+
+    if (project && project?.ProjectRequiredComponent?.length) {
+        if ((route.query && route.query.tab && (project?.ProjectRequiredComponent.filter((x) => x.keyName === route.query.tab || x.id != route.query.eid).length)) || route.query.tab == 'EmbedView') {
+            activeTab.value = route.query.tab;
         } else {
-            usersArr = users.value.map((x) => x._id);
+            activeTab.value = route.query.tab ? route.query.tab : 'ProjectListView';
         }
-
-        usersArr.forEach((x) => {
-            if(x !== userId.value) {
-                let user = getUser(x);
-                if(!user.ghostUser) {
-                    assigneeFilterOptions.value.push({
-                        value: x,
-                        label: user.Employee_Name,
-                        image: user.Employee_profileImageURL
-                    })
-                }
-            }
-        })
-        assigneeFilterOptions.value = assigneeFilterOptions.value.sort((a, b) => a.label?.trim()?.toLowerCase().localeCompare(b.label?.trim()?.toLowerCase()));
-    },{deep: true})
-
-    function getView(val) {
-        switch(val) {
-            case "ProjectListView":
-                return ProjectListView;
-            case "Comments":
-                return Comments;
-            case "ActivityLog":
-                return ActivityLog;
-            case "ProjectDetail":
-                if(projectDetailPermission.value == null){
-                    return NotFound;
-                }else{
-                    return ProjectDetail;
-                }
-            case "EmbedView":
-                return EmbedViewItem;
-            case "Workload":
-                return WorkloadView;
-            case "TableView":
-                return TableViewComp;
-            case "Calendar":
-                return ProjectListView;
-            case "ProjectKanban":
-                return BoardView;
-            default:
-                return NotFound;
-        }
+    } else {
+        activeTab.value = 'ProjectListView';
     }
 
-    async function changeAssignee(type, user) {
-        if(assigneeInProgress.value[user.id] && assigneeInProgress.value[user.id] === type) return;
-        assigneeInProgress.value[user.id] = type;
-
-        const usr = getUser(userId.value);
-        const userData = {
-            id: usr.id,
-            Employee_Name: usr.Employee_Name,
-            companyOwnerId: companyOwner.value.userId
-        }
-
-        let obj;
-        let key;
-        if (type === "add") {
-            if(projectData.value.AssigneeUserId.includes(user.id)) return;
-            obj = { AssigneeUserId: user.id };
-            key = '$addToSet';
-        } else {
-            if(!projectData.value.AssigneeUserId.includes(user.id)) return;
-            obj = {
-                AssigneeUserId: user.id,
-                ...(projectData.value.LeadUserId.includes(user.id) && { LeadUserId: user.id })
-            } 
-            key = '$pull';
-        }
-        try {
-            await apiRequest("put",`/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`,{updateObject: obj,key: key})
-
-            commit('projectData/projectLocalUpdate', {
-                itemData: {...projectData.value},
-                projectId: projectData.value._id,
-                key: 'AssigneeChange',
-                subKey: key === '$addToSet' ? 'add' : 'remove',
-                userId: user.id
-            });
-
-            delete assigneeInProgress.value[user.id];
-
-            const msg = `Assignee ${type === "add" ? "added" : "removed"} successfully`;
-            $toast.success(msg, {position: "top-right"});
-
-            let historyObj = {
-                'message': `<b>${userData.Employee_Name}</b> ${type === 'add' ? 'added' : 'removed'} the <b>Assignee</b> to <b>${user.label}</b>`,
-                'key' : 'Assignee_Changed',
-            }
-            let notifyObj = {
-                'projectName' : projectData.value.ProjectName,
-                'Employee_Name' : user.label
-            }
-            let notificationObject = {
-                message: type === 'add' ? projectAssignee(notifyObj) : projectAssigneeRemove(notifyObj),
-                key: "project_assignee",
-            };
-            apiRequest("post", env.HANDLE_HISTORY, {
-                type: 'project', 
-                companyId: companyId.value,
-                projectId: projectData.value._id,
-                taskId: null,
-                object: historyObj,
-                userData: userData
-            })
-            .catch((error) => {
-                console.error("ERROR in update history", error);
-            })
-            apiRequest("post", env.HANDLE_NOTIFICATION, {
-                type: 'project',
-                companyId: companyId.value,
-                projectId: projectData.value._id,
-                object: notificationObject,
-                userData: userData,
-                mentionUserId:[user.id]
-            })
-            .catch((error) => {
-                console.error("ERROR in update notification", error);
-            })
-        } catch (error) {
-            console.error('Error in update project', error);
-        }
+    assigneeFilterOptions.value = [];
+    let usersArr = [];
+    if (project.isPrivateSpace) {
+        usersArr = project.AssigneeUserId;
+    } else {
+        usersArr = users.value.map((x) => x._id);
     }
 
-    function markProjectFavourite() {
-        if(!projectData.value.favouriteTasks || !projectData.value.favouriteTasks.find((x) => x.userId === userId.value)) {
-            markFavourite({
-                cid: companyId.value,
-                projectId: projectData.value._id,
-                userId: userId.value
-            })
-            .then((msg) => {
-                commit('projectData/projectLocalUpdate', {itemData:  {...projectData.value},projectId:projectData.value._id,key:'MarkAsFavourite',subKey:'add',userId: userId.value});
-                $toast.success(msg, {position: "top-right"});
-            })
-            .catch((error) => {
-                console.error("ERROR in mark project fav: ", error);
-            })
-        } else {
-            markFavourite({
-                cid: companyId.value,
-                projectId: projectData.value._id,
-                userId: userId.value,
-                data: projectData.value.favouriteTasks.find((x) => x.userId === userId.value)
-            })
-            .then((msg) => {
-                commit('projectData/projectLocalUpdate', {itemData:  {...projectData.value},projectId:projectData.value._id,key:'MarkAsFavourite',subKey:'remove',userId: userId.value});
-                $toast.success(msg, {position: "top-right"});
-            })
-            .catch((error) => {
-                console.error("ERROR in mark project fav: ", error);
-            })
-        }
-    }
-
-    //Task Detail
-    const isTaskDetail = ref(false);
-    const selectedTask = ref({});
-
-    watch(() => route.params.taskId, (taskId) => { 
-        if (taskId && !isTaskDetail.value) {
-            selectedTask.value = { id: taskId, sprintId: route.params.sprintId };
-            isTaskDetail.value = true;
-        } else if (!taskId) {
-            isTaskDetail.value = false;
-            selectedTask.value = {};
-        }
-    }, { immediate: true });
-
-    const toggleTaskDetail = async(task) => {
-        skipWatcher.value = true;
-        const routeObj = {
-            cid: companyId.value,
-            id: task.ProjectID,
-            sprintId: task.sprintId,
-        }
-        if(task.folderObjId) {
-            routeObj.folderId = task.folderObjId;
-        }
-
-        if(!isTaskDetail.value) {
-            routeObj.taskId = task._id;
-            const taskDetail = {...task, sprintName:task?.sprintArray?.name,folderName:task?.sprintArray?.folderName,id: task._id}
-            selectedTask.value = taskDetail;
-            isTaskDetail.value = true;
-            // Force navigation by going to a different route first, then to target
-            await router.push({name: task.folderObjId?.length ? "ProjectFolderSprint" : "ProjectSprint", params: routeObj});
-            await router.push({name: task.folderObjId?.length ? "ProjectFolderSprintTask" : "ProjectSprintTask", params: routeObj, query: {...route.query, detailTab: "task-detail-tab"}});
-        } else {
-            isTaskDetail.value = false;
-            selectedTask.value = {};
-            await router.push({name: task.folderObjId?.length ? "ProjectFolderSprint" : "ProjectSprint", params: routeObj, query: {tab: route.query.tab}});
-        }
-        await nextTick();
-        skipWatcher.value = false;
-    }
-    provide('toggleTaskDetail', toggleTaskDetail);
-    provide('isRouteRequired', true);
-    const hanldeProjectTaktypeTour = ref(null);
-    const hanldeProjectLastStep = ref(null);
-    // const hanldeProjectViewAndOption = ref(null);
-    const hanldeBlankProjectTour = () => {
-        if(companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
-            if(getUser(userId.value)?.tourStatus?.isProjectTour == undefined || getUser(userId.value)?.tourStatus?.isProjectTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
-                if(clientWidth.value > 767) {
-                    tourHandler('isProjectTour1',true);
-                }
+    usersArr.forEach((x) => {
+        if (x !== userId.value) {
+            const user = getUser(x);
+            if (!user.ghostUser) {
+                assigneeFilterOptions.value.push({
+                    value: x,
+                    label: user.Employee_Name,
+                    image: user.Employee_profileImageURL,
+                });
             }
         }
+    });
+    assigneeFilterOptions.value = assigneeFilterOptions.value.sort((a, b) => a.label?.trim()?.toLowerCase().localeCompare(b.label?.trim()?.toLowerCase()));
+}, { deep: true });
+
+function getView(val) {
+    switch (val) {
+        case 'ProjectListView':
+            return ProjectListView;
+        case 'Comments':
+            return Comments;
+        case 'ActivityLog':
+            return ActivityLog;
+        case 'ProjectDetail':
+            return projectDetailPermission.value == null ? NotFound : ProjectDetail;
+        case 'EmbedView':
+            return EmbedViewItem;
+        case 'Workload':
+            return WorkloadView;
+        case 'TableView':
+            return TableViewComp;
+        case 'Calendar':
+            return ProjectListView;
+        case 'ProjectKanban':
+            return BoardView;
+        default:
+            return NotFound;
     }
-    hanldeProjectTaktypeTour.value = () => {
-        if(companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
-            if(getUser(userId.value)?.tourStatus?.isProjectTour == undefined || getUser(userId.value)?.tourStatus?.isProjectTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
-                if(clientWidth.value > 767) {
-                    tourHandler('isProjectTour2',true);
-                }
-            }
-        }
+}
+
+// Task Detail
+const isTaskDetail = ref(false);
+const selectedTask = ref({});
+
+watch(() => route.params.taskId, (taskId) => {
+    if (taskId && !isTaskDetail.value) {
+        selectedTask.value = { id: taskId, sprintId: route.params.sprintId };
+        isTaskDetail.value = true;
+    } else if (!taskId) {
+        isTaskDetail.value = false;
+        selectedTask.value = {};
     }
-    hanldeProjectLastStep.value = () => {
-        if(companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
-            if(getUser(userId.value)?.tourStatus?.isProjectTour == undefined || getUser(userId.value)?.tourStatus?.isProjectTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
-                if(clientWidth.value > 767) {
-                    tourHandler('isProjectTour3',true);
-                }
-            }
-        }
-    }
-    provide('hanldeBlankProjectTour', hanldeBlankProjectTour);
-    provide('hanldeProjectTaktypeTour', hanldeProjectTaktypeTour);
-    provide('hanldeProjectLastStep', hanldeProjectLastStep);
-    // provide('hanldeProjectViewAndOption', hanldeProjectViewAndOption);
-    const users = computed(() => getters["users/users"]);
-    const teams = computed(() => getters["settings/teams"])
-    /**
-     * This function is used to manage "Files & Links" and "Audio" sidebar
-     */
-    const isSidebar = ref(false);
-    const sidebarTitle = ref('');
-    const open = (val) => {
-        switch (val) {
-            case 'filesLinks':
-                isSidebar.value = true;
-                sidebarTitle.value = t('Projects.files_links');
-                break;
-            case 'audio':
-                isSidebar.value = true;
-                sidebarTitle.value = t('Projects.audio_files');
-                break;
-            case 'searchIcon':
-                visible.value = true;
-                break;
-            default:
-                break;
-        }
-    }
-    const billingPer = ref('');
-    const projectStartDate = ref({});
-    const handleEmitProjectRightSide = (action,value) => {
-        if(action === 'billingPeriod'){
-            projectData.value.BillingPeriod = value;
-            billingPer.value = value;
-        }
-        if(action === 'startDate'){
-            projectStartDate.value = value;
-        }
-        if(action === 'currency'){
-            projectData.value.ProjectCurrency = value;
-        }
-        if(action === 'projectType'){
-            if(value?.updateObject?.ProjectType){
-                projectData.value.ProjectType = value?.updateObject?.ProjectType || '';
-            }
-            if(value?.updateObject?.BillingPeriod){
-                projectData.value.BillingPeriod = value?.updateObject?.BillingPeriod || '';
-            }
-        }
-    } 
-    /**
-     * This function is used to perfom filter based on selected fields
-     * @param {String} query 
-     */
-    const applyFilter = (query) => {
-        filterQuery.value = query;
-        searchMongoDB()
-    }
+}, { immediate: true });
 
-    /**
-     * This function is used to clear all the selected filters
-     */
-    const clearFilter = () => {
-        filterQuery.value = '';
-        searchMongoDB()
-    }
-
-    function assignAvatarData(data) {
-        formData.value.projectName = data.name;
-        formData.value.projectId = data.id;
-        formData.value.icon= data?.icon || ''
-
-        if(data.icon.type === 'image') {
-            formData.value.projectProfileField.previewImage.value = data?.icon?.data || '';
-        } else {
-            formData.value.projectProfileField.selectedColor.value = data?.icon?.data || '';
-        }
-    }
-
-    async function saveProjectAvatar() {
-        const updateObject = {type: "color", data : ""};
-        const prevIcon = formData?.value?.icon || '';
-        savingAvatar.value = true;
-
-        const deleteWasabiImage = () => {
-            try {
-                let axiousObject = storageQueryBuilder('delete',companyId.value,((env.STORAGE_TYPE && env.STORAGE_TYPE === 'server') ? (prevIcon.data + "&thubmkey=projectIcon") : prevIcon.data));
-                apiRequest(axiousObject.method, axiousObject.route, axiousObject.data)
-                .then((response) => {
-                    if(!response.data.status) {
-                        console.error("ERROR in delete wasabi image: ", response.data.statusText);
-                    }
-                })
-                .catch((error) => {
-                    console.error("ERROR in upload image: ", error);
-                })
-            } catch (error) {
-                console.error("ERROR in upload image: ", error);
-            }
-        }
-
-        if(formData.value.projectProfileField.previewImage.value !== ""){
-            let name = generateFileName(previewImage.value.name,env.STORAGE_TYPE);
-            const filePath = `Project/${projectData.value._id}/Settings/ProjectIcon/${name}`
-            updateObject.type = "image";
-
-            const apiFormData = new FormData();
-            apiFormData.append("companyId", companyId.value);
-            apiFormData.append("path", filePath);
-            apiFormData.append("key", 'projectIcon');
-            apiFormData.append("file", previewImage.value);
-
-            if(prevIcon.type === 'image' && !prevIcon.data.includes('http')) {
-                deleteWasabiImage();
-            }
-            
-            updateObject.data = await apiRequestWithoutCompnay("post", storageQueryBuilder('upload').route, apiFormData, "form")
-            .then((response) => {
-                if(response.data.status) {
-                    let imageUrlPath = env.STORAGE_TYPE && env.STORAGE_TYPE==='server' ? response.data.statusText : response.data.statusText[0];
-                    return imageUrlPath
-                } else {
-                    return "";
-                }
-            })
-            .catch((error) => {
-                console.error("ERROR in upload image: ", error);
-            })
-        }
-        else {
-            if(prevIcon.type === 'image' && !prevIcon.data.includes('http')) {
-                deleteWasabiImage();
-            }
-            
-            updateObject.data = formData.value.projectProfileField.selectedColor.value;
-        }
-
-        if(!updateObject.data?.length) {
-            $toast.error(t(`Toast.something went worng`), {position: "top-right"})
-            savingAvatar.value = false;
-            return;
-        }
-        try {
-            await apiRequest("put",`/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`,{updateObject: { projectIcon: {...updateObject} }})
-            resetFormData();
-            savingAvatar.value = false;
-            showColorAvatar.value = false;
-            const user = getUser(userId.value);
-            const userData = {
-                id: user.id,
-                Employee_Name: user.Employee_Name,
-                companyOwnerId: user.companyOwnerId
-            }
-            let historyObj = {
-                key : "Project_EndDate",
-                message : `<b>${userData.Employee_Name}</b> has changed <b> ${updateObject.type === 'color' ? 'color' : 'avatar'} </b> </b>.`
-            }
-            apiRequest("post", env.HANDLE_HISTORY, {
-                "type": 'project',
-                "companyId": companyId.value,
-                "projectId": projectData.value._id,
-                "taskId": null,
-                "object": historyObj,
-                "userData": userData
-            })
-            commit('projectData/projectLocalUpdate', {itemData:  {...updateObject},projectId:projectData.value._id,key:'ProjectIcon',subKey:'',userId: ''});
-            $toast.success(t(`Toast.Project_avatar_updated_successfully`), {position: "top-right"});
-        } catch (error) {
-            resetFormData();
-            savingAvatar.value = false;
-            $toast.error(t(`Toast.something_went_wrong`), {position: "top-right"})
-            console.error(`Error while change avatar of project:`,error);
-        }
-    }
-    const handleDescription = (value) => {
-        isVisibleProjectDetial.value = value
+const toggleTaskDetail = async (task) => {
+    skipWatcher.value = true;
+    const routeObj = {
+        cid: companyId.value,
+        id: task.ProjectID,
+        sprintId: task.sprintId,
     };
-    const handleViewName = (value) => {
-        if(value === 'Project Details'){
-            isVisibleProjectDetial.value = true;
+    if (task.folderObjId) {
+        routeObj.folderId = task.folderObjId;
+    }
+
+    if (!isTaskDetail.value) {
+        routeObj.taskId = task._id;
+        const taskDetail = { ...task, sprintName: task?.sprintArray?.name, folderName: task?.sprintArray?.folderName, id: task._id };
+        selectedTask.value = taskDetail;
+        isTaskDetail.value = true;
+        await router.push({ name: task.folderObjId?.length ? 'ProjectFolderSprint' : 'ProjectSprint', params: routeObj });
+        await router.push({ name: task.folderObjId?.length ? 'ProjectFolderSprintTask' : 'ProjectSprintTask', params: routeObj, query: { ...route.query, detailTab: 'task-detail-tab' } });
+    } else {
+        isTaskDetail.value = false;
+        selectedTask.value = {};
+        await router.push({ name: task.folderObjId?.length ? 'ProjectFolderSprint' : 'ProjectSprint', params: routeObj, query: { tab: route.query.tab } });
+    }
+    await nextTick();
+    skipWatcher.value = false;
+};
+provide('toggleTaskDetail', toggleTaskDetail);
+provide('isRouteRequired', true);
+provide('hanldeBlankProjectTour', hanldeBlankProjectTour);
+provide('hanldeProjectTaktypeTour', hanldeProjectTaktypeTour);
+provide('hanldeProjectLastStep', hanldeProjectLastStep);
+
+const users = computed(() => getters['users/users']);
+const teams = computed(() => getters['settings/teams']);
+
+const isSidebar = ref(false);
+const sidebarTitle = ref('');
+const open = (val) => {
+    switch (val) {
+        case 'filesLinks':
+            isSidebar.value = true;
+            sidebarTitle.value = t('Projects.files_links');
+            break;
+        case 'audio':
+            isSidebar.value = true;
+            sidebarTitle.value = t('Projects.audio_files');
+            break;
+        case 'searchIcon':
+            visible.value = true;
+            break;
+        default:
+            break;
+    }
+};
+const billingPer = ref('');
+const projectStartDate = ref({});
+const handleEmitProjectRightSide = (action, value) => {
+    if (action === 'billingPeriod') {
+        projectData.value.BillingPeriod = value;
+        billingPer.value = value;
+    }
+    if (action === 'startDate') {
+        projectStartDate.value = value;
+    }
+    if (action === 'currency') {
+        projectData.value.ProjectCurrency = value;
+    }
+    if (action === 'projectType') {
+        if (value?.updateObject?.ProjectType) {
+            projectData.value.ProjectType = value?.updateObject?.ProjectType || '';
+        }
+        if (value?.updateObject?.BillingPeriod) {
+            projectData.value.BillingPeriod = value?.updateObject?.BillingPeriod || '';
         }
     }
+};
 
-    function updateImageValue(ele) {
-        previewImage.value = ele[0]
+const handleDescription = (value) => {
+    isVisibleProjectDetial.value = value;
+};
+const handleViewName = (value) => {
+    if (value === 'Project Details') {
+        isVisibleProjectDetial.value = true;
     }
+};
 
-    async function updateProject(value = null) {
-        showSpinner.value = true;
-        let updateObject = {};
-        if(value !== null || archive.value !== 0) {
-            updateObject.deletedStatusKey = value !== null ? value : archive.value === 1 ? 2 : 1;
-        } else {
-            let status = projectData.value.projectStatusData.find((x) => x.type === "close");
-            updateObject.status = status.value;
-            updateObject.statusType = status.type;
-        }
-        try {
-            await apiRequest("put", `/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`, {updateObject: { ...updateObject }});
-            showSidebar.value = false;
-            showSpinner.value = false;
-            const ProjectId = JSON.parse(JSON.stringify(projectData.value._id))
-            updateChildTasks(value !== null,ProjectId);
-            const user = getUser(userId.value);
-            const userData = {
-                id: user.id,
-                Employee_Name: user.Employee_Name,
-                companyOwnerId: user.companyOwnerId
-            }
-
-            let type = `${value !== null ? 'restored' : archive.value === 0 ? 'closed' : archive.value === 1 ? 'archived' : 'deleted'}`;
-
-            $toast.success(t(`Toast.Project ${type} successfully`), {position: 'top-right'});
-
-            let notificationObject = {
-                'message': `<p><strong>${userData.Employee_Name}</strong> has ${type} the <strong>${sanitizeInput(projectData.value.ProjectName)}</strong> Project</p>`,
-                'key': 'project_close',
-                'projectId': projectData.value._id,
-            }
-            var historyObj = {
-                'message': `<b>${userData.Employee_Name}</b> has ${type} the <b>${sanitizeInput(projectData.value.ProjectName)}</b> Project`,
-                'key' : 'Project_Name',
-            }
-            addHistory({
-                "type": 'project',
-                "companyId": companyId.value,
-                "projectId": projectData.value._id,
-                "taskId": null,
-                "object": historyObj,
-                "userData": userData
-            });
-            addNotification({
-                type:'project',
-                "companyId": companyId.value,
-                projectId: projectData.value._id,
-                object: notificationObject,
-                userData
-            });
-            commit('projectData/projectLocalUpdate', {itemData: {...projectData.value,...updateObject},projectId:projectData.value._id,key:value === null ? 'RemoveProject' : 'AddProject',subKey:'',userId: ''});
-        } catch (error) {
-            showSidebar.value = false;
-            showSpinner.value = false;
-            $toast.error(t(`Toast.something_went_wrong`), {position: "top-right"})
-            console.error("ERROR in update project: ", error);
-        }
-    }
-
-    function updateChildTasks(restore = false,ProjectId='') {
-        try {
-            let dsk = archive.value;
-            let taskDeleteStatusKey = 0;
-            let deletedStatusKey;
-            if(restore) {
-                deletedStatusKey = dsk ? 8 : 7;
-                taskDeleteStatusKey = 0;
-            } else {
-                deletedStatusKey = 0
-                if(dsk === 1 || dsk === 0) {
-                    taskDeleteStatusKey = (dsk === 0 ? 8 : 7)
-                } else if(dsk === 2) {
-                    taskDeleteStatusKey = 1
-                }
-            }
-            try {
-                const object = {
-                    firstParameter:{
-                        objId: {
-                            ProjectID: ProjectId,
-                        },
-                        deletedStatusKey:deletedStatusKey
-                    },
-                    secondParameter:{
-                        $set: {deletedStatusKey: taskDeleteStatusKey}
-                    },
-                    key:"updateMany",
-                    isConvertFirstParameter:true,
-                    isConvertSecondParameter:false
-                }
-                
-                apiRequest("put",env.TASK,object)
-                .catch((error) =>{
-                    console.error(error)
-                })
-            } catch (error) {
-                console.error(error)
-            }
-        } catch (error) {
-            console.error(`ERROR in update tasks: `, error);
-        }
-    }
-
-    function openPermissionSidebar () {
-        permissionSidebar.value = true;
-    }
-    const handleView = (view) => {
-        activeTab.value = view.keyName;
-        if (route.query.tab !== view.keyName) {
-            router.push({
-                query: {
+function openPermissionSidebar() {
+    permissionSidebar.value = true;
+}
+const handleView = (view) => {
+    activeTab.value = view.keyName;
+    if (route.query.tab !== view.keyName) {
+        router.push({
+            query: {
                 ...route.query,
-                tab: view.keyName
-                },
-            })
-        }
+                tab: view.keyName,
+            },
+        });
     }
-    function handleUnarchived() {
-        showArchived.value = false;
-        visible.value = !visible.value;
-        showArchivedProjects.value = false;
-    }
+};
+function handleUnarchived() {
+    showArchived.value = false;
+    visible.value = !visible.value;
+    showArchivedProjects.value = false;
+}
 
-    function getProjectRule(data) {
-        if(data.isGlobalPermission === false) {
-            isRuleData.value = true;
-            if(getters["settings/projectRawRules"] && getters["settings/projectRawRules"].length > 0){
-                if(getters["settings/projectRawRules"].some((x) => x.projectId !== data._id)){
-                    dispatch("settings/setProjectRules", {pid: data._id}).then(() => {
-                        nextTick(()=>{
-                            isRuleData.value = false;
-                            rulePermission.value = checkPermission('project.project_list',data.isGlobalPermission,{gettersVal: getters})
-                        })
-                    }).catch(() => {
-                        nextTick(()=>{
-                            isRuleData.value = false;
-                            rulePermission.value = checkPermission('project.project_list',data.isGlobalPermission,{gettersVal: getters})
-                        })
-                    })
-                }else{
-                    nextTick(()=>{
-                        isRuleData.value = false;
-                        rulePermission.value = checkPermission('project.project_list',data.isGlobalPermission,{gettersVal: getters})
-                    })
-                }
-            }
-            else{
-                dispatch("settings/setProjectRules", {pid: data._id}).then(() => {
-                    nextTick(()=>{
-                        isRuleData.value = false;
-                        rulePermission.value = checkPermission('project.project_list',data.isGlobalPermission,{gettersVal: getters})
-                    })
-                }).catch(() => {
-                    nextTick(()=>{
-                        isRuleData.value = false;
-                        rulePermission.value = checkPermission('project.project_list',data.isGlobalPermission,{gettersVal: getters})
-                    })
-                })
-            }
-        }
-    }
+// Tour modal handlers (kept inline since they touch local refs)
+function updateTourStatusInUser() {
+    showDriverSidebar.value = false;
+}
+function closeModal() {
+    showDriverSidebar.value = false;
+}
+
 </script>
 <style scoped>
 @import "./style.css";
@@ -2572,7 +1201,7 @@ const copy = require("@/assets/images/svg/copy-link.svg")
     list-style: none !important;
 }
 .mark__project-favourite{
-    width: 13.6px; 
+    width: 13.6px;
     height: 13px;
 }
 .mobile-projectlist-icon{
@@ -2592,7 +1221,7 @@ const copy = require("@/assets/images/svg/copy-link.svg")
     margin-left: 0px  !important;
 }
 .project__name-error{
-    bottom: -10px; 
+    bottom: -10px;
     left: 0px;
 }
 .view__activeproject-name{
@@ -2600,9 +1229,9 @@ const copy = require("@/assets/images/svg/copy-link.svg")
     height:35px;
 }
 .addview__dropdown{
-    border-color: #2F3990; 
-    background-color: white !important; 
-    margin-bottom: 0px !important; 
+    border-color: #2F3990;
+    background-color: white !important;
+    margin-bottom: 0px !important;
     bottom: 0px;
 }
 .project__requirementcomponent-wrapper{
@@ -2632,11 +1261,10 @@ const copy = require("@/assets/images/svg/copy-link.svg")
     top: 3px;
 }
 .open__watcher{
-    height: 30px; 
+    height: 30px;
     width: 30px;
 }
 .task-filtersearchassignee-wrapper{
-    /* height: 50px;  */
     padding: 14px 20px 14px 20px;
 }
 .board-veiw-main-parent.list-view-body,
@@ -2647,7 +1275,7 @@ const copy = require("@/assets/images/svg/copy-link.svg")
     margin-bottom: 0;
 }
 .dropdown-image-horizontal{
-   right: 10px; 
+   right: 10px;
    top: 5px;
 }
 .search__in{
@@ -2660,8 +1288,8 @@ const copy = require("@/assets/images/svg/copy-link.svg")
     height: 30px;
 }
 .saving__avtar-div{
-    top: 0px; 
-    left: 0px; 
+    top: 0px;
+    left: 0px;
     background-color: #FFFFFFde !important;
 }
 .skelaton__option{
@@ -2693,7 +1321,6 @@ const copy = require("@/assets/images/svg/copy-link.svg")
     background: linear-gradient(270deg, #F241CD 0%, #4B5DEE 100%);
     border: 0px solid transparent;
     border-radius: 8px;
-    /* width: 79px; */
     color: #FFFFFF;
     box-shadow: 0px 5px 10px 0px #9941F24D;
     padding: 0px 15px 0px 15px;

--- a/frontend/src/views/Projects/components/ProjectActionsBar.vue
+++ b/frontend/src/views/Projects/components/ProjectActionsBar.vue
@@ -1,0 +1,164 @@
+<template>
+    <div class="list-head-right">
+        <ul class="d-flex align-items-center m-0">
+            <li v-if="clientWidth > 767">
+                <img @click="$emit('openSidebar', 'filesLinks')" id="projectviewfiles_driver" :src="fileLinks" class="cursor-pointer"/>
+            </li>
+            <li class="ml-10px" v-if="clientWidth > 767" :class="clientWidth>767 ? 'mr-10px' : 'm-0'">
+                <img @click="$emit('openSidebar', 'audio')" id="projectviewaudio_driver" :src="audio" alt="audio" class="cursor-pointer"/>
+            </li>
+            <li v-if="clientWidth > 767">
+                <div class="position-re">
+                    <a href.prevent="#" @click="$emit('openWatcher')" class="d-flex align-items-center justify-content-center border border-radius-5-px open__watcher cursor-pointer">
+                        <img id="projectviewwatch_driver" :src="eyeIcon">
+                    </a>
+                    <span class="sprint-watcher-count">{{ Object.keys(projectData?.watchers || {})?.length || 0 }}</span>
+                </div>
+            </li>
+            <li :style="[{marginLeft : clientWidth > 767 ? '1rem' : '20px'}]" class="audio-list-wrapper">
+                <DropDown maxHeight="64dvh" class="audio_dropdown" :bodyClass="{'assigneelist-audiofile-dropdown' : true}">
+                    <template #head v-if="clientWidth <= 767">
+                        <div class="mobiledropdown-projecttitleimage-wrapper">
+                            <span v-if="projectData?.projectIcon && projectData?.projectIcon.type === 'color'" class="d-flex align-items-center justify-content-center ml-9px" :class="{'inital-box' : clientWidth > 767 , 'project-firtsleeter-box' : clientWidth <=767}" :style="[{'background-color': projectData?.projectIcon.data}]">{{ projectData?.ProjectName.charAt(0).toUpperCase() }}</span>
+                            <template v-else-if="projectData?.projectIcon && projectData?.projectIcon?.type === 'image'">
+                                <WasabiImage thumbnail="60x60" class="profile-sm-square mobile-projectlist-icon" v-if="!projectData.projectIcon.data.includes('http')" :data="{url: projectData.projectIcon.data, filename: projectData.projectIcon.data.split('/').pop(), extension: projectData.projectIcon.data.split('/').pop().split('.').pop()}"/>
+                                <img v-else class="profile-sm-square mobile-projectlist-icon" :src="projectData.projectIcon.data" alt=""/>
+                            </template>
+                            <div class="list-text-wrapper">
+                                <span class="text-ellipsis font-weight-bold text-capitalize black list-view-header-title ml-12px" @dblclick="$emit('startEditName')" :title="projectData.ProjectName">
+                                    {{ projectData?.ProjectName }}
+                                </span>
+                            </div>
+                        </div>
+                    </template>
+                    <template #button>
+                        <button class="cursor-pointer dot-btn border-0" :ref="`projectdd_${projectData._id || ''}`">
+                            <img :src="clientWidth > 767 ? horizontalDots : horizontalDotsMobile" id="projectoptions_driver"/>
+                        </button>
+                    </template>
+                    <template #options>
+                        <div id="projectoptionslist_driver">
+                            <DropDownOption v-if="projectData?.isPrivateSpace && clientWidth <= 767" class="border-bottom mb-20px">
+                                <Assignee
+                                    class="assignee-data ml-15px"
+                                    :users="projectData.AssigneeUserId"
+                                    :options="[...users.map((x) => x._id), ...teams.map((x) => 'tId_'+x._id)]"
+                                    :imageWidth="clientWidth>1024 ? '30px' : '25px'"
+                                    :num-of-users="clientWidth>1024 ? 4 : 2"
+                                    :addUser="checkPermission('project.project_assignee',projectData.isGlobalPermission) === true"
+                                    :showAddUser="true"
+                                    @selected="$emit('changeAssignee', 'add', $event)"
+                                    @removed="$emit('changeAssignee', 'remove', $event)"
+                                    :isDisplayTeam="true"
+                                    :z-index-assigne="8"
+                                />
+                            </DropDownOption>
+                            <template v-if="clientWidth <= 767">
+                                <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('openWatcher')">
+                                    <div :style="[{padding : clientWidth <= 767 ? '10px 0px !important' : '3.5px 10px !important'}]" class="d-flex align-items-center">
+                                        <div class="position-re mr-15px">
+                                            <div class="d-flex align-items-center justify-content-center border border-radius-5-px open__watcher">
+                                                <img :src="eyeIcon">
+                                            </div>
+                                            <span class="sprint-watcher-count">{{ Object.keys(projectData?.watchers || {})?.length || 0 }}</span>
+                                        </div>
+                                        <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.watchers') }}</span>
+                                    </div>
+                                </DropDownOption>
+                                <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('openSidebar', 'filesLinks')">
+                                    <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
+                                        <div class="d-flex align-items-center">
+                                            <img :src="fileLink" class="mr-20px"/>
+                                        </div>
+                                        <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.files_links') }}</span>
+                                    </div>
+                                </DropDownOption>
+                                <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('openSidebar', 'audio')" class="border-bottom pb-20px">
+                                    <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
+                                        <div class="d-flex align-items-center">
+                                            <img :src="audioLinkMobile" class="mr-20px"/>
+                                        </div>
+                                        <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.audio_files') }}</span>
+                                    </div>
+                                </DropDownOption>
+                            </template>
+                            <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('openPermissionSidebar')" v-if="checkPermission('settings.settings_security_permissions') !== null">
+                                <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
+                                    <div class="d-flex align-items-center">
+                                        <img :src="lockIcon" alt="lockIcon" class="mr-20px">
+                                    </div>
+                                    <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.project_permissions') }}</span>
+                                </div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('startEditName')" v-if="checkPermission('project.project_name_edit',projectData.isGlobalPermission) === true">
+                                <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
+                                    <div class="d-flex align-items-center">
+                                        <img :src="listIcon" alt="listIcon" class="mr-20px">
+                                    </div>
+                                    <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.rename') }}</span>
+                                </div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('openColorAvatar')" v-if="checkPermission('project.project_create',projectData.isGlobalPermission) === true">
+                                <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
+                                    <div class="d-flex align-items-center">
+                                        <img :src="colorPalletIcon" alt="colorPalletIcon" class="mr-20px">
+                                    </div>
+                                    <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.color_avatar') }}</span>
+                                </div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('archiveProject', 0)" v-if="checkPermission('project.project_close',projectData.isGlobalPermission) === true">
+                                <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
+                                    <div class="d-flex align-items-center">
+                                        <img :src="cancelIcon" alt="cancelIcon" class="mr-20px">
+                                    </div>
+                                    <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.close_project') }}</span>
+                                </div>
+                            </DropDownOption>
+                            <DropDownOption v-if="checkPermission('project.project_delete',projectData.isGlobalPermission) === true" @click="$refs[`projectdd_${projectData._id || ''}`].click(); $emit('archiveProject', 2)">
+                                <div class="d-flex align-items-center project-mobile-desc avtar-options" :class="`${clientWidth <= 767 ? 'project_detail_dropdown_wrapper' : ''}`">
+                                    <div class="d-flex align-items-center">
+                                        <img :src="deleteIcon" alt="deleteIcon" class="mr-20px">
+                                    </div>
+                                    <span :class="{'font-size-16': clientWidth <= 767 }" class="font-weight-400 gray4b">{{ $t('Projects.delete') }}</span>
+                                </div>
+                            </DropDownOption>
+                        </div>
+                    </template>
+                </DropDown>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+import DropDown from '@/components/molecules/DropDown/DropDown.vue';
+import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue';
+import Assignee from '@/components/molecules/Assignee/Assignee.vue';
+import WasabiImage from '@/components/atom/WasabiIamgeCompp/WasabiIamgeCompp.vue';
+import { useCustomComposable } from '@/composable';
+
+const { checkPermission } = useCustomComposable();
+
+defineProps({
+    projectData: { type: Object, required: true },
+    clientWidth: { type: Number, required: true },
+    users: { type: Array, default: () => [] },
+    teams: { type: Array, default: () => [] },
+});
+
+defineEmits(['openSidebar', 'openWatcher', 'changeAssignee', 'openPermissionSidebar', 'startEditName', 'openColorAvatar', 'archiveProject']);
+
+const fileLinks = require('@/assets/images/svg/Fileslinks.svg');
+const audio = require('@/assets/images/svg/Voice_Record.svg');
+const audioLinkMobile = require('@/assets/images/svg/AudioLink.svg');
+const fileLink = require('@/assets/images/svg/Files_links.svg');
+const eyeIcon = require('@/assets/images/svg/PriorityIcon/watchProjectEye.svg');
+const horizontalDots = require('@/assets/images/svg/horizontalDots.svg');
+const horizontalDotsMobile = require('@/assets/images/svg/threedot_mobile_list.svg');
+const lockIcon = require('@/assets/images/lock.png');
+const listIcon = require('@/assets/images/svg/edit_rename_icon.svg');
+const colorPalletIcon = require('@/assets/images/svg/palette.svg');
+const cancelIcon = require('@/assets/images/svg/cancel.svg');
+const deleteIcon = require('@/assets/images/svg/Delete_Icon.svg');
+</script>

--- a/frontend/src/views/Projects/components/ProjectBottomModals.vue
+++ b/frontend/src/views/Projects/components/ProjectBottomModals.vue
@@ -1,0 +1,124 @@
+<template>
+    <div>
+        <DropDown title="All Views" :ref="projectAddView" :bodyClass="{'viewlist-mobile-dropdown-new' : true}" maxHeight="unset" v-if="clientWidth <= 768">
+            <template #button>
+                <span ref="all_views_dd"></span>
+            </template>
+            <template #options>
+                <div>
+                    <ViewsDropdown @handleCloseDropdown="$refs.all_views_dd.click()" :projectData="projectData"/>
+                </div>
+            </template>
+        </DropDown>
+
+        <ProjectWatcher
+            :openSidebar="openProjectWatcher"
+            @update:openSidebar="(v) => $emit('update:openProjectWatcher', v)"
+            :watchers="projectData?.watchers"
+            :options="projectData?.isPrivateSpace ? projectData?.AssigneeUserId : users.map((x) => x._id)"
+            :projectId="projectData?._id || ''"
+        />
+        <ConfirmationSidebar
+            :modelValue="showSidebar"
+            @update:modelValue="(v) => $emit('update:showSidebar', v)"
+            :title="`${archive === 0 ? $t('Projects.close') : archive === 1 ? $t('Projects.archive') : $t('Projects.delete')}`"
+            :message="archive === 0 ? $t('conformationmsg.archive0mesg') : archive === 1 ? $t('conformationmsg.archive') : $t('conformationmsg.delete')"
+            :confirmationString="`${archive === 0 ? 'close' : archive === 1 ? 'archive' : 'delete'}`"
+            :acceptButtonClass="archive === 1 ? 'btn-primary' : 'btn-danger'"
+            :acceptButton="`${archive === 0 ? $t('Projects.close') : archive === 1 ? $t('Projects.archive') : $t('Projects.delete')}`"
+            @confirm="$emit('confirmArchive')"
+            :showSpinner="showSpinner"
+        />
+        <CreateProjectSidebar
+            v-if="isActiveCreateSidebar"
+            :isAdvanceFilterApplied="isAdvanceFilterApplied"
+            :isActiveCreateSidebar="isActiveCreateSidebar"
+            @click:closeSidebar="(v) => $emit('closeCreateSidebar', v)"
+            @closeSidebar="(v) => $emit('closeCreateSidebar', v)"
+        />
+        <AiProjectCreator
+            v-if="isActiveAiCreator"
+            :visible="isActiveAiCreator"
+            @close="$emit('closeAiCreator')"
+            @created="(p) => $emit('aiProjectCreated', p)"
+        />
+        <ProjectPermission
+            v-if="permissionSidebar"
+            @isClose="(v) => $emit('update:permissionSidebar', !v)"
+            :projectData="projectData"
+        />
+        <ConfirmModal
+            className="projecttourend_driver_modal"
+            :modelValue="showDriverSidebar"
+            :acceptButtonText="$t('Tour.watch_video')"
+            :cancelButtonText="$t('Projects.cancel')"
+            :header="false"
+            :cancelButton="false"
+            :showCloseIcon="false"
+            :footer="false"
+            @accept="$emit('tourModalAccept')"
+            @close="$emit('tourModalClose')"
+        >
+            <template #body>
+                <div class="d-flex flex-column justify-content-center align-items-center position-re">
+                    <div class="position-ab tourendmodal__close_button">
+                        <img :src="cancelIconForTour" class="cursor-pointer cancel__icon-img tourendmodal__close_img" alt="close" @click.prevent="$emit('tourModalClose')">
+                    </div>
+                    <div>
+                        <img :src="tourModalImage" alt="tourmodalimage">
+                    </div>
+                    <div class="text-center">
+                        <h1>{{ $t('Tour.tour_completed') }}</h1>
+                    </div>
+                </div>
+            </template>
+        </ConfirmModal>
+        <AISidebar v-if="openAiSidebar" @closeAi="$emit('closeAiSidebar')"></AISidebar>
+    </div>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+import DropDown from '@/components/molecules/DropDown/DropDown.vue';
+import ViewsDropdown from '@/components/molecules/ProjectViews/ViewsDropdown.vue';
+import ProjectWatcher from '@/components/organisms/ProjectWatcher/ProjectWatcher.vue';
+import ConfirmationSidebar from '@/components/molecules/ConfirmationSidebar/ConfirmationSidebar.vue';
+import CreateProjectSidebar from '@/components/organisms/CreateProject/CreateProjectSidebar.vue';
+import AiProjectCreator from '@/components/organisms/AiProjectCreator/AiProjectCreator.vue';
+import ProjectPermission from '@/components/atom/ProjectPermission/ProjectPermission.vue';
+import ConfirmModal from '@/components/atom/Modal/Modal.vue';
+import AISidebar from '@/components/molecules/AISidebar/AISidebar.vue';
+
+defineProps({
+    clientWidth: { type: Number, required: true },
+    projectAddView: { type: String, default: '' },
+    projectData: { type: Object, required: true },
+    users: { type: Array, default: () => [] },
+    openProjectWatcher: { type: Boolean, default: false },
+    showSidebar: { type: Boolean, default: false },
+    archive: { type: Number, default: 0 },
+    showSpinner: { type: Boolean, default: false },
+    isActiveCreateSidebar: { type: Boolean, default: false },
+    isAdvanceFilterApplied: { type: Boolean, default: false },
+    isActiveAiCreator: { type: Boolean, default: false },
+    permissionSidebar: { type: Boolean, default: false },
+    showDriverSidebar: { type: Boolean, default: false },
+    openAiSidebar: { type: Boolean, default: false },
+});
+
+defineEmits([
+    'update:openProjectWatcher',
+    'update:showSidebar',
+    'confirmArchive',
+    'closeCreateSidebar',
+    'closeAiCreator',
+    'aiProjectCreated',
+    'update:permissionSidebar',
+    'tourModalAccept',
+    'tourModalClose',
+    'closeAiSidebar',
+]);
+
+const cancelIconForTour = require('@/assets/images/cancel_icon.png');
+const tourModalImage = require('@/assets/images/tourmodalimage.png');
+</script>

--- a/frontend/src/views/Projects/components/ProjectEmptyState.vue
+++ b/frontend/src/views/Projects/components/ProjectEmptyState.vue
@@ -1,0 +1,32 @@
+<template>
+    <div class="bg-light-gray d-flex align-items-center justify-content-center flex-column w-100 h-100">
+        <img :src="noProjectsIcon" alt="noProjectsIcon">
+        <template v-if="!showArchivedProjects">
+            <h2>{{ $t('ProjectSlider.you_dont') }}</h2>
+            <div v-if="canCreate && !isFilterHasData">
+                <button class="outline-primary ml-1 font-size-16 p0x-13px" @click="$emit('createProject')">+ {{ $t('ProjectSlider.new_project') }}</button>
+                <button v-if="currentCompany?.planFeature?.aiPermission" class="btn btn-primary ml-1 font-size-16 p0x-13px" @click="$emit('createAiProject')">{{ aiButtonLabel }}</button>
+            </div>
+        </template>
+        <template v-else>
+            <h2>{{ $t('ProjectSlider.no_archived') }}</h2>
+            <button class="outline-primary" @click="$emit('hideArchive')">{{ $t('ProjectSlider.hide_archive') }}</button>
+        </template>
+    </div>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+
+defineProps({
+    showArchivedProjects: { type: Boolean, default: false },
+    canCreate: { type: Boolean, default: false },
+    isFilterHasData: { type: Boolean, default: false },
+    currentCompany: { type: Object, default: () => ({}) },
+});
+
+defineEmits(['createProject', 'createAiProject', 'hideArchive']);
+
+const noProjectsIcon = require('@/assets/images/svg/No-Search-Result.svg');
+const aiButtonLabel = '✨ Create with AI';
+</script>

--- a/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
+++ b/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
@@ -1,0 +1,239 @@
+<template>
+    <div class="task-assigneesearch-groupbywrapper" :class="{'overflow-auto' : clientWidth <=767}">
+        <div class="d-flex align-items-center justify-content-between flex-wrap task-filtersearchassignee-wrapper" :class="{'w-545' : clientWidth <=767 }" v-if="['ProjectListView', 'Calendar', 'ProjectKanban','TableView'].includes(activeTab)">
+            <div class="d-flex align-items-center justify-content-start task-filtersearch" :class="[{ 'mb-10px': clientWidth <= 767 }]" :style="{width: (clientWidth <= 767 ? '100%' : '')}" v-if="!showArchived">
+                <TaskFilter :projectData="projectData" @apply="(q) => $emit('applyFilter', q)" @clear="$emit('clearFilter')" v-if="Object.keys(projectData).length > 0"/>
+                <div class="position-re task-fitler-search" id="projectviewfiltersearch_driver">
+                    <input
+                        type="text"
+                        :placeHolder="$t('PlaceHolder.search')"
+                        class="form-control"
+                        :style="{width: (clientWidth > 1025 ? '392px' : '90%')}"
+                        :value="taskSearch"
+                        @input="$emit('update:taskSearch', $event.target.value)"
+                    >
+                    <DropDown title="Search In" id="searchfilterdropdownoptions_driver" class="position-ab dropdown-image-horizontal" :bodyClass="{'search__in-dropdown' : true}">
+                        <template #head>
+                            <h4 class="black font-size-13 font-weight-500 p-10px m-0 search__in" :class="{'border-bottom': clientWidth > 767}">
+                                {{ $t('Projects.search_in') }}
+                            </h4>
+                        </template>
+                        <template #button>
+                            <img :src="horizontalDots" alt="horizontalDots" class="vertical-middle" id="searchfilterdropdown_driver">
+                        </template>
+                        <template #options>
+                            <DropDownOption @click="taskDescriptionSearch || taskKeySearch ? $emit('update:taskNameSearch', !taskNameSearch) : ''" class="task-serachstatus-dropdown border-radius-4-px">
+                                <span class="project-mobile-desc mr-10px">{{ $t('Projects.task_name') }}</span>
+                                <Toggle width="20" :modelValue="taskNameSearch" @update:modelValue="(v) => $emit('update:taskNameSearch', v)" :disabled="taskNameSearch && !taskDescriptionSearch && !taskKeySearch" @change="$emit('search')"/>
+                            </DropDownOption>
+                            <DropDownOption @click="$emit('update:taskKeySearch', !taskKeySearch)" class="task-serachstatus-dropdown border-radius-4-px">
+                                <span class="project-mobile-desc mr-10px">{{ $t('Projects.task_key') }}</span>
+                                <Toggle width="20" :modelValue="taskKeySearch" @update:modelValue="(v) => $emit('update:taskKeySearch', v)" @change="$emit('toggleSearch'),$emit('search')"/>
+                            </DropDownOption>
+                            <DropDownOption @click="$emit('update:taskDescriptionSearch', !taskDescriptionSearch)" class="task-serachstatus-dropdown border-radius-4-px">
+                                <span class="project-mobile-desc mr-10px">{{ $t('ProjectDetails.description') }}</span>
+                                <Toggle width="20" :modelValue="taskDescriptionSearch" @update:modelValue="(v) => $emit('update:taskDescriptionSearch', v)" @change="$emit('toggleSearch'),$emit('search')"/>
+                            </DropDownOption>
+                        </template>
+                    </DropDown>
+                </div>
+                <Assignee
+                    :tourId="'projectviewassignee_driver'"
+                    v-if="clientWidth > 767 && projectData?.isPrivateSpace"
+                    class="assignee-data ml-15px"
+                    :users="projectData.AssigneeUserId"
+                    :options="[...users.map((x) => x._id), ...teams.map((x) => 'tId_'+x._id)]"
+                    :imageWidth="clientWidth>1024 ? '30px' : '25px'"
+                    :num-of-users="clientWidth>1024 ? 4 : 2"
+                    :showAddUser="true"
+                    :addUser="checkPermission('project.project_assignee',projectData.isGlobalPermission) === true"
+                    @selected="$emit('changeAssignee', 'add', $event)"
+                    @removed="$emit('changeAssignee', 'remove', $event)"
+                    :isDisplayTeam="true"
+                />
+            </div>
+            <div v-if="['ProjectListView', 'ProjectKanban','TableView'].includes(activeTab)" class="d-flex align-items-center justify-content-end task-filter-assignee overflow-auto style-scroll" :style="`${showArchived ? 'width: 100%;' : ''}`" :class="clientWidth <= 767 ? 'justify-content-start' : ''">
+                <template v-if="!showArchived">
+                    <button class="text-nowrap btn ai_button mr-1 cursor-pointer" @click="$emit('openAi')" v-if="checkApps('AI',projectData) && checkPermission('artificial_intelligence',projectData?.isGlobalPermission) === true">
+                        <img src="@/assets/images/svg/ai_image_white.svg" class="mr-10-px"/>
+                        <span>{{ $t('AI.write_with_ai') }}</span>
+                    </button>
+                    <DropDown id="group_by" class="mr-1 group_by">
+                        <template #button>
+                            <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="group_by_status" @click="currentActive='group'">
+                                <div class="group-by-dropdown" :class="{'active' : clientWidth <= 767 && currentActive == 'group' }">
+                                    <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.group_by') }} : </strong>
+                                    <span :style="{color: (clientWidth <= 767 ? '#535358' : '#818181')}" :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}">{{ $t(`Projects.${groupByOptions.find(x => x.id === groupBy).label}`) }}</span>
+                                </div>
+                            </button>
+                        </template>
+                        <template #options>
+                            <DropDownOption v-for="item in groupByOptions" :key="item.id" @click="$emit('update:groupBy', item.id); $refs.group_by_status.click(item)" :class="{'bg-light-gray' : item.id === groupBy}">
+                                <div>
+                                    <img :src="item.image" :alt="item.label" class="pr-10px">
+                                    <span :class="{'purple' : item.id === groupBy}">{{ $t(`Projects.${item.label}`) }}</span>
+                                </div>
+                            </DropDownOption>
+                        </template>
+                    </DropDown>
+                    <DropDown class="mr-1 group_by" v-if="activeTab === 'ProjectListView'">
+                        <template #button>
+                            <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="expand_collapse" @click="currentActive='subtask'">
+                                <div class="group-by-dropdown current__dropdown" :class="{'active' : clientWidth <= 767 && currentActive == 'subtask' }">
+                                    <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.subtask') }}: </strong>
+                                    <span :style="{color: (clientWidth <= 767 ? '#535358' : '#818181')}" :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}"> {{collapsed ? $t('Projects.collapsed') : $t('Projects.expanded')}}</span>
+                                </div>
+                            </button>
+                        </template>
+                        <template #options>
+                            <DropDownOption @click="$emit('update:collapsed', false); $refs.expand_collapse.click()" :class="{'bg-light-gray' : !collapsed}">
+                                <span :class="{'purple' : !collapsed}">{{ $t('Projects.expanded') }}</span>
+                            </DropDownOption>
+                            <DropDownOption @click="$emit('update:collapsed', true); $refs.expand_collapse.click()" :class="{'bg-light-gray' : collapsed}">
+                                <span :class="{'purple' : collapsed}">{{ $t('Projects.collapsed') }}</span>
+                            </DropDownOption>
+                        </template>
+                    </DropDown>
+                    <div class="mr-1 border-groupBy border-radius-6-px d-flex align-items-center assignee-filter manage__filter-users">
+                        <div
+                            @click="$emit('manageFilterUsers', userId)"
+                            :class="{'bg-white' : filterUsers.includes(userId)}"
+                            class="border-radius-6-px border-right-radius-0 border-right cursor-pointer assignee-user font-size-12 font-weight-400 p7x-5px"
+                        >
+                            <img :src="filterUsers.includes(userId) ? activeUserIcon : userIcon" alt="user icon" class="vertical-middle">
+                            <span class="font-size-12 font-weight-400 ml-7px"> {{ $t('Projects.me') }} </span>
+                        </div>
+                        <div
+                            v-if="projectData?.isGlobalPermission === false ? checkPermission('task.show_tasks',projectData.isGlobalPermission) === 2 || checkPermission('task.show_tasks',projectData.isGlobalPermission) === true : true"
+                            @click="$emit('update:userSidebar', !userSidebar)"
+                            class="border-radius-6-px border-left-radius-0 cursor-pointer assignee-status p4x-5px"
+                            :class="{'bg-white blue' : filterUsers.length && filterUsers.filter((x) => x !== userId).length}"
+                        >
+                            <img :src="filterUsers.length && filterUsers.filter((x) => x !== userId).length ? activeGroupIcon : groupIcon" alt="user icon">
+                            <span class="font-size-12 font-weight-400 ml-10px"> {{filterUsers.length && filterUsers.filter((x) => x !== userId).length ? `(${filterUsers.filter((x) => x !== userId).length})` : $t('ProjectDetails.assignee')}}</span>
+                        </div>
+                    </div>
+                </template>
+                <button class="archived-btn font-weight-400 d-flex align-items-center justify-content-between" :style="{color: (clientWidth <= 767 ? '#535358' : '')}" :class="{'outline-primary show-archived-active': showArchived, 'outline-secondary': !showArchived, 'border-radius-6-px font-size-14' : clientWidth <=767 , 'border-0 font-size-13' : clientWidth > 767 }">
+                    <template v-if="showArchived">
+                        <span class="font-weight-bold font-size-16 dark-gray">{{ $t('ProjectSlider.archived_list') }}</span>
+                        <span v-if="!showArchivedProjects" @click="$emit('update:showArchived', false)">{{ $t('ProjectSlider.hide_archive') }}</span>
+                    </template>
+                    <template v-else>
+                        <span @click="$emit('update:showArchived', true)" class="text-nowrap">{{ $t('ProjectSlider.show_archive') }}</span>
+                    </template>
+                </button>
+            </div>
+            <div v-if="['Calendar'].includes(activeTab)" class="d-flex align-items-center justify-content-end task-filter-assignee style-scroll" :class="clientWidth <= 767 ? 'justify-content-start' : ''">
+                <div class="mr-1 border-groupBy border-radius-6-px d-flex align-items-center assignee-filter manage__filter-users">
+                    <div
+                        @click="$emit('manageFilterUsers', userId)"
+                        :class="{'bg-white' : filterUsers.includes(userId)}"
+                        class="border-radius-6-px border-right-radius-0 border-right cursor-pointer assignee-user font-size-12 font-weight-400 p7x-5px"
+                    >
+                        <img :src="filterUsers.includes(userId) ? activeUserIcon : userIcon" alt="user icon" class="vertical-middle">
+                        <span class="font-size-12 font-weight-400 ml-7px">{{ $t('Projects.me') }} </span>
+                    </div>
+                    <div
+                        v-if="projectData?.isGlobalPermission === false ? checkPermission('task.show_tasks',projectData.isGlobalPermission) === 2 || checkPermission('task.show_tasks',projectData.isGlobalPermission) === true : true"
+                        @click="$emit('update:userSidebar', !userSidebar)"
+                        class="border-radius-6-px border-left-radius-0 cursor-pointer assignee-status p4x-5px"
+                        :class="{'bg-white blue' : filterUsers.length && filterUsers.filter((x) => x !== userId).length}"
+                    >
+                        <img :src="filterUsers.length && filterUsers.filter((x) => x !== userId).length ? activeGroupIcon : groupIcon" alt="user icon">
+                        <span class="font-size-12 font-weight-400 ml-10px"> {{filterUsers.length && filterUsers.filter((x) => x !== userId).length ? `(${filterUsers.filter((x) => x !== userId).length})` : $t('ProjectDetails.assignee')}}</span>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center assignee-filter">
+                    <div class="mr-1 group_by monthly-calendar monthly-calendar-view" @click="$emit('openCalendar')">
+                        {{ calendarDate ? calendarDate : new Date().toLocaleString('default', { month: 'long', year: 'numeric' }) }}
+                        <MonthlyCalendarMilestone
+                            v-if="calendartoggle"
+                            :rangeObject="rangeObject"
+                            :startDate="calendarDate ? new Date(calenderSelectDate) : new Date()"
+                            @startEndDate="(val) => $emit('handleStartEndDate', val)"
+                        />
+                    </div>
+                    <div class="mr-1 group_by d-flex">
+                        <button type="button" title="Previous month" class="calendar-button" @click="$emit('prevMonth')">
+                            <span class="fc-icon fc-icon-chevron-left"></span>
+                        </button>
+                        <button type="button" title="Next month" class="calendar-button" @click="$emit('nextMonth')">
+                            <span class="fc-icon fc-icon-chevron-right"></span>
+                        </button>
+                    </div>
+                    <div class="mr-1 group_by">
+                        <button type="button" title="This month" class="calendar-button calendar-currentday-text" @click="$emit('defaultMonth')">{{ $t('Home.Today') }}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, defineProps, defineEmits } from 'vue';
+import DropDown from '@/components/molecules/DropDown/DropDown.vue';
+import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue';
+import Toggle from '@/components/atom/Toggle/Toggle.vue';
+import Assignee from '@/components/molecules/Assignee/Assignee.vue';
+import TaskFilter from '@/components/molecules/TaskFilter/TaskFilter.vue';
+import MonthlyCalendarMilestone from '@/components/atom/MonthlyCalendarMilestone/MonthlyCalendarMilestone.vue';
+import { useCustomComposable } from '@/composable';
+
+const { checkPermission, checkApps } = useCustomComposable();
+
+defineProps({
+    activeTab: { type: String, required: true },
+    projectData: { type: Object, required: true },
+    clientWidth: { type: Number, required: true },
+    showArchived: { type: Boolean, default: false },
+    showArchivedProjects: { type: Boolean, default: false },
+    taskSearch: { type: String, default: '' },
+    taskNameSearch: { type: Boolean, default: true },
+    taskKeySearch: { type: Boolean, default: false },
+    taskDescriptionSearch: { type: Boolean, default: false },
+    filterUsers: { type: Array, default: () => [] },
+    userSidebar: { type: Boolean, default: false },
+    collapsed: { type: Boolean, default: true },
+    groupBy: { type: Number, default: 0 },
+    groupByOptions: { type: Array, default: () => [] },
+    users: { type: Array, default: () => [] },
+    teams: { type: Array, default: () => [] },
+    userId: { type: String, default: '' },
+    calendartoggle: { type: Boolean, default: false },
+    calendarDate: { type: String, default: '' },
+    calenderSelectDate: { type: Number, default: 0 },
+    rangeObject: { type: Object, default: () => ({}) },
+});
+
+defineEmits([
+    'update:taskSearch',
+    'update:taskNameSearch',
+    'update:taskKeySearch',
+    'update:taskDescriptionSearch',
+    'update:userSidebar',
+    'update:collapsed',
+    'update:groupBy',
+    'update:showArchived',
+    'applyFilter',
+    'clearFilter',
+    'search',
+    'toggleSearch',
+    'manageFilterUsers',
+    'changeAssignee',
+    'openAi',
+    'openCalendar',
+    'handleStartEndDate',
+    'prevMonth',
+    'nextMonth',
+    'defaultMonth',
+]);
+
+const currentActive = ref('');
+const horizontalDots = require('@/assets/images/svg/horizontalDots.svg');
+const activeUserIcon = require('@/assets/images/peopleBlue.png');
+const userIcon = require('@/assets/images/peopleGray.png');
+const activeGroupIcon = require('@/assets/images/peopleBlue.png');
+const groupIcon = require('@/assets/images/peopleGray.png');
+</script>

--- a/frontend/src/views/Projects/components/ProjectSidebars.vue
+++ b/frontend/src/views/Projects/components/ProjectSidebars.vue
@@ -1,0 +1,102 @@
+<template>
+    <div>
+        <Sidebar
+            :value="filterUsers.map((x) => ({value: x}))"
+            :multiSelect="true"
+            :enableSearch="true"
+            :options="assigneeFilterOptions"
+            :visible="userSidebar"
+            @update:visible="(v) => $emit('update:userSidebar', v)"
+            :title="$t('Projects.list_of_user')"
+            @selected="$emit('manageFilterUsers', $event.value)"
+            @itemClicked="$emit('manageFilterUsers', $event.value)"
+            @removed="$emit('manageFilterUsers', $event.value)"
+            @clear="$emit('clearFilterUsers')"
+        />
+        <Sidebar
+            className="task-sub-sidebar"
+            :visible="isSidebar"
+            @update:visible="(v) => $emit('update:isSidebar', v)"
+            :title="$t(`${sidebarTitle}`)"
+            width="358px"
+            :top="clientWidth <= 767 ? '0px' : '46px'"
+        >
+            <template #body>
+                <FileAndLinks
+                    v-if="sidebarTitle === $t('Projects.Files_&_Links')"
+                    :attachments="projectData.attachments"
+                    :description="projectData.description"
+                    @closeSidebar="(val) => $emit('update:isSidebar', val)"
+                    :handleType="'project'"
+                    :selectedData="projectData"
+                />
+                <TaskAudioFiles
+                    v-else-if="sidebarTitle === $t('Projects.audio_files')"
+                    :key="`${projectData?._id}` + 'audiofiles'"
+                    :fromWhich="'project'"
+                    :selectedData="projectData"
+                />
+            </template>
+        </Sidebar>
+        <Sidebar
+            :visible="showColorAvatar"
+            @update:visible="(v) => { $emit('update:showColorAvatar', v); if(!v) $emit('resetFormData'); }"
+            width="607px"
+            :title="$t('Projects.change_color')"
+        >
+            <template #head-right>
+                <div>
+                    <button class="btn-primary p0x-10px" @click="$emit('saveAvatar')">{{ $t('Projects.save') }}</button>
+                    <button class="outline-secondary p0x-10px ml-10px" @click="$emit('update:showColorAvatar', false)">{{ $t('Projects.cancel') }}</button>
+                </div>
+            </template>
+            <template #body>
+                <div class="bg-white p-1 m-1 border-radius-8-px">
+                    <div v-if="savingAvatar" class="bg-blue position-ab z-index-1 h-100 w-100 saving__avtar-div">
+                        <SpinnerComp :isSpinner="true"/>
+                    </div>
+                    <ProjectProfileForm
+                        :modelValue="formData.projectProfileField"
+                        @update:modelValue="(v) => $emit('updateFormData', v)"
+                        :name="{value: formData.projectName} || {value: 'N/A'}"
+                        @update:image="(ele) => $emit('updateImage', ele)"
+                    />
+                </div>
+            </template>
+        </Sidebar>
+    </div>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+import Sidebar from '@/components/molecules/Sidebar/Sidebar.vue';
+import FileAndLinks from '@/components/molecules/FileAndLinks/FileAndLinks.vue';
+import TaskAudioFiles from '@/components/molecules/TaskAudioFiles/TaskAudioFiles.vue';
+import SpinnerComp from '@/components/atom/SpinnerComp/SpinnerComp.vue';
+import ProjectProfileForm from '@/components/templates/CreateProject/ProjectProfileForm.vue';
+
+defineProps({
+    filterUsers: { type: Array, default: () => [] },
+    assigneeFilterOptions: { type: Array, default: () => [] },
+    userSidebar: { type: Boolean, default: false },
+    isSidebar: { type: Boolean, default: false },
+    sidebarTitle: { type: String, default: '' },
+    showColorAvatar: { type: Boolean, default: false },
+    savingAvatar: { type: Boolean, default: false },
+    formData: { type: Object, required: true },
+    projectData: { type: Object, required: true },
+    clientWidth: { type: Number, required: true },
+});
+
+defineEmits([
+    'update:userSidebar',
+    'update:isSidebar',
+    'update:showColorAvatar',
+    'manageFilterUsers',
+    'clearFilterUsers',
+    'resetFormData',
+    'saveAvatar',
+    'updateFormData',
+    'updateImage',
+]);
+</script>

--- a/frontend/src/views/Projects/composables/useEmbedViews.js
+++ b/frontend/src/views/Projects/composables/useEmbedViews.js
@@ -1,0 +1,147 @@
+import { inject } from 'vue';
+import { useStore } from 'vuex';
+import { useToast } from 'vue-toast-notification';
+import { useI18n } from 'vue-i18n';
+import { useGetterFunctions } from '@/composable';
+import { deleteView, editView } from '@/components/molecules/EmbedView/helper.js';
+import { deletePrivateView, editPrivateName } from '@/components/molecules/ProjectViews/helper.js';
+import * as env from '@/config/env';
+import { apiRequest } from '@/services';
+
+/**
+ * Embed-view CRUD helpers.
+ *
+ * @param projectData ref to the current project
+ * @param embedViews ref to the array of embed views (used for duplicate-name check)
+ * @param companyUser ref to the current company user (used for private-view edits)
+ * @param renameValue ref shared with the parent template (in-progress rename)
+ * @param openDelete ref shared with the parent template (delete-confirmation state)
+ * @param selectedEmbedView ref shared with the parent (currently-active embed view)
+ */
+export function useEmbedViews(projectData, embedViews, companyUser, renameValue, openDelete, selectedEmbedView) {
+    const { commit, getters } = useStore();
+    const $toast = useToast();
+    const { t } = useI18n();
+    const { getUser } = useGetterFunctions();
+
+    const userId = inject('$userId');
+    const companyId = inject('$companyId');
+
+    const copyToClipboard = (id) => {
+        let link = window.location.href.split('?')[0];
+        link = link + `?tab=EmbedView&eid=${id}`;
+        navigator.clipboard.writeText(link);
+        $toast.success(t('Toast.Link_copied_to_clipboard_successfully'), { position: 'top-right' });
+    };
+
+    const editViewName = (element) => {
+        const user = getUser(userId.value);
+        const userData = {
+            id: user.id,
+            Employee_Name: user.Employee_Name,
+            companyOwnerId: getters['settings/companyOwnerDetail'].userId,
+        };
+
+        if (renameValue.value.name.trim() == element.name.trim()) {
+            renameValue.value = { name: '', id: '' };
+            return;
+        }
+        if (!renameValue.value.name.trim()) {
+            $toast.error(t('Toast.View_name_is_required'), { position: 'top-right' });
+            return;
+        }
+        if ((renameValue.value.name.trim().length) < 3) {
+            $toast.error(t('Toast.name_should_be_at_least_3_characters_long'), { position: 'top-right' });
+            return;
+        }
+        const duplicate = embedViews.value.filter((item) => item.id !== element.id && item.name.trim() === renameValue.value.name.trim());
+        if (duplicate.length) {
+            $toast.error(t('Toast.View_name_already_exists'), { position: 'top-right' });
+            return;
+        }
+        if (element.isPrivate) {
+            editPrivateName({ cid: companyId.value, uid: companyUser.value._id, uniqueId: element.id }, element, renameValue.value.name.trim());
+        } else {
+            editView({ cid: companyId.value, pid: projectData.value._id }, element, renameValue.value.name.trim(), 'name').then((res) => {
+                commit('projectData/projectLocalUpdate', { itemData: res.data, projectId: projectData.value._id, key: 'ProjectView', subKey: 'edit', userId: '' });
+            }).catch((error) => {
+                console.error(error);
+            });
+            if (selectedEmbedView.value && selectedEmbedView.value.id == element.id) {
+                selectedEmbedView.value.name = renameValue.value.name;
+            }
+        }
+        const historyObj = {
+            message: `<b>${userData.Employee_Name}</b> has changed the  <b> Embed View name </b> as <b> ${renameValue.value.name.trim()} </b>  from <b>${element?.name} </b>`,
+            key: 'Project_Name',
+        };
+        apiRequest('post', env.HANDLE_HISTORY, {
+            type: 'project',
+            companyId: companyId.value,
+            projectId: projectData.value._id,
+            taskId: null,
+            object: historyObj,
+            userData,
+        }).catch((error) => {
+            console.error('ERROR in update project history: ', error);
+        });
+        renameValue.value = { name: '', id: '' };
+    };
+
+    const deleteEmbedView = () => {
+        const user = getUser(userId.value);
+        const userData = {
+            id: user.id,
+            Employee_Name: user.Employee_Name,
+            companyOwnerId: getters['settings/companyOwnerDetail'].userId,
+        };
+        const historyObj = {
+            message: `<b> ${userData.Employee_Name} </b> has deleted the  <b> Embed View ${openDelete.value.data.name} </b>`,
+            key: 'Project_Name',
+        };
+
+        if (openDelete.value.data.isPrivate) {
+            deletePrivateView({ cid: companyId.value, uid: companyUser.value._id, uniqueId: openDelete.value.data.id }).then(() => {
+                $toast.success(t('Toast.View_Deleted_Successfully'), { position: 'top-right' });
+            }).catch((err) => {
+                console.error(err.statusText);
+            });
+            openDelete.value.flag = false;
+            apiRequest('post', env.HANDLE_HISTORY, {
+                type: 'project',
+                companyId: companyId.value,
+                projectId: projectData.value._id,
+                taskId: null,
+                object: historyObj,
+                userData,
+            }).catch((error) => {
+                console.error('ERROR in update project history: ', error);
+            });
+            return;
+        }
+
+        deleteView({ cid: companyId.value, pid: projectData.value._id }, openDelete.value.data).then((res) => {
+            commit('projectData/projectLocalUpdate', { itemData: res.data, projectId: projectData.value._id, key: 'ProjectView', subKey: 'delete', userId: '' });
+        }).catch((err) => {
+            console.error(err.statusText);
+        });
+        openDelete.value.flag = false;
+        apiRequest('post', env.HANDLE_HISTORY, {
+            type: 'project',
+            companyId: companyId.value,
+            projectId: projectData.value._id,
+            taskId: null,
+            object: historyObj,
+            userData,
+        }).catch((error) => {
+            console.error('ERROR in update project history: ', error);
+        });
+        $toast.success(t('Toast.View_Deleted_Successfully'), { position: 'top-right' });
+    };
+
+    return {
+        copyToClipboard,
+        editViewName,
+        deleteEmbedView,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectAssignee.js
+++ b/frontend/src/views/Projects/composables/useProjectAssignee.js
@@ -1,0 +1,101 @@
+import { ref, inject } from 'vue';
+import { useStore } from 'vuex';
+import { useToast } from 'vue-toast-notification';
+import { useGetterFunctions } from '@/composable';
+import { projectAssignee, projectAssigneeRemove } from '@/utils/NotificationTemplate';
+import * as env from '@/config/env';
+import { apiRequest } from '@/services';
+
+export function useProjectAssignee(projectData) {
+    const { commit, getters } = useStore();
+    const $toast = useToast();
+    const { getUser } = useGetterFunctions();
+
+    const userId = inject('$userId');
+    const companyId = inject('$companyId');
+
+    const assigneeInProgress = ref({});
+
+    async function changeAssignee(type, user) {
+        if (assigneeInProgress.value[user.id] && assigneeInProgress.value[user.id] === type) return;
+        assigneeInProgress.value[user.id] = type;
+
+        const usr = getUser(userId.value);
+        const userData = {
+            id: usr.id,
+            Employee_Name: usr.Employee_Name,
+            companyOwnerId: getters['settings/companyOwnerDetail'].userId,
+        };
+
+        let obj;
+        let key;
+        if (type === 'add') {
+            if (projectData.value.AssigneeUserId.includes(user.id)) return;
+            obj = { AssigneeUserId: user.id };
+            key = '$addToSet';
+        } else {
+            if (!projectData.value.AssigneeUserId.includes(user.id)) return;
+            obj = {
+                AssigneeUserId: user.id,
+                ...(projectData.value.LeadUserId.includes(user.id) && { LeadUserId: user.id }),
+            };
+            key = '$pull';
+        }
+        try {
+            await apiRequest('put', `/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`, { updateObject: obj, key });
+
+            commit('projectData/projectLocalUpdate', {
+                itemData: { ...projectData.value },
+                projectId: projectData.value._id,
+                key: 'AssigneeChange',
+                subKey: key === '$addToSet' ? 'add' : 'remove',
+                userId: user.id,
+            });
+
+            delete assigneeInProgress.value[user.id];
+
+            const msg = `Assignee ${type === 'add' ? 'added' : 'removed'} successfully`;
+            $toast.success(msg, { position: 'top-right' });
+
+            const historyObj = {
+                message: `<b>${userData.Employee_Name}</b> ${type === 'add' ? 'added' : 'removed'} the <b>Assignee</b> to <b>${user.label}</b>`,
+                key: 'Assignee_Changed',
+            };
+            const notifyObj = {
+                projectName: projectData.value.ProjectName,
+                Employee_Name: user.label,
+            };
+            const notificationObject = {
+                message: type === 'add' ? projectAssignee(notifyObj) : projectAssigneeRemove(notifyObj),
+                key: 'project_assignee',
+            };
+            apiRequest('post', env.HANDLE_HISTORY, {
+                type: 'project',
+                companyId: companyId.value,
+                projectId: projectData.value._id,
+                taskId: null,
+                object: historyObj,
+                userData,
+            }).catch((error) => {
+                console.error('ERROR in update history', error);
+            });
+            apiRequest('post', env.HANDLE_NOTIFICATION, {
+                type: 'project',
+                companyId: companyId.value,
+                projectId: projectData.value._id,
+                object: notificationObject,
+                userData,
+                mentionUserId: [user.id],
+            }).catch((error) => {
+                console.error('ERROR in update notification', error);
+            });
+        } catch (error) {
+            console.error('Error in update project', error);
+        }
+    }
+
+    return {
+        assigneeInProgress,
+        changeAssignee,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectAvatar.js
+++ b/frontend/src/views/Projects/composables/useProjectAvatar.js
@@ -1,0 +1,162 @@
+import { ref, inject } from 'vue';
+import { useStore } from 'vuex';
+import { useToast } from 'vue-toast-notification';
+import { useI18n } from 'vue-i18n';
+import { useGetterFunctions } from '@/composable';
+import { storageQueryBuilder, generateFileName } from '@/utils/storageQueryBuild.js';
+import * as env from '@/config/env';
+import { apiRequest, apiRequestWithoutCompnay } from '@/services';
+
+export function useProjectAvatar(projectData) {
+    const { commit } = useStore();
+    const $toast = useToast();
+    const { t } = useI18n();
+    const { getUser } = useGetterFunctions();
+
+    const userId = inject('$userId');
+    const companyId = inject('$companyId');
+
+    const showColorAvatar = ref(false);
+    const savingAvatar = ref(false);
+    const previewImage = ref(null);
+
+    const formData = ref({
+        projectName: '',
+        projectId: '',
+        projectProfileField: {
+            selectedColor: { value: '', rules: 'required', name: 'selectedColor', error: '' },
+            uploadedImage: { value: '', rules: 'required', name: 'Choose an Image to Upload', error: '' },
+            previewImage: { value: '', rules: 'required', name: 'previewImage', error: '' },
+        },
+    });
+
+    const resetFormData = () => {
+        formData.value = {
+            projectName: '',
+            projectId: '',
+            projectProfileField: {
+                selectedColor: { value: '', rules: 'required', name: 'selectedColor', error: '' },
+                uploadedImage: { value: '', rules: 'required', name: 'Choose an Image to Upload', error: '' },
+                previewImage: { value: '', rules: 'required', name: 'previewImage', error: '' },
+            },
+        };
+    };
+
+    function assignAvatarData(data) {
+        formData.value.projectName = data.name;
+        formData.value.projectId = data.id;
+        formData.value.icon = data?.icon || '';
+
+        if (data.icon.type === 'image') {
+            formData.value.projectProfileField.previewImage.value = data?.icon?.data || '';
+        } else {
+            formData.value.projectProfileField.selectedColor.value = data?.icon?.data || '';
+        }
+    }
+
+    function updateImageValue(ele) {
+        previewImage.value = ele[0];
+    }
+
+    async function saveProjectAvatar() {
+        const updateObject = { type: 'color', data: '' };
+        const prevIcon = formData?.value?.icon || '';
+        savingAvatar.value = true;
+
+        const deleteWasabiImage = () => {
+            try {
+                const axiousObject = storageQueryBuilder('delete', companyId.value, ((env.STORAGE_TYPE && env.STORAGE_TYPE === 'server') ? (prevIcon.data + '&thubmkey=projectIcon') : prevIcon.data));
+                apiRequest(axiousObject.method, axiousObject.route, axiousObject.data).then((response) => {
+                    if (!response.data.status) {
+                        console.error('ERROR in delete wasabi image: ', response.data.statusText);
+                    }
+                }).catch((error) => {
+                    console.error('ERROR in upload image: ', error);
+                });
+            } catch (error) {
+                console.error('ERROR in upload image: ', error);
+            }
+        };
+
+        if (formData.value.projectProfileField.previewImage.value !== '') {
+            const name = generateFileName(previewImage.value.name, env.STORAGE_TYPE);
+            const filePath = `Project/${projectData.value._id}/Settings/ProjectIcon/${name}`;
+            updateObject.type = 'image';
+
+            const apiFormData = new FormData();
+            apiFormData.append('companyId', companyId.value);
+            apiFormData.append('path', filePath);
+            apiFormData.append('key', 'projectIcon');
+            apiFormData.append('file', previewImage.value);
+
+            if (prevIcon.type === 'image' && !prevIcon.data.includes('http')) {
+                deleteWasabiImage();
+            }
+
+            updateObject.data = await apiRequestWithoutCompnay('post', storageQueryBuilder('upload').route, apiFormData, 'form').then((response) => {
+                if (response.data.status) {
+                    const imageUrlPath = env.STORAGE_TYPE && env.STORAGE_TYPE === 'server' ? response.data.statusText : response.data.statusText[0];
+                    return imageUrlPath;
+                } else {
+                    return '';
+                }
+            }).catch((error) => {
+                console.error('ERROR in upload image: ', error);
+            });
+        } else {
+            if (prevIcon.type === 'image' && !prevIcon.data.includes('http')) {
+                deleteWasabiImage();
+            }
+
+            updateObject.data = formData.value.projectProfileField.selectedColor.value;
+        }
+
+        if (!updateObject.data?.length) {
+            $toast.error(t('Toast.something went worng'), { position: 'top-right' });
+            savingAvatar.value = false;
+            return;
+        }
+        try {
+            await apiRequest('put', `/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`, { updateObject: { projectIcon: { ...updateObject } } });
+            resetFormData();
+            savingAvatar.value = false;
+            showColorAvatar.value = false;
+            const user = getUser(userId.value);
+            const userData = {
+                id: user.id,
+                Employee_Name: user.Employee_Name,
+                companyOwnerId: user.companyOwnerId,
+            };
+            const historyObj = {
+                key: 'Project_EndDate',
+                message: `<b>${userData.Employee_Name}</b> has changed <b> ${updateObject.type === 'color' ? 'color' : 'avatar'} </b> </b>.`,
+            };
+            apiRequest('post', env.HANDLE_HISTORY, {
+                type: 'project',
+                companyId: companyId.value,
+                projectId: projectData.value._id,
+                taskId: null,
+                object: historyObj,
+                userData,
+            });
+            commit('projectData/projectLocalUpdate', { itemData: { ...updateObject }, projectId: projectData.value._id, key: 'ProjectIcon', subKey: '', userId: '' });
+            $toast.success(t('Toast.Project_avatar_updated_successfully'), { position: 'top-right' });
+        } catch (error) {
+            resetFormData();
+            savingAvatar.value = false;
+            $toast.error(t('Toast.something_went_wrong'), { position: 'top-right' });
+            console.error('Error while change avatar of project:', error);
+        }
+    }
+
+    return {
+        showColorAvatar,
+        savingAvatar,
+        previewImage,
+        formData,
+        resetFormData,
+        assignAvatarData,
+        updateImageValue,
+        saveProjectAvatar,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectCalendar.js
+++ b/frontend/src/views/Projects/composables/useProjectCalendar.js
@@ -1,0 +1,93 @@
+import { ref, onMounted, onUnmounted } from 'vue';
+import { calendar } from '@/components/organisms/HourlyMilestone/helper.js';
+
+export function useProjectCalendar() {
+    const { calendarRange } = calendar();
+
+    const calendartoggle = ref(false);
+    const rangeObject = ref({});
+    const calendarDate = ref('');
+    const calenderSelectDate = ref(0);
+
+    const prevMonth = () => {
+        const base = calendarDate.value ? new Date(calenderSelectDate.value) : new Date();
+        const nextDate = base.setMonth(base.getMonth() - 1, 1);
+        calenderSelectDate.value = nextDate;
+        calendarDate.value = new Date(nextDate).toLocaleString('default', { month: 'long', year: 'numeric' });
+    };
+
+    const nextMonth = () => {
+        const base = calendarDate.value ? new Date(calenderSelectDate.value) : new Date();
+        const nextDate = base.setMonth(base.getMonth() + 1, 1);
+        calenderSelectDate.value = nextDate;
+        calendarDate.value = new Date(nextDate).toLocaleString('default', { month: 'long', year: 'numeric' });
+    };
+
+    const defaultMonth = () => {
+        if (calendarDate.value) {
+            calendarDate.value = '';
+            calenderSelectDate.value = 0;
+        }
+    };
+
+    const handleStartEndDate = (value) => {
+        calendartoggle.value = false;
+        const startEndObj = value;
+        const getYear = new Date(startEndObj.start).getFullYear();
+        const getMonth = new Date(startEndObj.start);
+        const month = getMonth.toLocaleString('default', { month: 'short' });
+        const tmpValue = JSON.parse(JSON.stringify(value));
+        rangeObject.value.monthValueRange = `${getYear}`;
+        rangeObject.value.selectedmonth = `${month}`;
+        rangeObject.value.rangeValueMonthly = rangeObject.value.monthlyOrweeklyRangesValue[`${getYear}`];
+        calenderSelectDate.value = new Date(tmpValue.start).getTime();
+        calendarDate.value = new Date(tmpValue.start).toLocaleString('default', { month: 'long', year: 'numeric' });
+    };
+
+    const rangeObjectFRun = (value) => {
+        const startEndObj = value;
+        const getYear = new Date(startEndObj).getFullYear();
+        const getMonth = new Date(startEndObj);
+        const month = getMonth.toLocaleString('default', { month: 'short' });
+        rangeObject.value.monthValueRange = `${getYear}`;
+        rangeObject.value.selectedmonth = `${month}`;
+        rangeObject.value.rangeValueMonthly = rangeObject.value.monthlyOrweeklyRangesValue[`${getYear}`];
+    };
+
+    const handleClickOutside = (event) => {
+        if (calendartoggle.value && !event.target.closest('.monthly-calendar')) {
+            calendartoggle.value = false;
+        }
+    };
+
+    function calendarDateChange(status, key) {
+        if (key === 'calendar' && status) {
+            defaultMonth();
+        }
+    }
+
+    onMounted(() => {
+        calendarRange(new Date('01-jan-1970'), [], 'Monthly', true, new Date('31-dec-2100'))
+            .then((value) => {
+                rangeObject.value = value;
+            });
+        document.body.addEventListener('click', handleClickOutside);
+    });
+
+    onUnmounted(() => {
+        document.body.removeEventListener('click', handleClickOutside);
+    });
+
+    return {
+        calendartoggle,
+        rangeObject,
+        calendarDate,
+        calenderSelectDate,
+        prevMonth,
+        nextMonth,
+        defaultMonth,
+        handleStartEndDate,
+        rangeObjectFRun,
+        calendarDateChange,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectLifecycle.js
+++ b/frontend/src/views/Projects/composables/useProjectLifecycle.js
@@ -1,0 +1,159 @@
+import { ref, inject } from 'vue';
+import { useStore } from 'vuex';
+import { useToast } from 'vue-toast-notification';
+import { useI18n } from 'vue-i18n';
+import { useCustomComposable, useGetterFunctions, useHistoryNotification } from '@/composable';
+import { useProjects } from '@/composable/projects';
+import * as env from '@/config/env';
+import { apiRequest } from '@/services';
+
+export function useProjectLifecycle(projectData) {
+    const { commit } = useStore();
+    const $toast = useToast();
+    const { t } = useI18n();
+    const { sanitizeInput } = useCustomComposable();
+    const { getUser } = useGetterFunctions();
+    const { addHistory, addNotification } = useHistoryNotification();
+    const { markFavourite } = useProjects();
+
+    const userId = inject('$userId');
+    const companyId = inject('$companyId');
+
+    const archive = ref(0);
+    const showSidebar = ref(false);
+    const showSpinner = ref(false);
+
+    function updateChildTasks(restore = false, ProjectId = '') {
+        try {
+            const dsk = archive.value;
+            let taskDeleteStatusKey = 0;
+            let deletedStatusKey;
+            if (restore) {
+                deletedStatusKey = dsk ? 8 : 7;
+                taskDeleteStatusKey = 0;
+            } else {
+                deletedStatusKey = 0;
+                if (dsk === 1 || dsk === 0) {
+                    taskDeleteStatusKey = (dsk === 0 ? 8 : 7);
+                } else if (dsk === 2) {
+                    taskDeleteStatusKey = 1;
+                }
+            }
+            try {
+                const object = {
+                    firstParameter: {
+                        objId: { ProjectID: ProjectId },
+                        deletedStatusKey,
+                    },
+                    secondParameter: { $set: { deletedStatusKey: taskDeleteStatusKey } },
+                    key: 'updateMany',
+                    isConvertFirstParameter: true,
+                    isConvertSecondParameter: false,
+                };
+
+                apiRequest('put', env.TASK, object).catch((error) => {
+                    console.error(error);
+                });
+            } catch (error) {
+                console.error(error);
+            }
+        } catch (error) {
+            console.error('ERROR in update tasks: ', error);
+        }
+    }
+
+    async function updateProject(value = null) {
+        showSpinner.value = true;
+        const updateObject = {};
+        if (value !== null || archive.value !== 0) {
+            updateObject.deletedStatusKey = value !== null ? value : archive.value === 1 ? 2 : 1;
+        } else {
+            const status = projectData.value.projectStatusData.find((x) => x.type === 'close');
+            updateObject.status = status.value;
+            updateObject.statusType = status.type;
+        }
+        try {
+            await apiRequest('put', `/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`, { updateObject: { ...updateObject } });
+            showSidebar.value = false;
+            showSpinner.value = false;
+            const ProjectId = JSON.parse(JSON.stringify(projectData.value._id));
+            updateChildTasks(value !== null, ProjectId);
+            const user = getUser(userId.value);
+            const userData = {
+                id: user.id,
+                Employee_Name: user.Employee_Name,
+                companyOwnerId: user.companyOwnerId,
+            };
+
+            const type = `${value !== null ? 'restored' : archive.value === 0 ? 'closed' : archive.value === 1 ? 'archived' : 'deleted'}`;
+
+            $toast.success(t(`Toast.Project ${type} successfully`), { position: 'top-right' });
+
+            const notificationObject = {
+                message: `<p><strong>${userData.Employee_Name}</strong> has ${type} the <strong>${sanitizeInput(projectData.value.ProjectName)}</strong> Project</p>`,
+                key: 'project_close',
+                projectId: projectData.value._id,
+            };
+            const historyObj = {
+                message: `<b>${userData.Employee_Name}</b> has ${type} the <b>${sanitizeInput(projectData.value.ProjectName)}</b> Project`,
+                key: 'Project_Name',
+            };
+            addHistory({
+                type: 'project',
+                companyId: companyId.value,
+                projectId: projectData.value._id,
+                taskId: null,
+                object: historyObj,
+                userData,
+            });
+            addNotification({
+                type: 'project',
+                companyId: companyId.value,
+                projectId: projectData.value._id,
+                object: notificationObject,
+                userData,
+            });
+            commit('projectData/projectLocalUpdate', { itemData: { ...projectData.value, ...updateObject }, projectId: projectData.value._id, key: value === null ? 'RemoveProject' : 'AddProject', subKey: '', userId: '' });
+        } catch (error) {
+            showSidebar.value = false;
+            showSpinner.value = false;
+            $toast.error(t('Toast.something_went_wrong'), { position: 'top-right' });
+            console.error('ERROR in update project: ', error);
+        }
+    }
+
+    function markProjectFavourite() {
+        if (!projectData.value.favouriteTasks || !projectData.value.favouriteTasks.find((x) => x.userId === userId.value)) {
+            markFavourite({
+                cid: companyId.value,
+                projectId: projectData.value._id,
+                userId: userId.value,
+            }).then((msg) => {
+                commit('projectData/projectLocalUpdate', { itemData: { ...projectData.value }, projectId: projectData.value._id, key: 'MarkAsFavourite', subKey: 'add', userId: userId.value });
+                $toast.success(msg, { position: 'top-right' });
+            }).catch((error) => {
+                console.error('ERROR in mark project fav: ', error);
+            });
+        } else {
+            markFavourite({
+                cid: companyId.value,
+                projectId: projectData.value._id,
+                userId: userId.value,
+                data: projectData.value.favouriteTasks.find((x) => x.userId === userId.value),
+            }).then((msg) => {
+                commit('projectData/projectLocalUpdate', { itemData: { ...projectData.value }, projectId: projectData.value._id, key: 'MarkAsFavourite', subKey: 'remove', userId: userId.value });
+                $toast.success(msg, { position: 'top-right' });
+            }).catch((error) => {
+                console.error('ERROR in mark project fav: ', error);
+            });
+        }
+    }
+
+    return {
+        archive,
+        showSidebar,
+        showSpinner,
+        updateProject,
+        markProjectFavourite,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectNameEdit.js
+++ b/frontend/src/views/Projects/composables/useProjectNameEdit.js
@@ -1,0 +1,110 @@
+import { ref, inject } from 'vue';
+import { useStore } from 'vuex';
+import { useToast } from 'vue-toast-notification';
+import { useI18n } from 'vue-i18n';
+import { useCustomComposable, useGetterFunctions } from '@/composable';
+import { useValidation } from '@/composable/Validation';
+import { EditProjectName } from '@/utils/NotificationTemplate';
+import * as env from '@/config/env';
+import { apiRequest } from '@/services';
+
+export function useProjectNameEdit(projectData) {
+    const { commit, getters } = useStore();
+    const $toast = useToast();
+    const { t } = useI18n();
+    const { sanitizeInput } = useCustomComposable();
+    const { checkAllFields } = useValidation();
+    const { getUser } = useGetterFunctions();
+
+    const userId = inject('$userId');
+    const companyId = inject('$companyId');
+    const companyOwner = () => getters['settings/companyOwnerDetail'];
+
+    const editProject = ref(false);
+    const editProject2 = ref(false);
+    const projectName = ref({
+        value: '',
+        rules: 'required | min: 3',
+        name: 'name',
+        error: '',
+    });
+
+    function resetProjectName() {
+        projectName.value.value = '';
+        projectName.value.error = '';
+    }
+
+    function updateProjectName() {
+        checkAllFields({ projectName: projectName.value })
+            .then(async (valid) => {
+                const prevName = sanitizeInput(projectData.value.ProjectName);
+                const newName = sanitizeInput(projectName.value.value);
+                if (!valid) return;
+
+                editProject.value = false;
+                editProject2.value = false;
+                try {
+                    const updateObj = { ProjectName: projectName.value.value };
+                    await apiRequest('put', `/api/v1/${env.PROJECTACTIONS}/${projectData.value._id}`, { updateObject: updateObj });
+                    $toast.success(t('Toast.Project_name_updated_successfully'), { position: 'top-right' });
+                    const user = getUser(userId.value);
+                    const userData = {
+                        id: user.id,
+                        Employee_Name: user.Employee_Name,
+                        companyOwnerId: companyOwner().userId,
+                    };
+
+                    const axiosData = {
+                        type: 'project',
+                        companyId: companyId.value,
+                        projectId: projectData.value._id,
+                        taskId: null,
+                        object: {
+                            sprintId: null,
+                            key: 'Project_Name',
+                            message: `<b>${userData.Employee_Name}</b> has changed the name of <b>${prevName}</b> to <b>${newName}</b>`,
+                        },
+                        userData,
+                    };
+                    apiRequest('post', env.HANDLE_HISTORY, axiosData).then((result) => {
+                        if (result.data.status) {
+                            console.info(result.data.statusText);
+                        }
+                    });
+                    const updatedPr = { ...projectData.value, ProjectName: projectName.value.value };
+                    commit('projectData/projectLocalUpdate', { itemData: updatedPr, key: 'ProjectName', subKey: '', userId: userId.value });
+                    const notifyObj = { TaskName: newName, previousTaskName: prevName };
+                    const notificationObject = {
+                        message: EditProjectName(notifyObj),
+                        key: 'project_name',
+                    };
+
+                    apiRequest('post', env.HANDLE_NOTIFICATION, {
+                        type: 'project',
+                        companyId: companyId.value,
+                        projectId: projectData.value._id,
+                        object: notificationObject,
+                        userData,
+                        changeType: 'name',
+                        changeData: notifyObj,
+                    }).catch((error) => {
+                        console.error('ERROR in update notification', error);
+                    });
+                    resetProjectName();
+                } catch (error) {
+                    console.error(error);
+                }
+            })
+            .catch((error) => {
+                console.error('ERROR in validation: ', error);
+            });
+    }
+
+    return {
+        editProject,
+        editProject2,
+        projectName,
+        resetProjectName,
+        updateProjectName,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectRules.js
+++ b/frontend/src/views/Projects/composables/useProjectRules.js
@@ -1,0 +1,46 @@
+import { ref, nextTick } from 'vue';
+import { useStore } from 'vuex';
+import { useCustomComposable } from '@/composable';
+
+export function useProjectRules() {
+    const { getters, dispatch } = useStore();
+    const { checkPermission } = useCustomComposable();
+
+    const isRuleData = ref(false);
+    const rulePermission = ref(true);
+
+    function getProjectRule(data) {
+        if (data.isGlobalPermission !== false) return;
+
+        isRuleData.value = true;
+
+        const finalize = () => {
+            nextTick(() => {
+                isRuleData.value = false;
+                rulePermission.value = checkPermission('project.project_list', data.isGlobalPermission, { gettersVal: getters });
+            });
+        };
+
+        const rawRules = getters['settings/projectRawRules'];
+
+        if (rawRules && rawRules.length > 0) {
+            if (rawRules.some((x) => x.projectId !== data._id)) {
+                dispatch('settings/setProjectRules', { pid: data._id })
+                    .then(finalize)
+                    .catch(finalize);
+            } else {
+                finalize();
+            }
+        } else {
+            dispatch('settings/setProjectRules', { pid: data._id })
+                .then(finalize)
+                .catch(finalize);
+        }
+    }
+
+    return {
+        isRuleData,
+        rulePermission,
+        getProjectRule,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectSearch.js
+++ b/frontend/src/views/Projects/composables/useProjectSearch.js
@@ -1,0 +1,143 @@
+import { ref, computed, inject, watch } from 'vue';
+import { useStore } from 'vuex';
+import { useCustomComposable } from '@/composable';
+
+export function useProjectSearch(projectData, showArchived) {
+    const { commit, dispatch, getters } = useStore();
+    const { checkPermission, debounce } = useCustomComposable();
+    const userId = inject('$userId');
+
+    const taskSearch = ref('');
+    const taskNameSearch = ref(true);
+    const taskKeySearch = ref(false);
+    const taskDescriptionSearch = ref(false);
+    const filterUsers = ref([]);
+    const filterQuery = ref({});
+    const searchTask = ref(false);
+    const collapsed = ref(true);
+    const groupBy = ref(0);
+    const userSidebar = ref(false);
+
+    const showTasks = computed(() => checkPermission('task.show_tasks', projectData.value.isGlobalPermission, { gettersVal: getters }));
+
+    function resetFilters() {
+        groupBy.value = 0;
+        filterUsers.value = [];
+        searchTask.value = false;
+        filterQuery.value = '';
+        collapsed.value = true;
+    }
+
+    function toggleSearch() {
+        if (taskDescriptionSearch.value === false && taskKeySearch.value === false) {
+            taskNameSearch.value = true;
+        }
+    }
+
+    function searchMongoDB() {
+        if (!taskSearch.value.trim().length && !filterUsers.value.length && !showArchived.value && !Object.keys(filterQuery.value).length) {
+            commit('projectData/mutateSearchTask', { data: [], op: 'added' });
+            searchTask.value = false;
+            return;
+        }
+
+        const query_by = {};
+        const searchStr = taskSearch.value ? taskSearch.value.toString() : '';
+        const andOr = '$or';
+        query_by[andOr] = [];
+        if (taskNameSearch.value) {
+            query_by[andOr].push({ TaskName: { $regex: searchStr, $options: 'i' } });
+        }
+        if (taskKeySearch.value) {
+            query_by[andOr].push({ TaskKey: { $regex: searchStr, $options: 'i' } });
+        }
+        if (taskDescriptionSearch.value) {
+            query_by[andOr].push({ rawDescription: { $regex: searchStr, $options: 'i' } });
+        }
+        searchTask.value = true;
+        const query = [
+            {
+                $match: {
+                    $and: [
+                        {
+                            $and: [
+                                { ProjectID: { objId: { $in: [projectData.value._id] } } },
+                                { deletedStatusKey: { $in: [showArchived.value ? 2 : 0] } },
+                            ],
+                        },
+                    ],
+                },
+            },
+        ];
+
+        if (filterQuery.value) {
+            query[0].$match.$and.push(filterQuery.value);
+        }
+
+        if (searchStr && searchStr.length) {
+            query[0].$match.$and.push(query_by);
+        }
+
+        if (filterUsers.value && filterUsers.value.length > 0) {
+            query[0].$match.$and.push({ AssigneeUserId: { $in: filterUsers.value } });
+        }
+
+        if (showTasks.value === 1) {
+            query[0].$match.$and.push({ AssigneeUserId: { $in: [userId.value] } });
+        }
+
+        dispatch('projectData/searchTask', { query, showArchived: showArchived.value }).catch((error) => {
+            console.error('ERROR in search tasks: ', error);
+        });
+    }
+
+    function manageFilterUsers(uid = null) {
+        if (uid) {
+            if (filterUsers.value.includes(uid)) {
+                filterUsers.value = filterUsers.value.filter((x) => x !== uid);
+            } else {
+                filterUsers.value.push(uid);
+            }
+        }
+
+        searchMongoDB();
+    }
+
+    const applyFilter = (query) => {
+        filterQuery.value = query;
+        searchMongoDB();
+    };
+
+    const clearFilter = () => {
+        filterQuery.value = '';
+        searchMongoDB();
+    };
+
+    watch(taskSearch, debounce(() => {
+        searchMongoDB();
+    }, 1000));
+
+    watch([projectData, showArchived], () => {
+        searchMongoDB();
+    });
+
+    return {
+        taskSearch,
+        taskNameSearch,
+        taskKeySearch,
+        taskDescriptionSearch,
+        filterUsers,
+        filterQuery,
+        searchTask,
+        collapsed,
+        groupBy,
+        userSidebar,
+        showTasks,
+        resetFilters,
+        toggleSearch,
+        searchMongoDB,
+        manageFilterUsers,
+        applyFilter,
+        clearFilter,
+    };
+}

--- a/frontend/src/views/Projects/composables/useProjectTour.js
+++ b/frontend/src/views/Projects/composables/useProjectTour.js
@@ -1,0 +1,92 @@
+import { ref, inject, computed } from 'vue';
+import { useStore } from 'vuex';
+import { useGetterFunctions } from '@/composable';
+import { tourHepler } from '@/components/organisms/Tour/helper';
+
+export function useProjectTour() {
+    const { getters } = useStore();
+    const { getUser } = useGetterFunctions();
+    const { startProjectTour } = tourHepler();
+
+    const userId = inject('$userId');
+    const clientWidth = inject('$clientWidth');
+    const mainTour = inject('$mainTour');
+
+    const companyUserDetail = computed(() => getters['settings/companyUserDetail']);
+
+    const hanldeProjectTaktypeTour = ref(null);
+    const hanldeProjectLastStep = ref(null);
+
+    function tourHandler(key, isDirectTour = false) {
+        try {
+            if (!isDirectTour) {
+                mainTour.value.handleTour(key);
+            } else {
+                startProjectTour(key);
+            }
+        } catch (error) {
+            console.error('ER: ', error);
+        }
+    }
+
+    const hanldeBlankProjectTour = () => {
+        if (companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
+            if (getUser(userId.value)?.tourStatus?.isProjectTour == undefined || getUser(userId.value)?.tourStatus?.isProjectTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
+                if (clientWidth.value > 767) {
+                    tourHandler('isProjectTour1', true);
+                }
+            }
+        }
+    };
+
+    hanldeProjectTaktypeTour.value = () => {
+        if (companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
+            if (getUser(userId.value)?.tourStatus?.isProjectTour == undefined || getUser(userId.value)?.tourStatus?.isProjectTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
+                if (clientWidth.value > 767) {
+                    tourHandler('isProjectTour2', true);
+                }
+            }
+        }
+    };
+
+    hanldeProjectLastStep.value = () => {
+        if (companyUserDetail.value && (companyUserDetail.value.roleType === 1 || companyUserDetail.value.roleType === 2)) {
+            if (getUser(userId.value)?.tourStatus?.isProjectTour == undefined || getUser(userId.value)?.tourStatus?.isProjectTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
+                if (clientWidth.value > 767) {
+                    tourHandler('isProjectTour3', true);
+                }
+            }
+        }
+    };
+
+    function runProjectStartupTours(projectsLength) {
+        if (!companyUserDetail.value || (companyUserDetail.value.roleType !== 1 && companyUserDetail.value.roleType !== 2)) return;
+
+        if (getUser(userId.value)?.tourStatus?.isProjectAndNavbarTour == undefined || getUser(userId.value)?.tourStatus?.isProjectAndNavbarTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
+            if (clientWidth.value > 767) {
+                tourHandler('isProjectAndNavbarTour');
+            }
+            return;
+        }
+
+        if (getUser(userId.value)?.tourStatus?.isProjectViewTour == undefined || getUser(userId.value)?.tourStatus?.isProjectViewTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
+            if (clientWidth.value > 767 && projectsLength) {
+                tourHandler('isProjectViewTour');
+            }
+        }
+
+        if (getUser(userId.value)?.tourStatus?.isProjectLeftViewTour == undefined || getUser(userId.value)?.tourStatus?.isProjectLeftViewTour === false || (getUser(userId.value)?.tourStatus == undefined || Object.keys(getUser(userId.value)?.tourStatus).length == 0)) {
+            if (clientWidth.value > 1300) {
+                tourHandler('isProjectLeftViewTour');
+            }
+        }
+    }
+
+    return {
+        tourHandler,
+        hanldeBlankProjectTour,
+        hanldeProjectTaktypeTour,
+        hanldeProjectLastStep,
+        runProjectStartupTours,
+    };
+}


### PR DESCRIPTION
Closes #167

## Summary

- `Projects.vue`: 2,737 → 1,365 lines (50% reduction)
- `Task.vue`: 1,015 → 540 lines (47% reduction)
- 9 composables + 5 sub-components extracted for `Projects.vue`
- 2 composables + 1 sub-component extracted for `Task.vue` (quick-menu markup deduped)
- 7 view components converted to `defineAsyncComponent` for route-level lazy loading

## Bundle impact (`npm run build`)

| Chunk | Before | After |
|---|---|---|
| `project.*.js` (main) | 2,621,285 B | **2,047,548 B (-22%, -560 KB)** |
| `project-list-view.*.js` | bundled | 381 KB (lazy) |
| `project-detail.*.js` | bundled | 117 KB (lazy) |
| `project-kanban.*.js` | bundled | 42 KB (lazy) |
| `project-table-view.*.js` | bundled | 28 KB (lazy) |
| `project-workload.*.js` | bundled | 17 KB (lazy) |
| `embed-view.*.js` | bundled | 3 KB (lazy) |
| `project-activity-log.*.js` | bundled | 0.5 KB (lazy) |

## Test plan

- [ ] Open a project → verify list view renders (was crashing with `Cannot read properties of undefined (reading 'find')` before fix)
- [ ] Switch between List / Comments / ActivityLog / ProjectDetail / Kanban / TableView / Workload tabs
- [ ] Rename project, change color/avatar
- [ ] Archive/close/delete project
- [ ] Add/remove project assignee
- [ ] Embed-view create, rename (inline), delete
- [ ] Task search + filters, group-by, collapsed toggle, show-archive
- [ ] Task quick-menu actions (copy link/key, queue, archive, restore, delete, convert to sub/list/task, move, merge, duplicate)
- [ ] Mobile (≤767px): sidebar toggle, more-menu dropdown, rename-on-double-click
- [ ] No regression on sprint-list watcher (sprints still filter correctly by archive/search/permission)

## Notes

- `Projects.vue` lands at 1,365 lines — over the ~800 target from the issue. Further reduction would require extracting the 160-line sprint-filter watcher or the inline embed-view rename dropdown, both of which have cross-dependencies (`skipWatcher`, `projectSearchText`, route-name string handling) that make a safe extraction risky without functional regression. `Task.vue` is comfortably under 800.
- Three behavior-preserving fixes landed before merge: `projectObject`/`item` prop defaults restored to falsy, `useEmbedViews` now shares `renameValue`/`openDelete`/`selectedEmbedView` refs with parent, and the separate `visible` ref (initially false, mutated by `handleUnarchived`/`open('searchIcon')) restored alongside `isVisible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)