### PR TITLE
fix(bulk-action): show all company users in assignee picker for public projects

### DIFF
--- a/frontend/src/components/molecules/BulkActionBar/BulkActionBar.vue
+++ b/frontend/src/components/molecules/BulkActionBar/BulkActionBar.vue
@@ -345,15 +345,16 @@ const availablePriorities = computed(() => {
     return Array.isArray(data) ? data : [];
 });
 // Build a clean { id, label, image } list of users available to assign.
-// Prefer project members (AssigneeUserId on projectData). Fall back to
-// active company users for projects without a restricted member list.
-// Backend re-validates permission per task in any case.
+// Private-space projects restrict to the project's member list; public
+// projects allow any active company user — matches the per-task assignee
+// picker in TaskDetailRightSide. Backend re-validates permission per task.
 const assigneeUserList = computed(() => {
+    const isPrivateSpace = !!projectData?.value?.isPrivateSpace;
     const projectIds = Array.isArray(projectData?.value?.AssigneeUserId)
         ? projectData.value.AssigneeUserId
         : [];
     const companyUsers = getters['settings/companyUsers'] || [];
-    const sourceIds = projectIds.length
+    const sourceIds = isPrivateSpace
         ? projectIds
         : companyUsers.filter((u) => u && u.isDelete === false).map((u) => u.userId);
 


### PR DESCRIPTION
## Summary
- Bulk-action **Assignees** dropdown was showing only one user (e.g. just *Modi Owner*) on public projects, even though those projects allow any company user to be assigned.
- Root cause: `assigneeUserList` in `BulkActionBar.vue` always preferred `projectData.AssigneeUserId` when non-empty, restricting the picker to explicitly listed project members. The per-task picker in `TaskDetailRightSide.vue` correctly falls back to all active company users when the project is not a private space.
- Fix: gate the project-vs-company fallback on `projectData.isPrivateSpace`, matching the per-task picker's logic.

## Test plan
- [x] Open a **public** project with explicit members fewer than total company users
- [x] Select 2+ tasks, click **Assignees** in the bulk-action bar
- [x] Confirm the dropdown lists **all active company users** (not just those in `projectData.AssigneeUserId`)
- [x] Assign tasks to a user who was previously missing — verify it persists after refresh
- [x] Repeat on a **private-space** project; confirm dropdown stays restricted to the project's member list
- [x] Confirm the per-task assignee picker behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)