### PR TITLE
ci(docker): skip PR triggers — build only on push to main + release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,21 +26,16 @@ name: Docker
 # ─────────────────────────────────────────────────────────────────────
 
 on:
+  # Build + publish image when a release tag is cut by release-please
   release:
     types: [published]
+
+  # Build + publish image on every commit to main (after a PR merges)
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'Dockerfile'
-      - '.dockerignore'
-      - 'docker-compose.yml'
-      - '.github/workflows/docker.yml'
-      - 'package.json'
-      - 'frontend/package.json'
+
+  # Manual trigger from the Actions UI
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Stop running the Docker multi-arch build on PRs. From now on, it only runs when something **actually needs to be published**:

- `release: published` → publishes versioned tags + `latest` (release-please-driven)
- `push: branches: [main]` → publishes `edge` + `main-<sha>`
- `workflow_dispatch` → manual run from the Actions UI

The `pull_request` trigger is removed.

## Why

Multi-arch docker builds (amd64 + arm64 via QEMU emulation) are slow:

| Scenario | Build time |
|---|---|
| First-time / cold cache | **12–18 min** |
| Warm GHA cache, only source changed | 3–6 min |
| Warm GHA cache, Dockerfile changed | 8–12 min |

Even the cached case is longer than every other CI check in this repo. On PR #216 today, the build was visibly blocking review for ~15 minutes per attempt. Since PR builds are `push: false` anyway (verification-only, nothing pushed to a registry), the value-to-cost ratio is poor.

## Trade-off

| Before | After |
|---|---|
| Docker breakage caught at PR-review time | Docker breakage caught at post-merge time on `main` |
| 15 min added to every Docker-touching PR | PRs are fast again |
| `push: false` build artifact discarded | (same — PR builds were never published anyway) |

If a Docker-breaking change does land on `main`:
- `release.yml` will fail when release-please tries to build for the release tag — surfaced before users see anything
- Revert via "Revert" button on the offending PR → 30 seconds

## What still triggers a build

| Event | Triggers? |
|---|---|
| PR opened against `main` (touches Docker files) | ❌ No (changed) |
| PR opened against `main` (no Docker changes) | ❌ No (was already no) |
| PR opened against `staging` | ❌ No (was already no — we removed staging earlier) |
| Push to `main` (e.g., PR merged) | ✅ Yes — builds + pushes `edge` + `main-<sha>` |
| Push to `staging` | ❌ No (was already no) |
| Release tag published (release-please) | ✅ Yes — builds + pushes `vX.Y.Z`, `latest`, `X.Y`, `X` |
| Manual trigger from Actions UI | ✅ Yes |

## Files changed (1)

| File | Change |
|---|---|
| `.github/workflows/docker.yml` | Remove `pull_request` trigger + its `paths` filter; add inline comments documenting each remaining trigger |

Diff: `+5 / -10 lines`.

## Test plan

- [ ] After merge, open any PR touching `Dockerfile` → Docker workflow should NOT run on it
- [ ] After merge, push a commit to `main` (or merge a PR to main) → Docker workflow SHOULD run and push `edge` + `main-<sha>` to GHCR
- [ ] Trigger `workflow_dispatch` manually → should run on demand
- [ ] When release-please publishes the next release, the `release: published` event should fire the workflow + push versioned tags

## Compatibility

✅ No conflict with any open PR (touches only `.github/workflows/docker.yml`)
✅ Doesn't touch the Dockerfile, docker-compose.yml, or any build artifact
✅ Doesn't change what gets published — only *when* it gets built

🤖 Generated with [Claude Code](https://claude.com/claude-code)