### PR TITLE
ci(docker): auto-detect Docker Hub credentials for dual-registry publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,12 +12,22 @@ name: Docker
 #                            still builds on every change
 #   • workflow_dispatch   — manual trigger from the Actions UI
 #
-# Pushing to Docker Hub:
-#   To also push to hub.docker.com, add two repo secrets:
-#     DOCKERHUB_USERNAME
-#     DOCKERHUB_TOKEN
-#   and uncomment the "Login to Docker Hub" and Docker Hub tag lines
-#   in the metadata-action `images:` block below.
+# Pushing to Docker Hub (optional, auto-detected):
+#   This workflow always publishes to GHCR. To also publish to
+#   hub.docker.com once the official Docker Hub account exists, add
+#   two repo SECRETS:
+#     DOCKERHUB_USERNAME   (the login username/account)
+#     DOCKERHUB_TOKEN      (a Docker Hub access token)
+#   The workflow auto-detects them on each run — no code changes
+#   needed. If the secrets are absent, the Docker Hub login + push
+#   are skipped cleanly and only GHCR is published.
+#
+#   Image namespace: defaults to `alianhub` → docker.io/alianhub/alianhub.
+#   If the official account/org is named differently, set the repo
+#   VARIABLE `DOCKERHUB_NAMESPACE` to that name (not a secret — it's
+#   not sensitive). Example: a personal login `rasheshmak` pushing to
+#   the `alianhub` org → DOCKERHUB_USERNAME=rasheshmak (secret) and
+#   DOCKERHUB_NAMESPACE=alianhub (variable).
 #
 # Multi-arch:
 #   Built for linux/amd64 and linux/arm64.
@@ -69,6 +79,33 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Detect Docker Hub credentials. This gates BOTH the Docker
+      # Hub login step below AND the docker.io image-name line in
+      # the metadata step further down. The workflow stays valid
+      # whether the secrets are set or not.
+      #
+      # The image namespace defaults to `alianhub` but can be
+      # overridden with the repo VARIABLE `DOCKERHUB_NAMESPACE`
+      # (Settings → Secrets and variables → Actions → Variables).
+      # This matters when the official Docker Hub account/org ends
+      # up named something other than `alianhub` — set the variable
+      # instead of editing this workflow.
+      - name: Detect Docker Hub credentials
+        id: dockerhub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ]; then
+            NS="${DOCKERHUB_NAMESPACE:-alianhub}"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "namespace=$NS" >> "$GITHUB_OUTPUT"
+            echo "✓ Docker Hub credentials detected — will publish to docker.io/$NS/alianhub"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ Docker Hub credentials not configured — publishing to GHCR only"
+          fi
+
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -77,23 +114,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # ── Uncomment after adding Docker Hub secrets ───────────────
-      # - name: Log in to Docker Hub
-      #   if: github.event_name != 'pull_request'
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request' && steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract image metadata (tags + labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # GHCR is always included; add Docker Hub by uncommenting the
-          # second line below after secrets are configured.
+          # GHCR is always included. The docker.io target is included
+          # only when Docker Hub secrets are configured — the expression
+          # below resolves to an empty line otherwise, which the action
+          # silently skips.
           images: |
             ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
-            # docker.io/alianhub/alianhub
+            ${{ steps.dockerhub.outputs.enabled == 'true' && format('docker.io/{0}/alianhub', steps.dockerhub.outputs.namespace) || '' }}
           tags: |
             # Semantic-version tags from release-please (e.g. v14.1.0)
             type=semver,pattern={{version}}


### PR DESCRIPTION
## Summary

Adds **optional Docker Hub publishing** alongside the existing GHCR publishing. The workflow auto-detects whether Docker Hub credentials are configured and adapts at runtime — so this PR can merge **now**, before the official Docker Hub account exists, and start working the moment the secrets are added later.

## Why merge before the account is ready

The team will set up an official Docker Hub account later. Rather than leave commented-out code that needs editing in three places when that happens, this workflow:

- ✅ Runs exactly as today (GHCR only) while no Docker Hub secrets exist — **zero behavior change on merge**
- ✅ Auto-detects `DOCKERHUB_USERNAME` on each run and, when present, publishes to Docker Hub too
- ✅ Needs **no code change** when the account is ready — just add the secrets

## How it behaves

| State | GHCR | Docker Hub |
|---|---|---|
| **Today (no secrets)** | ✅ Publishes | ⏭️ Skipped cleanly |
| **After secrets added** | ✅ Publishes | ✅ Publishes (same tag set) |

## Namespace is account-name-agnostic

The image namespace defaults to `alianhub` (`docker.io/alianhub/alianhub`) but is overridable **without editing the workflow**, via the repo **variable** `DOCKERHUB_NAMESPACE`:

| Official account scenario | Secrets / variables to set |
|---|---|
| Standalone account named `alianhub` | `DOCKERHUB_USERNAME=alianhub` + token. Namespace defaults to `alianhub` ✓ |
| Account named something else (e.g. `aliansoftware`) | `DOCKERHUB_USERNAME=aliansoftware` + token + set variable `DOCKERHUB_NAMESPACE=aliansoftware` |
| Personal login pushing into a brand org | `DOCKERHUB_USERNAME=<personal-login>` + token + `DOCKERHUB_NAMESPACE=alianhub` |

This covers every account shape without a future code edit.

## Files changed (1)

| File | Change |
|---|---|
| `.github/workflows/docker.yml` | New "Detect Docker Hub credentials" step (emits `enabled` + `namespace` outputs); conditional Docker Hub login step; `format()` expression in metadata `images:` list; updated header docs |

Diff: `+54 / -16`.

## What you (the team) do when the official account is ready

1. Create the official Docker Hub account/org
2. Generate a Docker Hub access token (Read + Write)
3. Add repo secrets:
   ```bash
   gh secret set DOCKERHUB_USERNAME --body "<account>" --repo aliansoftwareteam/AlianHub-Project-Management-System
   gh secret set DOCKERHUB_TOKEN --body "dckr_pat_..." --repo aliansoftwareteam/AlianHub-Project-Management-System
   ```
4. (Only if namespace ≠ `alianhub`) add the variable:
   ```bash
   gh variable set DOCKERHUB_NAMESPACE --body "<namespace>" --repo aliansoftwareteam/AlianHub-Project-Management-System
   ```
5. Trigger `workflow_dispatch` on the Docker workflow (or wait for the next release) → image publishes to Docker Hub

## Test plan

- [ ] After merge, with NO Docker Hub secrets set: push to main / cut a release → workflow publishes to GHCR only, "Detect Docker Hub credentials" step logs "publishing to GHCR only", no failure
- [ ] After adding secrets: trigger `workflow_dispatch` → workflow logs "will publish to docker.io/<ns>/alianhub", both registries get the image
- [ ] Verify GHCR publishing is unaffected (still publishes `latest`, version tags, `edge`, `main-<sha>` as before)

## Compatibility

✅ GHCR publishing path is unchanged — still the always-on default
✅ No new required secrets — Docker Hub is purely additive and optional
✅ No conflict with other files — touches only `.github/workflows/docker.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)