### PR TITLE
revert(staging): disable hardening middleware and unbound tenant pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,21 +20,6 @@ UNDER_MAINTENANCE="false"                  # true | false
 MONGODB_URL="mongodb://localhost:27017"    # REQUIRED — mongo connection string (no trailing slash)
 MONGO_CLOUD_URL="https://cloud.mongodb.com/api"
 
-# Per-tenant Mongoose connection pool bounds (issue #162).
-# Each active company opens its own Mongoose connection; without limits the
-# array grows unbounded under multi-tenant load.
-# - MAX_TENANT_CONNECTIONS: hard cap on cached connections. When the cap is
-#   reached, opening a new one evicts the least-recently-used entry (skipping
-#   connections used in the last 5s to avoid aborting in-flight queries).
-#   Default 100. Multiply by maxPoolSize (3) to estimate physical sockets.
-# - TENANT_CONNECTION_IDLE_MS: a cached connection is closed when it has been
-#   idle this long. Default 1800000 (30 min).
-# - TENANT_CONNECTION_SWEEP_MS: how often the idle-cleanup sweep runs.
-#   Default 300000 (5 min).
-MAX_TENANT_CONNECTIONS="100"
-TENANT_CONNECTION_IDLE_MS="1800000"
-TENANT_CONNECTION_SWEEP_MS="300000"
-
 # ─────────────────────────────────────────
 # AUTH / JWT
 # ─────────────────────────────────────────

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const app = express();
 // proxy IP. Override via TRUST_PROXY env (e.g. "1" for one upstream, or
 // "true" for any). Safe in dev because requests from outside loopback
 // fall back to req.connection.remoteAddress.
-app.set('trust proxy', process.env.TRUST_PROXY || 'loopback');
+// app.set('trust proxy', process.env.TRUST_PROXY || 'loopback');
 
 // CORS — BUG-002 / #56. Replace wildcard with an env-driven allow-list.
 // See utils/cors.js for the exact rules and supported env vars.
@@ -43,28 +43,39 @@ app.use(cors({ origin: corsOriginDelegate }));
 // existing third-party embeds keep working. Everything else (HSTS,
 // X-Content-Type-Options, X-Frame-Options, Referrer-Policy, etc.) is on
 // with helmet defaults.
-app.use(helmet({
-    contentSecurityPolicy: false,
-    crossOriginEmbedderPolicy: false,
-    crossOriginResourcePolicy: { policy: 'cross-origin' },
-}));
+// app.use(helmet({
+//     contentSecurityPolicy: false,
+//     crossOriginEmbedderPolicy: false,
+//     crossOriginResourcePolicy: { policy: 'cross-origin' },
+// }));
 
-// Global rate limiting. Generous default (600 req/min per IP ≈ 10 req/sec)
-// to leave headroom for SPA polling and bulk operations. Per-account
-// brute-force protection on auth endpoints lives in
-// `Modules/Auth/helper.js#manageResetAttempt` (5 attempts / 15-min
-// window / 30-min lockout), so no separate auth-specific middleware
-// limit is needed here.
-const GLOBAL_RATE_LIMIT = Number(process.env.GLOBAL_RATE_LIMIT_PER_MIN || 600);
+// Global rate limiting. Counts only API traffic — static assets and
+// socket.io are skipped so SPA cold-loads can't trip the limit. Set
+// GLOBAL_RATE_LIMIT_PER_MIN=0 (or "off"/"false") to disable entirely;
+// useful for internal deployments where auth-level brute-force
+// protection (Modules/Auth/helper.js#manageResetAttempt) is enough.
+// const rawGlobalLimit = String(process.env.GLOBAL_RATE_LIMIT_PER_MIN ?? '10000').trim().toLowerCase();
+// const rateLimitDisabled = ['0', 'off', 'false', 'no', 'disabled'].includes(rawGlobalLimit);
 
