### PR TITLE
feat(estimated-time): manual AI trigger + accuracy rewrite

### DIFF
--- a/Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md
+++ b/Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md
@@ -4,41 +4,101 @@ A single integer estimate of how many minutes an AI coding agent
 (Claude Code) needs to complete this task end-to-end, with NO manual
 human implementation work.
 
+# Accuracy matters
+
+Two failure modes ruin estimates equally:
+
+- **Inflated:** counting the same work twice because the description
+  repeats it in different words, or padding for vague "context" that
+  isn't actual work.
+- **Underestimated:** missing implicit work the description names
+  obliquely (tests, error handling, edge cases) or skipping iteration
+  overhead.
+
+Your job is to extract the **actual unique work** from the
+description and estimate that — nothing more, nothing less.
+
 # How you make the estimate
 
-Read the task description carefully and derive the number from what
-the task actually asks for. Do NOT round to a generic bucket. Two
-tasks with similar titles can be very different jobs once you read
-the description — let the description drive the number.
+Work through these four phases in order. Do not skip ahead.
 
-Concretely, work through these in order:
+## Phase 1 — Normalize the description
 
-1. **What is the deliverable?** A copy change, a config tweak, a bug
-   fix, a new feature, a refactor, a migration, an integration? The
-   shape of the deliverable sets the floor.
+Before you count anything, mentally clean up the description:
 
-2. **How much surface area is involved?** Count the things the task
-   description names or strongly implies: files, modules, APIs,
-   schemas, UI screens, tests, migrations, third-party services. More
-   surface = more time.
+1. **Remove redundancy.** If two sentences or paragraphs convey the
+   same meaning, count them as one. Repeating the same instruction
+   in different words does not double the work.
 
