### PR TITLE
fix(aipg): collapse plan flow to one-shot, fix staging 504 / conversation-expired loop

### DIFF
--- a/Modules/AIProjectGenerator/controller.js
+++ b/Modules/AIProjectGenerator/controller.js
@@ -16,9 +16,7 @@ const orchestrator = require('./orchestrator');
 const { normalizePlanColors, forceDefaultStatusToDoName } = orchestrator;
 
 const PLAN_TTL_SECONDS = 15 * 60;        // 15 min
-const CONVO_TTL_SECONDS = 30 * 60;       // 30 min
 const BRIEF_TTL_SECONDS = 30 * 60;       // 30 min
-const MAX_CLARIFY_ROUNDS = 3;
 const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
 
 function token() {
@@ -214,45 +212,25 @@ exports.plan = async (req, res) => {
             if (stash && stash.companyId === companyId) briefText = stash.text;
         }
 
-        let conversation = [];
-        let conversationId = (req.body && req.body.conversationId) || null;
-        if (conversationId) {
-            const stash = myCache.get(cacheKey('convo', uid, conversationId));
-            if (stash && stash.companyId === companyId) conversation = stash.conversation || [];
-        } else {
-            conversationId = token();
-        }
-        const clarifyRound = conversation.length;
-        if (clarifyRound > MAX_CLARIFY_ROUNDS) return sendError(res, 400, 'Max clarification rounds reached');
-
         const members = await loadActiveMembers(companyId);
 
+        // One-shot plan call. The /clarify endpoint and conversation cache
+        // were removed (staging-app intermittently 504s on the proxy and the
+        // cached conversation expired between retries, producing
+        // "Conversation not found or expired" errors). The system prompt
+        // forces needsClarification=false so the model commits to a plan
+        // from whatever description the user gave — vague inputs get
+        // reasonable defaults rather than a follow-up question.
         const { result, tokens, model } = await callLlmForPlan({
-            description, hints, briefText, members, conversation, clarifyRound,
+            description, hints, briefText, members,
+            conversation: [],
+            clarifyRound: 3, // force "final round" rules: must return a plan
         });
 
-        if (result.needsClarification) {
-            myCache.set(cacheKey('convo', uid, conversationId), {
-                companyId,
-                description,
-                hints,
-                briefText,
-                conversation,
-                pendingQuestions: result.questions || [],
-                lastUpdated: Date.now(),
-            }, CONVO_TTL_SECONDS);
-            return res.send({
-                status: true,
-                needsClarification: true,
-                conversationId,
-                questions: result.questions || [],
-                tokensUsed: tokens,
-                model,
-            });
-        }
-
-        // Full plan path.
         let { plan } = result;
+        if (!plan) {
+            return sendError(res, 502, 'The AI did not return a plan. Please try again.');
+        }
         try {
             const allowed = new Set(members.map((m) => String(m.id)));
             const sanitized = sanitizeMemberIds(plan, allowed);
@@ -281,8 +259,6 @@ exports.plan = async (req, res) => {
             plan,
             createdAt: Date.now(),
         }, PLAN_TTL_SECONDS);
-        // Drop the conversation cache — plan is committed.
-        myCache.del(cacheKey('convo', uid, conversationId));
 
         return res.send({
             status: true,
@@ -295,102 +271,17 @@ exports.plan = async (req, res) => {
     } catch (error) {
         logger.error(`AIPG plan error: ${error && error.message ? error.message : error}`);
         const code = error.code === 'LLM_INVALID_OUTPUT' ? 502 : 500;
-        return sendError(res, code, error && error.message ? error.message : 'Plan generation failed');
+        return sendError(res, code, error && error.message ? error.message : 'Plan generation failed. Please try again.');
     }
 };
 
+// /clarify was removed when we collapsed the wizard to one-shot. The route
+// is no longer registered (see routes.js). This stub stays in case any
+// frontend cache still POSTs to the old URL during a deploy roll-out — it
+// returns a clear "endpoint removed, just retry /plan" response instead of
+// 404'ing.
 exports.clarify = async (req, res) => {
-    if (!isAnyProviderConfigured()) {
-        return sendError(res, 503, 'AI provider is not configured');
-    }
-    try {
-        const uid = req.uid;
-        if (!uid) return sendError(res, 401, 'Unauthorized');
-        const companyId = resolveCompanyId(req);
-        if (!companyId) return sendError(res, 403, 'Company access denied');
-
-        const conversationId = req.body && req.body.conversationId;
-        if (!conversationId) return sendError(res, 400, 'conversationId required');
-
-        const stash = myCache.get(cacheKey('convo', uid, conversationId));
-        if (!stash || stash.companyId !== companyId) return sendError(res, 404, 'Conversation not found or expired');
-
-        const answers = Array.isArray(req.body.answers) ? req.body.answers.map((a) => String(a || '').trim()) : [];
-        if (!answers.length) return sendError(res, 400, 'answers required (array of strings)');
-
-        const pendingQuestions = stash.pendingQuestions || [];
-        const newTurns = answers.slice(0, pendingQuestions.length).map((answer, i) => ({
-            question: pendingQuestions[i] || `Question ${i + 1}`,
-            answer,
-        }));
-        const conversation = (stash.conversation || []).concat(newTurns);
-
-        if (conversation.length > MAX_CLARIFY_ROUNDS) {
-            return sendError(res, 400, 'Max clarification rounds reached');
-        }
-
-        // Re-run plan generation with updated conversation. clarifyRound is the
-        // round we're answering, not the next pending round.
-        const members = await loadActiveMembers(companyId);
-        const { result, tokens, model } = await callLlmForPlan({
-            description: stash.description,
-            hints: stash.hints,
-            briefText: stash.briefText,
-            members,
-            conversation,
-            clarifyRound: conversation.length,
-        });
-
-        if (result.needsClarification && conversation.length < MAX_CLARIFY_ROUNDS) {
-            myCache.set(cacheKey('convo', uid, conversationId), {
-                ...stash,
-                conversation,
-                pendingQuestions: result.questions || [],
-                lastUpdated: Date.now(),
-            }, CONVO_TTL_SECONDS);
-            return res.send({
-                status: true,
-                needsClarification: true,
-                conversationId,
-                questions: result.questions || [],
-                tokensUsed: tokens,
-                model,
-            });
-        }
-
-        // Final plan.
-        let { plan } = result;
-        if (!plan) return sendError(res, 502, 'LLM did not return a plan after clarification');
-        const allowed = new Set(members.map((m) => String(m.id)));
-        const sanitized = sanitizeMemberIds(plan, allowed);
-        plan = sanitized.plan;
-        if (plan && plan.project && typeof req.body.isPrivateSpace === 'boolean') {
-            plan.project.isPrivateSpace = req.body.isPrivateSpace;
-        }
-        const reCheck = PlanSchema.safeParse(plan);
-        if (!reCheck.success) {
-            const issues = reCheck.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('\n');
-            return sendError(res, 502, `Plan failed final validation: ${issues}`);
-        }
-        plan = reCheck.data;
-
-        const planId = token();
-        myCache.set(cacheKey('plan', uid, planId), { companyId, plan, createdAt: Date.now() }, PLAN_TTL_SECONDS);
-        myCache.del(cacheKey('convo', uid, conversationId));
-
-        return res.send({
-            status: true,
-            needsClarification: false,
-            planId,
-            plan,
-            tokensUsed: tokens,
-            model,
-        });
-    } catch (error) {
-        logger.error(`AIPG clarify error: ${error && error.message ? error.message : error}`);
-        const code = error.code === 'LLM_INVALID_OUTPUT' ? 502 : 500;
-        return sendError(res, code, error && error.message ? error.message : 'Clarification failed');
-    }
+    return sendError(res, 410, 'Clarification flow was removed. Submit the same description to /plan again.');
 };
 
 exports.execute = async (req, res) => {

--- a/Modules/AIProjectGenerator/promptTemplates.js
+++ b/Modules/AIProjectGenerator/promptTemplates.js
@@ -88,7 +88,6 @@ Plan-shape rules:
 Task count rules (CRITICAL — the user expects a fully-fleshed project, not a stub):
 - Each sprint MUST contain 4-8 concrete tasks. NEVER stop at 1-3 tasks per sprint — that is treated as a failed plan.
 - Plan-level total: generate every task that's genuinely needed to ship the project end-to-end. There is no upper "budget" you should ration. Hard ceiling: 100 tasks.
-- If the user supplies hints.targetTaskCount, treat it as a FLOOR you should meet or exceed. Going more than 15% below the target is a violation. Going above is fine if the work warrants it.
 - Cover the full lifecycle for each phase: setup tasks, the main build tasks, edge-cases / error states, testing, docs, deployment / handoff. A "Backend" folder with only "Set up API" and "Create routes" is incomplete — add auth, validation, error handling, tests, logging, rate-limiting, deployment, etc.
 
 Color rules:
@@ -96,19 +95,20 @@ Color rules:
 - The server derives bgColor from textColor automatically — only emit textColor and you can omit bgColor entirely.
 
 Clarification rule:
-- If the description is too vague to produce a meaningful plan (under ~20 chars of substantive intent, or missing the basics like what the project is), ask 1-3 SHORT clarifying questions and set needsClarification=true. Otherwise produce the plan.
-- Maximum of 3 clarification rounds — after the third, you MUST return a plan.
+- DO NOT ask clarifying questions. ALWAYS set needsClarification=false and return a full plan. If the description is vague, fill in reasonable defaults and proceed — the user explicitly opted in to a one-shot plan with no follow-up.
 `;
 
-function buildSystemPrompt({ clarifyRound = 0 } = {}) {
-    let header = `You are AlianHub's AI Project Bootstrapper. Given a project description (plus optional hints, an uploaded brief, and the user's prior answers), produce a complete project plan (project metadata + folders + sprints + 10-50 actionable tasks).`;
-    if (clarifyRound >= 3) {
-        header += `\n\nThis is the FINAL round. You MUST set needsClarification=false and return a full plan even if some details are still unclear — make reasonable defaults and note assumptions inside task descriptions.`;
-    }
+function buildSystemPrompt(/* { clarifyRound = 0 } = {} */) {
+    // The wizard always runs in one-shot mode now — there is no clarification
+    // round-trip. Tell the model unambiguously: commit to a plan with sensible
+    // defaults rather than ever asking a follow-up question.
+    const header = `You are AlianHub's AI Project Bootstrapper. Given a project description (plus optional hints and an uploaded brief), produce a complete project plan (project metadata + folders + sprints + actionable tasks) in a SINGLE response.
+
+This is a ONE-SHOT call. You MUST set needsClarification=false and return a full plan, even if some details are unclear. Invent reasonable defaults silently and note any assumptions inside task descriptions. Never ask the user a question.`;
     return `${header}\n\n${SHARED_RULES}`;
 }
 
-function buildUserMessage({ description, hints, briefText, members, conversation, clarifyRound }) {
+function buildUserMessage({ description, hints, briefText, members /* conversation, clarifyRound */ }) {
     const sections = [];
     sections.push(`Project description:\n${(description || '').trim() || '(none)'}`);
     if (hints && Object.keys(hints).length) {
@@ -125,12 +125,7 @@ function buildUserMessage({ description, hints, briefText, members, conversation
         }));
         sections.push(`Available members (id+name+role) — you may use these ids in AssigneeUserId / LeadUserId, otherwise leave empty arrays:\n${JSON.stringify(slim, null, 2)}`);
     }
-    if (Array.isArray(conversation) && conversation.length) {
-        const lines = conversation.map((t, i) => `Q${i + 1}: ${t.question}\nA${i + 1}: ${t.answer}`);
-        sections.push(`Prior clarification:\n${lines.join('\n\n')}`);
-    }
-    sections.push(`Clarification round: ${clarifyRound}/3`);
-    sections.push(`Reminder: emit ONE JSON object only. needsClarification must be true (with questions) OR false (with plan).`);
+    sections.push(`Reminder: emit ONE JSON object only. needsClarification MUST be false. Include the full "plan" object.`);
     return sections.join('\n\n');
 }
 

--- a/Modules/AIProjectGenerator/routes.js
+++ b/Modules/AIProjectGenerator/routes.js
@@ -16,8 +16,12 @@ exports.init = (app) => {
      * @swagger
      * /api/v1/ai/project/plan:
      *   post:
-     *     summary: Generate a project plan (or follow-up questions) from a description
+     *     summary: Generate a complete project plan from a description (one-shot)
      *     tags: [AI Project Generator]
+     *     description: |
+     *       Always returns a full plan in a single round-trip. The previous
+     *       multi-turn clarification flow was removed because the conversation
+     *       cache expired between proxy 504 retries on staging.
      */
     app.post('/api/v1/ai/project/plan', ctrl.plan);
 
@@ -25,8 +29,12 @@ exports.init = (app) => {
      * @swagger
      * /api/v1/ai/project/clarify:
      *   post:
-     *     summary: Answer follow-up questions and continue plan generation
+     *     summary: (Removed) — returns 410 Gone; clients should retry /plan
      *     tags: [AI Project Generator]
+     *     description: |
+     *       Retained as a transient stub so frontend caches that still POST to
+     *       the old URL during a deploy roll-out get a clear "endpoint
+     *       removed, retry /plan" response instead of a 404.
      */
     app.post('/api/v1/ai/project/clarify', ctrl.clarify);
 

--- a/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
+++ b/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
@@ -90,22 +90,6 @@
                     </div>
 
                     <div class="aipg-card">
-                        <label class="aipg-field-label">
-                            Target task count
-                            <strong class="aipg-target-count">{{ hints.targetTaskCount }}</strong>
-                        </label>
-                        <p class="aipg-helper">A floor — the AI will generate at least this many tasks, more if the project needs it.</p>
-                        <input
-                            type="range"
-                            min="10"
-                            max="80"
-                            step="5"
-                            v-model.number="hints.targetTaskCount"
-                            :disabled="loading"
-                            class="aipg-range"/>
-                    </div>
-
-                    <div class="aipg-card">
                         <label class="aipg-field-label">Attach a brief <span class="aipg-muted">— optional</span></label>
                         <p class="aipg-helper">PDF, DOCX, TXT, or MD — up to 10 MB.</p>
                         <label class="aipg-file-drop" :class="{ 'is-disabled': loading || briefUploading }">
@@ -127,40 +111,20 @@
                         </label>
                     </div>
 
-                    <!-- Clarification questions inline -->
-                    <div v-if="pendingQuestions.length" class="aipg-card aipg-card-accent">
-                        <h5 class="aipg-section-title">Quick questions to sharpen the plan</h5>
-                        <div v-for="(q, idx) in pendingQuestions" :key="idx" class="aipg-q-row">
-                            <label class="aipg-field-label-sm">{{ q }}</label>
-                            <textarea
-                                v-model="clarifyAnswers[idx]"
-                                rows="3"
-                                class="aipg-textarea aipg-textarea-sm"
-                                placeholder="Your answer…"
-                                :disabled="loading"></textarea>
-                        </div>
-                    </div>
-
                     <transition name="aipg-fade">
-                        <div v-if="error" class="aipg-alert aipg-alert-danger">{{ error }}</div>
+                        <div v-if="error" class="aipg-alert aipg-alert-danger">
+                            <div>{{ error }}</div>
+                            <p class="aipg-alert-hint">Click <strong>Generate plan</strong> again — the AI will retry from your description.</p>
+                        </div>
                     </transition>
 
                     <div class="aipg-actions">
                         <button
-                            v-if="!pendingQuestions.length"
                             class="aipg-btn aipg-btn-primary"
                             :disabled="!canGenerate || loading || briefUploading"
                             @click="onGeneratePlan">
                             <span v-if="loading" class="aipg-spinner aipg-spinner-sm" aria-hidden="true"></span>
-                            {{ loading ? 'Generating plan…' : 'Generate plan' }}
-                        </button>
-                        <button
-                            v-else
-                            class="aipg-btn aipg-btn-primary"
-                            :disabled="!canSubmitAnswers || loading"
-                            @click="onSubmitClarification">
-                            <span v-if="loading" class="aipg-spinner aipg-spinner-sm" aria-hidden="true"></span>
-                            {{ loading ? 'Working…' : 'Continue' }}
+                            {{ loading ? 'Generating plan…' : (error ? 'Try again' : 'Generate plan') }}
                         </button>
                     </div>
                 </section>
@@ -335,9 +299,11 @@ export default defineComponent({
         const rolledBack = ref(false);
 
         const description = ref('');
-        const hints = reactive({
-            targetTaskCount: 25,
-        });
+        // No-frills hints. The clarification round-trip + target-task-count
+        // slider were removed in favour of a one-shot plan call — fewer
+        // moving parts, no cached conversation state to expire, retryable
+        // without "Conversation not found" errors when the proxy 504s.
+        const hints = reactive({});
         // Mirrors the manual flow's workspace step: 'public' → private=false.
         // We force this onto the plan server-side so the user's choice always
         // wins over whatever the LLM picked.
@@ -345,10 +311,6 @@ export default defineComponent({
         const briefFile = ref(null);
         const briefId = ref(null);
         const briefStats = reactive({ tokenEstimate: 0, charCount: 0, truncated: false });
-
-        const conversationId = ref(null);
-        const pendingQuestions = ref([]);
-        const clarifyAnswers = ref([]);
 
         const plan = ref(null);
         const planId = ref(null);
@@ -377,7 +339,6 @@ export default defineComponent({
         const placeholderText = 'e.g. "A 3-month SaaS launch for a 5-person team building an invoicing tool with Stripe billing. Kanban workflow. GitHub + Slack integrations. MVP in 6 weeks; full launch in 12."';
 
         const canGenerate = computed(() => description.value.trim().length >= 20);
-        const canSubmitAnswers = computed(() => pendingQuestions.value.length > 0 && clarifyAnswers.value.filter((a) => (a || '').trim().length).length === pendingQuestions.value.length);
 
         const totals = computed(() => {
             if (!plan.value) return { folders: 0, sprints: 0, tasks: 0 };
@@ -467,10 +428,7 @@ export default defineComponent({
         }
 
         function cleanHints() {
-            const out = {};
-            if (hints.targetTaskCount) out.targetTaskCount = Number(hints.targetTaskCount);
-            out.isPrivateSpace = !!isPrivateSpace.value;
-            return out;
+            return { isPrivateSpace: !!isPrivateSpace.value };
         }
 
         async function onGeneratePlan() {
@@ -478,56 +436,26 @@ export default defineComponent({
             loading.value = true;
             error.value = '';
             try {
+                // One-shot plan call. No conversation state, no clarification
+                // round-trip. If the proxy 504s mid-call or anything else
+                // fails, the user just clicks "Try again" and we re-run from
+                // the same description — there's no expirable cache to lose.
                 const result = await api.generatePlan({
                     description: description.value.trim(),
                     hints: cleanHints(),
                     briefId: briefId.value,
-                    conversationId: conversationId.value,
                     isPrivateSpace: isPrivateSpace.value,
                 });
                 if (!result || !result.status) {
-                    error.value = (result && result.statusText) || 'Plan generation failed';
+                    error.value = (result && result.statusText) || 'Plan generation failed. Please try again.';
                     return;
                 }
-                if (result.needsClarification) {
-                    conversationId.value = result.conversationId;
-                    pendingQuestions.value = result.questions || [];
-                    clarifyAnswers.value = pendingQuestions.value.map(() => '');
+                if (!result.plan) {
+                    error.value = 'The AI did not return a plan. Please try again.';
                     return;
                 }
                 plan.value = result.plan;
                 planId.value = result.planId;
-                step.value = 'preview';
-            } catch (e) {
-                error.value = friendlyErr(e);
-            } finally {
-                loading.value = false;
-            }
-        }
-
-        async function onSubmitClarification() {
-            if (!canSubmitAnswers.value) return;
-            loading.value = true;
-            error.value = '';
-            try {
-                const result = await api.clarify({
-                    conversationId: conversationId.value,
-                    answers: clarifyAnswers.value,
-                    isPrivateSpace: isPrivateSpace.value,
-                });
-                if (!result || !result.status) {
-                    error.value = (result && result.statusText) || 'Clarify failed';
-                    return;
-                }
-                if (result.needsClarification) {
-                    pendingQuestions.value = result.questions || [];
-                    clarifyAnswers.value = pendingQuestions.value.map(() => '');
-                    return;
-                }
-                plan.value = result.plan;
-                planId.value = result.planId;
-                pendingQuestions.value = [];
-                clarifyAnswers.value = [];
                 step.value = 'preview';
             } catch (e) {
                 error.value = friendlyErr(e);
@@ -651,9 +579,6 @@ export default defineComponent({
             briefStats.tokenEstimate = 0;
             briefStats.truncated = false;
             briefStats.charCount = 0;
-            conversationId.value = null;
-            pendingQuestions.value = [];
-            clarifyAnswers.value = [];
             plan.value = null;
             planId.value = null;
             jobId.value = null;
@@ -690,14 +615,13 @@ export default defineComponent({
             closeIcon,
             clientWidth, step, loading, briefUploading, error, rolledBack,
             description, hints, isPrivateSpace, briefFile, briefId, briefStats,
-            conversationId, pendingQuestions, clarifyAnswers,
             plan, planId, editableProjectName,
             jobId, progress, createdProjectId,
             placeholderText,
-            canGenerate, canSubmitAnswers, totals,
+            canGenerate, totals,
             countFolderTasks, isStepDone, stepClass, stepDoneDot, rowClass, stepIcon, stepStatusLabel,
             onFileChosen, clearBrief,
-            onGeneratePlan, onSubmitClarification,
+            onGeneratePlan,
             onApprovePlan, onOpenProject, onRetry, onClose,
         };
     },
@@ -1330,6 +1254,7 @@ details[open] > .aipg-task-desc-trigger .aipg-chevron { transform: rotate(90deg)
     line-height: 1.45;
 }
 .aipg-alert-danger { background: #fee2e2; color: #b91c1c; }
+.aipg-alert-hint { margin: 6px 0 0; font-size: 12px; opacity: 0.85; }
 
 .aipg-actions {
     display: flex;

--- a/frontend/src/composable/aiProjectGenerator.js
+++ b/frontend/src/composable/aiProjectGenerator.js
@@ -6,10 +6,14 @@ import * as env from '@/config/env';
  *
  * Endpoints (see Modules/AIProjectGenerator):
  *   POST /api/v1/ai/project/upload-brief   — multipart form, returns briefId
- *   POST /api/v1/ai/project/plan           — generates plan OR returns follow-up questions
- *   POST /api/v1/ai/project/clarify        — answers follow-ups, then plan
+ *   POST /api/v1/ai/project/plan           — generates a plan in one shot
  *   POST /api/v1/ai/project/execute        — kicks off orchestrator, returns jobId
- *   GET  /api/v1/ai/project/execute/events/:jobId  — SSE progress stream
+ *   GET  /api/v1/ai-progress/:jobId        — SSE progress stream
+ *
+ * The /clarify endpoint and its multi-turn flow were removed because the
+ * conversation cache expired between proxy 504 retries, surfacing
+ * "Conversation not found or expired" to the user. The plan call is now
+ * always a single round-trip and is freely retryable from the UI.
  */
 export function useAiProjectGenerator() {
 
@@ -20,21 +24,11 @@ export function useAiProjectGenerator() {
         return res.data;
     }
 
-    async function generatePlan({ description, hints, briefId, conversationId, isPrivateSpace }) {
+    async function generatePlan({ description, hints, briefId, isPrivateSpace }) {
         const res = await apiRequest('post', env.AI_PROJECT_PLAN, {
             description,
             hints: hints || {},
             briefId: briefId || null,
-            conversationId: conversationId || null,
-            isPrivateSpace: !!isPrivateSpace,
-        });
-        return res.data;
-    }
-
-    async function clarify({ conversationId, answers, isPrivateSpace }) {
-        const res = await apiRequest('post', env.AI_PROJECT_CLARIFY, {
-            conversationId,
-            answers,
             isPrivateSpace: !!isPrivateSpace,
         });
         return res.data;
@@ -89,7 +83,6 @@ export function useAiProjectGenerator() {
     return {
         uploadBrief,
         generatePlan,
-        clarify,
         execute,
         subscribeToProgress,
     };


### PR DESCRIPTION
## Why

On `staging-app.alianhub.com` the AI Project Generator was intermittently 504'ing on `POST /api/v1/ai/project/clarify`. The proxy timeout fired after ~60s; the LLM call kept going and (sometimes) finished server-side, but the user had already seen "Request failed". When they retried, the cached conversation had expired and the server returned **"Conversation not found or expired"** — leaving the user stuck with no way to recover except closing the sidebar and starting over.

## What this PR does

Collapses the wizard to a **one-shot plan call** so there is no conversation state to lose between attempts.

### Backend (`Modules/AIProjectGenerator`)

- `/api/v1/ai/project/plan` — single round-trip. No `conversationId`, no `clarifyRound`, no `myCache "convo:"` keys.
- `/api/v1/ai/project/clarify` — returns **410 Gone** with `"Clarification flow was removed. Submit the same description to /plan again."` Kept for one deploy cycle so any cached frontend that still POSTs the old URL gets a clear response instead of a 404.
- **System prompt** now hard-codes *"DO NOT ask clarifying questions. ALWAYS set needsClarification=false."* The model fills in reasonable defaults silently for any vague input and notes assumptions inside task descriptions.
- `hints.targetTaskCount` floor language stripped — the model picks the count from the existing 4-8/sprint rule + hard ceiling of 100.

### Frontend (`AiProjectCreator.vue` + `aiProjectGenerator.js`)

- ❌ Removed the **"Quick questions to sharpen the plan"** card and all `pendingQuestions` / `clarifyAnswers` / `conversationId` state.
- ❌ Removed the **"Target task count"** slider card.
- ✅ Error state now shows a retry hint and the primary button re-labels itself to **"Try again"**. Clicking it just re-runs the same `/plan` call from the same description — no state to lose between attempts, no conversation to expire.
- 🧹 Composable lost the `clarify()` method.

## What the user sees after this

Step 1 now has three cards: **description**, **public/private workspace**, **optional brief upload**. One button: *Generate plan*. If anything goes wrong (504, network blip, malformed LLM output, etc.) the button becomes *Try again* and re-submitting just works. No "Conversation expired" dead-end.

## What this does *not* fix

The underlying proxy 504 still exists — it's a function of how long the LLM takes. Future work to address that properly would be either:
- stream the model output so the proxy keeps seeing bytes, or
- promote `/plan` to the SSE pattern that `/execute` already uses (return a `jobId`, push the plan over SSE).

Out of scope for this PR — but worth noting because *some* of the 504s on staging will still surface as a generic error toast. The difference is that retrying now just works instead of erroring with "Conversation not found".

## Test plan

- [x] `cp .env.example .env`, set `LLM_PROVIDER` + provider keys, `npm run nodemon`.
- [x] Step 1 now shows only three cards (description / workspace / brief). No slider, no Q&A block.
- [x] Submit a 20+ char description → plan returned directly (no clarification round).
- [x] Submit a deliberately vague description ("a project") → plan still returned with reasonable defaults (no follow-up questions).
- [x] Force a 502 (e.g. `LLM_PROVIDER=anthropic` with a bad key) → error shows with retry hint; clicking *Try again* re-attempts.
- [x] Browser DevTools: confirm no POST to `/api/v1/ai/project/clarify` from the new UI.
- [x] Hit the old `/api/v1/ai/project/clarify` URL directly → 410 with the friendly retry message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)