### PR TITLE
fix(logging): replace console.log with Winston logger across modules (#165)

### DIFF
--- a/Modules/AI/controller.js
+++ b/Modules/AI/controller.js
@@ -235,7 +235,7 @@ exports.resetAiRequestCount = async() => {
             ]
         }
         MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL,obj,"updateMany").then(() => {
-            console.log("COMPLETE COMP");
+            logger.info("COMPLETE COMP");
         }).catch((error)=> {
             logger.error(`${error} error in updatemany company count`);
         })

--- a/Modules/Admin/common/controller.js
+++ b/Modules/Admin/common/controller.js
@@ -54,7 +54,7 @@ exports.getlogo = (req, res) => {
         });
 
     } catch (error) {
-        console.log("error", error);
+        logger.error(`error: ${error}`);
         res.send("Not Set Logo");
     }
 };

--- a/Modules/CheckInstallStep/controller.js
+++ b/Modules/CheckInstallStep/controller.js
@@ -14,6 +14,7 @@ const pjson = require('../../package.json');
 const { requestHandler } = require('../../Config/config.js');
 const aiModals = require('../../utils/aiModals.json');
 const { makeUniqueId } = require('../../utils/commonFunctions.js');
+const logger = require('../../Config/loggerConfig.js');
 // BUG-036 / #90 — path-traversal-safe resolver for the firebase service-account file.
 const { resolveServiceFile } = require('../../utils/safeServiceFile.js');
 
