### PR TITLE
feat(ai-project-generator): preserve plan across Back nav + bypass plan-limit gate

### DIFF
--- a/Modules/AIProjectGenerator/orchestrator.js
+++ b/Modules/AIProjectGenerator/orchestrator.js
@@ -826,7 +826,26 @@ async function executePlan({ plan, companyId, uid, userData, jobId }) {
     const emit = (payload) => sseEmitter.emit(jobId, payload);
 
     try {
-        // 1. Plan-limit gate — matches the manual createProject flow.
+        // 1. Plan-limit gate — INTENTIONALLY BYPASSED.
+        //
+        // We still call `checkProjectPlan` because internally it $inc's the
+        // company's `projectCount.{projectCount,publicCount,privateCount}`
+        // counters BEFORE checking the limit ceiling. Keeping that call
+        // means AI-created projects stay accurately counted in the
+        // companies doc — matching how the manual createProject flow
+        // tracks them. We just swallow the rejection that comes back
+        // when the ceiling is tripped, so creation proceeds anyway.
+        //
+        // checkProjectPlan rejects in two distinct cases:
+        //   (a) `countRollBack === false` — the $inc itself failed (e.g.
+        //       Mongo write error). Count was NOT mutated, so we leave
+        //       tracker.countIncremented = false. Nothing for the
+        //       downstream rollback path to undo.
+        //   (b) Otherwise — the $inc succeeded and only the ceiling
+        //       check failed. Count WAS mutated, so we mark
+        //       countIncremented = true and the existing rollback() in
+        //       the outer catch will correctly decrement on later
+        //       failure, exactly like the limit-not-tripped path.
         emit({ event: 'progress', step: 'project', status: 'started' });
         logger.info(`[AIPG][${jobId}] step 1: checkProjectPlan start (company=${companyId})`);
         try {
@@ -836,20 +855,16 @@ async function executePlan({ plan, companyId, uid, userData, jobId }) {
             );
             tracker.countIncremented = true;
         } catch (err) {
-            // checkProjectPlan increments the count BEFORE checking limits,
-            // so if it rejects we still need to roll the count back. We
-            // detect the count-not-rolled case via err.countRollBack !== false.
-            const rolledByCheck = err && err.countRollBack === false;
-            if (!rolledByCheck) {
-                // removeProjectCount is fire-and-forget (no Promise returned).
-                try { removeProjectCount(companyId, tracker.isPrivateSpace); } catch (_e) {}
+            const incrementFailed = err && err.countRollBack === false;
+            if (!incrementFailed) {
+                tracker.countIncremented = true;
             }
-            const reason = (err && err.statusText) || 'Project limit reached for this plan. Please upgrade or remove an existing project.';
-            const e = new Error(reason);
-            e.code = 'PLAN_LIMIT';
-            throw e;
+            const reason = (err && err.statusText)
+                || (err && err.message)
+                || 'unknown';
+            logger.warn(`[AIPG][${jobId}] checkProjectPlan rejected — bypassed (reason: ${reason}, incrementApplied: ${!incrementFailed})`);
         }
-        logger.info(`[AIPG][${jobId}] step 1: checkProjectPlan done`);
+        logger.info(`[AIPG][${jobId}] step 1: checkProjectPlan done (limit gate bypassed)`);
 
         // 2. Load company context.
         logger.info(`[AIPG][${jobId}] step 2: loadCompanyContext start`);

--- a/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
+++ b/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
@@ -129,7 +129,22 @@
                         </div>
                     </transition>
 
-                    <div class="aipg-actions">
+                    <div v-if="hasGeneratedPlan" class="aipg-actions aipg-actions-split">
+                        <button
+                            class="aipg-btn aipg-btn-ghost"
+                            :disabled="!canGenerate || loading || briefUploading"
+                            @click="onGeneratePlan">
+                            <span v-if="loading" class="aipg-spinner aipg-spinner-sm" aria-hidden="true"></span>
+                            {{ loading ? 'Generating plan…' : 'Re-Generate Plan' }}
+                        </button>
+                        <button
+                            class="aipg-btn aipg-btn-primary"
+                            :disabled="loading || briefUploading"
+                            @click="onNextWithExistingPlan">
+                            Next →
+                        </button>
+                    </div>
+                    <div v-else class="aipg-actions">
                         <button
                             class="aipg-btn aipg-btn-primary"
                             :disabled="!canGenerate || loading || briefUploading"
@@ -324,6 +339,25 @@ export default defineComponent({
         const placeholderText = 'e.g. "A 3-month SaaS launch for a 5-person team building an invoicing tool with Stripe billing. Kanban workflow. GitHub + Slack integrations. MVP in 6 weeks; full launch in 12."';
 
         const canGenerate = computed(() => description.value.trim().length >= 20);
+
+        // True once a plan has been produced and is still held in memory.
+        // Drives the dual-button layout on Step 1 (Next + Re-Generate)
+        // when the user comes back from the preview/review screen.
+        // We check `sprints` length too so a stale `{}` or partial object
+        // from a failed run never trips this flag.
+        const hasGeneratedPlan = computed(() => {
+            const p = plan.value;
+            return !!(p && p.project && Array.isArray(p.sprints) && p.sprints.length > 0);
+        });
+
+        // Navigate to the review step using the in-memory plan as-is —
+        // no LLM call, no token spend. Used by the "Next" button on
+        // Step 1 when the user returned from the preview screen.
+        function onNextWithExistingPlan() {
+            if (!hasGeneratedPlan.value) return;
+            error.value = '';
+            step.value = 'preview';
+        }
 
         const totals = computed(() => {
             if (!plan.value || !Array.isArray(plan.value.sprints)) return { sprints: 0, tasks: 0 };
@@ -603,10 +637,10 @@ export default defineComponent({
             plan, planId, editableProjectName,
             jobId, progress, createdProjectId,
             placeholderText,
-            canGenerate, totals,
+            canGenerate, hasGeneratedPlan, totals,
             renderTaskDescription, isStepDone, stepClass, stepDoneDot, rowClass, stepIcon, stepStatusLabel,
             onFileChosen, clearBrief,
-            onGeneratePlan,
+            onGeneratePlan, onNextWithExistingPlan,
             onApprovePlan, onOpenProject, onRetry, onClose,
         };
     },


### PR DESCRIPTION
Two independent improvements to the AI Project Generator. Both land in the same PR because they're typically tested in the same flow.

## 1. Preserve generated plan across Step 1 ↔ Step 2 navigation

**File:** `frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue`

### Before

User generates a plan → reviews it on Step 2 → clicks Back to tweak the description → returns to Step 1 → **the only forward path is to regenerate the plan from scratch**, burning tokens unnecessarily.

The interesting detail: the plan ref was *already* being preserved across the Back navigation — the existing handler did `step = 'input'` without nulling `plan.value`. The behaviour was half-implemented; only the UI surface to act on the still-present plan was missing.

### After

Step 1's actions row now has two layouts depending on whether a plan is already in memory:

| State | Layout |
|---|---|
| First-time, no plan | Single primary `Generate plan` button (unchanged) |
| Returned from preview | Split row: ghost `Re-Generate Plan` (left) · primary `Next →` (right) |

- `Next →` flips `step` to `'preview'` directly — zero LLM calls, zero token spend.
- `Re-Generate Plan` reuses the existing `onGeneratePlan()` — same behaviour as the first-time path.
- New `hasGeneratedPlan` computed guards the dual-button render and explicitly checks `Array.isArray(p.sprints) && p.sprints.length > 0` so a stale or partial object can't trip the layout.

### Safety

- ✅ The "Next" handler does NOT call any AI endpoint (verified by automated check).
- ✅ Failed regeneration keeps the previous plan intact (`plan.value` is only assigned after success in `onGeneratePlan`).
- ✅ Closing the modal still nulls `plan.value` (existing behaviour in `onClose`), so reopening returns to the single-button layout.

## 2. Bypass the project-limit gate in the orchestrator

**File:** `Modules/AIProjectGenerator/orchestrator.js`

### Before

`checkProjectPlan` failures (e.g. plan ceiling tripped) bubbled up as a thrown `PLAN_LIMIT` error → the outer catch fired `rollback()` → users saw `"Project limit reached for this plan. Please upgrade or remove an existing project."` and the AI flow aborted.

### After

The rejection is caught and logged as a warning. Project creation proceeds.

### Key implementation detail — counter accuracy

`checkProjectPlan` internally `$inc`s the company's `projectCount.{projectCount,publicCount,privateCount}` counters **before** checking the ceiling. We keep the call so AI-created projects stay counted exactly like manually-created ones.

`tracker.countIncremented` is now set based on **whether the `$inc` actually happened**:

```js
const incrementFailed = err && err.countRollBack === false;
if (!incrementFailed) tracker.countIncremented = true;
```

This preserves rollback math for two distinct rejection modes:

| Rejection mode | `countRollBack === false`? | `countIncremented` after bypass | If a downstream step fails, rollback decrements? |
|---|---|---|---|
| Mongo write error (`$inc` didn't run) | yes | false | no — correct, nothing to undo |
| Ceiling tripped (`$inc` ran, then limit check failed) | no | true | yes — correct, mirrors the limit-not-tripped path |

### What's untouched

- The manual `createProject` flow (`Modules/createProject/controller.js`) still enforces its limits. The bypass is **only** for the AI flow.
- The orchestrator's outer `rollback()` and its decrement logic are untouched — they still fire on downstream failures.

## Test plan

### Plan-preservation
- [ ] Open AI Project Creator, type a 20+ char description, click `Generate plan`. Wait for preview.
- [ ] On Step 2, click Back. Verify Step 1 now shows two buttons: `Re-Generate Plan` (left, ghost) and `Next →` (right, primary).
- [ ] Click `Next →`. Verify it returns to the preview screen **instantly** with no AI call (network tab should show no `/api/ai/...` request, no SSE traffic).
- [ ] Click Back again, then `Re-Generate Plan`. Verify an AI call fires and a new plan appears.
- [ ] Close the modal and reopen it. Verify Step 1 shows the single `Generate plan` button (no leftover dual-button state).
- [ ] Trigger a generation that produces a partial / malformed plan. Verify the dual-button state does NOT appear (the `sprints[]` length guard).

### Limit bypass
- [ ] Set the company's `planFeature.project` (or `maxPublicProject` / `maxPrivateProject`) to `0` so the limit ceiling will trip on any AI-create attempt.
- [ ] Trigger the AI Project Generator flow. Verify project creation **completes successfully** (no `PLAN_LIMIT` error).
- [ ] After completion, check the company doc: `projectCount.projectCount` should be `+1` from before — counter still tracking accurately.
- [ ] Trigger a flow that fails downstream (e.g. break a Mongo connection mid-flow). Verify the rollback still decrements the counter back to its pre-flow value.
- [ ] Trigger the **manual** createProject flow (non-AI) with the same `planFeature.project = 0`. Verify it still rejects with the limit error — proving the manual flow is unaffected.
- [ ] Check logs: every bypassed rejection should produce a `[AIPG][jobId] checkProjectPlan rejected — bypassed (reason: …, incrementApplied: …)` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)