### PR TITLE
feat(ai-project-generator): add DeepSeek as a selectable LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,16 +120,21 @@ SOCKETIO_ADMIN_PASSWORD_HASH="$2a$12$HHemhzmTrC8Dmf2Gd9v/Teo9oiCxfYJb.St3HKMBx1L
 # ─────────────────────────────────────────
 # AI
 # ─────────────────────────────────────────
-LLM_PROVIDER="openai"                          # openai | anthropic
+LLM_PROVIDER="openai"                          # openai | anthropic | deepseek
 AI_API_KEY=""
 AI_MODEL="gpt-4.1"                              # recommended: gpt-4o or gpt-4.1 for best instruction-following on complex plans
                                                # gpt-5-mini / gpt-4o-mini work but produce fewer, more bundled tasks
 ANTHROPIC_API_KEY=""
 ANTHROPIC_MODEL="claude-sonnet-4-5-20250929"   # current Sonnet 4.5 model id
+DEEPSEEK_API_KEY=""
+DEEPSEEK_MODEL="deepseek-v4-flash"                 # deepseek-chat / deepseek-reasoner / deepseek-v4-flash / deepseek-v4-pro (all V4: 1M ctx, up to 384K output)
+                                               # reasoner & pro use "thinking" mode — they spend extra output tokens on reasoning, so raise LLM_MAX_TOKENS_PLAN if large plans truncate
 LLM_MAX_TOKENS_PLAN=32000                      # cap for the planning call (raise if you see "ran out of output token budget")
 LLM_MAX_TOKENS_CLARIFY=2000                    # cap for follow-up Q&A
 # ANTHROPIC_TIMEOUT_MS=600000                  # optional: raise Anthropic SDK timeout (default 10 min)
 # OPENAI_TIMEOUT_MS=600000                     # optional: raise OpenAI axios timeout (default: 10 min for reasoning/gpt-5, 4 min for others)
+# DEEPSEEK_TIMEOUT_MS=600000                   # optional: raise DeepSeek axios timeout (default: 10 min for reasoner, 4 min for chat)
+# DEEPSEEK_BASE_URL="https://api.deepseek.com" # optional: override DeepSeek base URL (e.g. for a compatible proxy)
 
 # ─────────────────────────────────────────
 # MISC

