### PR TITLE
fix(ai-project): default ProjectType to "Fix" to match manual flow

### DIFF
--- a/Modules/AIProjectGenerator/orchestrator.js
+++ b/Modules/AIProjectGenerator/orchestrator.js
@@ -337,7 +337,7 @@ function buildProjectDoc({ plan, context, companyId, uid, userData, projectIdHin
         ProjectName: proj.ProjectName,
         ProjectCode: String(proj.ProjectCode || '').toUpperCase(),
         ProjectCurrency: { code: 'USD', symbol: '$' },
-        ProjectType: proj.ProjectType || 'General',
+        ProjectType: 'Fix',
         ProjectRequiredComponent: projectRequired,
         ProjectRequiredDefaultComponent: defaultRequired,
         LeadUserId: Array.isArray(proj.LeadUserId) ? proj.LeadUserId : [],

--- a/Modules/AIProjectGenerator/promptTemplates.js
+++ b/Modules/AIProjectGenerator/promptTemplates.js
@@ -26,7 +26,6 @@ Hard rules:
         "projectIcon": { "emoji": string, "backgroundColor": "#RRGGBB" },
         "DueDate": "YYYY-MM-DD" | null,
         "isPrivateSpace": boolean,              // default false
-        "ProjectType": string,                  // e.g. "Software", "Marketing", "Operations"
         "projectStatusData": [{"name": string, "textColor": "#RRGGBB", "type": string}], // 2-6 lifecycle states for the PROJECT as a whole
         "taskStatusData":   [{"name": string, "textColor": "#RRGGBB", "type": string}], // 3-8 workflow states a TASK moves through
         "taskTypeCounts":   [{"name": string, "key": number}],                          // 2-6 entries: "Task","Bug","Story","Epic","Subtask"

--- a/Modules/AIProjectGenerator/schemaValidator.js
+++ b/Modules/AIProjectGenerator/schemaValidator.js
@@ -65,7 +65,7 @@ const ProjectSchema = z.object({
     }).default({ emoji: '🚀', backgroundColor: '#6473E8' }),
     DueDate: DateLike.optional(),
     isPrivateSpace: z.boolean().default(false),
-    ProjectType: z.string().min(1).max(60).optional().default('General'),
+    ProjectType: z.string().min(1).max(60).optional().default('Fix'),
     projectStatusData: z.array(StatusEntrySchema).min(2).max(8),
     taskStatusData: z.array(StatusEntrySchema).min(2).max(8),
     taskTypeCounts: z.array(TaskTypeSchema).min(1).max(8),


### PR DESCRIPTION
## Summary

The AI Project Generator was defaulting `ProjectType` to `"General"` and instructing the LLM to invent values like `"Software"` / `"Marketing"` / `"Operations"`. None of these are valid — only `"Fix"` and `"Hourly"` are recognised across the app (see `frontend/src/components/atom/ProjectType/ProjectType.vue`, and the milestone branching in `ProjectDetail.vue`).

The manual flow already hardcodes `"Fix"` on submit (`CreateProjectSidebar.vue:677`, `TemplateAllDetail.vue:88`). This PR aligns the AI flow with the manual flow.

## Changes

- `Modules/AIProjectGenerator/orchestrator.js` — always assign `ProjectType: 'Fix'`; LLM-supplied value is no longer used.
- `Modules/AIProjectGenerator/schemaValidator.js` — Zod default changed `'General'` → `'Fix'` (defence in depth).
- `Modules/AIProjectGenerator/promptTemplates.js` — removed `ProjectType` from the LLM schema description so the model doesn't waste tokens generating an ignored value.

## Test plan

- [x] Create a project via the AI Project Generator with any prompt; confirm the resulting project has `ProjectType === 'Fix'` in the database and the UI.
- [x] Open the new project — confirm the milestone section behaves as a `Fix` project (`ProjectDetail.vue` shows the Fix branch, not Hourly).
- [x] Change `ProjectType` to `Hourly` afterwards from the project header — confirm it still toggles correctly (regression check on existing behaviour).
- [x] Create a project via the manual flow — confirm `ProjectType === 'Fix'` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
