### PR TITLE
fix(ai-project-creator): block outside-click while a run is in flight

### DIFF
--- a/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
+++ b/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
@@ -2,10 +2,10 @@
     <Sidebar
         v-if="visible"
         :visible="visible"
-        :close-on-back-drop="step !== 'executing'"
+        :close-on-back-drop="!isBusy"
         :width="clientWidth <= 768 ? '100%' : '780px'"
         :top="clientWidth <= 767 ? '0px' : '46px'"
-        @update:visible="onClose">
+        @update:visible="onSidebarVisibleChange">
         <template #head-left>
             <span class="aipg-head-title">
                 <span class="aipg-spark" aria-hidden="true">✨</span>
@@ -18,8 +18,8 @@
                 :src="closeIcon"
                 alt="Close"
                 class="aipg-close-icon"
-                :class="{ 'aipg-close-icon-disabled': loading || briefUploading }"
-                @click="(loading || briefUploading) ? null : onClose()"/>
+                :class="{ 'aipg-close-icon-disabled': isBusy }"
+                @click="isBusy ? null : onClose()"/>
         </template>
         <template #body>
             <div class="aipg-wrapper">
@@ -346,6 +346,17 @@ export default defineComponent({
         // The answers/skips the user submitted from the Clarify step,
         // sent verbatim into /plan as the `clarifications` array.
         const clarifications = ref(null);
+
+        // True when ANY in-flight operation owns the modal — brief upload,
+        // clarify LLM call, plan LLM call, or the orchestrator's execute
+        // job. The backdrop-close + X-icon both gate on this so a stray
+        // outside click cannot abort an in-flight LLM/orchestrator run.
+        const isBusy = computed(() =>
+            step.value === 'executing'
+            || loading.value
+            || clarifyLoading.value
+            || briefUploading.value,
+        );
 
         const description = ref('');
         // Mirrors the manual flow's workspace step: 'public' → private=false.
@@ -756,6 +767,16 @@ export default defineComponent({
             rolledBack.value = false;
         }
 
+        // Defensive guard for the Sidebar's `update:visible` event. The
+        // backdrop already honors `:close-on-back-drop="!isBusy"`, but
+        // Sidebar may also emit close from ESC key or programmatic paths
+        // — refuse all of them while a run is in flight.
+        function onSidebarVisibleChange(nextVisible) {
+            if (nextVisible) return;     // open events are parent-driven; ignore
+            if (isBusy.value) return;    // mid-run: refuse to close
+            onClose();
+        }
+
         function onClose() {
             if (step.value === 'executing') return;
             if (unsubscribeProgress.value) {
@@ -812,12 +833,12 @@ export default defineComponent({
             plan, planId, editableProjectName,
             jobId, progress, createdProjectId,
             placeholderText,
-            canGenerate, hasGeneratedPlan, hasGeneratedQuestions, totals,
+            canGenerate, hasGeneratedPlan, hasGeneratedQuestions, totals, isBusy,
             renderTaskDescription, isStepDone, stepClass, stepDoneDot, rowClass, stepIcon, stepStatusLabel,
             onFileChosen, clearBrief,
             onGeneratePlan, onNextWithExistingPlan,
             onRegenerateQuestions, onNextWithExistingQuestions,
-            onApprovePlan, onOpenProject, onRetry, onClose,
+            onApprovePlan, onOpenProject, onRetry, onClose, onSidebarVisibleChange,
             // Clarify step
             clarifyLoading, clarifyQuestions, clarifyUnderstanding, clarifyError,
             onClarifySubmit, onClarifyBack, onClarifyRetry, onClarifySkipAll,


### PR DESCRIPTION
## Summary

The AI project wizard's backdrop-close only checked `step !== 'executing'`, so an accidental click outside the sidebar would close the modal mid-clarify or mid-plan call — aborting an in-progress LLM run from the user's point of view.

This change introduces an `isBusy` computed that is true whenever the modal owns an in-flight operation, and wires it into every close-path.

## What's busy?

```js
const isBusy = computed(() =>
    step.value === 'executing'    // orchestrator running
    || loading.value              // plan LLM call
    || clarifyLoading.value       // clarify LLM call
    || briefUploading.value,      // brief PDF/DOCX upload
);
```

## Close-paths now guarded

| Path | Before | After |
|---|---|---|
| Backdrop click | Allowed except during `'executing'` | Refused whenever `isBusy` |
| **X** icon click | Hidden during `'executing'`; disabled-styled during `loading \|\| briefUploading` (didn't include `clarifyLoading`) | Hidden during `'executing'`; disabled-styled and click-guarded on `isBusy` |
| `update:visible(false)` from Sidebar (ESC, programmatic) | Always routed straight to `onClose` | Routed through `onSidebarVisibleChange`, which refuses while `isBusy` |

Idle states (Step 1 / Clarify with rendered questions / Preview / Done / Error) still close freely. Only mid-run closes are refused.

## Test plan

- [x] Click "Create with AI", type a description, click **Generate plan** → while the clarify spinner is showing, click outside the sidebar — modal stays open, clarify call completes.
- [x] On the Clarify step, click **Generate plan (n/n)** → while the plan is generating, click outside — modal stays open, plan completes and transitions to Preview.
- [x] Drop a PDF brief → while it's uploading, click outside — modal stays open until upload finishes.
- [x] During the orchestrator's `executing` phase, click outside — modal stays open (was already true; verify no regression).
- [x] Press ESC while a clarify or plan call is in flight — modal stays open.
- [x] On any idle state (initial Step 1, Clarify with questions rendered, Preview, Done, Error) — click outside or X — modal closes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)