### PR TITLE
ci: optimize staging deploy — lower RAM, merge-only trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,10 @@
 name: CI / Deploy
 
 on:
+  # Run only when changes land on `staging` — i.e. when a PR is merged.
   push:
     branches:
       - staging
-
-  pull_request:
-    branches:
-      - staging
-    types:
-      - opened
-      - synchronize
-      - reopened
 
   workflow_dispatch:
 
@@ -168,15 +161,62 @@ jobs:
             echo "📥 Updating backend source"
 
             git fetch origin staging
+
+            # ---------------------------------
+            # Decide whether backend dependencies need reinstalling
+            # ---------------------------------
+            # Run `npm ci` only when one of these is true; otherwise skip it
+            # and avoid the RAM spike:
+            #   1. node_modules is missing      (first deploy / wiped)
+            #   2. package-lock.json changed    (dependencies changed)
+            #   3. Node major changed since the last install (e.g. 22 <-> 20.x)
+            #      — native addons like bcrypt/sharp are built per Node ABI, so
+            #      a version switch must rebuild them or the app crashes on boot.
+            #
+            # The lockfile check runs BEFORE `git reset --hard`, while HEAD
+            # still points at the currently-deployed commit.
+
+            NODE_MAJOR="$(node -v | cut -d. -f1 | tr -d 'v')"   # e.g. 22 or 20
+            NODE_MARKER="node_modules/.node-major"
+            BUILT_MAJOR="$(cat "$NODE_MARKER" 2>/dev/null || echo '')"
+
+            NEED_INSTALL=0
+            INSTALL_REASON=""
+
+            if [ ! -d node_modules ]; then
+              NEED_INSTALL=1
+              INSTALL_REASON="node_modules missing (first deploy)"
+            elif ! git diff --quiet HEAD origin/staging -- package-lock.json; then
+              NEED_INSTALL=1
+              INSTALL_REASON="dependencies changed"
+            elif [ "$BUILT_MAJOR" != "$NODE_MAJOR" ]; then
+              NEED_INSTALL=1
+              INSTALL_REASON="Node version changed (built on ${BUILT_MAJOR:-unknown}, now $NODE_MAJOR)"
+            fi
+
             git reset --hard origin/staging
 
             # ---------------------------------
-            # Install Backend Dependencies
+            # Install Backend Dependencies (only when needed)
             # ---------------------------------
 
-            echo "📦 Installing backend dependencies"
+            if [ "$NEED_INSTALL" = "1" ]; then
+              echo "📦 Installing backend dependencies — reason: $INSTALL_REASON"
 
-            npm ci --omit=dev
+              # Cap native-module build parallelism to keep peak RAM low:
+              # JOBS=1 makes node-gyp/make compile addons (e.g. bcrypt) one
+              # job at a time instead of one per CPU core. It only bites when a
+              # module has no prebuilt binary and falls back to a source build.
+              # --no-audit / --no-fund drop the post-install network audit and
+              # funding scan (the security audit already runs in the CI job).
+              JOBS=1 npm ci --omit=dev --no-audit --no-fund
+
+              # Record the Node major these modules were built against, so the
+              # next deploy can detect a version switch and rebuild them.
+              echo "$NODE_MAJOR" > "$NODE_MARKER"
+            else
+              echo "📦 No dependency or Node-version change — skipping npm ci"
+            fi
 
             # ---------------------------------
             # Frontend Backup + Deploy


### PR DESCRIPTION
## Summary
Optimizes the staging CI/Deploy workflow to lower peak RAM on the VPS during deployment and to run only when changes actually land on `staging`.

## Changes
- **Trigger on merge only** — runs on `push` to `staging` (a merged PR) and `workflow_dispatch`; removed the `pull_request` opened/synchronize/reopened triggers.
- **Skip redundant installs** — backend `npm ci` reruns only when `package-lock.json` changed (or `node_modules` is missing), avoiding the install RAM spike on code-only deploys.
- **Cap native build parallelism** — `JOBS=1` builds native addons (bcrypt/sharp) serially instead of one-per-core; `--no-audit --no-fund` drop post-install overhead (the security audit still runs in the `validate` job).
- **Safe across Node versions** — records the Node major used for the last install and rebuilds native modules when it changes, so switching between Node 22 and 20.x never leaves ABI-mismatched binaries (no crash on restart).

## Notes
- Because the `pull_request` trigger was removed, this PR does not run CI on itself — CI/Deploy runs when it is merged into `staging` (by design).
- The first deploy after merge runs one `npm ci` to establish the Node-version marker; subsequent code-only deploys skip it.
- Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