-3. **How ambiguous is the description?** Crisp, specific requirements
-   are faster than vague ones. If the description leaves open
-   questions the agent will have to resolve mid-task, add time for
-   that exploration.
+2. **Merge overlapping requirements.** If multiple lines describe
+   the same functionality from different angles (e.g. "users can log
+   in", "add login flow", "implement authentication"), they describe
+   ONE unit of work, not three.
 
-4. **What verification will the agent perform?** Anything that
-   touches data, auth, payments, or user-visible UI needs a real
-   verification loop (run, click, observe, iterate). Pure internal
-   refactors verify faster.
+3. **Ignore filler content.** Skip:
+   - Introductions ("This task is about…", "We need to…").
+   - Re-statements of project context that aren't actionable.
+   - Generic closing summaries ("Once done, the user will be able
+     to…") that just paraphrase what was already specified.
+   - Marketing-style phrasing that doesn't translate to code.
 
-5. **Iteration overhead.** The agent typically writes, runs, sees a
-   failure, and fixes — at least 1-2 iteration loops on anything
-   non-trivial. Bake that in.
+4. **Keep implicit work.** Acceptance criteria, edge cases, error
+   handling, and verification steps are real work even if they're
+   bullet points. Don't drop them as "filler" just because they're
+   short.
+
+## Phase 2 — Extract unique work items
+
+Build a mental list of the distinct, actionable engineering deliverables
+the description requires. Each work item should be something you could
+hand a developer and they'd know what to build.
+
+Good items: "Create POST /api/foo endpoint with validation",
+"Add login form with email + password fields",
+"Wire up Stripe webhook handler for invoice.paid",
+"Write unit tests for the parser".
+
+Bad items: "Make the system better", "Improve user experience",
+"Polish the UI" — these are too vague to be a single deliverable;
+either translate them into concrete items or drop them.
+
+## Phase 3 — Estimate each unique work item
+
+For EACH item on your list (not for the whole description), judge:
+
+1. **Deliverable shape:**
+   - Copy / config tweak — small floor.
+   - Bug fix — locate, reproduce, fix, verify.
+   - New feature — design + implement + test + integrate.
+   - Refactor — touches many files, broad verification.
+   - Migration — data risk → careful planning + rollback thinking.
+   - Integration — external system = unknowns + iteration.
+
+2. **Surface area.** Files, modules, APIs, schemas, UI screens,
+   tests, third-party services. More surface = more time.
+
+3. **Clarity.** Specific requirements estimate tighter than vague
+   ones. If an item leaves open questions the agent will have to
+   resolve mid-task, add time for that exploration.
+
+4. **Verification.** Pure internal refactors verify by running
+   tests. Anything touching data, auth, payments, or UI needs a
+   real verification loop (run, click, observe, iterate).
+
+5. **Iteration overhead.** The agent typically writes, runs, sees
+   a failure, and fixes — 1-2 iteration loops on anything
+   non-trivial. Bake that in per item.
+
+## Phase 4 — Sum and return
+
+Add up the per-item estimates. If two items genuinely share setup
+(e.g. both touch the same new file), don't double-count the setup.
+The final number is the sum of the unique work, not the sum of every
+line in the description.
 
 # Scope of the estimate
 
-The number you return represents the agent's wall-clock time:
+The number represents the AI agent's wall-clock time:
 
 - Reading the task and locating the relevant code.
 - Planning the change.
@@ -54,14 +114,35 @@ Do NOT include:
 
 # Bounds
 
-- Minimum: 5 minutes. Even the most trivial task has some overhead.
-- Maximum: 10080 minutes (7 days). Anything that would genuinely take
-  longer should have been split into multiple tasks; cap at the
-  ceiling.
+- Minimum: 5 minutes.
+- Maximum: 10080 minutes (7 days). Anything that would genuinely
+  take longer should have been split into multiple tasks.
 
-Pick a specific integer inside this range based on the description.
-Do not default to round numbers like 60, 120, 240 unless the work
-genuinely matches them.
+Pick a specific integer based on the work items. Do not default to
+round numbers like 60 / 120 / 240 unless the math actually lands
+there.
+
+# Worked examples
+
+**Example A — redundancy.** Description: *"Build a user profile
+page. The user should have a profile page. Create the profile screen
+where users can view their info."* → ONE work item (a profile page),
+not three.
+
+**Example B — overlapping requirements.** Description: *"Add login.
+Implement authentication. Set up sign-in flow."* → ONE work item
+(login/auth flow), not three.
+
+**Example C — filler.** Description: *"This task is critical for our
+roadmap. We need to add a search bar to the navbar. Once done, users
+will be able to search faster."* → ONE work item (search bar in
+navbar). The first and third sentences are filler.
+
+**Example D — keep implicit work.** Description: *"Add Stripe
+webhook handler. Acceptance: handles invoice.paid, refund.created,
+and dispute.created events. Log failures."* → Counts as ONE feature
+but with FOUR sub-deliverables (three event handlers + failure
+logging) — all real work, all estimated.
 
 # Output format
 
@@ -71,10 +152,16 @@ before or after. No markdown code fences.
 Shape:
 
 ```
-{"minutes": <integer>, "reasoning": "<one short sentence>"}
+{
+  "work_items": ["<item 1>", "<item 2>", ...],
+  "minutes": <integer>,
+  "reasoning": "<one short sentence>"
+}
 ```
 
+- `work_items` is the deduplicated list of distinct deliverables you
+  extracted in Phase 2. Each entry is a short, concrete phrase.
+  Keep this list to the items that actually drove the estimate.
 - `minutes` is an integer between 5 and 10080.
 - `reasoning` is one short sentence (under 25 words) naming the
-  concrete factors that drove the number — what in the description
-  made it big or small.
+  concrete factors that drove the number.

--- a/Modules/EstimatedTime/aiTaskEstimator.js
+++ b/Modules/EstimatedTime/aiTaskEstimator.js
@@ -79,12 +79,60 @@ function extractDescription(task) {
     return lines.join('\n').trim();
 }
 
+/**
+ * Lightweight whitespace normalization for the description before it
+ * hits the LLM. We don't deduplicate text here — that's the model's
+ * job per the prompt's Phase 1 — but we strip whitespace noise so the
+ * model spends its reasoning budget on real content:
+ *
+ *   - Trim trailing whitespace on every line (so two lines that differ
+ *     only by trailing spaces look identical to the model).
+ *   - Collapse 3+ consecutive blank lines into a single blank line.
+ *   - Collapse 3+ repeats of the same non-empty line (e.g. accidental
+ *     copy/paste) into a single occurrence.
+ *
+ * This is conservative: it removes accidental duplication, not
+ * intentional repetition with different wording.
+ */
+function normalizeDescriptionForPrompt(text) {
+    if (typeof text !== 'string' || !text) return '';
+    // Strip trailing whitespace per line and normalize newlines.
+    let lines = text.replace(/\r\n/g, '\n').split('\n').map((l) => l.replace(/\s+$/, ''));
+    // Collapse 3+ blank lines into one.
+    const collapsed = [];
+    let blankRun = 0;
+    for (const line of lines) {
+        if (line === '') {
+            blankRun += 1;
+            if (blankRun <= 1) collapsed.push('');
+        } else {
+            blankRun = 0;
+            collapsed.push(line);
+        }
+    }
+    // Collapse 3+ identical consecutive non-empty lines into one.
+    const out = [];
+    let lastNonEmpty = null;
+    let lastRun = 0;
+    for (const line of collapsed) {
+        if (line !== '' && line === lastNonEmpty) {
+            lastRun += 1;
+            if (lastRun <= 1) out.push(line);
+        } else {
+            lastNonEmpty = line === '' ? lastNonEmpty : line;
+            lastRun = line === '' ? lastRun : 1;
+            out.push(line);
+        }
+    }
+    return out.join('\n').trim();
+}
+
 function buildUserMessage(task) {
     const title = (task && task.TaskName) ? String(task.TaskName) : '(no title)';
     const priority = (task && task.Task_Priority) ? String(task.Task_Priority) : 'MEDIUM';
     const taskType = (task && task.TaskType) ? String(task.TaskType) : 'task';
     const isParent = !task || task.isParentTask !== false;
-    let description = extractDescription(task);
+    let description = normalizeDescriptionForPrompt(extractDescription(task));
     if (description.length > DESCRIPTION_CHAR_CAP) {
         description = `${description.slice(0, DESCRIPTION_CHAR_CAP)}…`;
     }
@@ -96,6 +144,8 @@ function buildUserMessage(task) {
         '',
         'Description:',
         description || '(no description provided — estimate from the title only)',
+        '',
+        'Follow the four-phase pipeline in the system prompt. Deduplicate before estimating; do not double-count overlapping requirements.',
     ].join('\n');
 }
 
@@ -149,8 +199,14 @@ async function callProvider(task) {
         systemPrompt: SYSTEM_PROMPT,
         messages: [{ role: 'user', content: userMessage }],
         jsonMode: true,
-        temperature: 0.2,
-        maxTokens: 256,
+        // Low temperature pulls the model toward deterministic, calibrated
+        // numbers — accuracy depends on the model NOT being creative here.
+        temperature: 0.15,
+        // 1024 leaves room for the work_items[] array (Phase 2 chain-of-
+        // thought) without truncating the JSON. A truncated response
+        // means parseMinutes returns null and we skip the estimate, so
+        // this directly affects success rate.
+        maxTokens: 1024,
     });
     const result = await Promise.race([
         chatPromise,
@@ -194,9 +250,12 @@ async function persistEstimate(companyId, taskId, minutes) {
  * @param {string} params.companyId
  * @param {string} params.taskId
  * @param {object} params.task        Task-shaped object (TaskName, description, etc.)
+ * @param {boolean} [params.force]    When true, bypass the "estimate already set"
+ *                                    guard. Used by the manual sidebar button
+ *                                    which is an explicit recalculation request.
  * @returns {Promise<{status: boolean, minutes?: number, reason?: string}>}
  */
-async function estimateAndPersist({ companyId, taskId, task } = {}) {
+async function estimateAndPersist({ companyId, taskId, task, force = false } = {}) {
     try {
         if (!companyId || !taskId || !task) {
             return { status: false, reason: 'missing required input' };
@@ -206,8 +265,11 @@ async function estimateAndPersist({ companyId, taskId, task } = {}) {
             || !providerFactory.isAnyProviderConfigured()) {
             return { status: false, reason: 'no LLM provider configured' };
         }
-        // Don't overwrite an explicit value the caller already set.
-        if (typeof task.totalEstimatedTime === 'number' && task.totalEstimatedTime > 0) {
+        // Don't overwrite an explicit value the caller already set — unless
+        // the caller is explicitly recalculating (manual sidebar button).
+        if (!force
+            && typeof task.totalEstimatedTime === 'number'
+            && task.totalEstimatedTime > 0) {
             return { status: false, reason: 'estimate already set' };
         }
         const minutes = await callProvider(task);
@@ -230,6 +292,7 @@ module.exports = {
         parseMinutes,
         buildUserMessage,
         extractDescription,
+        normalizeDescriptionForPrompt,
         MIN_MINUTES,
         MAX_MINUTES,
     },

--- a/Modules/EstimatedTime/controller.js
+++ b/Modules/EstimatedTime/controller.js
@@ -4,6 +4,7 @@ const { SCHEMA_TYPE } = require("../../Config/schemaType");
 const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries");
 const { replaceObjectKey } = require("../Auth/helper");
 const socketEmitter = require("../../event/socketEventEmitter");
+const { estimateAndPersist: estimateTaskTimeWithAI } = require("./aiTaskEstimator");
 
 exports.getEstimatedTime = async(req,res) => {
     try {
@@ -62,6 +63,75 @@ exports.updateEstimatedTime = async(req,res) => {
         res.status(500).json({ message: "An error occurred while updating the estimated time.", error: error.message });
     }
 }
+
+// Manual AI estimate trigger — invoked from the task detail sidebar's
+// "Generate estimate using AI" icon button. Unlike the post-create
+// auto-estimate (which silently no-ops if a value already exists), this
+// endpoint always recalculates because the user explicitly asked for it.
+// The estimator helper does the LLM call, clamping, persistence, and
+// Socket.io emit, so this controller just orchestrates and returns.
+exports.generateAiEstimate = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'];
+        const taskId = req.params.tid;
+
+        if (!companyId) {
+            return res.status(400).json({ status: false, statusText: 'companyId header required' });
+        }
+        if (!taskId || !mongoose.Types.ObjectId.isValid(taskId)) {
+            return res.status(400).json({ status: false, statusText: 'valid taskId required' });
+        }
+
+        // Fetch the task with just the fields the estimator needs so the
+        // payload to the LLM is built from the canonical DB state — not
+        // from whatever stale shape the client happened to send.
+        const taskObj = {
+            type: SCHEMA_TYPE.TASKS,
+            data: [
+                { _id: new mongoose.Types.ObjectId(taskId) },
+                {
+                    TaskName: 1,
+                    Task_Priority: 1,
+                    TaskType: 1,
+                    isParentTask: 1,
+                    rawDescription: 1,
+                    descriptionBlock: 1,
+                    totalEstimatedTime: 1,
+                },
+            ],
+        };
+        const taskDoc = await MongoDbCrudOpration(companyId, taskObj, 'findOne');
+        if (!taskDoc || !taskDoc._id) {
+            return res.status(404).json({ status: false, statusText: 'task not found' });
+        }
+
+        const result = await estimateTaskTimeWithAI({
+            companyId,
+            taskId,
+            task: taskDoc,
+            force: true,
+        });
+
+        if (!result.status) {
+            return res.status(400).json({
+                status: false,
+                statusText: result.reason || 'estimate not generated',
+            });
+        }
+        return res.status(200).json({
+            status: true,
+            statusText: 'Estimate generated successfully',
+            data: { totalEstimatedTime: result.minutes },
+        });
+    } catch (error) {
+        loggerConfig.error(`generateAiEstimate error: ${error && error.message ? error.message : error}`);
+        return res.status(500).json({
+            status: false,
+            statusText: 'An error occurred while generating the AI estimate.',
+            error: error && error.message ? error.message : String(error),
+        });
+    }
+};
 
 exports.getEstimateByAggregate = async (req,res) => {
     try {

--- a/Modules/EstimatedTime/routes.js
+++ b/Modules/EstimatedTime/routes.js
@@ -4,4 +4,9 @@ exports.init = (app) => {
     app.get('/api/v1/estimatedTime/:pid/:tid',ctrl.getEstimatedTime);
     app.put('/api/v1/estimatedTime',ctrl.updateEstimatedTime);
     app.post('/api/v1/estimatedTime', ctrl.getEstimateByAggregate);
+    // Manual AI-estimate trigger from the task detail sidebar. Path-only
+    // params so the existing axios interceptor's companyId header flows
+    // through unchanged — matches the convention used by other v1 routes
+    // in this module.
+    app.post('/api/v1/estimatedTime/ai/:tid', ctrl.generateAiEstimate);
 }

--- a/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
+++ b/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
@@ -154,11 +154,38 @@
              <div class="d-flex task-detail-right-side-label" v-if="checkApps('TimeEstimates') && checkPermission('task.task_estimated_hours',project?.isGlobalPermission) !== null">
                 <h4>{{$t('UserTimesheet.estimated')}}</h4>
                 <Skelaton v-if="isMainSpinner" style="height: 24px;" class="w-100px border-radius-7-px"/>
-                <EstimatedTimeInput
-                    v-if="Object.keys(task || {}).length && !isMainSpinner"
-                    :task="task"
-                    @update:totalEstimatedTime="(val) => updateTotalEstimatedTime(val)"
-                />
+                <div v-if="Object.keys(task || {}).length && !isMainSpinner" class="d-flex align-items-center estimated-with-ai">
+                    <EstimatedTimeInput
+                        :task="task"
+                        @update:totalEstimatedTime="(val) => updateTotalEstimatedTime(val)"
+                    />
+                    <!--
+                      Icon-only AI estimator trigger. Tooltip via the native
+                      title attribute matches the project's existing tooltip
+                      convention (see BulkActionBar.vue / CheckList.vue).
+                      Disabled + spinner state while a request is in flight.
+
+                      Permission gate: `=== true` (read-write) only. The outer
+                      row's `!== null` gate already covers visibility for the
+                      read-only case; this inner gate hides the AI trigger
+                      from users who can see the estimate but not edit it —
+                      matching the convention used by Priority / Start Date /
+                      Due Date rows in this same component.
+                    -->
+                    <button
+                        v-if="checkPermission('task.task_estimated_hours', project?.isGlobalPermission) === true"
+                        type="button"
+                        class="ai-estimate-btn"
+                        :class="{ 'is-loading': isAiEstimateLoading }"
+                        :disabled="isAiEstimateLoading"
+                        :title="isAiEstimateLoading ? 'Generating estimate…' : 'Generate estimate using AI'"
+                        :aria-label="isAiEstimateLoading ? 'Generating estimate' : 'Generate estimate using AI'"
+                        @click.stop="generateAiEstimate"
+                    >
+                        <span v-if="isAiEstimateLoading" class="ai-estimate-spinner" aria-hidden="true"></span>
+                        <img v-else :src="aiEstimateIcon" alt="" class="ai-estimate-icon" />
+                    </button>
+                </div>
             </div>
             <div class="d-flex task-detail-right-side-label" v-if="checkApps('TimeEstimates') && checkPermission('task.task_estimated_hours',project?.isGlobalPermission) !== null">
                 <h4>{{$t('UserTimesheet.task_planning')}}</h4>
@@ -200,6 +227,13 @@ import { taskDueDateAdd, taskDueDateChange } from '@/utils/NotificationTemplate'
 import { useToast } from 'vue-toast-notification';
 import { useI18n } from "vue-i18n";
 import Skelaton from '@/components/atom/Skelaton/Skelaton.vue';
+import { apiRequest } from '@/services';
+import * as env from '@/config/env';
+
+// Icon for the "Generate estimate using AI" sidebar button. Same asset
+// the SubTasks / Checklist / Sprints components use for their AI actions
+// so the visual language stays consistent.
+const aiEstimateIcon = require("@/assets/images/svg/ai_image.svg");
 const { t } = useI18n();
 
 const {convertDateFormat} = useConvertDate();
@@ -253,6 +287,9 @@ const props = defineProps({
 const taskLeaderData = ref(getUser(props.task?.Task_Leader));
 const assigneeInProgress = ref({});
 const isSpinner = ref(false);
+// In-flight flag for the manual AI-estimate request — drives both the
+// button's spinner state and the click-debounce.
+const isAiEstimateLoading = ref(false);
 watch(() => props.task,(val) => {
     taskLeaderData.value = getUser(val?.Task_Leader);
 });
@@ -660,6 +697,40 @@ const displayTime = (time) => {
   const hours = Math.floor(totalMinutes / 60)
   const minutes = totalMinutes % 60
   return `${String(hours).padStart(2, '0')}h ${String(minutes).padStart(2, '0')}m`
+}
+
+// Manual AI-estimate trigger. Posts to the EstimatedTime route which
+// loads the canonical task doc server-side, runs the LLM estimator with
+// force=true (so it overwrites any existing value), persists to
+// `totalEstimatedTime`, and emits a Socket.io `task` update — so other
+// connected clients see the new value without a refresh. We don't need
+// to patch local state here because the socket update flows back through
+// the same channel that drives `props.task`.
+const generateAiEstimate = async () => {
+    if (isAiEstimateLoading.value) return;
+    const taskId = props.task && props.task._id;
+    if (!taskId) {
+        $toast.error('Task is not available', { position: 'top-right' });
+        return;
+    }
+    isAiEstimateLoading.value = true;
+    try {
+        const response = await apiRequest('post', `${env.ESTIMATED_TIME}/ai/${taskId}`, {});
+        if (response && response.data && response.data.status) {
+            $toast.success('Estimate generated', { position: 'top-right' });
+        } else {
+            const msg = (response && response.data && response.data.statusText)
+                || 'Could not generate estimate';
+            $toast.error(msg, { position: 'top-right' });
+        }
+    } catch (err) {
+        const msg = (err && err.response && err.response.data && err.response.data.statusText)
+            || (err && err.message)
+            || 'Could not generate estimate';
+        $toast.error(msg, { position: 'top-right' });
+    } finally {
+        isAiEstimateLoading.value = false;
+    }
 }
 </script>
 <style scoped src='./style.css'>

--- a/frontend/src/components/organisms/TaskDetailRightSide/style.css
+++ b/frontend/src/components/organisms/TaskDetailRightSide/style.css
@@ -127,3 +127,58 @@
     .task-detail-right-side-label h4{width: 35%;font-size: 16px;font-weight: 400;}
     .taskdetail-label, .task-esitmate-hours{font-size: 16px !important;padding-right: 0 !important;}
 }
+
+/* AI-estimate icon button — sits inline with the EstimatedTimeInput on
+   the right of the "Estimated" row. Sized to match the inline time
+   value's visual height (24px) so the row stays balanced. */
+.estimated-with-ai {
+    gap: 6px;
+}
+.ai-estimate-btn {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease-in-out;
+}
+.ai-estimate-btn:hover:not(:disabled) {
+    background-color: rgba(100, 115, 232, 0.10);
+}
+.ai-estimate-btn:disabled {
+    cursor: progress;
+    opacity: 0.75;
+}
+.ai-estimate-icon {
+    width: 16px;
+    height: 16px;
+    pointer-events: none;
+}
+/* Inline ring spinner. The `.task-detail-right-side-label span` rule
+   above (lines 25-35) targets every <span> inside the label container
+   and forces height/padding/border-radius/line-height on it — which
+   squashes the spinner into a pill if we don't override it. We bump
+   specificity with the `.ai-estimate-btn` ancestor selector (which
+   wins against the bare-element rule) and explicitly reset every
+   property the parent rule touches. */
+.ai-estimate-btn .ai-estimate-spinner {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 14px;
+    height: 14px;
+    padding: 0;
+    line-height: 0;
+    border: 2px solid #E2E6FA;
+    border-top-color: #6473E8;
+    border-radius: 50%;
+    font-size: 0;
+    animation: ai-estimate-spin 0.7s linear infinite;
+}
+@keyframes ai-estimate-spin {
+    to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Builds on #188. Adds a manual AI-estimate trigger to the task detail sidebar, rewrites the estimator prompt for description-driven accuracy, and tunes the LLM call.

## What changed

### 1. Manual AI trigger in the task detail sidebar

| File | Change |
|---|---|
| `Modules/EstimatedTime/aiTaskEstimator.js` | Added a `force` flag to `estimateAndPersist`. When `true`, the "estimate already set" guard is bypassed — used by the sidebar button which is an explicit recalculation. |
| `Modules/EstimatedTime/controller.js` | New `generateAiEstimate(req, res)`: validates `companyId` header + `taskId` param, fetches the canonical task doc server-side (so the LLM payload comes from the DB, not stale client data), calls the estimator with `force: true`, returns `{ status, data: { totalEstimatedTime } }`. |
| `Modules/EstimatedTime/routes.js` | New route: `POST /api/v1/estimatedTime/ai/:tid`. |
| `frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue` | Icon-only button next to `<EstimatedTimeInput>`. Tooltip via native `title` attribute. Inline spinner + disabled state while the request is in flight. **Permission-gated:** inner `=== true` check mirrors the read-only / read-write pattern Priority / Start Date / Due Date use in this same component — read-only users see the estimate but not the AI trigger. |
| `frontend/src/components/organisms/TaskDetailRightSide/style.css` | `.ai-estimate-btn` styling. The spinner uses `.ai-estimate-btn .ai-estimate-spinner` to beat the existing `.task-detail-right-side-label span` rule on specificity, plus explicit padding / line-height / font-size resets so the parent rule can't deform the circle into a pill. |

### 2. Accuracy rewrite of the prompt

`Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md` is restructured into a strict four-phase pipeline the model must run **in order**:

| Phase | What it does | Maps to |
|---|---|---|
| **Phase 1 — Normalize** | Remove redundancy, merge overlapping requirements, drop filler, keep implicit work | Rules 1–3 of the accuracy spec |
| **Phase 2 — Extract** | Enumerate distinct, actionable engineering deliverables | Rule 4 |
| **Phase 3 — Estimate per item** | Apply deliverable shape / surface area / clarity / verification / iteration to **each** unique item | Rule 5 |
| **Phase 4 — Sum** | Add up the per-item estimates without double-counting shared setup | Rule 5 |

Output JSON now includes a `work_items[]` array forcing chain-of-thought enumeration before the number — structurally preventing both inflation (no item → no minutes) and underestimation (each implicit item must be named). Four worked examples cover redundancy, overlapping requirements, filler stripping, and implicit work.

### 3. Estimator tuning

| Setting | Before | After | Why |
|---|---|---|---|
| `maxTokens` | 256 | 1024 | Room for `work_items[]` array. Truncated JSON = parser returns null = estimate skipped, so this directly affects success rate. |
| `temperature` | 0.2 | 0.15 | Pulls toward deterministic, calibrated outputs — estimation should not be creative. |
| `normalizeDescriptionForPrompt` | n/a | new | Strips trailing whitespace; collapses 3+ blank or 3+ accidental-duplicate lines. Conservative: does not semantic-dedup (the model's job). |
| Reinforcement directive | n/a | new | Inline reminder after the description so the four-phase pipeline is the last instruction the model sees before generating. |

## Backward compatibility

The parser was untouched and verified against:
- ✅ Old shape `{minutes, reasoning}` (pre-#188 prompt)
- ✅ New shape `{work_items, minutes, reasoning}` (this PR)
- ✅ Truncated mid-array (regex rescue still extracts `minutes`)

Existing tasks created before this change keep working. The fire-and-forget hook (single-task create), the orchestrator bulk path, and the new manual trigger all use the same estimator, so they all benefit immediately with no other code changes.

## Test plan

- [ ] Open any task. Verify the AI button appears next to the "Estimated" value.
- [ ] Hover the button → tooltip shows "Generate estimate using AI".
- [ ] Click → spinner replaces the icon, button is disabled, tooltip changes to "Generating estimate…".
- [ ] On success → toast "Estimate generated", new value appears in the field via Socket.io (no page reload needed).
- [ ] **Permission check:** as a user with `task.task_estimated_hours = false` (read-only), open the task. Verify the estimate value is visible but the AI button is **hidden**.
- [ ] **Permission check:** as a user with `task.task_estimated_hours = null` (no access), open the task. Verify the whole "Estimated" row is hidden.
- [ ] Click the button on a task with no description — verify a (conservative) estimate is still produced.
- [ ] Click the button on a task with a description that repeats the same requirement 3 different ways — verify the estimate reflects ONE unit of work, not three.
- [ ] Click the button on a task with multiple distinct deliverables — verify the estimate reflects the sum.
- [ ] Temporarily unset `ANTHROPIC_API_KEY` / `AI_API_KEY` — verify the button still appears for users with permission, click produces a toast saying no provider is configured, and nothing in the DB is mutated.
- [ ] Verify race-safety: rapidly click the button. Verify only one in-flight request fires (the `isAiEstimateLoading` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)