### PR TITLE
perf(socket): phase 2 core refactor — Map-based room index

### DIFF
--- a/.claude/SOCKET-PERFORMANCE-PLAN.md
+++ b/.claude/SOCKET-PERFORMANCE-PLAN.md
@@ -132,12 +132,14 @@ Touches only backend, no frontend coordination needed.
 
 **Verification:** `npm test` → 20/20 pass. All touched files `node --check` clean. Namespaced emitter routing verified with a smoke harness.
 
-### Phase 2 — Core Refactor (3–5 days)
+### Phase 2 — Core Refactor (3–5 days) — ✅ COMPLETE (2026-05-22)
 Rework the room index. Backend-only.
-- [ ] Fix #1 — `Map`-based room index
-- [ ] Fix #5 — use `socket.rooms` not `adapter.rooms.keys()`
-- [ ] Fix #7 — shared `upsertRoom` helper
-- [ ] Fix #9 — cache `getTotalSprintCount`
+- [x] Fix #1 — `Map`-based room index (`socket/helper.js` now owns the `byPrefix` / `bySocket` indexes; `exports.rooms` array removed from `socket/socketinit.js`)
+- [x] Fix #5 — `data.socket.rooms.has(data.roomName)` liveness guard replaces `Array.from(adapter.rooms.keys()).filter(...)` in all 5 controllers
+- [x] Fix #7 — `upsertRoom(entry)` is idempotent on `roomName`; replaced hand-rolled findIndex / push-or-replace dedup across all controllers
+- [x] Fix #9 — `getTotalSprintCount` results cached in `node-cache` (`sprintPlanCheck:<companyId>:<sprintId>`, 30s TTL)
+
+**Verification:** `npm test` → 28/28 pass (20 existing + 8 new `tests/socket-room-index.test.js`). End-to-end smoke harness at `.claude/tests/smoke-phase2.js` confirms namespaced emitter still routes through the new index and `removeBySocket` purges entries on disconnect. All touched files `node --check` clean.
 
 ### Phase 3 — Payload + Debounce (2–3 days)
 Requires small frontend coordination for Fix #8.

--- a/.claude/tests/smoke-phase2.js
+++ b/.claude/tests/smoke-phase2.js
@@ -1,0 +1,94 @@
+/**
+ * Phase 2 end-to-end smoke test (run via `node .claude/tests/smoke-phase2.js`).
+ *
+ * Sets up a fake socket subscribed to a sprint room, emits a task:update
+ * via the real emitter, and asserts the handler routes through the new
+ * Map-based index and calls namespace.to(roomName).emit(...) exactly once.
+ *
+ * Why this isn't a Jest test: the controllers register listeners on
+ * import (module side-effects). Jest's per-file module isolation would
+ * make this test deterministic, but it would also reset the listeners
+ * between tests in unhelpful ways. Easier to run as a one-shot smoke.
+ */
+
+const assert = require('assert');
+const socketEmitter = require('../../event/socketEventEmitter');
+const helper = require('../../socket/helper');
+
+// Importing the controller registers its `task:update` listener against
+// the emitter. Same for the others — chat subscribes to `task:update`
+// too, so its listener will also see the event but bail because
+// `mainChat !== true`.
+require('../../socket/controller/taskSocket');
+require('../../socket/controller/chatSocket');
+require('../../socket/controller/commentSocket');
+require('../../socket/controller/companiesSocket');
+require('../../socket/controller/userNotificationCount');
+
+let emitCount = 0;
+let lastEmit = null;
+
+const fakeSocket = {
+    id: 'sock-1',
+    rooms: new Set(['project_sprint_PROJ_SPR**sock-1']),
+};
+const fakeNamespace = {
+    name: '/userid_user1',
+    to(roomName) {
+        return {
+            emit(eventName, payload) {
+                emitCount += 1;
+                lastEmit = { roomName, eventName, payload };
+            },
+        };
+    },
+};
+
+helper.upsertRoom({
+    roomName: 'project_sprint_PROJ_SPR**sock-1',
+    socketId: 'sock-1',
+    socket: fakeSocket,
+    namespace: fakeNamespace,
+});
+
+socketEmitter.emit('update', {
+    type: 'update',
+    module: 'task',
+    data: {
+        _id: 'task-1',
+        ProjectID: 'PROJ',
+        sprintId: 'SPR',
+        AssigneeUserId: [],
+        mainChat: false,
+    },
+    updatedFields: { TaskName: 'changed' },
+});
+
+assert.strictEqual(emitCount, 1, `expected exactly 1 emit, got ${emitCount}`);
+assert.strictEqual(lastEmit.roomName, 'project_sprint_PROJ_SPR**sock-1');
+assert.strictEqual(lastEmit.eventName, 'taskUpdate');
+assert.deepStrictEqual(lastEmit.payload.updatedFields, { TaskName: 'changed' });
+
+// Now test that an irrelevant module event doesn't trigger the task handler.
+emitCount = 0;
+socketEmitter.emit('update', {
+    type: 'update',
+    module: 'companies',
+    data: { data: { _id: 'doesnt-matter' } },
+});
+assert.strictEqual(emitCount, 0, `task handler must ignore companies events, got ${emitCount} emits`);
+
+// Disconnect cleanup.
+helper.removeBySocket(fakeSocket);
+assert.strictEqual(helper.getRoomCount(), 0, 'removeBySocket should empty the index');
+
+emitCount = 0;
+socketEmitter.emit('update', {
+    type: 'update',
+    module: 'task',
+    data: { _id: 'task-1', ProjectID: 'PROJ', sprintId: 'SPR', AssigneeUserId: [], mainChat: false },
+});
+assert.strictEqual(emitCount, 0, 'no emit after socket disconnected');
+
+console.log('Phase 2 smoke test: OK');
+process.exit(0);

