### PR TITLE
feat(tasks): AI-estimate completion time on task create

### DIFF
--- a/.claude/AI-TIME-ESTIMATION.md
+++ b/.claude/AI-TIME-ESTIMATION.md
@@ -1,0 +1,162 @@
+# AI Task Time Estimation — How It Works
+
+This doc explains how AlianHub estimates the time needed to finish a task,
+in plain language.
+
+---
+
+## The Big Idea
+
+When a task is created, we ask an AI model: **"If an AI coding agent
+(Claude Code) did this task end-to-end, how many minutes would it take?"**
+
+The answer is saved on the task as `totalEstimatedTime` (in minutes).
+
+That's it. No rules. No formulas. Just a smart guess based on what the
+task actually says.
+
+---
+
+## What the AI Looks At
+
+The AI gets these pieces of info about the task:
+
+1. **Task title** — the headline.
+2. **Task type** — bug, story, task, etc.
+3. **Priority** — LOW, MEDIUM, HIGH, URGENT.
+4. **Parent or subtask?** — subtasks are usually smaller.
+5. **Description** — the most important input. This is what the AI
+   reads to understand the actual work.
+
+If the description is empty, the AI is told so and will be more
+conservative (since it only has the title to go on).
+
+---
+
+## The 5 Things the AI Thinks About
+
+The prompt walks the AI through these **in order**. Each one pushes
+the estimate up or down.
+
+### 1. What is the deliverable?
+
+What kind of work is this? Different shapes have different floors:
+
+- **Copy or config change** → small.
+- **Bug fix** → medium, depends on how deep the bug is.
+- **New feature** → medium to big.
+- **Refactor** → big, because it touches many files.
+- **Migration** → big, because data is at risk.
+- **Integration** → big, because external systems bring surprises.
+
+### 2. How much surface area is involved?
+
+The AI counts the things the description mentions or implies:
+
+- How many files?
+- How many modules?
+- Any APIs, schemas, or UI screens?
+- Any third-party services?
+- Are tests needed?
+
+More things = more time.
+
+### 3. How clear is the description?
+
+This is a big one.
+
+- **Clear description** → faster. The AI agent knows exactly what to do.
+- **Vague description** → slower. The AI agent has to figure things
+  out as it goes, and that takes real time.
+
+### 4. How will the work be verified?
+
+Some work is "done" when tests pass. Other work has to be seen and
+clicked.
+
+- **Internal refactor** → run tests, done. Fast.
+- **Anything touching UI, data, auth, or payments** → run the app,
+  click around, watch what happens, fix issues. Slower.
+
+### 5. Iteration loops
+
+In real work, the first try is rarely the last. The agent writes
+code, runs it, sees what breaks, fixes it, runs again. The prompt
+tells the AI to bake in 1–2 iteration rounds for anything that isn't
+trivial.
+
+---
+
+## What the Estimate Does NOT Include
+
+The number is the AI agent's **focused work time**. It does NOT count:
+
+- Human review or approval time.
+- Waiting for CI, builds, or deploys.
+- Meetings, handoffs, status updates.
+- External system queues.
+
+So an estimate of 60 minutes means *the agent works for 60 minutes* —
+not that the task is done in 60 minutes of calendar time on a real team.
+
+---
+
+## Safety Bounds
+
+We never trust the AI's number blindly.
+
+- **Minimum: 5 minutes.** Even the smallest task has some overhead.
+- **Maximum: 10080 minutes (7 days).** If a task would genuinely take
+  longer, it should be split into smaller tasks.
+
+If the AI returns something outside these bounds (like 0 or 9999999),
+we clamp it back inside. If the AI returns total garbage we can't
+parse, the task just stays without an estimate — no broken data ever
+gets saved.
+
+---
+
+## The Single Biggest Driver
+
+**The description content drives the number more than anything else.**
+
+- The title and priority give the AI a starting feel.
+- The description tells the AI the actual scope.
+
+Two tasks both called "Fix login bug" can land at 30 minutes or 8
+hours depending on what their descriptions say. The prompt is built
+to make sure the AI actually reads the description before answering,
+and to discourage lazy round-number guesses like 60 / 120 / 240.
+
+---
+
+## How It Runs in the App
+
+- After a task is created, we fire the estimator in the background.
+- It does NOT block the create API — the response is returned first.
+- When the estimate comes back (usually a few seconds), we update
+  the task and send a Socket.io event so connected screens refresh
+  the value automatically.
+- If no AI provider is configured in `.env`, the estimator quietly
+  does nothing and task creation works exactly like before.
+
+---
+
+## Where the Pieces Live
+
+| What | File |
+|---|---|
+| The prompt the AI reads | `Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md` |
+| The estimator code | `Modules/EstimatedTime/aiTaskEstimator.js` |
+| Single-task hook | `Modules/Tasks/helpers/taskMongo/create.js` |
+| AI Project Generator bulk hook | `Modules/AIProjectGenerator/orchestrator.js` |
+| DB field | `tasks.totalEstimatedTime` (Number, in minutes) |
+
+---
+
+## In One Sentence
+
+> The AI reads the task description, judges how much real work the
+> description describes (size, clarity, verification needs, iteration),
+> and returns a minute estimate — which we clamp to safe bounds and
+> save on the task.

