### PR TITLE
docs: add manual test cases for the new features

### DIFF
--- a/.claude/test-cases/AutoArchive.md
+++ b/.claude/test-cases/AutoArchive.md
@@ -1,0 +1,20 @@
+# Auto-Archive — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Auto-archive · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Settings Modal
+
+| ID     | Title                                  | Precondition                              | Steps                                                                                        | Expected Result                                                                  | Actual Result | Status |
+|--------|----------------------------------------|-------------------------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|---------------|--------|
+| AA_001 | Enable auto-archive with a threshold   | Project open; user can edit settings      | 1. Open `...` → Auto-archive  2. Turn the toggle on  3. Set days to 30  4. Save and reopen   | Success toast on save; reopened modal shows toggle on with the saved day value  |               | ⏳     |
+| AA_002 | Disable auto-archive                   | AA_001 done                               | 1. Reopen the modal  2. Turn the toggle off  3. Save and reopen                              | Setting persists as off                                                         |               | ⏳     |
+| AA_003 | Invalid day threshold is rejected      | Auto-archive modal open                   | 1. Enter 0, a negative number or blank in the days field  2. Try to save                     | Value is rejected or normalized — no nonsensical threshold saved, no crash      |               | ⏳     |
+| AA_004 | Setting is per project                 | Two projects; auto-archive on in project 1 | 1. Open `...` → Auto-archive in project 2                                                   | Project 2 shows its own (default/off) state, unaffected by project 1            |               | ⏳     |
+
+---
+
+**Total:** 4 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/BurndownChart.md
+++ b/.claude/test-cases/BurndownChart.md
@@ -1,0 +1,20 @@
+# Burndown Chart — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Burndown · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Chart Rendering
+
+| ID     | Title                                        | Precondition                                                   | Steps                                                                            | Expected Result                                                                       | Actual Result | Status |
+|--------|----------------------------------------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|---------------|--------|
+| BD_001 | Chart renders for the current sprint         | Sprint with dated tasks, some completed                        | 1. Open the sprint board  2. Open `...` → Burndown                               | Modal shows the burndown chart with date axis, remaining-work line and ideal line   |               | ⏳     |
+| BD_002 | Completing a task lowers the remaining line  | BD_001 done; note today's remaining count                      | 1. Close the modal  2. Mark one open task completed  3. Reopen `...` → Burndown  | Today's remaining count is one lower than before                                    |               | ⏳     |
+| BD_003 | Sprint without tasks is handled gracefully   | A sprint with zero tasks                                       | 1. Open that sprint's board  2. Open `...` → Burndown                            | Empty/zero chart or empty-state message — no crash                                  |               | ⏳     |
+| BD_004 | Modal closes and reopens cleanly             | Burndown modal open                                            | 1. Close via ✕  2. Reopen  3. Close by clicking the overlay                      | Both close actions work; reopening renders the chart correctly again                |               | ⏳     |
+
+---
+
+**Total:** 4 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/CommentReactions.md
+++ b/.claude/test-cases/CommentReactions.md
@@ -1,0 +1,21 @@
+# Comment Reactions — Test Cases
+
+**Location:** Task comments / project Comments tab · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Add & Toggle Reactions
+
+| ID     | Title                                            | Precondition                                   | Steps                                                                                          | Expected Result                                                                      | Actual Result | Status |
+|--------|--------------------------------------------------|------------------------------------------------|--------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|---------------|--------|
+| CR_001 | Add an emoji reaction to a comment               | A task with at least one comment               | 1. Hover the comment  2. Click the reaction control  3. Pick an emoji (e.g. 👍)                  | Emoji chip appears under the comment with count 1, highlighted as your own reaction  |               | ⏳     |
+| CR_002 | Clicking your own reaction removes it            | CR_001 done                                    | 1. Click the same emoji chip again                                                                | Your reaction is removed; chip disappears or its count decreases by one              |               | ⏳     |
+| CR_003 | Counts aggregate across users                    | Two users can see the same comment             | 1. As user 1 react 👍  2. As user 2 (second browser) react 👍 on the same comment                | Chip shows 👍 2; each user sees only their own reaction highlighted                   |               | ⏳     |
+| CR_004 | Reactions update live for other viewers          | Two browser windows on the same comment thread | 1. In window 1 add a reaction  2. Watch window 2 without reloading                                | The reaction chip appears in window 2 within a couple of seconds                     |               | ⏳     |
+| CR_005 | Picker stays inside the viewport                 | A comment near the bottom/right screen edge    | 1. Open the reaction picker on that comment                                                       | Picker renders fully visible — not clipped behind panels or cut off by the viewport  |               | ⏳     |
+
+---
+
+**Total:** 5 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/Epics.md
+++ b/.claude/test-cases/Epics.md
@@ -1,0 +1,29 @@
+# Epics — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Epics · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Epic Management
+
+| ID     | Title                                    | Precondition                          | Steps                                                            | Expected Result                                                                | Actual Result | Status |
+|--------|------------------------------------------|---------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------------------------|---------------|--------|
+| EP_001 | Create an epic                           | Project open on its board             | 1. Open `...` → Epics  2. Create an epic with a name             | Epic appears in the panel list with zero progress; success toast               |               | ⏳     |
+| EP_002 | Rename an epic                           | EP_001 done                           | 1. Edit the epic name  2. Save                                   | List shows the new name                                                        |               | ⏳     |
+| EP_003 | Delete an epic keeps its tasks           | An epic with assigned tasks           | 1. Delete the epic and confirm                                   | Epic disappears; its former tasks remain intact, just without an epic          |               | ⏳     |
+
+---
+
+## Task Assignment & Progress
+
+| ID     | Title                                    | Precondition                          | Steps                                                            | Expected Result                                                                | Actual Result | Status |
+|--------|------------------------------------------|---------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------------------------|---------------|--------|
+| EP_004 | Assign tasks to an epic                  | EP_001 done; project has open tasks   | 1. Assign two tasks to the epic                                  | Epic shows 2 total tasks; the tasks carry the epic reference                   |               | ⏳     |
+| EP_005 | Completing a task updates progress       | EP_004 done                           | 1. Mark one assigned task completed  2. Reopen the Epics panel   | Epic shows 1 of 2 done                                                         |               | ⏳     |
+| EP_006 | Moving a task between epics fixes counts | Two epics; a task assigned to epic 1  | 1. Reassign the task to epic 2                                   | Epic 1 total decreases by one and epic 2 increases by one                      |               | ⏳     |
+
+---
+
+**Total:** 6 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/GlobalSearch.md
+++ b/.claude/test-cases/GlobalSearch.md
@@ -1,0 +1,29 @@
+# Global Search (Search All) — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Search all · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Searching
+
+| ID     | Title                                        | Precondition                                                       | Steps                                                                        | Expected Result                                                                                  | Actual Result | Status |
+|--------|----------------------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------|--------|
+| GS_001 | Results grouped by tasks, projects, comments | A keyword (e.g. "web") exists in a task, a project and a comment   | 1. Open `...` → Search all  2. Type the keyword (2+ characters)              | Grouped results appear under TASKS, PROJECTS and CHAT; task rows show key, name, status chip    |               | ⏳     |
+| GS_002 | No search under 2 characters                 | Search modal open                                                  | 1. Type a single character                                                   | No results render until the query is at least 2 characters                                      |               | ⏳     |
+| GS_003 | Matching is case-insensitive substring       | A task named in lowercase exists                                   | 1. Search an UPPERCASE fragment of its name                                  | The task is found                                                                               |               | ⏳     |
+| GS_004 | No-results state                             | Search modal open                                                  | 1. Search a nonsense string like "zzqqxx"                                    | A clear "no results" message; no stale results from the previous query                          |               | ⏳     |
+
+---
+
+## Opening Results
+
+| ID     | Title                                        | Precondition                                                       | Steps                                                                        | Expected Result                                                                                  | Actual Result | Status |
+|--------|----------------------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------|--------|
+| GS_005 | Clicking a task result opens the task        | GS_001 done                                                        | 1. Click a task row in the results                                           | Modal closes; app routes to the task detail (works for folder and non-folder sprints)           |               | ⏳     |
+| GS_006 | Clicking a project result opens its board    | GS_001 done                                                        | 1. Search a project by name  2. Click the project row                        | App opens that project's first sprint with the List view tab — no "Page not found"              |               | ⏳     |
+
+---
+
+**Total:** 6 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/JiraImporter.md
+++ b/.claude/test-cases/JiraImporter.md
@@ -1,0 +1,20 @@
+# Jira Importer — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Import Jira · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Import Flow
+
+| ID     | Title                                  | Precondition                                       | Steps                                                              | Expected Result                                                                                       | Actual Result | Status |
+|--------|----------------------------------------|----------------------------------------------------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|---------------|--------|
+| JI_001 | Import a valid Jira CSV                | A Jira CSV export with 3–5 rows; sprint selected   | 1. Open `...` → Import Jira  2. Choose the CSV  3. Start the import | Success message with the created count; new tasks appear on the board with names from Jira summaries  |               | ⏳     |
+| JI_002 | Imported task fields are sensible      | JI_001 done                                        | 1. Open one imported task                                          | Name = Jira summary; description carried over; valid status in the chosen sprint — no blank cards     |               | ⏳     |
+| JI_003 | Invalid file shows a readable error    | Import modal open                                  | 1. Try an empty CSV  2. Try a non-CSV file renamed to .csv         | Readable error toast in both cases; nothing is created; modal stays usable                            |               | ⏳     |
+| JI_004 | Malformed rows are skipped, not fatal  | A CSV where one row lacks a Summary                | 1. Import it                                                       | Valid rows import; the bad row is skipped; the import does not abort halfway                          |               | ⏳     |
+
+---
+
+**Total:** 4 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/Languages.md
+++ b/.claude/test-cases/Languages.md
@@ -1,0 +1,21 @@
+# Languages (Japanese / Korean / Brazilian Portuguese) — Test Cases
+
+**Location:** Settings → My Settings → Language · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Language Switching
+
+| ID     | Title                                     | Precondition          | Steps                                                                   | Expected Result                                                                                    | Actual Result | Status |
+|--------|-------------------------------------------|-----------------------|-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|---------------|--------|
+| LG_001 | Switch to Japanese                        | Logged in             | 1. Open Settings → My Settings  2. Select Japanese  3. Save            | Success toast; navigation and common labels switch to Japanese immediately, no reload needed       |               | ⏳     |
+| LG_002 | Switch to Korean and Brazilian Portuguese | Logged in             | 1. Repeat LG_001 choosing Korean, then Português (Brasil)               | Same behavior for both locales                                                                     |               | ⏳     |
+| LG_003 | Untranslated strings fall back to English | One new locale active | 1. Browse less common screens (e.g. the `...` menu features, settings) | Untranslated strings show English text — never blank, never a raw key like `Projects.more_features` |               | ⏳     |
+| LG_004 | Choice persists across sessions           | LG_001 done           | 1. Log out and back in (or hard-reload)                                 | UI comes back in the chosen language                                                               |               | ⏳     |
+| LG_005 | Switch back to English                    | A new locale active   | 1. Set the language back to English                                     | Everything returns to English cleanly                                                              |               | ⏳     |
+
+---
+
+**Total:** 5 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/PagesWiki.md
+++ b/.claude/test-cases/PagesWiki.md
@@ -1,0 +1,21 @@
+# Pages (Project Wiki) — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Pages · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Pages & Versions
+
+| ID     | Title                              | Precondition              | Steps                                                                     | Expected Result                                                                       | Actual Result | Status |
+|--------|------------------------------------|---------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|---------------|--------|
+| PW_001 | Create a page                      | Project open on its board | 1. Open `...` → Pages  2. Create a page with title and content  3. Save   | Page appears in the project's page list; reopening shows the saved content           |               | ⏳     |
+| PW_002 | Editing creates a new version      | PW_001 done               | 1. Edit the content and save  2. Open the page's version history          | Two versions exist, each with author and timestamp                                   |               | ⏳     |
+| PW_003 | Restore an old version             | PW_002 done               | 1. Restore version 1 from the history                                     | Content returns to the original; the restore is recorded as a new version            |               | ⏳     |
+| PW_004 | Pages are project-scoped           | Two projects              | 1. Create a page in project 1  2. Open `...` → Pages in project 2         | Project 2's list does not contain project 1's page                                   |               | ⏳     |
+| PW_005 | Delete a page                      | A page exists             | 1. Delete the page and confirm                                            | Page disappears from the list; other pages unaffected                                |               | ⏳     |
+
+---
+
+**Total:** 5 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/PublicSharing.md
+++ b/.claude/test-cases/PublicSharing.md
@@ -1,0 +1,29 @@
+# Public Sharing + Intake — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Public link · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Public Link
+
+| ID     | Title                                  | Precondition                        | Steps                                                                                       | Expected Result                                                                                   | Actual Result | Status |
+|--------|----------------------------------------|-------------------------------------|---------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------|--------|
+| PS_001 | Create a public link for a sprint      | Project with a sprint and tasks     | 1. Open `...` → Public link  2. Pick a sprint  3. Click Create public link                  | A `/share/<token>` URL appears with Copy Link button and "Link enabled" ticked                    |               | ⏳     |
+| PS_002 | Public page opens without login        | PS_001 done                         | 1. Copy the link  2. Open it in an incognito window                                         | Read-only board renders (tasks grouped by status) — no login redirect, no edit controls           |               | ⏳     |
+| PS_003 | Disabling the link blocks the page     | PS_002 done                         | 1. Untick "Link enabled"  2. Reload the public page in incognito  3. Re-enable and reload   | Disabled: page no longer shows the board; re-enabled: same URL works again                        |               | ⏳     |
+
+---
+
+## Intake Requests
+
+| ID     | Title                                  | Precondition                        | Steps                                                                                       | Expected Result                                                                                   | Actual Result | Status |
+|--------|----------------------------------------|-------------------------------------|---------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------|--------|
+| PS_004 | Visitor can submit a request           | Link enabled                        | 1. Tick "Accept public requests"  2. Reload the public page  3. Fill and submit the intake form | Thank-you page confirms the submission and links back to the board                                |               | ⏳     |
+| PS_005 | Review submissions in the inbox        | PS_004 done                         | 1. In the app reopen `...` → Public link for that sprint  2. Accept one request, reject another | Submissions show title/description/submitter; handled items leave the pending inbox               |               | ⏳     |
+| PS_006 | Empty title is rejected on the form    | Intake form visible on public page  | 1. Submit the form with an empty title                                                      | Submission rejected with a readable message; no junk entry appears in the inbox                   |               | ⏳     |
+
+---
+
+**Total:** 6 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/RecentTasks.md
+++ b/.claude/test-cases/RecentTasks.md
@@ -1,0 +1,21 @@
+# Recent Tasks — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Recent · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Recent List
+
+| ID     | Title                                      | Precondition                              | Steps                                                                                   | Expected Result                                                                          | Actual Result | Status |
+|--------|--------------------------------------------|-------------------------------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------|--------|
+| RT_001 | Visited tasks appear most-recent first     | Logged in; project with several tasks     | 1. Open three different tasks one after another  2. Open `...` → Recent                  | Modal lists the visited tasks newest first with task key, name and status chip          |               | ⏳     |
+| RT_002 | Clicking an entry opens that task          | RT_001 done                               | 1. Click one of the listed tasks                                                         | Modal closes and the app navigates to that task's detail view                           |               | ⏳     |
+| RT_003 | List is personal to the logged-in user     | Two users in the same company             | 1. As user 1 visit a task  2. As user 2 open `...` → Recent                              | User 2 does not see user 1's visit — only their own history                             |               | ⏳     |
+| RT_004 | Empty state for a fresh user               | A user who has not opened any task yet    | 1. Open `...` → Recent                                                                   | A "no recent tasks" message is shown instead of an empty area                           |               | ⏳     |
+| RT_005 | Modal closes via ✕ and overlay click       | Recent modal open                         | 1. Click the ✕ icon  2. Reopen and click the dark overlay outside the card               | Both actions close the modal without navigating                                         |               | ⏳     |
+
+---
+
+**Total:** 5 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/RelationAlerts.md
+++ b/.claude/test-cases/RelationAlerts.md
@@ -1,0 +1,19 @@
+# Relation Alerts — Test Cases
+
+**Location:** Notifications bell (after Linked Tasks changes) · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Watcher Notifications
+
+| ID     | Title                                          | Precondition                                                          | Steps                                                                          | Expected Result                                                                              | Actual Result | Status |
+|--------|------------------------------------------------|-----------------------------------------------------------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|---------------|--------|
+| RA_001 | Watcher is notified when a relation is added   | User 2 watches task B; tasks A and B in the same project              | 1. As user 1 link task A to task B ("blocks")  2. As user 2 open the notifications bell | User 2 has a notification on task B saying user 1 linked it, with the relation wording      |               | ⏳     |
+| RA_002 | Watcher is notified when a relation is removed | RA_001 done                                                           | 1. As user 1 remove the link  2. As user 2 check notifications                  | A new notification reports the link was removed                                             |               | ⏳     |
+| RA_003 | Watchers with "ignore" mode get nothing        | User 2 sets notification mode "ignore" for the task                    | 1. As user 1 add and remove a relation on the watched task  2. As user 2 check notifications | No relation notification is delivered to user 2                                             |               | ⏳     |
+
+---
+
+**Total:** 3 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/TaskExports.md
+++ b/.claude/test-cases/TaskExports.md
@@ -1,0 +1,20 @@
+# Task Exports (CSV / XLSX) — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Export · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Export Flow
+
+| ID     | Title                                   | Precondition                          | Steps                                                                                       | Expected Result                                                                                | Actual Result | Status |
+|--------|-----------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|---------------|--------|
+| TE_001 | CSV export downloads                    | Project with a handful of tasks       | 1. Open `...` → Export  2. Click CSV  3. Wait for the "preparing" toast, then the ready toast | A .csv file downloads containing the project's tasks (key, name, status, assignees, dates)    |               | ⏳     |
+| TE_002 | XLSX export downloads                   | Project with a handful of tasks       | 1. Open `...` → Export  2. Click XLSX  3. Wait for the toasts                               | A .xlsx file downloads and opens in Excel with the same data                                  |               | ⏳     |
+| TE_003 | No duplicate jobs from double-clicks    | Export modal open                     | 1. Click CSV  2. Immediately click either button again                                      | Buttons are disabled while submitting — only one job runs                                     |               | ⏳     |
+| TE_004 | Export reflects current data            | TE_001 done                           | 1. Rename a task  2. Run a fresh export                                                     | The new file contains the updated task name                                                   |               | ⏳     |
+
+---
+
+**Total:** 4 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/TaskRelations.md
+++ b/.claude/test-cases/TaskRelations.md
@@ -1,0 +1,29 @@
+# Task Relations — Test Cases
+
+**Location:** Task detail → Linked Tasks · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Add & Remove Relations
+
+| ID     | Title                                                  | Precondition                                  | Steps                                                                                                                       | Expected Result                                                                              | Actual Result | Status |
+|--------|--------------------------------------------------------|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------|--------|
+| TR_001 | Link two tasks with a "blocks" relation                | Two tasks A and B exist in the same project   | 1. Open task A  2. In Linked Tasks click add relation  3. Choose type "blocks"  4. Search task B by name or key and select it | Success toast; task B listed under Linked Tasks on task A with label "blocks"                |               | ⏳     |
+| TR_002 | Inverse relation appears on the other task             | TR_001 done (A blocks B)                      | 1. Open task B  2. Check its Linked Tasks section                                                                            | Task A is listed with the inverse label "blocked by"                                         |               | ⏳     |
+| TR_003 | Remove a relation from either side                     | A and B are linked                            | 1. Open task A  2. Click the unlink control on the linked row                                                                | Link disappears from both task A and task B; toast confirms removal                          |               | ⏳     |
+| TR_004 | Relation search only offers same-project tasks         | Two projects with tasks exist                 | 1. In project 1 open a task and add a relation  2. Search a task name that only exists in project 2                          | No cross-project results — only tasks of the current project are offered                     |               | ⏳     |
+
+---
+
+## History & Live Sync
+
+| ID     | Title                                                  | Precondition                                  | Steps                                                                                                                       | Expected Result                                                                              | Actual Result | Status |
+|--------|--------------------------------------------------------|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------|--------|
+| TR_005 | Activity history written on both tasks                 | TR_001 done                                   | 1. Open the activity log of task A  2. Open the activity log of task B                                                       | Both logs contain an entry describing who linked which task and the relation type            |               | ⏳     |
+| TR_006 | Linked list updates live in a second window            | Two browser windows both viewing task A       | 1. In window 1 link task A to task B  2. Watch window 2 without reloading                                                    | Window 2 shows the new linked task within a couple of seconds                                |               | ⏳     |
+
+---
+
+**Total:** 6 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/ToolbarMoreMenu.md
+++ b/.claude/test-cases/ToolbarMoreMenu.md
@@ -1,0 +1,21 @@
+# Toolbar More Menu (`...`) — Test Cases
+
+**Location:** Project board toolbar, next to the Subtask control · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Menu Behavior
+
+| ID     | Title                                          | Precondition               | Steps                                                                                  | Expected Result                                                                                                     | Actual Result | Status |
+|--------|------------------------------------------------|----------------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|---------------|--------|
+| TM_001 | Menu lists all nine feature entries            | Project open on its board  | 1. Click the `...` button on the toolbar                                               | Dropdown shows: Search all, Recent, Burndown, Epics, Pages, Export, Public link, Import Jira, Auto-archive          |               | ⏳     |
+| TM_002 | Each entry opens its feature and closes the menu | TM_001 done              | 1. Open the menu  2. Click an entry  3. Repeat for every entry                         | The matching modal/panel opens each time; the dropdown closes itself before the modal appears                       |               | ⏳     |
+| TM_003 | Menu closes without selection                  | Menu open                  | 1. Click anywhere outside the dropdown                                                 | Menu closes; nothing opens                                                                                          |               | ⏳     |
+| TM_004 | Toolbar stays on one line                      | Default board view, normal desktop width | 1. Look at the toolbar with search, filters, Group by, Subtask and `...` visible | Controls fit on a single line — no second-line wrap caused by feature buttons                                       |               | ⏳     |
+| TM_005 | Old standalone buttons are gone                | Project open on its board  | 1. Inspect the toolbar                                                                 | No separate Burndown/Recent/etc. buttons remain — the nine features exist only inside the `...` menu                |               | ⏳     |
+
+---
+
+**Total:** 5 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/WhatsNew.md
+++ b/.claude/test-cases/WhatsNew.md
@@ -1,0 +1,21 @@
+# What's New (Changelog) — Test Cases
+
+**Location:** Header → click the version badge (e.g. v14.2.0) · **Last updated:** 2026-06-11
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Page Content
+
+| ID     | Title                                          | Precondition                       | Steps                                                              | Expected Result                                                                                              | Actual Result | Status |
+|--------|------------------------------------------------|------------------------------------|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------|--------|
+| WN_001 | Page opens from the header version badge       | Logged in                          | 1. Click the version badge at the right of the header              | The What's New page opens listing every release, newest first                                               |               | ⏳     |
+| WN_002 | Latest and Installed chips are correct         | What's New page open               | 1. Check the chips on the release cards                            | The newest release shows "Latest"; the release matching the running version shows "Installed"               |               | ⏳     |
+| WN_003 | Release date shows time in 12-hour format      | What's New page open               | 1. Look at the date on each release card                           | Format like "10 June 2026, 3:59 PM" — date plus 12-hour local time with AM/PM                               |               | ⏳     |
+| WN_004 | Grouped sections render with working links     | A release with Features/Bug Fixes  | 1. Read a release card  2. Click a commit or compare link          | Sections are grouped (Features, Bug Fixes, …); links open GitHub in a new tab                               |               | ⏳     |
+| WN_005 | View on GitHub link                            | What's New page open               | 1. Click "View on GitHub" in the page header                       | The repository's releases page opens in a new tab                                                           |               | ⏳     |
+
+---
+
+**Total:** 5 test cases · **All status:** ⏳ Pending


### PR DESCRIPTION
﻿## What changed

Adds 15 manual QA test-case files to `.claude/test-cases/`, one per recently shipped feature, in the same table format as the existing files there (ID / Title / Precondition / Steps / Expected Result / Actual Result / Status, with the status legend and totals footer).

| File | Cases | File | Cases |
|------|-------|------|-------|
| TaskRelations | 6 | PagesWiki | 5 |
| CommentReactions | 5 | PublicSharing | 6 |
| RecentTasks | 5 | JiraImporter | 4 |
| BurndownChart | 4 | Languages | 5 |
| AutoArchive | 4 | RelationAlerts | 3 |
| GlobalSearch | 6 | ToolbarMoreMenu | 5 |
| TaskExports | 4 | WhatsNew | 5 |
| Epics | 6 | | |

**73 test cases total**, all status ⏳ Pending. Frontend feature behavior only — backend/API-only surfaces (webhooks, API tokens, instance admin) are intentionally not included.

Docs-only change: no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