--- a/Modules/Tasks/helpers/mongo_helper.js
+++ b/Modules/Tasks/helpers/mongo_helper.js
@@ -12,6 +12,10 @@ const { handleTaskAttachmentsDuplicateFunctionality } = require(`../../../common
 const { getCachedCompanyData } = require('../../../utils/planHelper');
 const serviceFun = require("../../serviceFunction");
 const socketEmitter = require('../../../event/socketEventEmitter');
+// SOCKET-PERFORMANCE-PLAN #9 (Phase 2): cache the plan-permission check
+// behind getTotalSprintCount in node-cache.
+const { myCache } = require('../../../Config/config');
+const SPRINT_PLAN_CHECK_TTL_SECONDS = 30;
 const { updateCommentCollection, addCommentCollection } = require('../../Comments/controller');
 // BUG-033 / #87 — self-healing reconciliation for sprint task counts.
 const { reconcileSprintTaskCount, scheduleReconciliation } = require('./reconcileTaskCount');
@@ -1072,18 +1076,39 @@ exports.getTaskCount = async(companyId, sprintId) => {
     }
 }
 
-exports.getTotalSprintCount = async (companyId,sprintId) => {
-    return new Promise(async(resolve,reject) => {
+// SOCKET-PERFORMANCE-PLAN #9 (Phase 2): every task create awaited this
+// function, and the inner `getTaskCount` fires an aggregate pipeline
+// against the tasks collection. Under task-heavy load (bulk imports, AI
+// project plan generation) it serialized every write behind a sequential
+// DB round-trip and inflated the time the connection pool spent saturated.
+//
+// Cache the boolean result for SPRINT_PLAN_CHECK_TTL_SECONDS keyed by
+// `companyId:sprintId`. Trade-offs:
+//   - up to TTL seconds of over-allocation after a sprint hits its task
+//     ceiling (next attempt within the window still sees the cached
+//     `true`). Plan limits are soft caps — the tolerance is acceptable.
+//   - up to TTL seconds of denial after a plan upgrade flips a previously
+//     blocked sprint. Same window, opposite direction. Documented so we
+//     can shorten TTL later if a customer complaint surfaces it.
+exports.getTotalSprintCount = async (companyId, sprintId) => {
+    const cacheKey = `sprintPlanCheck:${companyId}:${sprintId}`;
+    const cached = myCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+
+    return new Promise(async (resolve, reject) => {
         try {
-            Promise.allSettled([exports.getTaskCount(companyId, sprintId),getCachedCompanyData(companyId)]).then(async(results) => {
+            Promise.allSettled([exports.getTaskCount(companyId, sprintId), getCachedCompanyData(companyId)]).then(async (results) => {
                 const resolvedPromises = results.filter((result) => result.status === 'fulfilled');
                 if (resolvedPromises.length === 2) {
                     const [sprintCountResult, cachedCompanyResult] = resolvedPromises.map((result) => result.value);
 
                     const hasPermission = await exports.checkPlanPermission(cachedCompanyResult.data, sprintCountResult.count);
 
+                    myCache.set(cacheKey, hasPermission, SPRINT_PLAN_CHECK_TTL_SECONDS);
                     resolve(hasPermission);
-                }else{
+                } else {
+                    // Don't cache transient failures — we want the next call
+                    // to re-try fresh once Mongo / company-data come back.
                     resolve(false);
                 }
             })

--- a/socket/controller/chatSocket.js
+++ b/socket/controller/chatSocket.js
@@ -1,77 +1,55 @@
-const {joinRoom,leaveRoom} = require('../helper');
-const socketRef = require('../socketinit');
+const {
+    joinRoom,
+    leaveRoom,
+    upsertRoom,
+    removeRoom,
+    findRoomsByPrefixes,
+} = require('../helper');
 const socketEmitter = require('../../event/socketEventEmitter');
+
 function setEventName(type) {
-    let eventName;
     switch (type) {
-        case 'insert': { 
-            eventName = 'chatTaskInsert'
-            break;
-        }
-        case 'update': { 
-            eventName = 'chatTaskUpdate'
-            break;
-        }
-        case 'delete': { 
-            eventName = 'chatTaskDelete'
-            break;
-        }
-        case 'replace': { 
-            eventName = 'chatTaskReplace'
-            break;
-        }
+        case 'insert': return 'chatTaskInsert';
+        case 'update': return 'chatTaskUpdate';
+        case 'delete': return 'chatTaskDelete';
+        case 'replace': return 'chatTaskReplace';
     }
-    return eventName;
 }
 
 const handleTaskChange = (changeData, includeUpdatedFields = false) => {
-    if (changeData.module === 'task' && changeData.data.mainChat === true) {
-        const chatIdentifier = `chat_${changeData.data.ProjectID}_${changeData.data.AssigneeUserId[0]}`;
-        const chatIdentifier1 = `chat_${changeData.data.ProjectID}_${changeData.data.AssigneeUserId[1]}`;
-        const relatedRooms = socketRef.rooms.filter(x => x.roomName.includes(chatIdentifier) || x.roomName.includes(chatIdentifier1));
-        
-        relatedRooms.forEach(data => {
-            const eventName = setEventName(changeData.type);
-            const chat = `${chatIdentifier}**${data.socketId}`;
-            const chat1 = `${chatIdentifier1}**${data.socketId}`;
-            const matchingRooms = [...new Set(
-                Array.from(data.namespace.adapter.rooms.keys())
-                    .filter((roomName) => {
-                        let socId = roomName.split("**");
-                        if (socId.length > 1 && socId[1] === data.socketId) {
-                            return (
-                                (roomName.includes(chat) && data.roomName.includes(chat)) 
-                                || (roomName.includes(chat1) && data.roomName.includes(chat1)) 
-                            )
-                        }
-                    })
-            )];
-            const emitData = {
-                fullDocument: changeData.data,
-                ...(includeUpdatedFields && { updatedFields: changeData.updatedFields })
-            };
+    if (changeData.module !== 'task' || changeData.data.mainChat !== true) return;
 
-            matchingRooms.forEach(room => {
-                data.namespace.to(room).emit(`${eventName}`, emitData);
-            });
-        });
-    }
+    // SOCKET-PERFORMANCE-PLAN #1 (Phase 2): chat events broadcast to both
+    // participants in a 1:1 task chat. The room prefix is
+    // `chat_<projectId>_<userId>` per participant; look up both in one pass.
+    const chatIdentifier = `chat_${changeData.data.ProjectID}_${changeData.data.AssigneeUserId[0]}`;
+    const chatIdentifier1 = `chat_${changeData.data.ProjectID}_${changeData.data.AssigneeUserId[1]}`;
+    const relatedRooms = findRoomsByPrefixes(chatIdentifier, chatIdentifier1);
+    if (!relatedRooms.length) return;
+
+    const eventName = setEventName(changeData.type);
+    const emitData = {
+        fullDocument: changeData.data,
+        ...(includeUpdatedFields && { updatedFields: changeData.updatedFields }),
+    };
+
+    relatedRooms.forEach(data => {
+        if (!data.socket.rooms.has(data.roomName)) return;
+        data.namespace.to(data.roomName).emit(eventName, emitData);
+    });
 };
 
-exports.chatSocketHandler = ({socket, namespace}) => {
-    socket.on('joinChats',(data)=>{
+exports.chatSocketHandler = ({ socket, namespace }) => {
+    socket.on('joinChats', (data) => {
         const roomName = `chat_${data.projectId}_${data.userId}**${data.socketId}`;
-        joinRoom(socket,roomName);
-        socketRef.rooms.push({roomName, socketId: data.socketId,namespace,socket});
+        joinRoom(socket, roomName);
+        upsertRoom({ roomName, socketId: data.socketId, namespace, socket });
     });
-    socket.on('leaveChats',(roomName)=>{
-        let index = socketRef.rooms.findIndex((x)=> x.roomName === roomName);        
-        if (index !== -1) {
-            socketRef.rooms.splice(index, 1);
-        }
-        leaveRoom(socket,roomName);
-    })
-}
+    socket.on('leaveChats', (roomName) => {
+        removeRoom(roomName);
+        leaveRoom(socket, roomName);
+    });
+};
 
 // SOCKET-PERFORMANCE-PLAN #2: chat events live on the `task` module too —
 // the chat handler only forwards events where `mainChat === true`, so it

--- a/socket/controller/commentSocket.js
+++ b/socket/controller/commentSocket.js
@@ -1,122 +1,70 @@
-const socketRef = require('../socketinit');
-const {joinRoom,leaveRoom} = require('../helper');
+const {
+    joinRoom,
+    leaveRoom,
+    upsertRoom,
+    removeRoom,
+    findRoomsByPrefix,
+} = require('../helper');
 const socketEmitter = require('../../event/socketEventEmitter');
-exports.commentSocketHandler = ({socket, namespace}) => {
-    socket.on('joinCommentRoom',(data)=>{
+
+exports.commentSocketHandler = ({ socket, namespace }) => {
+    socket.on('joinCommentRoom', (data) => {
         const roomName = data.roomName;
-        joinRoom(socket,roomName);
-        const existingIndex = socketRef.rooms.findIndex((x) => x.roomName === roomName && x.socketId === data.socketId);
-        if (existingIndex === -1) {
-            socketRef.rooms.push({roomName, socketId: data.socketId,namespace,socket});
-        } else {
-            socketRef.rooms[existingIndex] = {roomName, socketId: data.socketId,namespace,socket};
-        }
+        joinRoom(socket, roomName);
+        // SOCKET-PERFORMANCE-PLAN #7 (Phase 2): upsertRoom replaces the
+        // hand-rolled findIndex / push-or-replace dedup that used to live
+        // inline here. The Map-based index keys on roomName, so re-joining
+        // is naturally idempotent.
+        upsertRoom({ roomName, socketId: data.socketId, namespace, socket });
     });
-    socket.on('leaveCommentRoom',(roomName)=>{
-        for (let index = socketRef.rooms.length - 1; index >= 0; index--) {
-            if (socketRef.rooms[index].roomName === roomName) {
-                socketRef.rooms.splice(index, 1);
-            }
-        }
-        leaveRoom(socket,roomName);
-    })
-}
-function setEventName(type) {
-    let eventName;
-    switch (type) {
-        case 'insert': { 
-            eventName = 'commentInsert'
-            break;
-        }
-        case 'update': { 
-            eventName = 'commentUpdate'
-            break;
-        }
-        case 'delete': { 
-            eventName = 'commentDelete'
-            break;
-        }
-        case 'replace': { 
-            eventName = 'commentReplace'
-            break;
-        }
-    }
-    return eventName;
-}
-const handleCommentChange = (changeData, includeUpdatedFields = false) => {
-    if (changeData.module === 'comments') {
-        // SOCKET-PERFORMANCE-PLAN #3: dropped three back-to-back deep clones of
-        // the full comment document; field access on the doc directly works
-        // for both plain objects and Mongoose documents.
-        const { projectId, sprintId, taskId } = changeData.data;
-        const comentIdentifier = `comments_${projectId}_${sprintId}_${taskId}`;
-        const relatedRooms = uniqueRooms(socketRef.rooms.filter(x => x.roomName.includes(comentIdentifier)));
-        
-        relatedRooms.forEach(data => {
-            const eventName = setEventName(changeData.type);
-            const comment = `${comentIdentifier}**${data.socketId}`;
-            const matchingRooms = [...new Set(
-                Array.from(data.namespace.adapter.rooms.keys())
-                    .filter((roomName) => {
-                        let socId = roomName.split("**");
-                        if (socId.length > 1 && socId[1] === data.socketId) {
-                            return (
-                                (roomName.includes(comment) && data.roomName.includes(comment)) 
-                            )
-                        }
-                    })
-            )];
-            const emitData = {
-                fullDocument: changeData.data,
-                ...(includeUpdatedFields && { updatedFields: changeData.updatedFields })
-            };
-
-            matchingRooms.forEach(room => {
-                data.namespace.to(room).emit(`${eventName}`, emitData);
-            });
-        });
-    }
-
-    if (changeData.module === 'comments_project') {
-        // SOCKET-PERFORMANCE-PLAN #3: same dedup-via-clone removal as above.
-        const comentProjectIdentifier = `comments_project_${changeData.data.projectId}`;
-        const relatedRooms = uniqueRooms(socketRef.rooms.filter(x => x.roomName.includes(comentProjectIdentifier)));
-        
-        relatedRooms.forEach(data => {
-            const eventName = setEventName(changeData.type);
-            const commentProject = `${comentProjectIdentifier}**${data.socketId}`;
-            const matchingRooms = [...new Set(
-                Array.from(data.namespace.adapter.rooms.keys())
-                    .filter((roomName) => {
-                        let socId = roomName.split("**");
-                        if (socId.length > 1 && socId[1] === data.socketId) {
-                            return (
-                                (roomName.includes(commentProject) && data.roomName.includes(commentProject)) 
-                            )
-                        }
-                    })
-            )];
-            const emitData = {
-                fullDocument: changeData.data,
-                ...(includeUpdatedFields && { updatedFields: changeData.updatedFields })
-            };
-
-            matchingRooms.forEach(room => {
-                data.namespace.to(room).emit(`${eventName}`, emitData);
-            });
-        });
-    }
+    socket.on('leaveCommentRoom', (roomName) => {
+        removeRoom(roomName);
+        leaveRoom(socket, roomName);
+    });
 };
 
-function uniqueRooms(rooms) {
-    const seen = new Set();
-    return rooms.filter((room) => {
-        const key = `${room.roomName}**${room.socketId}`;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-    });
+function setEventName(type) {
+    switch (type) {
+        case 'insert': return 'commentInsert';
+        case 'update': return 'commentUpdate';
+        case 'delete': return 'commentDelete';
+        case 'replace': return 'commentReplace';
+    }
 }
+
+const handleCommentChange = (changeData, includeUpdatedFields = false) => {
+    // Both modules share the same emit shape; the only difference is the
+    // prefix used to find subscribed rooms.
+    let prefix;
+    if (changeData.module === 'comments') {
+        const { projectId, sprintId, taskId } = changeData.data;
+        prefix = `comments_${projectId}_${sprintId}_${taskId}`;
+    } else if (changeData.module === 'comments_project') {
+        prefix = `comments_project_${changeData.data.projectId}`;
+    } else {
+        return;
+    }
+
+    // SOCKET-PERFORMANCE-PLAN #1 (Phase 2): O(1) prefix lookup replaces the
+    // full-array filter + `uniqueRooms` dedup helper. The Map-based index
+    // is already deduped by construction (key = roomName), so a second-pass
+    // dedup is no longer needed.
+    const relatedRooms = findRoomsByPrefix(prefix);
+    if (!relatedRooms.length) return;
+
+    const eventName = setEventName(changeData.type);
+    const emitData = {
+        fullDocument: changeData.data,
+        ...(includeUpdatedFields && { updatedFields: changeData.updatedFields }),
+    };
+
+    relatedRooms.forEach(data => {
+        // SOCKET-PERFORMANCE-PLAN #5 (Phase 2): see taskSocket.js — small-Set
+        // membership check beats scanning the namespace's full adapter.rooms.
+        if (!data.socket.rooms.has(data.roomName)) return;
+        data.namespace.to(data.roomName).emit(eventName, emitData);
+    });
+};
 
 // SOCKET-PERFORMANCE-PLAN #2: comments are published under two modules —
 // `comments` (task-level comments) and `comments_project` (project-level

--- a/socket/controller/companiesSocket.js
+++ b/socket/controller/companiesSocket.js
@@ -1,73 +1,54 @@
-const socketRef = require('../socketinit');
-const {joinRoom,leaveRoom} = require('../helper');
+const {
+    joinRoom,
+    leaveRoom,
+    upsertRoom,
+    removeRoom,
+    findRoomsByPrefix,
+} = require('../helper');
 const socketEmitter = require('../../event/socketEventEmitter');
-exports.companiesSocketHandler = ({socket, namespace}) => {
-    socket.on('joinCompaniesRoom',(data)=>{
+
+exports.companiesSocketHandler = ({ socket, namespace }) => {
+    socket.on('joinCompaniesRoom', (data) => {
         const roomName = data.roomName;
-        joinRoom(socket,roomName);
-        socketRef.rooms.push({roomName, socketId: data.socketId,namespace,socket});
+        joinRoom(socket, roomName);
+        upsertRoom({ roomName, socketId: data.socketId, namespace, socket });
     });
-    socket.on('leaveCompaniesRoom',(roomName)=>{
-        let index = socketRef.rooms.findIndex((x)=> x.roomName === roomName);        
-        if (index !== -1) {
-            socketRef.rooms.splice(index, 1);
-        }
-        leaveRoom(socket,roomName);
-    })
-}
+    socket.on('leaveCompaniesRoom', (roomName) => {
+        removeRoom(roomName);
+        leaveRoom(socket, roomName);
+    });
+};
+
 function setEventName(type) {
-    let eventName;
     switch (type) {
-        case 'insert': { 
-            eventName = 'companiesInsert'
-            break;
-        }
-        case 'update': { 
-            eventName = 'companiesUpdate'
-            break;
-        }
-        case 'delete': { 
-            eventName = 'companiesDelete'
-            break;
-        }
-        case 'replace': { 
-            eventName = 'companiesReplace'
-            break;
-        }
+        case 'insert': return 'companiesInsert';
+        case 'update': return 'companiesUpdate';
+        case 'delete': return 'companiesDelete';
+        case 'replace': return 'companiesReplace';
     }
-    return eventName;
 }
+
 const handleCompaniesChange = (changeData, includeUpdatedFields = false) => {
-    if (changeData.module === 'companies') {
-        try {
-            // SOCKET-PERFORMANCE-PLAN #3: dropped deep clone — template
-            // literal already calls toString() on the ObjectId.
-            const companiesIdentifier = `selected_companies_${changeData.data.data._id}`;
-            const relatedRooms = socketRef.rooms.filter(x => x.roomName.includes(companiesIdentifier));
-            
-            relatedRooms.forEach(data => {
-                const eventName = setEventName(changeData.type);
-                const companies = `${companiesIdentifier}**${data.socketId}`;
-                const matchingRooms = [...new Set(
-                    Array.from(data.namespace.adapter.rooms.keys())
-                        .filter((roomName) => {
-                            let socId = roomName.split("**");
-                            if (socId.length > 1 && socId[1] === data.socketId) {
-                                return (roomName.includes(companies) && data.roomName.includes(companies))
-                            }
-                        })
-                )];
-                const emitData = {
-                    fullDocument: changeData.data.data,
-                    ...(includeUpdatedFields && { updatedFields: changeData.updatedFields })
-                };
-                matchingRooms.forEach(room => {
-                    data.namespace.to(room).emit(`${eventName}`, emitData);
-                });
-            });
-        } catch (error) {
-            console.error(error)
-        }
+    if (changeData.module !== 'companies') return;
+
+    try {
+        const companiesIdentifier = `selected_companies_${changeData.data.data._id}`;
+        // SOCKET-PERFORMANCE-PLAN #1 (Phase 2): O(1) prefix lookup.
+        const relatedRooms = findRoomsByPrefix(companiesIdentifier);
+        if (!relatedRooms.length) return;
+
+        const eventName = setEventName(changeData.type);
+        const emitData = {
+            fullDocument: changeData.data.data,
+            ...(includeUpdatedFields && { updatedFields: changeData.updatedFields }),
+        };
+
+        relatedRooms.forEach(data => {
+            if (!data.socket.rooms.has(data.roomName)) return;
+            data.namespace.to(data.roomName).emit(eventName, emitData);
+        });
+    } catch (error) {
+        console.error(error);
     }
 };
 

--- a/socket/controller/taskSocket.js
+++ b/socket/controller/taskSocket.js
@@ -1,132 +1,111 @@
-const {joinRoom,leaveRoom} = require('../helper');
-const socketRef = require('../socketinit');
+const {
+    joinRoom,
+    leaveRoom,
+    upsertRoom,
+    removeRoom,
+    findRoomsByPrefixes,
+} = require('../helper');
 const socketEmitter = require('../../event/socketEventEmitter');
+
 function setEventName(type) {
-    let eventName;
     switch (type) {
-        case 'insert': { 
-            eventName = 'taskInsert'
-            break;
-        }
-        case 'update': { 
-            eventName = 'taskUpdate'
-            break;
-        }
-        case 'delete': { 
-            eventName = 'taskDelete'
-            break;
-        }
-        case 'replace': { 
-            eventName = 'taskReplace'
-            break;
-        }
+        case 'insert': return 'taskInsert';
+        case 'update': return 'taskUpdate';
+        case 'delete': return 'taskDelete';
+        case 'replace': return 'taskReplace';
     }
-    return eventName;
 }
 
 const handleTaskChange = (changeData, includeUpdatedFields = false) => {
-    if (changeData.module === 'task') {
-        const sprintIdentifier = `project_sprint_${changeData.data.ProjectID}_${changeData.data.sprintId}`;
-        // SOCKET-PERFORMANCE-PLAN #3: dropped JSON.parse(JSON.stringify(...))
-        // around `_id` access. The deep clone was used solely to coerce the
-        // Mongoose ObjectId to a string for template literal interpolation —
-        // template literals already call .toString() on objects, so the clone
-        // was a pure allocation/GC cost on every event.
-        const taskDetail = `taskDetail_${changeData.data._id}`;
-        const subTaskDetail = `taskDetail_${changeData.data.ParentTaskId}`;
-        const relatedRooms = socketRef.rooms.filter(x => x.roomName.includes(sprintIdentifier) || x.roomName.includes(taskDetail) || x.roomName.includes(subTaskDetail));
-        
-        relatedRooms.forEach(data => {
-            const eventName = setEventName(changeData.type);
-            if (data.isUserIdCheck) {
-                
-                let userId = data.namespace.name.split("_").pop();
-                if (changeData.data.AssigneeUserId.includes(userId)) {
-                    const projectID = `${sprintIdentifier}**${data.socketId}`;
-            
-                    const matchingRooms = [...new Set(
-                        Array.from(data.namespace.adapter.rooms.keys())
-                            .filter(roomName => roomName.includes(projectID))
-                    )];
-    
-                    const emitData = {
-                        fullDocument: changeData.data,
-                        ...(includeUpdatedFields && { updatedFields: changeData.updatedFields })
-                    };
-    
-                    matchingRooms.forEach(room => {
-                        data.namespace.to(room).emit(eventName, emitData);
-                    });        
-                }
+    if (changeData.module !== 'task') return;
+
+    // SOCKET-PERFORMANCE-PLAN #1 (Phase 2): O(1) prefix lookup. Three
+    // prefixes are checked because a task event needs to broadcast to:
+    //   - everyone watching the sprint board (`project_sprint_<pid>_<sid>`)
+    //   - everyone viewing the task detail panel (`taskDetail_<tid>`)
+    //   - everyone viewing the parent task detail panel
+    //     (`taskDetail_<parentTaskId>`) so subtask updates are visible
+    // findRoomsByPrefixes dedups across all three prefixes in one pass.
+    const sprintIdentifier = `project_sprint_${changeData.data.ProjectID}_${changeData.data.sprintId}`;
+    const taskDetail = `taskDetail_${changeData.data._id}`;
+    const subTaskDetail = `taskDetail_${changeData.data.ParentTaskId}`;
+    const relatedRooms = findRoomsByPrefixes(sprintIdentifier, taskDetail, subTaskDetail);
+    if (!relatedRooms.length) return;
+
+    const eventName = setEventName(changeData.type);
+    const changedTaskId = String(changeData.data._id);
+
+    relatedRooms.forEach(data => {
+        // SOCKET-PERFORMANCE-PLAN #5 (Phase 2): cheap O(1) liveness guard.
+        // Replaces the previous `Array.from(adapter.rooms.keys()).filter(...)`
+        // scan that iterated every room in the namespace per matching entry.
+        // socket.rooms is a small Set (3–5 rooms per socket); has() is O(1).
+        if (!data.socket.rooms.has(data.roomName)) return;
+
+        if (data.isUserIdCheck) {
+            const userId = data.namespace.name.split('_').pop();
+            if (!changeData.data.AssigneeUserId.includes(userId)) return;
+
+            const emitData = {
+                fullDocument: changeData.data,
+                ...(includeUpdatedFields && { updatedFields: changeData.updatedFields }),
+            };
+            data.namespace.to(data.roomName).emit(eventName, emitData);
+            return;
+        }
+
+        const emitData = {
+            fullDocument: changeData.data,
+            ...(includeUpdatedFields && { updatedFields: changeData.updatedFields }),
+        };
+
+        if (data.roomName.includes('taskDetail_')) {
+            // Detail-pane rooms get a distinct event name and an
+            // `isSubTaskUpdate` flag when the change is for a subtask of
+            // the task this detail pane is showing.
+            const taskId = data.roomName.split('**')[0].split('_')[1];
+            if (changedTaskId == taskId) {
+                data.namespace.to(data.roomName).emit(`taskDetail_${eventName}`, emitData);
             } else {
-                const projectID = `${sprintIdentifier}**${data.socketId}`;
-                const taskDetailIdentifier = `${taskDetail}**${data.socketId}`
-                const subTaskDetailIdentifiew = `${subTaskDetail}**${data.socketId}`;
-                const matchingRooms = [...new Set(
-                    Array.from(data.namespace.adapter.rooms.keys())
-                        .filter((roomName) => {
-                            let socId = roomName.split("**");
-                            if (socId.length > 1 && socId[1] === data.socketId) {
-                                return (
-                                    (roomName.includes(projectID) && data.roomName.includes(projectID)) 
-                                    ||(data.roomName.includes(taskDetailIdentifier) && roomName.includes(taskDetailIdentifier))
-                                    ||(data.roomName.includes(subTaskDetailIdentifiew) && roomName.includes(subTaskDetailIdentifiew))
-                                )
-                            }
-                        })
-                )];
-                const emitData = {
-                    fullDocument: changeData.data,
-                    ...(includeUpdatedFields && { updatedFields: changeData.updatedFields })
-                };
-    
-                // SOCKET-PERFORMANCE-PLAN #3: cache the stringified _id once
-                // per change instead of deep-cloning the entire task document
-                // inside the forEach loop.
-                const changedTaskId = String(changeData.data._id);
-                matchingRooms.forEach(room => {
-                    if (room.includes('taskDetail_')) {
-                        let taskId = room.split('**')[0].split('_')[1];
-                        if (changedTaskId == taskId) {
-                            data.namespace.to(room).emit(`taskDetail_${eventName}`, emitData);
-                        } else {
-                            data.namespace.to(room).emit(`taskDetail_${eventName}`, {...emitData, isSubTaskUpdate: true});
-                        }
-                    } else {
-                        data.namespace.to(room).emit(`${eventName}`, emitData);
-                    }
-                });
+                data.namespace.to(data.roomName).emit(`taskDetail_${eventName}`, { ...emitData, isSubTaskUpdate: true });
             }
-        });
-    }
+        } else {
+            data.namespace.to(data.roomName).emit(eventName, emitData);
+        }
+    });
 };
 
-exports.taskSocketHandler = ({socket, namespace}) => {
-    socket.on('joinProjectSprintForTask',(data)=>{
+exports.taskSocketHandler = ({ socket, namespace }) => {
+    socket.on('joinProjectSprintForTask', (data) => {
         const roomName = `project_sprint_${data.projectId}_${data.sprintId}**${data.socketId}`;
-        joinRoom(socket,roomName);
-        socketRef.rooms.push({roomName, socketId: data.socketId,namespace,socket,isUserIdCheck: data.userId ? true : false, userId: data.userId});
+        joinRoom(socket, roomName);
+        // SOCKET-PERFORMANCE-PLAN #7 (Phase 2): upsertRoom is idempotent on
+        // (roomName) — tab refresh / reconnect no longer produces duplicate
+        // entries that would have caused the same event to fire multiple
+        // times to the same room.
+        upsertRoom({
+            roomName,
+            socketId: data.socketId,
+            namespace,
+            socket,
+            isUserIdCheck: data.userId ? true : false,
+            userId: data.userId,
+        });
     });
-    socket.on('leaveProjectSprintForTask',(roomName)=>{
-        let index = socketRef.rooms.findIndex((x)=> x.roomName === roomName);        
-        if (index !== -1) {
-            socketRef.rooms.splice(index, 1);
-        }
-        leaveRoom(socket,roomName);
-    })
-    socket.on('joinTaskDetail',(data)=>{
+    socket.on('leaveProjectSprintForTask', (roomName) => {
+        removeRoom(roomName);
+        leaveRoom(socket, roomName);
+    });
+    socket.on('joinTaskDetail', (data) => {
         const roomName = `taskDetail_${data.taskId}**${data.socketId}`;
-        joinRoom(socket,roomName);
-        socketRef.rooms.push({roomName, socketId: data.socketId,namespace,socket});
-    })
-    socket.on('leaveTaskDetail',(roomName)=>{
-        let index = socketRef.rooms.findIndex((x)=> x.roomName === roomName);        
-        if (index !== -1) {
-            socketRef.rooms.splice(index, 1);
-        }
-        leaveRoom(socket,roomName);
-    })
-}
+        joinRoom(socket, roomName);
+        upsertRoom({ roomName, socketId: data.socketId, namespace, socket });
+    });
+    socket.on('leaveTaskDetail', (roomName) => {
+        removeRoom(roomName);
+        leaveRoom(socket, roomName);
+    });
+};
 
 // SOCKET-PERFORMANCE-PLAN #2: subscribe to module-scoped events only. The
 // emitter publishes `task:update` / `task:insert` for any payload tagged

--- a/socket/controller/userNotificationCount.js
+++ b/socket/controller/userNotificationCount.js
@@ -1,41 +1,42 @@
-const {joinRoom,leaveRoom} = require('../helper');
-const socketRef = require('../socketinit');
+const {
+    joinRoom,
+    leaveRoom,
+    upsertRoom,
+    findRoomsByPrefix,
+} = require('../helper');
 const socketEmitter = require('../../event/socketEventEmitter');
+
 const handleUserNotificationChange = (changeData) => {
-    if (changeData.module === 'userIdNotification') {
-        const userIdIdentifier = `userIdNotification_${changeData.data.userId}`;
-        const relatedRooms = socketRef.rooms.filter(x => x.roomName.includes(userIdIdentifier));
-        relatedRooms.forEach(data => {
-            const eventName = 'userIdNoticationUpdate';
-            const userCountIdefier = `${userIdIdentifier}**${data.socketId}`;
-            const matchingRooms = [...new Set(
-                Array.from(data.namespace.adapter.rooms.keys())
-                    .filter((roomName) => {
-                        let socId = roomName.split("**");
-                        if (socId.length > 1 && socId[1] === data.socketId) {
-                            return (
-                                (roomName.includes(userCountIdefier) && data.roomName.includes(userCountIdefier)) 
-                            )
-                        }
-                    })
-            )];
-            const emitData = {
-                fullDocument: changeData.data,
-            };
-            matchingRooms.forEach(room => {
-                data.namespace.to(room).emit(`${eventName}`, emitData);
-            });
-        })
-    }
+    if (changeData.module !== 'userIdNotification') return;
+
+    const userIdIdentifier = `userIdNotification_${changeData.data.userId}`;
+    // SOCKET-PERFORMANCE-PLAN #1 (Phase 2): O(1) prefix lookup.
+    const relatedRooms = findRoomsByPrefix(userIdIdentifier);
+    if (!relatedRooms.length) return;
+
+    const emitData = { fullDocument: changeData.data };
+
+    relatedRooms.forEach(data => {
+        // SOCKET-PERFORMANCE-PLAN #5 (Phase 2): see taskSocket.js for context.
+        if (!data.socket.rooms.has(data.roomName)) return;
+        data.namespace.to(data.roomName).emit('userIdNoticationUpdate', emitData);
+    });
 };
 
-exports.userNotificationCountHandler = ({socket, namespace}) => {
-    socket.on('joinUserIdNotification',(data)=>{
+exports.userNotificationCountHandler = ({ socket, namespace }) => {
+    socket.on('joinUserIdNotification', (data) => {
         const roomName = `userIdNotification_${data.uid}**${data.socketId}`;
-        joinRoom(socket,roomName);
-        socketRef.rooms.push({roomName, socketId: data.socketId,namespace,socket,isUserIdCheck: data.userId ? true : false, userId: data.userId});
+        joinRoom(socket, roomName);
+        upsertRoom({
+            roomName,
+            socketId: data.socketId,
+            namespace,
+            socket,
+            isUserIdCheck: data.userId ? true : false,
+            userId: data.userId,
+        });
     });
-}
+};
 
 // SOCKET-PERFORMANCE-PLAN #2: scoped to the `userIdNotification` module
 // only. Previously this fired for every task/comment/companies update too,

--- a/socket/helper.js
+++ b/socket/helper.js
@@ -1,7 +1,141 @@
-exports.joinRoom = (soket,roomName) => {
-    soket.join(roomName);
-}
+// SOCKET-PERFORMANCE-PLAN Phase 2.
+//
+// Phase 2 replaces the linear `socketRef.rooms` array (Phase 1 left it
+// alone) with a Map-based index keyed by room prefix. Lookups inside
+// every event handler go from O(n) substring scans over the whole
+// global array to O(1) by-prefix retrieval.
+//
+// Room-name convention (unchanged from before — every controller already
+// builds names this way):
+//   `<prefix>**<socketId>`
+//
+// where `<prefix>` is the part the handler cares about — e.g.
+// `project_sprint_<pid>_<sid>`, `taskDetail_<tid>`, `comments_<pid>_<sid>_<tid>`,
+// `comments_project_<pid>`, `chat_<pid>_<uid>`, `selected_companies_<id>`,
+// `userIdNotification_<uid>`.
+//
+// Indexes:
+//   byPrefix : prefix -> Map<roomName, entry>   (handler lookups, O(1))
+//   bySocket : socket -> Set<roomName>           (disconnect cleanup, O(rooms-per-socket))
+//
+// upsertRoom / removeRoom / removeBySocket keep both structures in sync.
+// upsertRoom is idempotent: re-joining the same room replaces the entry
+// rather than appending — which solves SOCKET-PERFORMANCE-PLAN #7
+// (duplicate entries on tab refresh / reconnect that previously caused
+// events to fire multiple times for the same room).
 
-exports.leaveRoom = (soket,roomName) => {
+exports.joinRoom = (soket, roomName) => {
+    soket.join(roomName);
+};
+
+exports.leaveRoom = (soket, roomName) => {
     soket.leave(roomName);
-}
+};
+
+const extractPrefix = (roomName) => {
+    const idx = roomName.indexOf('**');
+    return idx === -1 ? roomName : roomName.slice(0, idx);
+};
+
+const byPrefix = new Map();
+const bySocket = new Map();
+
+const upsertRoom = (entry) => {
+    if (!entry || !entry.roomName || !entry.socket) return;
+    const prefix = extractPrefix(entry.roomName);
+    let prefixMap = byPrefix.get(prefix);
+    if (!prefixMap) {
+        prefixMap = new Map();
+        byPrefix.set(prefix, prefixMap);
+    }
+    // Idempotent: if a stale entry under the same roomName exists, replace
+    // it so the latest namespace/socket reference wins. Same-key Map.set
+    // is the natural dedup primitive.
+    prefixMap.set(entry.roomName, entry);
+
+    let socketRooms = bySocket.get(entry.socket);
+    if (!socketRooms) {
+        socketRooms = new Set();
+        bySocket.set(entry.socket, socketRooms);
+    }
+    socketRooms.add(entry.roomName);
+};
+
+const removeRoom = (roomName) => {
+    if (!roomName) return;
+    const prefix = extractPrefix(roomName);
+    const prefixMap = byPrefix.get(prefix);
+    if (!prefixMap) return;
+    const entry = prefixMap.get(roomName);
+    if (!entry) return;
+    prefixMap.delete(roomName);
+    if (prefixMap.size === 0) {
+        byPrefix.delete(prefix);
+    }
+    const socketRooms = bySocket.get(entry.socket);
+    if (socketRooms) {
+        socketRooms.delete(roomName);
+        if (socketRooms.size === 0) {
+            bySocket.delete(entry.socket);
+        }
+    }
+};
+
+const removeBySocket = (socket) => {
+    if (!socket) return;
+    const socketRooms = bySocket.get(socket);
+    if (!socketRooms) return;
+    for (const roomName of socketRooms) {
+        const prefix = extractPrefix(roomName);
+        const prefixMap = byPrefix.get(prefix);
+        if (prefixMap) {
+            prefixMap.delete(roomName);
+            if (prefixMap.size === 0) {
+                byPrefix.delete(prefix);
+            }
+        }
+    }
+    bySocket.delete(socket);
+};
+
+const findRoomsByPrefix = (prefix) => {
+    const prefixMap = byPrefix.get(prefix);
+    if (!prefixMap) return [];
+    return Array.from(prefixMap.values());
+};
+
+const findRoomsByPrefixes = (...prefixes) => {
+    const seen = new Set();
+    const out = [];
+    for (const prefix of prefixes) {
+        if (!prefix) continue;
+        const prefixMap = byPrefix.get(prefix);
+        if (!prefixMap) continue;
+        for (const [roomName, entry] of prefixMap) {
+            if (!seen.has(roomName)) {
+                seen.add(roomName);
+                out.push(entry);
+            }
+        }
+    }
+    return out;
+};
+
+exports.upsertRoom = upsertRoom;
+exports.removeRoom = removeRoom;
+exports.removeBySocket = removeBySocket;
+exports.findRoomsByPrefix = findRoomsByPrefix;
+exports.findRoomsByPrefixes = findRoomsByPrefixes;
+exports.extractPrefix = extractPrefix;
+
+// Snapshot accessor for tests / diagnostics — never mutate the returned
+// array, the index lives in the Maps above.
+exports.getRoomCount = () => {
+    let count = 0;
+    for (const prefixMap of byPrefix.values()) count += prefixMap.size;
+    return count;
+};
+
+// Diagnostic-only internals. Tests can poke at these to assert invariants;
+// runtime code should use the named exports above.
+exports.__internals = { byPrefix, bySocket };

--- a/socket/socketinit.js
+++ b/socket/socketinit.js
@@ -8,10 +8,15 @@ const { instrument } = require('@socket.io/admin-ui');
 const jwt = require('jsonwebtoken');
 const logger = require('../Config/loggerConfig');
 const { corsOriginDelegate } = require('../utils/cors.js');
+const { removeRoom, removeBySocket } = require('./helper');
 exports.changeStreams = [];
 const EventEmitter = require('events');
 exports.emitter = new EventEmitter();
-exports.rooms = [];
+// SOCKET-PERFORMANCE-PLAN #1 (Phase 2): the linear `exports.rooms = []`
+// global array has been replaced by the Map-based index in socket/helper.js.
+// Every controller now goes through upsertRoom / removeRoom / findRoomsByPrefix.
+// The index is accessed via the helper module — there's no global array to
+// scan anymore.
 
 /**
  * Build the @socket.io/admin-ui config from env (BUG-004 / #58 fix).
@@ -82,45 +87,29 @@ exports.initSocket = (server) => {
         socket.customData = {userRole};
         const namespace = socket.nsp;
 
-        // SOCKET-PERFORMANCE-PLAN #4: auto-purge socketRef.rooms entries on
-        // socket disconnect. The pre-existing `disconnectNameSpace` event
-        // requires the client to call it explicitly — that doesn't fire when
-        // the browser closes, the network drops, or the mobile app is killed.
-        // Without this, every dead socket's room entries stay in the global
-        // array forever, growing it until every event scan becomes slow.
-        // Listening to Socket.io's native `disconnect` makes cleanup
-        // unconditional.
+        // SOCKET-PERFORMANCE-PLAN #4 (Phase 1) + #1 (Phase 2): auto-purge
+        // every entry for this socket from the room index when the socket
+        // disconnects. `removeBySocket` uses the bySocket reverse index
+        // (Set<roomName>) so cleanup is O(rooms-per-socket), not O(n) over
+        // the whole index.
         socket.on('disconnect', () => {
-            for (let i = exports.rooms.length - 1; i >= 0; i--) {
-                if (exports.rooms[i].socket === socket) {
-                    exports.rooms.splice(i, 1);
-                }
-            }
+            removeBySocket(socket);
         });
 
+        // SOCKET-PERFORMANCE-PLAN #1 (Phase 2): explicit client-driven
+        // namespace disconnect. Behaviourally identical to the original
+        // recursive `countFunction` — for every room in this adapter whose
+        // name encodes the target socket id, remove the index entry. Then
+        // forcibly close the target socket. The recursion in the previous
+        // version was synchronous busy-work; a plain forEach over
+        // `adapter.rooms` is equivalent and easier to follow.
         socket.on('disconnectNameSpace', (id) => {
-            let roomsArray = [];
             socket.adapter.rooms.forEach((_, roomName) => {
-                roomsArray.push(roomName);
-            })
-            let count = 0
-            let countFunction = (roomName) => {
-                if (count >= roomsArray.length) {
-                    namespace.sockets.get(id)?.disconnect(true);
-                    return;
-                } else {
-                    let index = exports.rooms.findIndex((x)=> (x.roomName === roomName && x.roomName.includes(id)));
-                    if (index !== -1){
-                        exports.rooms.splice(index, 1);
-                        count++;
-                        countFunction(roomsArray[count]);
-                    } else {
-                        count++;
-                        countFunction(roomsArray[count]);
-                    }
+                if (roomName.includes(id)) {
+                    removeRoom(roomName);
                 }
-            }
-            countFunction(roomsArray[count]);
+            });
+            namespace.sockets.get(id)?.disconnect(true);
         });
 
         socket.on('getRoomList', (socketId, callback) => {

--- a/tests/socket-room-index.test.js
+++ b/tests/socket-room-index.test.js
@@ -1,0 +1,117 @@
+/**
+ * SOCKET-PERFORMANCE-PLAN Phase 2 — room index regression tests.
+ *
+ * Covers:
+ *   - upsertRoom is idempotent on (roomName) — Fix #7
+ *   - findRoomsByPrefix returns exactly the entries with that prefix — Fix #1
+ *   - findRoomsByPrefixes dedups across multiple prefixes — Fix #1
+ *   - removeRoom cleans both byPrefix and bySocket indexes
+ *   - removeBySocket purges every entry for a given socket — Fix #4 (Phase 1)
+ *   - prefix extraction handles roomNames with no `**` delimiter
+ */
+
+const helper = require('../socket/helper');
+
+// Re-require for each test to get a fresh module-level index. Jest gives
+// each `test()` a fresh require cache by default? No — Jest reuses modules
+// inside a single test file. So we manually reset the indexes before each
+// test.
+beforeEach(() => {
+    const { byPrefix, bySocket } = helper.__internals;
+    byPrefix.clear();
+    bySocket.clear();
+});
+
+const makeSocket = (id) => ({ id, rooms: new Set() });
+
+test('upsertRoom inserts a new entry', () => {
+    const socket = makeSocket('sock1');
+    helper.upsertRoom({
+        roomName: 'project_sprint_A_B**sock1',
+        socketId: 'sock1',
+        socket,
+        namespace: {},
+    });
+    expect(helper.getRoomCount()).toBe(1);
+    expect(helper.findRoomsByPrefix('project_sprint_A_B')).toHaveLength(1);
+});
+
+test('upsertRoom is idempotent on (roomName) — replaces, not duplicates', () => {
+    const socket = makeSocket('sock1');
+    const entry = {
+        roomName: 'taskDetail_X**sock1',
+        socketId: 'sock1',
+        socket,
+        namespace: { name: 'first' },
+    };
+    helper.upsertRoom(entry);
+    helper.upsertRoom({ ...entry, namespace: { name: 'second' } });
+
+    const rooms = helper.findRoomsByPrefix('taskDetail_X');
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0].namespace.name).toBe('second'); // most recent wins
+});
+
+test('findRoomsByPrefix returns only matching prefix entries', () => {
+    const socket = makeSocket('sock1');
+    helper.upsertRoom({ roomName: 'taskDetail_X**sock1', socketId: 'sock1', socket, namespace: {} });
+    helper.upsertRoom({ roomName: 'taskDetail_Y**sock1', socketId: 'sock1', socket, namespace: {} });
+    helper.upsertRoom({ roomName: 'project_sprint_A_B**sock1', socketId: 'sock1', socket, namespace: {} });
+
+    expect(helper.findRoomsByPrefix('taskDetail_X')).toHaveLength(1);
+    expect(helper.findRoomsByPrefix('taskDetail_Y')).toHaveLength(1);
+    expect(helper.findRoomsByPrefix('project_sprint_A_B')).toHaveLength(1);
+    expect(helper.findRoomsByPrefix('nonexistent')).toHaveLength(0);
+});
+
+test('findRoomsByPrefixes dedups across overlapping lookups', () => {
+    const socket = makeSocket('sock1');
+    // Same roomName accidentally requested under two prefixes (defensive).
+    helper.upsertRoom({ roomName: 'taskDetail_X**sock1', socketId: 'sock1', socket, namespace: {} });
+    helper.upsertRoom({ roomName: 'taskDetail_Y**sock1', socketId: 'sock1', socket, namespace: {} });
+
+    const out = helper.findRoomsByPrefixes('taskDetail_X', 'taskDetail_Y', 'taskDetail_X');
+    expect(out).toHaveLength(2);
+    const names = out.map(r => r.roomName).sort();
+    expect(names).toEqual(['taskDetail_X**sock1', 'taskDetail_Y**sock1']);
+});
+
+test('removeRoom clears both indexes', () => {
+    const socket = makeSocket('sock1');
+    helper.upsertRoom({ roomName: 'comments_a_b_c**sock1', socketId: 'sock1', socket, namespace: {} });
+    expect(helper.getRoomCount()).toBe(1);
+
+    helper.removeRoom('comments_a_b_c**sock1');
+    expect(helper.getRoomCount()).toBe(0);
+    expect(helper.findRoomsByPrefix('comments_a_b_c')).toHaveLength(0);
+
+    const { bySocket } = helper.__internals;
+    expect(bySocket.has(socket)).toBe(false);
+});
+
+test('removeBySocket purges every entry for a socket', () => {
+    const sockA = makeSocket('A');
+    const sockB = makeSocket('B');
+    helper.upsertRoom({ roomName: 'project_sprint_1_2**A', socketId: 'A', socket: sockA, namespace: {} });
+    helper.upsertRoom({ roomName: 'taskDetail_X**A',         socketId: 'A', socket: sockA, namespace: {} });
+    helper.upsertRoom({ roomName: 'taskDetail_X**B',         socketId: 'B', socket: sockB, namespace: {} });
+    expect(helper.getRoomCount()).toBe(3);
+
+    helper.removeBySocket(sockA);
+    expect(helper.getRoomCount()).toBe(1);
+    expect(helper.findRoomsByPrefix('project_sprint_1_2')).toHaveLength(0);
+    expect(helper.findRoomsByPrefix('taskDetail_X')).toHaveLength(1);
+    expect(helper.findRoomsByPrefix('taskDetail_X')[0].socketId).toBe('B');
+});
+
+test('extractPrefix handles roomNames without `**` delimiter', () => {
+    expect(helper.extractPrefix('plain_room')).toBe('plain_room');
+    expect(helper.extractPrefix('taskDetail_X**sock1')).toBe('taskDetail_X');
+});
+
+test('upsertRoom ignores malformed entries (no crash)', () => {
+    helper.upsertRoom(null);
+    helper.upsertRoom({});
+    helper.upsertRoom({ roomName: 'x' }); // no socket
+    expect(helper.getRoomCount()).toBe(0);
+});


### PR DESCRIPTION
## Summary

Phase 2 of [SOCKET-PERFORMANCE-PLAN](.claude/SOCKET-PERFORMANCE-PLAN.md). Backend-only refactor; **wire protocol unchanged**. Follows [#183](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/pull/183) (Phase 1 quick-wins).

Replaces the linear `socketRef.rooms = []` global array — which every event handler scanned with `.filter(...)` on every mutation — with a Map-based index keyed by room prefix. Lookups in the hot path go from O(n) substring scans over 2,500+ entries (500 users × 5 rooms) to O(1) by-prefix retrieval.

### What changed

| # | Fix | Before | After |
|---|---|---|---|
| 1 | Room index | Linear array, `.filter(includes(prefix))` per event | `Map<prefix, Map<roomName, entry>>`, O(1) lookup |
| 5 | Liveness guard | `Array.from(namespace.adapter.rooms.keys()).filter(...)` per matching entry | `data.socket.rooms.has(data.roomName)` — O(1) Set membership |
| 7 | Dedup on re-join | Hand-rolled findIndex / push-or-replace, inconsistently inlined per controller | `upsertRoom(entry)` — idempotent via `Map.set` |
| 9 | `getTotalSprintCount` | Aggregate pipeline + plan check on every task create | node-cache 30s TTL, keyed by `sprintPlanCheck:<companyId>:<sprintId>` |

### Files touched

**Socket layer** (the meat of the refactor)
- `socket/helper.js` — owns the `byPrefix` / `bySocket` indexes and the `upsertRoom`/`removeRoom`/`removeBySocket`/`findRoomsByPrefix(es)` API
- `socket/socketinit.js` — drops `exports.rooms = []`; `disconnect` and `disconnectNameSpace` now go through the helper
- `socket/controller/taskSocket.js` — switches to `findRoomsByPrefixes(sprint, taskDetail, subTaskDetail)`; preserves the `taskDetail_*` event-name special case and `isUserIdCheck` path
- `socket/controller/commentSocket.js` — collapses the duplicated `comments` and `comments_project` blocks; drops the `uniqueRooms` helper (now dedup is built in)
- `socket/controller/chatSocket.js`, `socket/controller/companiesSocket.js`, `socket/controller/userNotificationCount.js` — same shape: prefix lookup + `socket.rooms.has` guard + emit

**DB layer**
- `Modules/Tasks/helpers/mongo_helper.js` — adds 30s cache around `getTotalSprintCount`; trade-offs documented inline

**Tests + docs**
- `tests/socket-room-index.test.js` — 8 new Jest tests covering upsert idempotency, prefix lookup, multi-prefix dedup, removeRoom, removeBySocket, edge cases
- `.claude/tests/smoke-phase2.js` — end-to-end smoke (emitter → namespaced handler → Map index → `namespace.to().emit()`)
- `.claude/SOCKET-PERFORMANCE-PLAN.md` — Phase 2 marked complete

### Wire-protocol compatibility (frontend audited)

All client → server emits (`joinProjectSprintForTask`, `joinTaskDetail`, `joinChats`, `joinCommentRoom`, `joinCompaniesRoom`, `joinUserIdNotification`, `disconnectNameSpace`, `getRoomList`, plus the matching `leave*`) and server → client broadcasts (`taskInsert/Update/Delete/Replace`, `taskDetail_taskInsert/Update/Delete`, `chatTaskInsert/Update/Delete/Replace`, `commentInsert/Update`, `companiesUpdate`, `userIdNoticationUpdate`) are byte-identical to before. Room-name `<prefix>**<socketId>` convention preserved. No frontend code depended on duplicate emits.

## Test plan
- [x] `npm test` — 28/28 pass (20 existing + 8 new `tests/socket-room-index.test.js`)
- [x] `node .claude/tests/smoke-phase2.js` — emitter routing + `removeBySocket` cleanup verified end-to-end
- [x] `node --check` on every touched file
- [x] Frontend wire-protocol audit (`frontend/src/**`): all 12 client emits + 6 listener families + room-name convention compatible
- [x] Manual smoke in staging: open two sessions, mutate a task, confirm both see the update; refresh tab, confirm no duplicate events; force-close browser, confirm room entries don't leak
- [x] Watch staging logs for any `socket.rooms is undefined` / Map-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)