-app.use(rateLimit({
-    windowMs: 60 * 1000,
-    max: GLOBAL_RATE_LIMIT,
-    standardHeaders: true,
-    legacyHeaders: false,
-    // Skip Socket.io polling — it uses its own transport throttling.
-    skip: (req) => req.path.startsWith('/socket.io/'),
-}));
+// if (!rateLimitDisabled) {
+//     const GLOBAL_RATE_LIMIT = Math.max(1, Number(rawGlobalLimit) || 10000);
+//     const STATIC_ASSET_RX = /\.(js|mjs|css|map|svg|png|jpe?g|gif|ico|webp|avif|woff2?|ttf|otf|eot|html?|mp4|webm|mp3|wav|pdf)$/i;
+
+//     app.use(rateLimit({
+//         windowMs: 60 * 1000,
+//         max: GLOBAL_RATE_LIMIT,
+//         standardHeaders: true,
+//         legacyHeaders: false,
+//         // Don't count anything that isn't a real API call. Socket.io has
+//         // its own throttling; static assets are not a DoS vector here.
+//         skip: (req) => {
+//             if (req.path.startsWith('/socket.io/')) return true;
+//             if (STATIC_ASSET_RX.test(req.path)) return true;
+//             if (req.path === '/' || req.path.startsWith('/assets/') || req.path.startsWith('/static/')) return true;
+//             return false;
+//         },
+//     }));
+// }
 // BUG-037 / #91 — body limits.
 // Previously every endpoint accepted 50MB JSON/url-encoded/raw bodies,
 // so any unauthenticated POST could spend the request loop buffering

--- a/middlewares/mongoConnector/helper.js
+++ b/middlewares/mongoConnector/helper.js
@@ -12,59 +12,6 @@ const logger = require("../../Config/loggerConfig.js")
 */
 exports.connections = [];
 