--- a/Modules/AIProjectGenerator/orchestrator.js
+++ b/Modules/AIProjectGenerator/orchestrator.js
@@ -46,7 +46,38 @@ const { addSprintFun } = require('../Sprints/controller');
 const { HandleHistory } = require('../Tasks/helpers/helper');
 const { HandleBothNotification } = require('../Tasks/helpers/handleNotification');
 const { checkProjectPlan, removeProjectCount } = require('../createProject/controller');
+const { estimateAndPersist: estimateTaskTimeWithAI } = require('../EstimatedTime/aiTaskEstimator');
 const sseEmitter = require('./sseEmitter');
+
+// Concurrency cap for fire-and-forget AI estimates after bulk task insert —
+// keeps us well under the LLM provider's per-key rate limits when a single
+// project generates dozens of tasks at once.
+const ESTIMATE_CONCURRENCY = 3;
+
+function fireTaskEstimatesInBackground(companyId, docs) {
+    if (!Array.isArray(docs) || docs.length === 0) return;
+    let cursor = 0;
+    const runOne = async () => {
+        while (cursor < docs.length) {
+            const idx = cursor;
+            cursor += 1;
+            const d = docs[idx];
+            try {
+                await estimateTaskTimeWithAI({
+                    companyId,
+                    taskId: String(d._id),
+                    task: d,
+                });
+            } catch (e) {
+                logger.error(`AI task estimate error (orchestrator): ${e && e.message ? e.message : e}`);
+            }
+        }
+    };
+    const workers = Math.min(ESTIMATE_CONCURRENCY, docs.length);
+    for (let i = 0; i < workers; i += 1) {
+        runOne();
+    }
+}
 
 // Hardcoded list of view columns that manual createProject also injects
 // regardless of wizard input (see Modules/createProject/controller.js:440-487).
