### PR TITLE
fix(task-detail): always show AI estimate trigger in task sidebar

### DIFF
--- a/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
+++ b/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
@@ -164,16 +164,10 @@
                       title attribute matches the project's existing tooltip
                       convention (see BulkActionBar.vue / CheckList.vue).
                       Disabled + spinner state while a request is in flight.
-
-                      Permission gate: `=== true` (read-write) only. The outer
-                      row's `!== null` gate already covers visibility for the
-                      read-only case; this inner gate hides the AI trigger
-                      from users who can see the estimate but not edit it —
-                      matching the convention used by Priority / Start Date /
-                      Due Date rows in this same component.
+                      Shown whenever the Estimated row is visible — the per-user
+                      edit-permission gate (`=== true`) was removed on request.
                     -->
                     <button
-                        v-if="checkPermission('task.task_estimated_hours', project?.isGlobalPermission) === true"
                         type="button"
                         class="ai-estimate-btn"
                         :class="{ 'is-loading': isAiEstimateLoading }"


### PR DESCRIPTION
## What
Removes the per-user edit-permission gate on the manual **"Generate estimate using AI"** button in the task detail sidebar (the AI icon next to the **Estimated** field).

## Why
The button was gated on `checkPermission('task.task_estimated_hours') === true` (edit permission). Users who could **see** the estimate row but lacked edit permission never saw the button. It is now shown whenever the Estimated row is visible.

## Change
- `frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue` — remove the `v-if` edit-permission gate on the AI estimate trigger button (and update the stale explanatory comment).

Single-file, frontend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility of the AI estimate feature by refining permission requirements for task estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->