### PR TITLE
fix(tasks): resolve list-view assignee TypeError after Task.vue refactor

### DIFF
--- a/frontend/src/components/organisms/Task/Task.vue
+++ b/frontend/src/components/organisms/Task/Task.vue
@@ -164,8 +164,8 @@
                             :num-of-users="2"
                             imageWidth="30px"
                             :addUser="!showArchiveVar"
-                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event, assigneeInProgress)"
-                            @removed="changeAssignee('remove', $event, assigneeInProgress)"
+                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event)"
+                            @removed="changeAssignee('remove', $event)"
                             :isDisplayTeam="true"
                             :multiSelect="checkApps('MultipleAssignees')"
                         />
@@ -176,8 +176,8 @@
                             :num-of-users="2"
                             imageWidth="30px"
                             :addUser="!showArchiveVar"
-                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event, assigneeInProgress)"
-                            @removed="changeAssignee('remove', $event, assigneeInProgress)"
+                            @selected="changeAssignee(checkApps('MultipleAssignees',projectData) ? 'add' : 'replace', $event)"
+                            @removed="changeAssignee('remove', $event)"
                             :isDisplayTeam="true"
                             :multiSelect="checkApps('MultipleAssignees')"
                         />
@@ -384,7 +384,6 @@ const toggleTaskDetail = inject('toggleTaskDetail');
 const statusSearch = ref('');
 const taskName = ref(props.data.TaskName);
 const editTaskName = ref(false);
-const assigneeInProgress = ref({});
 
 const dueDate = computed(() => props.data.DueDate);
 

--- a/frontend/src/components/organisms/Task/composables/useTaskMutations.js
+++ b/frontend/src/components/organisms/Task/composables/useTaskMutations.js
@@ -1,4 +1,4 @@
-import { inject } from 'vue';
+import { inject, ref } from 'vue';
 import { useStore } from 'vuex';
 import { useToast } from 'vue-toast-notification';
 import { useI18n } from 'vue-i18n';
@@ -15,6 +15,8 @@ export function useTaskMutations({ projectData, task, props }) {
 
     const userId = inject('$userId');
     const companyId = inject('$companyId');
+
+    const assigneeInProgress = ref({});
 
     const companyOwner = () => getters['settings/companyOwnerDetail'];
 
@@ -97,7 +99,7 @@ export function useTaskMutations({ projectData, task, props }) {
         updateTaskByGroup(props.data, status, 4);
     }
 
-    function changeAssignee(type, value, assigneeInProgress) {
+    function changeAssignee(type, value) {
         if (!value?.id) return;
         if (assigneeInProgress.value[value?.id] && assigneeInProgress.value[value?.id] === type) return;
         assigneeInProgress.value[value?.id] = type;


### PR DESCRIPTION
## Summary
- Selecting a user from the assignee sidebar in the project **List view** threw `TypeError: Cannot read properties of undefined (reading '<userId>')` and surfaced an Uncaught runtime errors overlay.
- Root cause traced to the Task.vue mega-component split ([#167](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/pull/167)): `changeAssignee` was extracted into `useTaskMutations`, and `assigneeInProgress` was passed through the template as a 3rd arg. Vue 3 auto-unwraps top-level refs in templates, so the composable received the inner `{}` object — making `assigneeInProgress.value` `undefined`.
- Fix: move the `assigneeInProgress = ref({})` declaration into the composable (matching the pattern in `useProjectAssignee.js`) and drop the broken template hand-off.

## Files changed
- `frontend/src/components/organisms/Task/composables/useTaskMutations.js` — own the ref inside the composable; remove `assigneeInProgress` parameter from `changeAssignee`.
- `frontend/src/components/organisms/Task/Task.vue` — remove the redundant `ref({})` declaration; drop the 3rd arg from the four `@selected` / `@removed` handlers.

## Test plan
- [x] Open a project → List view.
- [x] Click the assignee `+` icon on a task; pick a user → user is added without runtime error.
- [x] Click an assigned user's avatar → user is removed without runtime error.
- [x] Confirm in `MultipleAssignees`-enabled projects that subsequent picks add (don't replace).
- [x] Confirm in single-assignee projects that picks replace the existing assignee.
- [x] Spot-check the same flow in Board / Table views to make sure nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)