### PR TITLE
ci: run validate + deploy only on push to staging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,13 @@
 name: CI / Deploy
 
 on:
+  # Run only when something lands on staging (a PR merge counts as a push,
+  # so validate + deploy still cover every code change going live).
+  # Open / updated PRs no longer trigger this workflow, which keeps CI
+  # minutes off in-progress branches.
   push:
     branches:
       - staging
-
-  pull_request:
-    branches:
-      - staging
-    types:
-      - opened
-      - synchronize
-      - reopened
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- Drop the `pull_request` trigger from the CI workflow so it only runs on `push` to `staging` (which a merged PR produces) and via `workflow_dispatch`.
- This stops the workflow from running on every PR open / synchronize / reopen, which was wasting CI minutes on in-progress branches.
- Every code change that actually lands on `staging` still gets validated and deployed because a PR merge produces a push event.

## Test plan

- [ ] Open any new PR against `staging` — no GitHub Actions run should appear on the PR.
- [ ] Merge a PR into `staging` — the **CI / Deploy** workflow runs, validates, and deploys as before.
- [ ] Trigger via Actions → Run workflow (workflow_dispatch) — still works manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)