### PR TITLE
feat(changelog): show release time in 12-hour format on whats new page

### DIFF
--- a/Modules/Changelog/controller.js
+++ b/Modules/Changelog/controller.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const axios = require("axios");
 const logger = require("../../Config/loggerConfig");
 const { version: appVersion } = require("../../package.json");
 
@@ -110,6 +111,43 @@ const deriveRepoUrl = (releases) => {
     return withUrl ? withUrl.compareUrl.split("/compare/")[0] : "";
 };
 
+// CHANGELOG.md only records a date, so the exact publish moment comes from
+// the GitHub Releases API. Cached per changelog revision (a new release
+// rewrites the file, so each release costs one fetch); a failed fetch backs
+// off for ten minutes and the page degrades to date-only display.
+const GITHUB_RETRY_MS = 10 * 60 * 1000;
+let githubTimes = { key: null, byVersion: null, retryAtMs: 0 };
+
+const fetchReleaseTimes = async (repoUrl, cacheKey) => {
+    if (githubTimes.byVersion && githubTimes.key === cacheKey) return githubTimes.byVersion;
+    if (Date.now() < githubTimes.retryAtMs) return githubTimes.byVersion || {};
+    const repoMatch = String(repoUrl || "").match(/github\.com\/([^/]+)\/([^/]+)/);
+    if (!repoMatch) return {};
+    try {
+        const response = await axios.get(`https://api.github.com/repos/${repoMatch[1]}/${repoMatch[2]}/releases`, {
+            params: { per_page: 100 },
+            timeout: 8000,
+            headers: {
+                Accept: "application/vnd.github+json",
+                "User-Agent": "AlianHub-Changelog",
+                ...(process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+            },
+        });
+        const byVersion = {};
+        (Array.isArray(response.data) ? response.data : []).forEach((release) => {
+            if (release.tag_name && release.published_at) {
+                byVersion[String(release.tag_name).replace(/^v/, "")] = release.published_at;
+            }
+        });
+        githubTimes = { key: cacheKey, byVersion, retryAtMs: 0 };
+        return byVersion;
+    } catch (fetchError) {
+        logger.error(`Changelog release times fetch failed: ${fetchError.message}`);
+        githubTimes = { ...githubTimes, retryAtMs: Date.now() + GITHUB_RETRY_MS };
+        return githubTimes.byVersion || {};
+    }
+};
+
 /**
  * GET /api/v2/changelog
  * Returns every release documented in CHANGELOG.md (newest first, as
@@ -138,7 +176,13 @@ exports.getChangelog = async (req, res) => {
             };
         }
 
-        return res.send({ status: true, statusText: "Changelog fetched.", data: cache.payload });
+        const releaseTimes = await fetchReleaseTimes(cache.payload.repoUrl, stats.mtimeMs);
+        const releases = cache.payload.releases.map((release) => ({
+            ...release,
+            publishedAt: releaseTimes[release.version] || "",
+        }));
+
+        return res.send({ status: true, statusText: "Changelog fetched.", data: { ...cache.payload, releases } });
     } catch (error) {
         logger.error(`ERROR in get changelog: ${error.message}`);
         return res.send({ status: false, statusText: error.message });

--- a/frontend/src/views/Changelog/Changelog.vue
+++ b/frontend/src/views/Changelog/Changelog.vue
@@ -39,7 +39,7 @@
                             <span v-if="release.version === currentVersion" class="changelog-chip changelog-chip--installed">{{ $t('Changelog.installed') }}</span>
                             <span v-if="release.label" class="changelog-release-label">{{ release.label }}</span>
                             <span class="changelog-release-spacer"></span>
-                            <span v-if="release.date" class="changelog-release-date">{{ formatDate(release.date) }}</span>
+                            <span v-if="release.date || release.publishedAt" class="changelog-release-date">{{ formatDate(release) }}</span>
                             <a v-if="release.compareUrl" :href="release.compareUrl" target="_blank" rel="noopener noreferrer" class="changelog-compare-link">{{ $t('Changelog.compare_changes') }}</a>
                         </div>
 
@@ -103,9 +103,18 @@ function fetchChangelog() {
     });
 }
 
-function formatDate(isoDate) {
-    const date = new Date(`${isoDate}T00:00:00`);
-    if (isNaN(date.getTime())) return isoDate;
+function formatDate(release) {
+    // publishedAt is the GitHub release timestamp; CHANGELOG.md only has a date.
+    if (release.publishedAt) {
+        const dateTime = new Date(release.publishedAt);
+        if (!isNaN(dateTime.getTime())) {
+            const datePart = dateTime.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+            const timePart = dateTime.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit", hour12: true });
+            return `${datePart}, ${timePart}`;
+        }
+    }
+    const date = new Date(`${release.date}T00:00:00`);
+    if (isNaN(date.getTime())) return release.date;
     return date.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
 }
 


### PR DESCRIPTION
﻿## What changed

The in-app What's New page now shows each release's publish time in 12-hour format next to the date, e.g. 10 June 2026, 3:59 PM.

- **Backend**: CHANGELOG.md only records a date, so `GET /api/v2/changelog` now merges each tag's `published_at` from the GitHub Releases API. Cached per changelog revision (one API call per new release, not per page view), 10-minute backoff on fetch failure, optional `GITHUB_TOKEN` support for rate limits.
- **Frontend**: `Changelog.vue` renders the date plus 12-hour local time when a timestamp exists, and degrades gracefully to date-only when it does not (e.g. GitHub unreachable).

## Verification
- End-to-end check against the real repo: v14.2.0 / v14.1.0 / v14.0.26 all resolve their publish timestamps; the baseline release (no date in CHANGELOG.md) now gains one too
- Controller runtime-loads with `STORAGE_TYPE` set
- ESLint clean, backend jest suite passes
- Manually tested in browser on the What's New page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
