### PR TITLE
fix(server): stop recursive restart wrapper causing spawn EAGAIN outage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,8 +251,29 @@ jobs:
 
             pm2 restart 18
 
+            # ---------------------------------
+            # Post-restart health check + diagnostics
+            # ---------------------------------
+            # Give the app a moment to boot, then probe it directly. A deploy
+            # that leaves the process crash-looping previously reported
+            # success (staging 502, 2026-06-10) — surface the truth in the
+            # run log instead. Never fail the deploy step itself: the log
+            # tail is the diagnostic.
+
+            sleep 8
+
             echo "📊 PM2 Status"
 
             pm2 status
+
+            if curl -sf -o /dev/null --max-time 5 http://127.0.0.1:4003/; then
+              echo "✅ App is responding on 4003"
+            else
+              echo "❌ App NOT responding on 4003 — recent logs follow"
+            fi
+
+            echo "🩺 Recent app logs (stdout + stderr)"
+
+            pm2 logs 18 --lines 60 --nostream || true
 
             echo "✅ Deployment completed"

--- a/server.js
+++ b/server.js
@@ -1,21 +1,10 @@
-const { spawn } = require('child_process');
-let server;
-
-// Function to start the crash server
-function startCrashServer() {
-    server = spawn('node', ['server.js'], { stdio: 'inherit' });
-}
-
-// Function to start the server
-function startServer() {
-    // Start the server process
-    server = spawn('node', ['index.js'], { stdio: 'inherit' });
-    server.on('exit', (code) => {
-        console.log(`Server exited with code ${code}. Restarting...`);
-        server.kill();
-        startCrashServer(); // Restart the server on exit
-    });
-}
-
-// Start the server initially
-startServer();
+// Entry point for `npm start` / pm2.
+//
+// This file used to be a restart wrapper that re-spawned `node server.js`
+// recursively on every crash. Under a crash-loop each exit stacked another
+// wrapper process, exhausting the OS process table until every spawn failed
+// with EAGAIN and took the whole instance down (staging outage, 2026-06-10).
+//
+// Process supervision belongs to pm2 (autorestart with backoff) — the app
+// now simply runs in-process.
+require('./index.js');


### PR DESCRIPTION
Root cause of the persistent staging 502: server.js recursively spawned new wrapper processes on every crash. This morning's crash-loop stacked wrappers until the OS hit spawn EAGAIN (errno -11, confirmed in pm2 logs), so even the already-fixed code could not start. server.js now requires index.js in-process (pm2 owns restarts), and the deploy workflow gains a post-restart port-4003 health probe + pm2 log tail so failed boots are visible in the run log. NOTE: merging this is necessary but not sufficient — orphaned wrapper processes must be killed on the server once (commands provided in chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)