-// Issue #162 — bound the per-tenant Mongoose connection pool.
-// Defaults: 100 tenants, 30min idle terminate, 5min sweep, 5s grace window.
-const MINUTE_MS = 60 * 1000;
-const DEFAULT_MAX_TENANT_CONNECTIONS = 100;
-const DEFAULT_IDLE_MS = 30 * MINUTE_MS;
-const DEFAULT_SWEEP_MS = 5 * MINUTE_MS;
-const EVICTION_GRACE_MS = 5 * 1000;
-
-const parsePositiveInt = (raw, fallback) => {
-    const n = Number(raw);
-    return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
-};
-
-exports.getMaxTenantConnections = () =>
-    parsePositiveInt(process.env.MAX_TENANT_CONNECTIONS, DEFAULT_MAX_TENANT_CONNECTIONS);
-
-const closeAndRemove = (index) => {
-    const entry = exports.connections[index];
-    if (!entry) return;
-    try {
-        entry.connection.close();
-    } catch (err) {
-        logger.error(`Error closing tenant connection ${entry.db}: ${err?.message}`);
-    }
-    exports.connections.splice(index, 1);
-};
-
-/**
- * Evict the single least-recently-used connection that is outside the grace
- * window. Returns true if an eviction happened. Grace window prevents closing
- * a connection that was handed to a concurrent request seconds ago and may
- * still be executing queries against it.
- */
-exports.evictLeastRecentlyUsed = () => {
-    if (exports.connections.length === 0) return false;
-    const now = Date.now();
-    let oldestIndex = -1;
-    let oldestStamp = Infinity;
-    for (let i = 0; i < exports.connections.length; i++) {
-        const c = exports.connections[i];
-        if (now - c.lastRequest < EVICTION_GRACE_MS) continue;
-        if (c.lastRequest < oldestStamp) {
-            oldestStamp = c.lastRequest;
-            oldestIndex = i;
-        }
-    }
-    if (oldestIndex === -1) return false;
-    const evicted = exports.connections[oldestIndex].db;
-    closeAndRemove(oldestIndex);
-    logger.info(`LRU eviction: closed tenant connection ${evicted}`);
-    return true;
-};
-
 exports.updateConnectionRecord = (db, conData = {}) => {
     const index = exports.connections.findIndex((x) => x.db === db)
     if (index !== -1) {
@@ -126,21 +73,30 @@ exports.createConnection = (db) => {
 
 exports.closeConnection = (db) => {
     const index = exports.connections.findIndex((x) => x.db === db)
+
     if (index !== -1) {
-        closeAndRemove(index);
+        exports.connections[index].connection.close();
+        exports.connections.splice(index, 1);
+        console.log("NEW CONNECTION", exports.connections.map((x) => ({ db: x.db, last: x.lastRequest })));
     }
 }
 
 exports.startInterval = () => {
-    const terminate = parsePositiveInt(process.env.TENANT_CONNECTION_IDLE_MS, DEFAULT_IDLE_MS);
-    const sweep = parsePositiveInt(process.env.TENANT_CONNECTION_SWEEP_MS, DEFAULT_SWEEP_MS);
+    const minute = 60 * 1000;
+    const timeout = 5 * minute;
+    const terminate = 30 * minute
     setInterval(() => {
-        const now = Date.now();
-        // Iterate in reverse so splices inside closeAndRemove don't skip entries.
-        for (let i = exports.connections.length - 1; i >= 0; i--) {
-            if (now - exports.connections[i].lastRequest >= terminate) {
-                closeAndRemove(i);
+        const terminateConnections = exports.connections.filter((x) => new Date().getTime() - x.lastRequest >= terminate)
+
+        terminateConnections.forEach((x) => {
+            x.connection.close();
+
+            const index = exports.connections.findIndex((y) => y.db === x.db)
+            if (index !== -1) {
+                exports.connections.splice(index, 1);
             }
-        }
-    }, sweep);
+        })
+        console.log("ACTIVE CONNECTIONS: ", exports.connections.length)
+        console.log("ACTIVE CONNECTIONS: ", exports.connections.map((x) => ({state: x.connection?.readyState, db: x.db})))
+    }, timeout)
 }

--- a/middlewares/mongoConnector/mongoConnection.js
+++ b/middlewares/mongoConnector/mongoConnection.js
@@ -1,15 +1,4 @@
-const { checkConnectionExists, createConnection, updateConnectionRecord, connections, evictLeastRecentlyUsed, getMaxTenantConnections } = require("./helper");
-
-// Issue #162 — enforce the per-tenant connection cap by evicting the
-// least-recently-used connection (outside a small grace window) before
-// opening a new one. If every entry is inside the grace window we accept
-// a transient overshoot rather than risk aborting an in-flight query.
-const enforceConnectionCap = () => {
-    const cap = getMaxTenantConnections();
-    while (connections.length >= cap) {
-        if (!evictLeastRecentlyUsed()) break;
-    }
-};
+const { checkConnectionExists, createConnection, updateConnectionRecord, connections } = require("./helper");
 
 const requestedDbs = []
 function removeFromArray(db) {
@@ -36,7 +25,6 @@ exports.handleConnection = async (companyId) => {
                     if(reCheck >= 60) {
                         // console.log("INTERVAL >> CONNECTION CREATE");
                         clearInterval(interval);
-                        enforceConnectionCap();
                         createConnection(db)
                         .then((conData) => {
                             // console.log("REQUESTED DB FOUND", db);
@@ -76,7 +64,6 @@ exports.handleConnection = async (companyId) => {
                         resolve({ status: true, database: locals });
                     } else {
                         requestedDbs.push(db);
-                        enforceConnectionCap();
                         createConnection(db)
                             .then((conData) => {
                                 // console.log("REQUESTED DB FOUND", db);
@@ -94,7 +81,6 @@ exports.handleConnection = async (companyId) => {
                     }
                 } else {
                     requestedDbs.push(db);
-                    enforceConnectionCap();
                     createConnection(db)
                         .then((conData) => {
                             removeFromArray(db)


### PR DESCRIPTION
## Summary
- Comment out `trust proxy`, `helmet`, and the global `express-rate-limit` middleware in `index.js` (security headers + DoS limiter temporarily disabled).
- Revert PR #162 (issue #162) — the per-tenant Mongoose connection pool goes back to **unbounded** with a fixed 30-min idle / 5-min sweep timer; LRU eviction and `enforceConnectionCap()` calls are removed.
- Drop the `MAX_TENANT_CONNECTIONS` / `TENANT_CONNECTION_IDLE_MS` / `TENANT_CONNECTION_SWEEP_MS` doc block from `.env.example` (the cap they configured is gone).

## Why
Targeted rollback on the staging branch to unblock staging-only behaviour. Intended as temporary — code is **commented out** rather than deleted so it can be re-enabled once the underlying regression is diagnosed.

## Risk callouts
- Helmet off ⇒ no HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy on responses for this branch.
- Global rate limiter off ⇒ no per-IP throttle (auth brute-force protection in `Modules/Auth/helper.js#manageResetAttempt` still applies).
- Tenant connection pool unbounded ⇒ reintroduces the issue #162 growth risk under multi-tenant load.
- `middlewares/mongoConnector/helper.js` regains `console.log` debug statements instead of the Winston logger.

## Test plan
- [ ] Confirm staging boot succeeds without helmet/rate-limit middleware.
- [ ] Verify multi-tenant request path still routes correctly after revert (no `enforceConnectionCap` calls).
- [ ] Confirm absence of helmet headers on staging responses is expected for this rollback window.
- [ ] Track the follow-up to reinstate hardening before this reaches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)