@@ -701,6 +732,12 @@ async function createTasksForSprint({ companyId, projectDoc, sprintDoc, tasks, s
     for (const d of docs) {
         try { socketEmitter.emit('insert', { type: 'insert', data: d, module: 'task' }); } catch (_e) { /* ignore */ }
     }
+
+    // Estimates run in the background so the orchestrator's progress stream
+    // is not blocked by the per-task LLM calls. Each estimate persists its
+    // own `totalEstimatedTime` update and emits a follow-up socket event.
+    fireTaskEstimatesInBackground(companyId, docs);
+
     return docs;
 }
 

--- a/Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md
+++ b/Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md
@@ -1,0 +1,80 @@
+# What you produce
+
+A single integer estimate of how many minutes an AI coding agent
+(Claude Code) needs to complete this task end-to-end, with NO manual
+human implementation work.
+
+# How you make the estimate
+
+Read the task description carefully and derive the number from what
+the task actually asks for. Do NOT round to a generic bucket. Two
+tasks with similar titles can be very different jobs once you read
+the description — let the description drive the number.
+
+Concretely, work through these in order:
+
+1. **What is the deliverable?** A copy change, a config tweak, a bug
+   fix, a new feature, a refactor, a migration, an integration? The
+   shape of the deliverable sets the floor.
+
+2. **How much surface area is involved?** Count the things the task
+   description names or strongly implies: files, modules, APIs,
+   schemas, UI screens, tests, migrations, third-party services. More
+   surface = more time.
+
+3. **How ambiguous is the description?** Crisp, specific requirements
+   are faster than vague ones. If the description leaves open
+   questions the agent will have to resolve mid-task, add time for
+   that exploration.
+
+4. **What verification will the agent perform?** Anything that
+   touches data, auth, payments, or user-visible UI needs a real
+   verification loop (run, click, observe, iterate). Pure internal
+   refactors verify faster.
+
+5. **Iteration overhead.** The agent typically writes, runs, sees a
+   failure, and fixes — at least 1-2 iteration loops on anything
+   non-trivial. Bake that in.
+
+# Scope of the estimate
+
+The number you return represents the agent's wall-clock time:
+
+- Reading the task and locating the relevant code.
+- Planning the change.
+- Editing files.
+- Running commands, builds, tests.
+- Self-verifying the result.
+
+Do NOT include:
+
+- Human review or approval time.
+- Waiting for CI queues, deploys, or external systems.
+- Meetings, handoffs, or status updates.
+
+# Bounds
+
+- Minimum: 5 minutes. Even the most trivial task has some overhead.
+- Maximum: 10080 minutes (7 days). Anything that would genuinely take
+  longer should have been split into multiple tasks; cap at the
+  ceiling.
+
+Pick a specific integer inside this range based on the description.
+Do not default to round numbers like 60, 120, 240 unless the work
+genuinely matches them.
+
+# Output format
+
+Respond with EXACTLY ONE JSON object and nothing else. No prose
+before or after. No markdown code fences.
+
+Shape:
+
+```
+{"minutes": <integer>, "reasoning": "<one short sentence>"}
+```
+
+- `minutes` is an integer between 5 and 10080.
+- `reasoning` is one short sentence (under 25 words) naming the
+  concrete factors that drove the number — what in the description
+  made it big or small.

--- a/Modules/EstimatedTime/aiTaskEstimator.js
+++ b/Modules/EstimatedTime/aiTaskEstimator.js
@@ -1,0 +1,236 @@
+/**
+ * AI-powered task time estimator.
+ *
+ * Given a freshly-created task, asks the configured LLM (Anthropic preferred,
+ * OpenAI fallback — reuses the AIProjectGenerator/llmProvider factory) for an
+ * estimated completion time assuming an AI coding agent (Claude Code) does
+ * the work end-to-end with no human implementation effort. The estimate is
+ * persisted to `tasks.totalEstimatedTime` (minutes) and broadcast over
+ * Socket.io so connected clients see the value appear without a refresh.
+ *
+ * Designed to be invoked fire-and-forget right after task creation: it never
+ * throws, never blocks the caller, and silently no-ops when no LLM provider
+ * is configured (so the feature degrades gracefully on installs without AI).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
+const logger = require('../../Config/loggerConfig');
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const socketEmitter = require('../../event/socketEventEmitter');
+
+let providerFactory = null;
+try {
+    providerFactory = require('../AIProjectGenerator/llmProvider');
+} catch (_e) {
+    providerFactory = null;
+}
+
+// Bounds chosen so a malformed LLM response can't write nonsense.
+// 5 minutes — smallest meaningful "AI does the task end-to-end" unit.
+// 7 days  — anything larger should be broken into subtasks.
+const MIN_MINUTES = 5;
+const MAX_MINUTES = 60 * 24 * 7;
+const REQUEST_TIMEOUT_MS = 60_000;
+const DESCRIPTION_CHAR_CAP = 4000;
+
+// Load the system prompt from the shared AIProjectGenerator prompts dir so
+// it lives alongside the other model-facing prompts and can be edited
+// without a code change. Read once at module load (require() caches this
+// module) — zero file I/O per estimate call. BOM stripped and CRLF
+// normalized so files authored on different OSes produce identical bytes.
+const SYSTEM_PROMPT = (() => {
+    const promptPath = path.join(
+        __dirname,
+        '..',
+        'AIProjectGenerator',
+        'prompts',
+        'project-plan',
+        'task-time-estimate.md',
+    );
+    const raw = fs.readFileSync(promptPath, 'utf8');
+    return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').trim();
+})();
+
+function extractDescription(task) {
+    if (!task) return '';
+    if (typeof task.rawDescription === 'string' && task.rawDescription.trim()) {
+        return task.rawDescription.trim();
+    }
+    const blocks = task.descriptionBlock && Array.isArray(task.descriptionBlock.blocks)
+        ? task.descriptionBlock.blocks
+        : null;
+    if (!blocks) return '';
+    const lines = [];
+    for (const b of blocks) {
+        if (!b || !b.data) continue;
+        if ((b.type === 'paragraph' || b.type === 'header') && typeof b.data.text === 'string') {
+            lines.push(b.data.text);
+        } else if (b.type === 'list' && Array.isArray(b.data.items)) {
+            for (const item of b.data.items) {
+                if (typeof item === 'string') lines.push(`- ${item}`);
+                else if (item && typeof item.content === 'string') lines.push(`- ${item.content}`);
+            }
+        }
+    }
+    return lines.join('\n').trim();
+}
+
+function buildUserMessage(task) {
+    const title = (task && task.TaskName) ? String(task.TaskName) : '(no title)';
+    const priority = (task && task.Task_Priority) ? String(task.Task_Priority) : 'MEDIUM';
+    const taskType = (task && task.TaskType) ? String(task.TaskType) : 'task';
+    const isParent = !task || task.isParentTask !== false;
+    let description = extractDescription(task);
+    if (description.length > DESCRIPTION_CHAR_CAP) {
+        description = `${description.slice(0, DESCRIPTION_CHAR_CAP)}…`;
+    }
+    return [
+        `Task title: ${title}`,
+        `Task type: ${taskType}`,
+        `Priority: ${priority}`,
+        `Is parent task: ${isParent ? 'yes' : 'no (subtask)'}`,
+        '',
+        'Description:',
+        description || '(no description provided — estimate from the title only)',
+    ].join('\n');
+}
+
+function clampMinutes(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return null;
+    const rounded = Math.round(num);
+    if (rounded < MIN_MINUTES) return MIN_MINUTES;
+    if (rounded > MAX_MINUTES) return MAX_MINUTES;
+    return rounded;
+}
+
+function parseMinutes(content) {
+    if (typeof content !== 'string') return null;
+    const trimmed = content.trim();
+    if (!trimmed) return null;
+    const stripped = trimmed
+        .replace(/^```(?:json)?\s*/i, '')
+        .replace(/```$/i, '')
+        .trim();
+    try {
+        const parsed = JSON.parse(stripped);
+        if (parsed && typeof parsed === 'object') {
+            if ('minutes' in parsed) return clampMinutes(parsed.minutes);
+            if ('estimate' in parsed) return clampMinutes(parsed.estimate);
+            if ('totalEstimatedTime' in parsed) return clampMinutes(parsed.totalEstimatedTime);
+        }
+    } catch (_e) {
+        // Fall through to regex rescue below.
+    }
+    const keyMatch = stripped.match(/"minutes"\s*:\s*(-?\d+(?:\.\d+)?)/);
+    if (keyMatch) return clampMinutes(keyMatch[1]);
+    const bareNumber = stripped.match(/^\s*(-?\d+(?:\.\d+)?)\s*$/);
+    return bareNumber ? clampMinutes(bareNumber[1]) : null;
+}
+
+async function callProvider(task) {
+    if (!providerFactory || typeof providerFactory.getProvider !== 'function') return null;
+    if (typeof providerFactory.isAnyProviderConfigured === 'function'
+        && !providerFactory.isAnyProviderConfigured()) {
+        return null;
+    }
+    let provider;
+    try {
+        provider = providerFactory.getProvider();
+    } catch (_e) {
+        return null;
+    }
+    const userMessage = buildUserMessage(task);
+    const chatPromise = provider.chat({
+        systemPrompt: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: userMessage }],
+        jsonMode: true,
+        temperature: 0.2,
+        maxTokens: 256,
+    });
+    const result = await Promise.race([
+        chatPromise,
+        new Promise((_, reject) => setTimeout(
+            () => reject(new Error('AI estimate request timed out')),
+            REQUEST_TIMEOUT_MS,
+        )),
+    ]);
+    if (!result || typeof result.content !== 'string') return null;
+    return parseMinutes(result.content);
+}
+
+async function persistEstimate(companyId, taskId, minutes) {
+    const updateQuery = {
+        type: SCHEMA_TYPE.TASKS,
+        data: [
+            { _id: new mongoose.Types.ObjectId(taskId) },
+            { $set: { totalEstimatedTime: minutes } },
+            { returnDocument: 'after' },
+        ],
+    };
+    const result = await MongoDbCrudOpration(companyId, updateQuery, 'findOneAndUpdate');
+    if (result && result._id) {
+        try {
+            socketEmitter.emit('update', {
+                type: 'update',
+                data: result,
+                updatedFields: { totalEstimatedTime: minutes },
+                module: 'task',
+            });
+        } catch (_e) { /* socket emit best-effort */ }
+    }
+    return result;
+}
+
+/**
+ * Estimate task completion time and persist to `totalEstimatedTime` (minutes).
+ * Never throws; safe to invoke without `await`.
+ *
+ * @param {object} params
+ * @param {string} params.companyId
+ * @param {string} params.taskId
+ * @param {object} params.task        Task-shaped object (TaskName, description, etc.)
+ * @returns {Promise<{status: boolean, minutes?: number, reason?: string}>}
+ */
+async function estimateAndPersist({ companyId, taskId, task } = {}) {
+    try {
+        if (!companyId || !taskId || !task) {
+            return { status: false, reason: 'missing required input' };
+        }
+        if (!providerFactory
+            || typeof providerFactory.isAnyProviderConfigured !== 'function'
+            || !providerFactory.isAnyProviderConfigured()) {
+            return { status: false, reason: 'no LLM provider configured' };
+        }
+        // Don't overwrite an explicit value the caller already set.
+        if (typeof task.totalEstimatedTime === 'number' && task.totalEstimatedTime > 0) {
+            return { status: false, reason: 'estimate already set' };
+        }
+        const minutes = await callProvider(task);
+        if (minutes == null) {
+            return { status: false, reason: 'no estimate returned' };
+        }
+        await persistEstimate(companyId, taskId, minutes);
+        return { status: true, minutes };
+    } catch (error) {
+        logger.error(`AI task estimator failed for task ${taskId}: ${error && error.message ? error.message : error}`);
+        return { status: false, reason: (error && error.message) || 'estimator error' };
+    }
+}
+
+module.exports = {
+    estimateAndPersist,
+    // Exposed for unit tests / debugging — not part of the runtime contract.
+    _internal: {
+        clampMinutes,
+        parseMinutes,
+        buildUserMessage,
+        extractDescription,
+        MIN_MINUTES,
+        MAX_MINUTES,
+    },
+};

--- a/Modules/Tasks/helpers/taskMongo/create.js
+++ b/Modules/Tasks/helpers/taskMongo/create.js
@@ -20,6 +20,7 @@ const { emitListener } = require("../../../Company/eventController.js");
 const { createCustomFields } = require("../helper.js");
 const { removeCache } = require('../../../../utils/commonFunctions.js');
 const { updateRemainingTime } = require('../../../LogTime/controllerV2.js');
+const { estimateAndPersist: estimateTaskTimeWithAI } = require('../../../EstimatedTime/aiTaskEstimator.js');
 module.exports = {
     create({data, user, projectData ,indexObj, setNotif}) {
         return new Promise((resolve,reject) => {
@@ -95,7 +96,20 @@ module.exports = {
                         })
     
                         if(data?.mainChat) return;
-    
+
+                        // Fire-and-forget: ask the LLM for an end-to-end
+                        // completion-time estimate (in minutes, assuming an AI
+                        // coding agent does the work) and persist it to
+                        // `totalEstimatedTime`. No-op when no LLM provider is
+                        // configured, so the existing flow is unaffected.
+                        estimateTaskTimeWithAI({
+                            companyId: projectData.CompanyId,
+                            taskId: taskResult.id,
+                            task: data,
+                        }).catch((error) => {
+                            logger.error(`AI task estimate error: ${error && error.message ? error.message : error}`);
+                        });
+
                         let taskObj = {
                             'ProjectName' : projectData.ProjectName,
                             'newTaskname' : data.TaskName


### PR DESCRIPTION
## Summary

- After every task is created, ask the configured LLM how many minutes an AI coding agent (Claude Code) would need to complete it end-to-end, and save the result to `tasks.totalEstimatedTime`.
- Reuses the existing AIProjectGenerator `llmProvider` factory (Anthropic-preferred, OpenAI fallback). No new env vars — installs that already have AI configured pick this up automatically; installs that don't are unaffected (silent no-op).
- The estimate is **description-driven**: the prompt walks the model through deliverable shape → surface area → ambiguity → verification → iteration, and explicitly discourages lazy round-number defaults.
- Fire-and-forget: API responses are never delayed. Results land via Socket.io so connected screens refresh without a page reload.

## What changed

| File | Purpose |
|---|---|
| `Modules/EstimatedTime/aiTaskEstimator.js` *(new)* | Self-contained estimator. Loads prompt from .md, builds user message from task fields, parses JSON, clamps to [5 min, 7 days], persists + emits socket update. Never throws. |
| `Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md` *(new)* | System prompt as a partial, sitting alongside the other project-plan prompts. Tunable without a code change. |
| `Modules/Tasks/helpers/taskMongo/create.js` | Tiny hook after the central `create()` succeeds. Skips mainChat. |
| `Modules/AIProjectGenerator/orchestrator.js` | Background hook after the bulk `insertMany` so AI-orchestrated project tasks also get estimates. Concurrency capped at 3 to stay under provider rate limits. |
| `.claude/AI-TIME-ESTIMATION.md` *(new)* | Plain-language docs explaining the estimation model. |

## Safety

- **Bounds:** `clampMinutes` forces the result into `[5, 10080]` (5 min — 7 days). Garbage / unparsable model output → estimate is just skipped, no broken data is saved.
- **Non-blocking:** estimator runs after `resolve()` in `create()` and as a background worker in the orchestrator. Failures are logged, never propagated.
- **Idempotent on existing values:** if the caller already set `totalEstimatedTime > 0`, the estimator leaves it alone.
- **Graceful degradation:** when no LLM provider is configured, the estimator silently no-ops and task creation works exactly like before.

## Test plan

- [ ] Create a single task via UI with a clear description — verify `totalEstimatedTime` (minutes) appears on the task within a few seconds and the value reflects the description's actual complexity.
- [ ] Create a task with no description — verify the model still returns a (conservative) estimate.
- [ ] Create a task with an already-set `totalEstimatedTime` (e.g. via import) — verify the AI does NOT overwrite it.
- [ ] Generate a project via the AI Project Generator — verify all created tasks get estimates without slowing the SSE progress stream.
- [ ] Create a mainChat task — verify no estimate is attempted.
- [ ] Temporarily unset `ANTHROPIC_API_KEY` / `AI_API_KEY` — verify task creation still works and no errors are thrown (just a benign log line).
- [ ] Verify the new `totalEstimatedTime` value appears in connected clients without a page refresh (Socket.io `task` update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)