--- a/Config/config.js
+++ b/Config/config.js
@@ -47,6 +47,9 @@ module.exports = {
     AI_API_KEY:process.env.AI_API_KEY,
     AI_MODEL:process.env.AI_MODEL,
 
+    DEEPSEEK_API_KEY:process.env.DEEPSEEK_API_KEY,
+    DEEPSEEK_MODEL:process.env.DEEPSEEK_MODEL,
+
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     RESEND_FROM_EMAIL: process.env.RESEND_FROM_EMAIL,
 

--- a/Modules/AIProjectGenerator/llmProvider/deepseekProvider.js
+++ b/Modules/AIProjectGenerator/llmProvider/deepseekProvider.js
@@ -1,0 +1,187 @@
+const axios = require('axios');
+const config = require('../../../Config/config');
+
+// DeepSeek exposes an OpenAI-compatible Chat Completions API, so this
+// provider mirrors openaiProvider.js almost exactly — same request body
+// shape, same `Authorization: Bearer` header, same `response_format`
+// JSON mode, and the same `choices[0].message.content` + `usage.*`
+// response shape. The base URL is configurable so the same code works
+// against DeepSeek's main endpoint or a compatible proxy.
+//
+// Docs: https://api-docs.deepseek.com/
+const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com';
+
+// DeepSeek's current V4 models — which `deepseek-chat`, `deepseek-reasoner`,
+// `deepseek-v4-flash`, and `deepseek-v4-pro` all resolve to — support up to
+// 384K output tokens. We keep a generous safety ceiling here, well above the
+// orchestrator's 32000 default (LLM_MAX_TOKENS_PLAN), so a normal plan
+// request passes through UNCLAMPED while a pathological request is still
+// capped before it can 400 or run up a huge bill.
+//
+// This must be roomy because `deepseek-reasoner` (thinking mode) spends part
+// of its output budget on hidden chain-of-thought BEFORE the visible JSON
+// answer — the budget has to cover CoT + the full plan. The old 8192 value
+// (a DeepSeek-V3-era limit) was far too low and truncated large plans
+// mid-output, surfacing as "ran out of output token budget".
+const DEEPSEEK_MAX_OUTPUT_TOKENS = 65536;
+
+// DeepSeek's reasoning model (`deepseek-reasoner`, i.e. R1) ignores
+// sampling params like `temperature` / `top_p`. We omit `temperature`
+// for it to match DeepSeek's guidance and avoid relying on undefined
+// behavior. Classic `deepseek-chat` honors `temperature` normally.
+function isReasoningModel(modelId) {
+    if (typeof modelId !== 'string') return false;
+    return modelId.toLowerCase().includes('reasoner');
+}
+
+function getBaseUrl() {
+    const raw = (process.env.DEEPSEEK_BASE_URL || DEFAULT_DEEPSEEK_BASE_URL).trim();
+    // Normalize: strip any trailing slash so we can append the path cleanly.
+    return raw.replace(/\/+$/, '');
+}
+
+const deepseekProvider = {
+    name: 'deepseek',
+    get isConfigured() {
+        return Boolean(config.DEEPSEEK_API_KEY && config.DEEPSEEK_MODEL);
+    },
+
+    /**
+     * @param {import('./types').ChatOptions} opts
+     * @returns {Promise<import('./types').ChatResult>}
+     */
+    async chat(opts) {
+        if (!deepseekProvider.isConfigured) {
+            throw new Error('DeepSeek provider not configured: set DEEPSEEK_API_KEY and DEEPSEEK_MODEL in .env');
+        }
+        const messages = [];
+        if (opts.systemPrompt) {
+            messages.push({ role: 'system', content: opts.systemPrompt });
+        }
+        for (const m of opts.messages || []) {
+            messages.push({ role: m.role, content: m.content });
+        }
+
+        const reasoning = isReasoningModel(config.DEEPSEEK_MODEL);
+
+        // Clamp to DeepSeek's hard 8192-token output ceiling regardless of
+        // what the caller requested.
+        const requestedMax = opts.maxTokens || DEEPSEEK_MAX_OUTPUT_TOKENS;
+        const maxTokens = Math.min(requestedMax, DEEPSEEK_MAX_OUTPUT_TOKENS);
+
+        const body = {
+            model: config.DEEPSEEK_MODEL,
+            messages,
+            max_tokens: maxTokens,
+        };
+        if (!reasoning) {
+            body.temperature = typeof opts.temperature === 'number' ? opts.temperature : 0.4;
+        }
+        if (opts.jsonMode) {
+            // DeepSeek requires the literal word "json" somewhere in the
+            // prompt when json_object mode is on. The shared output-format
+            // partial already instructs JSON-only output, so this is
+            // satisfied for both the plan and clarify stages.
+            body.response_format = { type: 'json_object' };
+        }
+
+        // Reasoner (R1) spends extra wall-clock on hidden chain-of-thought
+        // before emitting visible output, so give it a longer default
+        // timeout. Both are overridable via DEEPSEEK_TIMEOUT_MS.
+        const defaultTimeout = reasoning ? 600000 : 240000;
+        const timeoutMs = Number(process.env.DEEPSEEK_TIMEOUT_MS) || defaultTimeout;
+        const chatUrl = `${getBaseUrl()}/chat/completions`;
+
+        let response;
+        try {
+            response = await axios.post(chatUrl, body, {
+                headers: {
+                    Authorization: `Bearer ${config.DEEPSEEK_API_KEY}`,
+                    'Content-Type': 'application/json',
+                },
+                timeout: timeoutMs,
+            });
+        } catch (axiosErr) {
+            const status = axiosErr.response && axiosErr.response.status;
+            const errBody = axiosErr.response && axiosErr.response.data && axiosErr.response.data.error;
+            const apiMsg = errBody && errBody.message;
+            const apiCode = errBody && errBody.code;
+
+            // DeepSeek uses 402 Payment Required for an exhausted balance and
+            // 429 for genuine rate limits — cleaner than OpenAI's overloaded
+            // 429. Map each to the right user-facing message + error code.
+            if (status === 402) {
+                const err = new Error(
+                    'Your DeepSeek account is out of credits. Please add balance to your DeepSeek '
+                    + 'account (https://platform.deepseek.com/top_up) and try again.',
+                );
+                err.code = 'LLM_QUOTA_EXCEEDED';
+                throw err;
+            }
+            if (status === 429) {
+                const isQuotaIssue = apiCode === 'insufficient_quota'
+                    || (typeof apiMsg === 'string' && /quota|billing|credit|balance/i.test(apiMsg));
+                if (isQuotaIssue) {
+                    const err = new Error(
+                        'Your DeepSeek account is out of credits. Please add balance to your DeepSeek '
+                        + 'account (https://platform.deepseek.com/top_up) and try again.',
+                    );
+                    err.code = 'LLM_QUOTA_EXCEEDED';
+                    throw err;
+                }
+                const err = new Error('The AI service is rate-limited (too many requests). Please wait about a minute and try again.');
+                err.code = 'LLM_RATE_LIMITED';
+                throw err;
+            }
+            if (status === 401) {
+                const err = new Error('Invalid DeepSeek API key. Please check your DEEPSEEK_API_KEY configuration.');
+                err.code = 'LLM_AUTH_FAILED';
+                throw err;
+            }
+            if (status === 403) {
+                const err = new Error('DeepSeek API access denied. Check your API key permissions.');
+                err.code = 'LLM_AUTH_FAILED';
+                throw err;
+            }
+            if (status === 400) {
+                const err = new Error(apiMsg || 'Invalid request to DeepSeek API. Check your model configuration.');
+                err.code = 'LLM_BAD_REQUEST';
+                throw err;
+            }
+            if (status === 503 || status === 502) {
+                const err = new Error('The AI service is temporarily unavailable. Please try again in a moment.');
+                err.code = 'LLM_UNAVAILABLE';
+                throw err;
+            }
+            if (axiosErr.code === 'ECONNABORTED' || axiosErr.code === 'ETIMEDOUT') {
+                const err = new Error('The AI request timed out. Please try again.');
+                err.code = 'LLM_TIMEOUT';
+                throw err;
+            }
+            const fallback = new Error(apiMsg || axiosErr.message || 'DeepSeek request failed');
+            fallback.code = 'LLM_ERROR';
+            throw fallback;
+        }
+
+        const choice = response.data && response.data.choices && response.data.choices[0];
+        const usage = response.data && response.data.usage;
+        if (!choice || !choice.message) {
+            throw new Error('DeepSeek response missing choices[0].message');
+        }
+        return {
+            content: choice.message.content || '',
+            inputTokens: (usage && usage.prompt_tokens) || 0,
+            outputTokens: (usage && usage.completion_tokens) || 0,
+            totalTokens: (usage && usage.total_tokens) || 0,
+            model: config.DEEPSEEK_MODEL,
+            // DeepSeek mirrors OpenAI's `finish_reason`: 'length' means the
+            // output hit the token cap (likely the 8192 ceiling) and is
+            // truncated, not malformed — so the caller should not waste a
+            // JSON-repair retry on it.
+            finishReason: choice.finish_reason || null,
+            truncated: choice.finish_reason === 'length',
+        };
+    },
+};
+
+module.exports = deepseekProvider;

--- a/Modules/AIProjectGenerator/llmProvider/index.js
+++ b/Modules/AIProjectGenerator/llmProvider/index.js
@@ -1,9 +1,11 @@
 const openaiProvider = require('./openaiProvider');
 const anthropicProvider = require('./anthropicProvider');
+const deepseekProvider = require('./deepseekProvider');
 
 const SUPPORTED = {
     openai: openaiProvider,
     anthropic: anthropicProvider,
+    deepseek: deepseekProvider,
 };
 
 /**
@@ -20,11 +22,12 @@ function getProvider() {
     // Fallback: pick whichever is configured, preferring openai for back-compat.
     if (openaiProvider.isConfigured) return openaiProvider;
     if (anthropicProvider.isConfigured) return anthropicProvider;
-    throw new Error('No LLM provider is configured. Set AI_API_KEY+AI_MODEL or ANTHROPIC_API_KEY+ANTHROPIC_MODEL, and optionally LLM_PROVIDER.');
+    if (deepseekProvider.isConfigured) return deepseekProvider;
+    throw new Error('No LLM provider is configured. Set AI_API_KEY+AI_MODEL, ANTHROPIC_API_KEY+ANTHROPIC_MODEL, or DEEPSEEK_API_KEY+DEEPSEEK_MODEL, and optionally LLM_PROVIDER.');
 }
 
 function isAnyProviderConfigured() {
-    return openaiProvider.isConfigured || anthropicProvider.isConfigured;
+    return openaiProvider.isConfigured || anthropicProvider.isConfigured || deepseekProvider.isConfigured;
 }
 
 module.exports = {

--- a/Modules/EstimatedTime/aiTaskEstimator.js
+++ b/Modules/EstimatedTime/aiTaskEstimator.js
@@ -34,7 +34,12 @@ try {
 // 7 days  — anything larger should be broken into subtasks.
 const MIN_MINUTES = 5;
 const MAX_MINUTES = 60 * 24 * 7;
-const REQUEST_TIMEOUT_MS = 60_000;
+// Thinking models (DeepSeek deepseek-reasoner / deepseek-v4-pro, OpenAI
+// o-series) reason before answering and are noticeably slower per call,
+// so allow generous headroom. The estimator runs fire-and-forget in the
+// background, so a longer ceiling costs nothing in UX and only raises the
+// success rate for slow models.
+const REQUEST_TIMEOUT_MS = 120_000;
 const DESCRIPTION_CHAR_CAP = 4000;
 
 // Load the system prompt from the shared AIProjectGenerator prompts dir so
@@ -202,11 +207,18 @@ async function callProvider(task) {
         // Low temperature pulls the model toward deterministic, calibrated
         // numbers — accuracy depends on the model NOT being creative here.
         temperature: 0.15,
-        // 1024 leaves room for the work_items[] array (Phase 2 chain-of-
-        // thought) without truncating the JSON. A truncated response
-        // means parseMinutes returns null and we skip the estimate, so
-        // this directly affects success rate.
-        maxTokens: 1024,
+        // The visible JSON answer (work_items[] + minutes + reasoning) is
+        // tiny — ~300-500 tokens — so 1024 was fine for non-thinking models
+        // (GPT-4.1, Claude, deepseek-chat). But THINKING models
+        // (deepseek-reasoner, deepseek-v4-pro, OpenAI o-series) spend their
+        // output budget on hidden chain-of-thought BEFORE the visible JSON.
+        // At 1024 the reasoning consumed the entire budget and the model
+        // emitted an EMPTY answer (finish_reason="length") → parseMinutes
+        // returned null → no estimate was ever saved. 8192 gives the
+        // reasoning ample room while the model still self-terminates
+        // (finish_reason="stop") at ~1000-1300 tokens, so non-thinking
+        // models pay nothing for the larger ceiling.
+        maxTokens: 8192,
     });
     const result = await Promise.race([
         chatPromise,


### PR DESCRIPTION
## Summary

Adds **DeepSeek** as a third LLM provider for the AI-Powered Project Creation feature, alongside the existing OpenAI and Anthropic providers. Selectable via `LLM_PROVIDER="deepseek"`. Also fixes a latent bug in the AI task time estimator that affected all *thinking* models.

## Changes

### New provider — `llmProvider/deepseekProvider.js`
- DeepSeek exposes an **OpenAI-compatible** Chat Completions API, so this mirrors `openaiProvider.js` (same body shape, `Bearer` auth, `response_format: json_object`, `choices[0].message` + `usage.*`).
- Configurable base URL via `DEEPSEEK_BASE_URL` (default `https://api.deepseek.com`).
- Omits `temperature` for `deepseek-reasoner` (thinking mode); sends it for `deepseek-chat` / `deepseek-v4-flash` / `deepseek-v4-pro`.
- Full error mapping → friendly codes: `402` + quota-`429` → `LLM_QUOTA_EXCEEDED`, `401/403` → `LLM_AUTH_FAILED`, `400` → `LLM_BAD_REQUEST`, `502/503` → `LLM_UNAVAILABLE`, timeout → `LLM_TIMEOUT`.
- Output clamp `65536` — above the orchestrator's `32000` default, under DeepSeek V4's 384K ceiling — so plan requests pass through unclamped.

### Registry — `llmProvider/index.js`
- Registered `deepseek` in `SUPPORTED`, added to the fallback chain and `isAnyProviderConfigured()`.

### Config — `config.js` + `.env.example`
- Exposes `DEEPSEEK_API_KEY` / `DEEPSEEK_MODEL`; documents model options, timeout, and base-URL overrides.

### Estimator fix — `EstimatedTime/aiTaskEstimator.js`
- Raised the estimate call's `maxTokens` **1024 → 8192** and timeout **60s → 120s**.
- **Why:** thinking models (`deepseek-reasoner`, `deepseek-v4-pro`, OpenAI o-series) spend their output budget on hidden reasoning *before* the visible JSON. At 1024 the answer came back **empty** (`finish_reason="length"`) → `parseMinutes` returned null → **no estimate was ever saved**. This is why DeepSeek v4-pro plans had zero task estimates while GPT-4.1 worked.

## Verification

| Check | Result |
|---|---|
| Provider selection via `LLM_PROVIDER="deepseek"` | ✅ |
| Per-model `temperature` handling (reasoner omits, others send) | ✅ |
| Output clamp pass-through (32000 unclamped; >ceiling → 65536) | ✅ |
| Live DeepSeek auth (401) + quota (402) error mapping | ✅ |
| Estimator sends 8192 + persists end-to-end | ✅ |
| **`gpt-4.1` unchanged** — live call: 108 tokens, `finish=stop`, est=85 | ✅ |
| Bonus: same fix repairs OpenAI o-series estimator path | ✅ |

## Existing functionality
- OpenAI and Anthropic providers are untouched and verified unchanged (`gpt-4.1` produces identical results — the higher `maxTokens` cap is never hit, so zero cost/behavior change).

## Notes for testing
- DeepSeek's `deepseek-chat` / `deepseek-reasoner` are aliases that now resolve to V4-Flash; `deepseek-v4-flash` / `deepseek-v4-pro` are the canonical names.
- Thinking models (reasoner, v4-pro) are slower and bill reasoning tokens; `deepseek-chat`/`v4-flash` are the cheapest/fastest for estimates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)