@@ -440,7 +441,7 @@ exports.checkTokenConnection = (req, cb) => {
  */
 exports.generateBuildFrontend = (cb) => {
     try {
-        console.log("Start Build");
+        logger.info("Start Build");
         const vueProjectDirectory = __dirname + '/../../frontend';
         const writePublicFilePath = __dirname + '/../../frontend/public/firebase-messaging-sw.js';
         const buildCommand = 'npm run build';
@@ -546,14 +547,14 @@ self.addEventListener('push', event => {
 
         fs.writeFile(filePathEnv, data, (err, data) => {
             if (err) {
-                console.log("Error Generate FrontEnd ENV", err);
+                logger.error(`Error Generate FrontEnd ENV: ${err}`);
                 cb({
                     status: false,
                     error: `Error Generate FrontEnd ENV: ${err}`
                 });
                 return;
             }
-            console.log("End Generate FrontEnd ENV");
+            logger.info("End Generate FrontEnd ENV");
             // Write Public Firebase message
             fs.writeFile(writePublicFilePath, bdCode, (err) => {
                 if (err) {
@@ -571,17 +572,17 @@ self.addEventListener('push', event => {
                         })
                         return;
                     }
-                    console.log(`Vue build generated: ${buildStdout}`);
+                    logger.info(`Vue build generated: ${buildStdout}`);
                     if (fs.existsSync(removeDist)) {
-                        fs.rmdir(removeDist, {recursive: true, force: true}, (error) => { 
-                            if (error) { 
-                                console.log(error); 
+                        fs.rmdir(removeDist, {recursive: true, force: true}, (error) => {
+                            if (error) {
+                                logger.error(`${error}`);
                                 cb({
                                     status: false,
                                     error: `Error Remove Dist Folder: ${error}`
                                 })
-                            } else { 
-                                console.log("Non Recursive: Directories Deleted!"); 
+                            } else {
+                                logger.info("Non Recursive: Directories Deleted!");
                                 cb({
                                     status: true,
                                     buildStdout: buildStdout,
@@ -909,7 +910,7 @@ exports.checkinstallstep = (req, res) => {
                 const finalEnvData = {...envData, ...exports.envVar};
                 fs.writeFile(filePath, convertToEnv(finalEnvData), (err, data) => {
                     if (err) {
-                        console.log("Error Generate FrontEnd ENV", err);
+                        logger.error(`Error Generate FrontEnd ENV: ${err}`);
                         exports.installSteps[6].status = "error";
                         serviceFun.writeFile(installStepsFilePath, JSON.stringify({installSteps: exports.installSteps, envVar: exports.envVar}, null, 4), () => {
                             emitListener(bodyData?.eventId, {step: "STOP", error: err || "Something went wrong; please contact the administrator"});
@@ -920,7 +921,7 @@ exports.checkinstallstep = (req, res) => {
                         });
                         return;
                     }
-                    console.log("End Generate FrontEnd ENV");
+                    logger.info("End Generate FrontEnd ENV");
                     setTimeout(() => {
                         const { startInitialization } = require('./initalizations.js');
                         startInitialization().then(() => {
@@ -972,7 +973,7 @@ exports.checkinstallstep = (req, res) => {
             });
         }
     } catch (error) {
-        console.log("error.message", error.message || error);
+        logger.error(`error.message: ${error.message || error}`);
         exports.installSteps[bodyData.step-1].status = "error";
         serviceFun.writeFile(installStepsFilePath, JSON.stringify({installSteps: exports.installSteps, envVar: exports.envVar}, null, 4), () => {
             res.json({
@@ -996,7 +997,7 @@ exports.getAiModels = (req, res) => {
             data: aiModals
         });
     } catch (error) {
-        console.log("error.message", error.message || error);
+        logger.error(`error.message: ${error.message || error}`);
         res.json({
             status: false,
             error: error?.message || error

--- a/Modules/CheckInstallStep/createCompany.js
+++ b/Modules/CheckInstallStep/createCompany.js
@@ -466,7 +466,7 @@ exports.createCompanyFromAPIFunction = (userId,obj) => {
             exports.createCompany(object).then(()=>{
                 resolve();
             }).catch((error)=>{
-                console.log(error);
+                logger.error(`${error}`);
             })
         } catch (error) {
             reject(error);

--- a/Modules/CheckInstallStep/initalizations.js
+++ b/Modules/CheckInstallStep/initalizations.js
@@ -1,6 +1,7 @@
 const { SCHEMA_TYPE } = require("../../Config/schemaType");
 const { importRestrictedExtensions, importCustomFields, importTours } = require("../../utils/data");
 const { uploadPublicAssets } = require('../storage/wasabi/controller');
+const logger = require('../../Config/loggerConfig.js');
 
 exports.startInitialization = () => {
     return new Promise((resolve, reject) => {
@@ -27,7 +28,7 @@ exports.startInitialization = () => {
 
             Promise.allSettled(promises)
             .then((result) => {
-                console.log("result: ", result);
+                logger.info(`initialization result: ${JSON.stringify(result.map(r => r.status))}`);
                 resolve();
             })
             .catch((error) => {

--- a/Modules/Company/controller.js
+++ b/Modules/Company/controller.js
@@ -708,7 +708,7 @@ exports.deleteCompany = (req, res) => {
         mongoose.connect(process.env.MONGODB_URL+"/"+req.body.companyId);
         const connection = mongoose.connection;
         connection.once('open', () => {
-            console.log("MongoDB database connection established successfully "+ req.body.companyId);
+            logger.info(`MongoDB database connection established successfully ${req.body.companyId}`);
         });
         mongoose.connection.dropDatabase().then(() => {
             try {

--- a/Modules/ImportSettings/controller.js
+++ b/Modules/ImportSettings/controller.js
@@ -17,10 +17,10 @@ async function batchUpdate(arr) {
 
             let results = []
             const loopFun = () => {
-                console.log("TOTAL: ", count, "/", arr.length, "==", ((count * 100) / arr.length).toFixed(2));
+                logger.info(`TOTAL: ${count} / ${arr.length} == ${((count * 100) / arr.length).toFixed(2)}`);
                 if(count >= arr.length) {
                     resolve(results)
-                    console.log("END");
+                    logger.info("END");
                     return;
                 } else {
                     try {
@@ -34,7 +34,7 @@ async function batchUpdate(arr) {
 
                             if(data) {
                                 promises.push(importData[data.name].apply(null, data.params))
-                                console.log("DATA FOR: ", data.name);
+                                logger.info(`DATA FOR: ${data.name}`);
                             }
                         }
 
@@ -52,7 +52,7 @@ async function batchUpdate(arr) {
                                 }, 200);
                             })
                             .catch((error) => {
-                                console.log(`UPDATE failed batch: ${batch} > ${error.message}`);
+                                logger.error(`UPDATE failed batch: ${batch} > ${error.message}`);
                                 reject(new Error(`Batch update failed: ${error.message}`));
                             });
 

--- a/Modules/LogTime/controllerV2/manualLogtime.js
+++ b/Modules/LogTime/controllerV2/manualLogtime.js
@@ -321,7 +321,7 @@ exports.manualLogTime = async (req, res) => {
                     })
                 }).catch((error) => {
                     logger.error(`TimeSheet===========>Error ${error.message}`);
-                    console.log("error=========>",error)
+                    logger.error(`error: ${error}`);
                     res.send({
                         status: false,
                         statusText: `Error4 1: ${error}`

--- a/Modules/Project/controller/getSprintFolder.js
+++ b/Modules/Project/controller/getSprintFolder.js
@@ -1,6 +1,7 @@
 const { SCHEMA_TYPE } = require("../../../Config/schemaType");
 const { MongoDbCrudOpration,validateObjectId } = require("../../../utils/mongo-handler/mongoQueries");
 const { mongoose } = require("mongoose");
+const logger = require("../../../Config/loggerConfig");
 
 
 exports.getDefaultSprintData = (uid, query, companyId, projectId, roleType) => {
@@ -177,8 +178,7 @@ exports.getSprintFolder = async (req,res) => {
                         exports.getDefaultSprintData(uid,req.query,companyId,projectId, roleType).then((ele)=>{
                             res.status(200).json(ele);
                         }).catch((error)=>{
-                            console.log(error);
-                            
+                            logger.error(`${error}`);
                             res.status(400).json({error: error});
                         })
                     } else if (req.query.collection === 'folders') {

--- a/Modules/Tasks/helpers/helper.js
+++ b/Modules/Tasks/helpers/helper.js
@@ -283,7 +283,7 @@ exports.createCustomFields = ({tasks, userData, projectData}) => {
                         resolve({tasks: tasks, customFields: customFieldsArr});
                     })
                     .catch((error) => {
-                        console.log("error here:", error);
+                        logger.error(`error here: ${error}`);
                         reject(error)
                     });
             } catch (error) {

--- a/Modules/Tasks/helpers/mongo_helper.js
+++ b/Modules/Tasks/helpers/mongo_helper.js
@@ -608,7 +608,7 @@ exports.convertToListSubTask = (companyId, projectData, subTask, sprintObj, oldS
                     logger.error(`error in update task count : ${error}`)
                 });
             }).catch((error) => {
-                console.log(error,"ERROR")
+                logger.error(`ERROR: ${error}`);
             });
         } catch (error) {
             reject(error);

--- a/Modules/Tasks/helpers/task_class.js
+++ b/Modules/Tasks/helpers/task_class.js
@@ -294,7 +294,7 @@ class Task {
                             changeData: editTaskObj
                         })
                         .catch((error) => {
-                            console.log(`ERROR in notification: ${error.message}`);
+                            logger.error(`ERROR in notification: ${error.message}`);
                         });
                     }
                     let historyObj = {
@@ -305,11 +305,11 @@ class Task {
                     HandleHistory('task',projectData.CompanyId, projectData._id,taskData._id,historyObj, userData).then(async () => {});
                 })
                 .catch((error) => {
-                    console.log(`ERROR in task Name update : ${error.message}`);
+                    logger.error(`ERROR in task Name update : ${error.message}`);
                     reject(error)
                 })
             } catch (error) {
-                console.log(`ERROR in task Name update : ${error.message}`);
+                logger.error(`ERROR in task Name update : ${error.message}`);
                 reject(error)
             }
         })

--- a/Modules/Tasks/routes.js
+++ b/Modules/Tasks/routes.js
@@ -4,6 +4,7 @@ const tabSyncTaskCtrl = require('./controller/getTabSyncTasks');
 const advanceFilter = require('./helpers/manageGlobalFilter');
 const getTaskCtrl = require('./helpers/getTasksData');
 const { handleEvents } = require('../Company/eventController');
+const logger = require('../../Config/loggerConfig');
 
 exports.init = (app) => {
     app.post('/api/tasks', (req, res) => {
@@ -13,11 +14,11 @@ exports.init = (app) => {
                 res.send({status: true, statusText: 'Task created successfully.'});
             })
             .catch((error) => {
-                console.log('ERROR: ', error.message);
+                logger.error(`ERROR: ${error.message}`);
                 res.send({status: false, statusText: error.message});
             });
         } catch (error) {
-            console.log('ERROR: ', error.message);
+            logger.error(`ERROR: ${error.message}`);
             res.send({status: false, statusText: error.message});
         }
     });
@@ -28,8 +29,7 @@ exports.init = (app) => {
             res.send({status: true, statusText: 'Task updated successfully.',data:response});
         })
         .catch((error) => {
-            console.log('ERROR: ', error);
-            console.error("ERRORsssss: ", error.message);
+            logger.error(`ERROR: ${error}`);
             res.send({status: false, statusText: error.message});
         });
     });
@@ -45,11 +45,11 @@ exports.init = (app) => {
                 }
             })
             .catch((error) => {
-                console.log('ERROR: ', error.message);
+                logger.error(`ERROR: ${error.message}`);
                 res.send({status: false, statusText: error.message});
             });
         } catch (error) {
-            console.log('ERROR: ', error.message);
+            logger.error(`ERROR: ${error.message}`);
             res.send({status: false, statusText: error.message});
         }
     });
@@ -60,8 +60,7 @@ exports.init = (app) => {
             res.send({status: true, statusText: 'Task updated successfully.',data:response});
         })
         .catch((error) => {
-            console.log('ERROR: ', error);
-            console.error("ERRORsssss: ", error.message);
+            logger.error(`ERROR: ${error}`);
             res.send({status: false, statusText: error.message});
         });
     });

--- a/Modules/createProject/controller.js
+++ b/Modules/createProject/controller.js
@@ -743,7 +743,7 @@ exports.removeProjectCount = (companyId,isPrivateSpace) => {
         }
         updateCompanyFun(SCHEMA_TYPE.GOLBAL,decObj,"findOneAndUpdate",companyId,true);
     } catch (error) {
-        console.log(error,"ERROR:");
+        logger.error(`ERROR: ${error}`);
     }
 }
 

--- a/Modules/projectSetting/controller.js
+++ b/Modules/projectSetting/controller.js
@@ -241,10 +241,10 @@ async function batchUpdate(updateArray, cid) {
 
             let results = []
             const loopFun = () => {
-                console.log("TOTAL: ", count, "/", updateArray.length, "==", ((count * 100) / updateArray.length).toFixed(2));
+                logger.info(`TOTAL: ${count} / ${updateArray.length} == ${((count * 100) / updateArray.length).toFixed(2)}`);
                 if(count >= updateArray.length) {
                     resolve(results)
-                    console.log("END");
+                    logger.info("END");
                     return;
                 } else {
                     try {
@@ -281,7 +281,7 @@ async function batchUpdate(updateArray, cid) {
                         Promise.allSettled(promises)
                         .then((result) => {
                             result.filter((x) => x.status === "rejected").forEach((x) => {
-                                console.log(`UPDATE failed for: ${x}`)
+                                logger.warn(`UPDATE failed for: ${x}`)
                             })
                             results = [...results, ...result]
                             setTimeout(() => {
@@ -289,7 +289,7 @@ async function batchUpdate(updateArray, cid) {
                             }, 200);
                         })
                         .catch((error) => {
-                            console.log(`UPDATE failed batch: ${batch} > ${error.message}`);
+                            logger.error(`UPDATE failed batch: ${batch} > ${error.message}`);
                             next();
                         })
                     } catch (e) {
@@ -309,14 +309,14 @@ exports.migrateSprintsFun = async (req, res) => {
         let projects = await MongoDbCrudOpration(req.body.companyId, { type: SCHEMA_TYPE.PROJECTS, data: [{}] }, "find");
         let mainChat = await MongoDbCrudOpration(req.body.companyId, { type: SCHEMA_TYPE.MAIN_CHATS, data: [{}] }, "find");
         projects = projects.concat(mainChat);
-        console.log(projects.length,"length");
+        logger.info(`projects length: ${projects.length}`);
 
         // Process projects sequentially and collect all promises
         const migrateAll = () => new Promise((resolveMigration) => {
             let count = 0;
             const countFunction = (project) => {
                 if (count >= projects.length) {
-                    console.log(`END PROJECT`);
+                    logger.info('END PROJECT');
                     resolveMigration();
                     return;
                 }
@@ -337,12 +337,12 @@ exports.migrateSprintsFun = async (req, res) => {
         await migrateAll().then(() => {
             res.send({ status: true, statusText: "done"});
         }).catch((error) => {
-            console.log(`Error in migration Promise: ${error}`);
+            logger.error(`Error in migration Promise: ${error}`);
         });
 
     } catch (error) {
         res.send({ status: false, statusText: error});
-        console.log(`Error in migration : ${error}`);
+        logger.error(`Error in migration : ${error}`);
     }
 };
 
@@ -367,7 +367,7 @@ exports.migrateProject = (project,companyId) => {
             let myArr = [...folders]
             folderPromise.push(batchUpdate(myArr, companyId));
             Promise.allSettled(folderPromise).then((response) => {
-                console.log(`FOLDER UPDATE END ${project._id}`);
+                logger.info(`FOLDER UPDATE END ${project._id}`);
                 let updatedFolders = response[0].value.map((result) => result.value);
                 sprints = sprints.map(sprint => {
                     let sprintObj = {
@@ -393,12 +393,12 @@ exports.migrateProject = (project,companyId) => {
                     Promise.allSettled([exports.updateTaksSprints(JSON.parse(JSON.stringify(project._id)),companyId),exports.updateTaksFolders(JSON.parse(JSON.stringify(project._id)),companyId), updateCommentSprint(JSON.parse(JSON.stringify(project._id)),companyId)]).then(() => {
                         resolve();
                     }).catch((error) => {
-                        console.log("Erro in update sprint and folders task");
+                        logger.error("Error in update sprint and folders task");
                         reject(error);
                     })
                 })
             }).catch((error) => {
-                console.log(`Error in Promise folder and sprint: ${error}`);
+                logger.error(`Error in Promise folder and sprint: ${error}`);
             });
         } catch (error) {
             reject(error);
@@ -427,9 +427,9 @@ exports.updateTaksSprints = (projectId,companyId) => {
                             ]
                         }
                         const promise =  MongoDbCrudOpration(companyId,updateObj,"updateMany").then(() => {
-                            console.log("IF DONE updateTaksSprints");
+                            logger.info("IF DONE updateTaksSprints");
                         }).catch((err) => {
-                            console.log(err,"ERROR IN IF UPDATE MANY");
+                            logger.error(`ERROR IN IF UPDATE MANY: ${err}`);
                         })
                         updatePromises.push(promise);
                     }else{
@@ -441,9 +441,9 @@ exports.updateTaksSprints = (projectId,companyId) => {
                             ]
                         }
                         const promise =  MongoDbCrudOpration(companyId,uObj,"updateMany").then(() => {
-                            console.log("ELSE DONE updateTaksSprints");
+                            logger.info("ELSE DONE updateTaksSprints");
                         }).catch((err) => {
-                            console.log(err,"ERROR IN ELSE UPDATE MANY");
+                            logger.error(`ERROR IN ELSE UPDATE MANY: ${err}`);
                         })
                         updatePromises.push(promise);
                     }
@@ -452,11 +452,11 @@ exports.updateTaksSprints = (projectId,companyId) => {
             Promise.allSettled(updatePromises).then(() => {
                 resolve();
             }).catch((error) => {
-                console.log(error,"ERROR IN ALL SETTLED");
+                logger.error(`ERROR IN ALL SETTLED: ${error}`);
                 reject();
             });
         } catch (error) {
-            console.log(error,"ERROR IN UPDATE SPRINTS:");
+            logger.error(`ERROR IN UPDATE SPRINTS: ${error}`);
             reject();
         }
     })
@@ -483,9 +483,9 @@ exports.updateTaksFolders = (projectId,companyId) => {
                             ]
                         }
                         const promise =  MongoDbCrudOpration(companyId,updateObj,"updateMany").then(() => {
-                            console.log("IF DONE updateTaksFolders");
+                            logger.info("IF DONE updateTaksFolders");
                         }).catch((err) => {
-                            console.log(err,"ERROR IN IF UPDATE MANY");
+                            logger.error(`ERROR IN IF UPDATE MANY: ${err}`);
                         })
                         updatePromises.push(promise);
                     }
@@ -494,12 +494,12 @@ exports.updateTaksFolders = (projectId,companyId) => {
             Promise.allSettled(updatePromises).then(() => {
                 resolve();
             }).catch((error) => {
-                console.log(error,"ERROR IN ALL SETTLED");
+                logger.error(`ERROR IN ALL SETTLED: ${error}`);
                 reject();
             });
         } catch (error) {
             reject();
-            console.log(error,"ERROR IN UPDATE FOLDERS:");
+            logger.error(`ERROR IN UPDATE FOLDERS: ${error}`);
         }
     })
 }


### PR DESCRIPTION
## Summary

- Replaces all active `console.log` calls (56 occurrences across 15 files in `Modules/`) with the existing Winston logger (`Config/loggerConfig.js`)
- Applies correct log levels: `logger.error` for catch blocks and errors, `logger.warn` for rejected batch items, `logger.info` for progress/completion messages
- Adds `logger` import to 4 files that lacked it: `Tasks/routes.js`, `Project/controller/getSprintFolder.js`, `CheckInstallStep/controller.js`, `CheckInstallStep/initalizations.js`

## Notes

The `console.log('Service worker activated')` inside `CheckInstallStep/controller.js` is **intentionally preserved** — it lives inside a template literal string (`bdCode`) that gets written to a Firebase service-worker `.js` file. It is browser-side code, not server-side Node.js.

The two commented-out `console.log` lines in `LogTime/controllerV2/tracker.js` and `notification/sendEmail/controllerV2.js` were already disabled and left as-is.

## Test plan

- [x] Server starts without errors (`npm run nodemon`)
- [x] Task create/update endpoints return correct responses
- [x] Log files (`log/combined-*.log`, `log/error-*.log`) receive entries instead of stdout noise
- [x] Firebase service-worker file still generates correctly after install wizard runs

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)