### PR TITLE
fix(ui): consolidate toolbar features into a more menu and fix search and share links

### DIFF
--- a/Modules/GlobalSearch/controller.js
+++ b/Modules/GlobalSearch/controller.js
@@ -48,12 +48,44 @@ exports.globalSearch = async (req, res) => {
             }, 'find'),
         ]);
 
+        // Client project routes always carry a sprint segment, so attach each
+        // project's first active sprint (the sprint the sidebar lands on).
+        let projectResults = projects || [];
+        if (projectResults.length) {
+            const sprints = await MongoDbCrudOpration(companyId, {
+                type: SCHEMA_TYPE.SPRINTS,
+                data: [
+                    {
+                        projectId: { $in: projectResults.map((project) => project._id) },
+                        deletedStatusKey: 0,
+                        private: { $ne: true },
+                    },
+                    'projectId folderId',
+                    { sort: { _id: 1 } },
+                ],
+            }, 'find');
+            const firstSprintByProject = {};
+            (sprints || []).forEach((sprint) => {
+                const key = String(sprint.projectId);
+                if (!firstSprintByProject[key]) firstSprintByProject[key] = sprint;
+            });
+            projectResults = projectResults.map((project) => {
+                const sprint = firstSprintByProject[String(project._id)];
+                return {
+                    _id: project._id,
+                    ProjectName: project.ProjectName,
+                    sprintId: sprint ? sprint._id : null,
+                    folderId: sprint && sprint.folderId ? sprint.folderId : null,
+                };
+            });
+        }
+
         return res.send({
             status: true,
             statusText: 'Search complete.',
             data: {
                 tasks: tasks || [],
-                projects: projects || [],
+                projects: projectResults,
                 comments: (comments || []).map((comment) => ({
                     _id: comment._id,
                     message: truncate(comment.message),

--- a/frontend/src/components/molecules/ExportTasks/ExportTasksDropdown.vue
+++ b/frontend/src/components/molecules/ExportTasks/ExportTasksDropdown.vue
@@ -1,14 +1,17 @@
 <template>
-    <span class="position-re">
-        <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" @click.stop="isOpen = !isOpen">
-            <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.export_tasks') }}</strong>
-        </button>
-        <span v-if="isOpen" class="export-tasks__overlay" @click.stop="isOpen = false"></span>
-        <div v-if="isOpen" class="export-tasks__panel">
-            <div class="cursor-pointer export-tasks__row font-size-13" @click="startExport('csv')">CSV</div>
-            <div class="cursor-pointer export-tasks__row font-size-13" @click="startExport('xlsx')">XLSX</div>
+    <div v-if="modelValue" class="export-tasks__overlay" @click.self="$emit('update:modelValue', false)">
+        <div class="export-tasks__card">
+            <div class="d-flex align-items-center justify-content-between export-tasks__head">
+                <span class="font-size-16 font-weight-700">{{ $t('Projects.export_tasks') }}</span>
+                <span class="cursor-pointer font-size-16 export-tasks__close" @click="$emit('update:modelValue', false)">&#10005;</span>
+            </div>
+            <div class="font-size-12 gray81 export-tasks__hint">{{ $t('Projects.export_hint') }}</div>
+            <div class="d-flex">
+                <button class="btn-primary font-size-13 mr-10px" :disabled="isBusy" @click="startExport('csv')">CSV</button>
+                <button class="btn-primary font-size-13" :disabled="isBusy" @click="startExport('xlsx')">XLSX</button>
+            </div>
         </div>
-    </span>
+    </div>
 </template>
 
 <script setup>
@@ -25,21 +28,27 @@ const { t } = useI18n();
 const $toast = useToast();
 const { getUser } = useGetterFunctions();
 const userId = inject('$userId');
-const clientWidth = inject('$clientWidth');
 
 const props = defineProps({
     projectData: {
         type: Object,
         required: true
+    },
+    modelValue: {
+        type: Boolean,
+        default: false
     }
 });
 
-const isOpen = ref(false);
+const emit = defineEmits(['update:modelValue']);
+
+const isBusy = ref(false);
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLLS = 30;
 
 function startExport(format) {
-    isOpen.value = false;
+    if (isBusy.value) return;
+    isBusy.value = true;
     const user = getUser(userId.value);
     apiRequest('post', '/api/v2/exports', {
         format,
@@ -49,11 +58,13 @@ function startExport(format) {
     }).then((response) => {
         if (response.data?.status) {
             $toast.info(t('Projects.export_preparing'), { position: 'top-right' });
+            emit('update:modelValue', false);
             pollUntilDone(response.data.data._id, 0);
         } else {
             $toast.error(response.data?.statusText || t('Toast.something_went_wrong'), { position: 'top-right' });
         }
-    }).catch((error) => console.error('ERROR in start export: ', error));
+    }).catch((error) => console.error('ERROR in start export: ', error))
+    .finally(() => { isBusy.value = false; });
 }
 
 function pollUntilDone(jobId, attempt) {
@@ -95,19 +106,24 @@ function downloadJob(job) {
 </script>
 
 <style scoped>
-.export-tasks__overlay { position: fixed; inset: 0; z-index: 19; }
-.export-tasks__panel {
-    position: absolute;
-    top: 36px;
-    right: 0;
-    z-index: 20;
-    min-width: 120px;
-    background: #fff;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
-    padding: 4px 0;
+.export-tasks__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
-.export-tasks__row { padding: 7px 14px; }
-.export-tasks__row:hover { background: #f7f9fc; }
+.export-tasks__card {
+    background: #fff;
+    border-radius: 10px;
+    width: min(360px, 92vw);
+    padding: 16px 20px;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.18);
+}
+.export-tasks__head { margin-bottom: 8px; }
+.export-tasks__close { color: #9a9a9a; }
+.export-tasks__close:hover { color: #e84a4a; }
+.export-tasks__hint { margin-bottom: 14px; }
 </style>

--- a/frontend/src/components/molecules/GlobalSearch/GlobalSearchModal.vue
+++ b/frontend/src/components/molecules/GlobalSearch/GlobalSearchModal.vue
@@ -131,9 +131,19 @@ function openTask(task) {
     router.push(path).catch((error) => console.error('ERROR opening search task: ', error));
 }
 
+// Project routes always include a sprint segment (see router/projects), so the
+// API returns each project's first active sprint. Projects without one fall
+// back to the sprint-less /p route, keeping the list view as landing tab.
 function openProject(project) {
     close();
-    router.push(`/${companyId.value}/project/${project._id}`).catch((error) => console.error('ERROR opening search project: ', error));
+    const base = `/${companyId.value}/project/${project._id}`;
+    let path = `${base}/p?tab=ProjectListView`;
+    if (project.sprintId) {
+        path = project.folderId
+            ? `${base}/fs/${project.folderId}/${project.sprintId}?tab=ProjectListView`
+            : `${base}/s/${project.sprintId}?tab=ProjectListView`;
+    }
+    router.push(path).catch((error) => console.error('ERROR opening search project: ', error));
 }
 </script>
 

--- a/frontend/src/components/molecules/RecentVisits/RecentVisitsDropdown.vue
+++ b/frontend/src/components/molecules/RecentVisits/RecentVisitsDropdown.vue
@@ -1,10 +1,10 @@
 <template>
-    <span class="position-re">
-        <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" @click.stop="toggleOpen">
-            <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.recent_tasks') }}</strong>
-        </button>
-        <span v-if="isOpen" class="recent-visits__overlay" @click.stop="isOpen = false"></span>
-        <div v-if="isOpen" class="recent-visits__panel">
+    <div v-if="modelValue" class="recent-visits__overlay" @click.self="$emit('update:modelValue', false)">
+        <div class="recent-visits__card">
+            <div class="d-flex align-items-center justify-content-between recent-visits__head">
+                <span class="font-size-16 font-weight-700">{{ $t('Projects.recent_tasks') }}</span>
+                <span class="cursor-pointer font-size-16 recent-visits__close" @click="$emit('update:modelValue', false)">&#10005;</span>
+            </div>
             <div v-if="isLoading" class="gray81 font-size-12 recent-visits__empty">{{ $t('Projects.searching') }}</div>
             <div v-else-if="!items.length" class="gray81 font-size-12 recent-visits__empty">{{ $t('Projects.no_recent_tasks') }}</div>
             <div
@@ -19,12 +19,12 @@
                 <span v-if="item.task.status && item.task.status.text" class="font-size-11 recent-visits__status">{{ item.task.status.text }}</span>
             </div>
         </div>
-    </span>
+    </div>
 </template>
 
 <script setup>
 // PACKAGES
-import { inject, ref } from "vue";
+import { defineProps, inject, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
 // UTILS
@@ -33,18 +33,22 @@ import { apiRequest } from '@/services';
 const router = useRouter();
 const userId = inject('$userId');
 const companyId = inject('$companyId');
-const clientWidth = inject('$clientWidth');
 
-const isOpen = ref(false);
+const props = defineProps({
+    modelValue: {
+        type: Boolean,
+        default: false
+    }
+});
+
+const emit = defineEmits(['update:modelValue']);
+
 const isLoading = ref(false);
 const items = ref([]);
 
-function toggleOpen() {
-    isOpen.value = !isOpen.value;
-    if (isOpen.value) {
-        fetchRecent();
-    }
-}
+watch(() => props.modelValue, (open) => {
+    if (open) fetchRecent();
+});
 
 function fetchRecent() {
     isLoading.value = true;
@@ -63,7 +67,7 @@ function fetchRecent() {
 // Task routes (router/projects): with folder → /:cid/project/:id/fs/:folderId/:sprintId/:taskId,
 // without → /:cid/project/:id/s/:sprintId/:taskId
 function openTask(task) {
-    isOpen.value = false;
+    emit('update:modelValue', false);
     const base = `/${companyId.value}/project/${task.ProjectID}`;
     const path = task.folderObjId
         ? `${base}/fs/${task.folderObjId}/${task.sprintId}/${task._id}`
@@ -78,24 +82,27 @@ function openTask(task) {
 .recent-visits__overlay {
     position: fixed;
     inset: 0;
-    z-index: 19;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
-.recent-visits__panel {
-    position: absolute;
-    top: 36px;
-    right: 0;
-    z-index: 20;
-    width: 300px;
-    max-height: 320px;
-    overflow-y: auto;
+.recent-visits__card {
     background: #fff;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
-    padding: 4px 0;
+    border-radius: 10px;
+    width: min(440px, 92vw);
+    max-height: 64vh;
+    overflow-y: auto;
+    padding: 14px 16px;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.18);
 }
+.recent-visits__head { margin-bottom: 8px; }
+.recent-visits__close { color: #9a9a9a; }
+.recent-visits__close:hover { color: #e84a4a; }
 .recent-visits__row {
-    padding: 7px 12px;
+    padding: 7px 8px;
+    border-radius: 6px;
     min-width: 0;
 }
 .recent-visits__row:hover {

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -565,6 +565,8 @@ export default {
         importing: "Importing...",
         start_import: "Import",
         auto_archive: "Auto-archive",
+        more_features: "More",
+        export_hint: "Download this project's tasks as a file.",
         auto_archive_hint: "Completed tasks untouched for the chosen number of days are archived automatically every night.",
         auto_archive_enable: "Enable auto-archive for this project",
         auto_archive_after: "Archive after",

--- a/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
+++ b/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
@@ -94,35 +94,53 @@
                             </DropDownOption>
                         </template>
                     </DropDown>
-                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer mr-1" @click="showBurndown = true">
-                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.burndown') }}</strong>
-                    </button>
-                    <BurndownModal v-model="showBurndown" :projectData="projectData" />
-                    <RecentVisitsDropdown class="mr-1" />
-                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer mr-1" :title="$t('Projects.global_search')" @click="showGlobalSearch = true">
-                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.global_search') }}</strong>
-                    </button>
+                    <!-- All newer features live behind one "…" menu (matches
+                         the task context-menu pattern) instead of nine
+                         separate toolbar buttons. -->
+                    <DropDown id="more_features" class="mr-1" :zIndex="10">
+                        <template #button>
+                            <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="more_features_trigger" :title="$t('Projects.more_features')">
+                                <img :src="horizontalDots" alt="more" class="vertical-middle">
+                            </button>
+                        </template>
+                        <template #options>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showGlobalSearch = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.global_search') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showRecent = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.recent_tasks') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showBurndown = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.burndown') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showEpics = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.epics') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showPages = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.pages') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showExport = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.export_tasks') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showPublicShare = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.public_link') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showImportJira = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.import_jira') }}</span></div>
+                            </DropDownOption>
+                            <DropDownOption @click="$refs.more_features_trigger.click(); showAutoArchive = true">
+                                <div><span class="dropdown-label">{{ $t('Projects.auto_archive') }}</span></div>
+                            </DropDownOption>
+                        </template>
+                    </DropDown>
                     <GlobalSearchModal v-model="showGlobalSearch" />
-                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer mr-1" @click="showEpics = true">
-                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.epics') }}</strong>
-                    </button>
+                    <RecentVisitsDropdown v-model="showRecent" />
+                    <BurndownModal v-model="showBurndown" :projectData="projectData" />
                     <EpicsPanel v-model="showEpics" :projectData="projectData" />
-                    <ExportTasksDropdown class="mr-1" :projectData="projectData" />
-                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer mr-1" @click="showPages = true">
-                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.pages') }}</strong>
-                    </button>
                     <PagesPanel v-model="showPages" :projectData="projectData" />
-                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer mr-1" @click="showPublicShare = true">
-                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.public_link') }}</strong>
-                    </button>
+                    <ExportTasksDropdown v-model="showExport" :projectData="projectData" />
                     <PublicShareModal v-model="showPublicShare" :projectData="projectData" />
-                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer mr-1" @click="showImportJira = true">
-                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.import_jira') }}</strong>
-                    </button>
                     <ImportJiraModal v-model="showImportJira" :projectData="projectData" />
-                    <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer mr-1" @click="showAutoArchive = true">
-                        <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.auto_archive') }}</strong>
-                    </button>
                     <AutoArchiveModal v-model="showAutoArchive" :projectData="projectData" />
                     <div class="mr-1 border-groupBy border-radius-6-px d-flex align-items-center assignee-filter manage__filter-users">
                         <div
@@ -226,6 +244,8 @@ const showPages = ref(false);
 const showPublicShare = ref(false);
 const showImportJira = ref(false);
 const showAutoArchive = ref(false);
+const showRecent = ref(false);
+const showExport = ref(false);
 import { useCustomComposable } from '@/composable';
 
 const { checkPermission, checkApps } = useCustomComposable();

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -11,6 +11,12 @@ module.exports = defineConfig({
         target: 'http://localhost:4000',
         changeOrigin: true
       },
+      // Server-rendered public share pages (GET /share/:token and its intake
+      // form POST) live on the backend, same as /api.
+      '^/share': {
+        target: 'http://localhost:4000',
+        changeOrigin: true
+      },
       'socket.io': {
         target: 'http://localhost:4000',
         changeOrigin: true


### PR DESCRIPTION
## What changed

**1. Toolbar: one `...` menu instead of nine buttons**
The new feature buttons (Search all, Recent, Burndown, Epics, Pages, Export, Public link, Import Jira, Auto-archive) crowded the board toolbar onto a second line. They now live behind a single dots trigger that opens a standard `DropDown` menu — same pattern as the task context menu. Recent and Export were converted from self-triggering dropdowns into `v-model` modals so all nine entries open uniformly from the menu.

**2. Search all: project click 404 fix**
Clicking a project result navigated to `/:cid/project/:id`, a route that does not exist (project routes always carry a sprint segment). The search API now attaches each project''s first active, non-private sprint, and the modal deep-links to `/:cid/project/:id/s/:sprintId?tab=ProjectListView` (or the `/fs/` folder variant), falling back to the `/p` route with the list view tab for projects without sprints.

**3. Public share links in local dev**
`/share/:token` pages are server-rendered by Express, but the copied link uses the page origin — on the Vue dev server (8080) the path fell through to the SPA and redirected to login. Added a `^/share` dev-server proxy rule to `vue.config.js`. Production is unaffected (nginx already sends everything to the Node app).

## Verification
- ESLint clean on all six frontend files
- Backend jest suite passes (exit 0)
- GlobalSearch controller runtime-loads with `STORAGE_TYPE` set
- Manually tested in browser: toolbar menu, search-all project click, public link in incognito

🤖 Generated with [Claude Code](https://claude.com/claude-code)