### PR TITLE
ci: allow manual workflow_dispatch to deploy staging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,10 @@ jobs:
 
   deploy:
     needs: validate
-    if: github.event_name == 'push'
+    # Deploy on a push to staging (PR merge) or a manual re-run from the
+    # Actions tab (workflow_dispatch) — the latter lets us rebuild + redeploy
+    # after a server-side env change without an empty commit.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
﻿## Why

A manual run of the deploy workflow (Actions tab → Run workflow, i.e. `workflow_dispatch`) only ran the `validate` job and **skipped `deploy`**, because the deploy job was gated on `if: github.event_name == 'push'`. So there was no way to rebuild + redeploy `staging` after a server-side env change without pushing a throwaway commit.

## What

Allow `workflow_dispatch` to deploy too:

`if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'`

Merging this is itself a push to `staging`, which triggers a normal build+deploy. After this, manual redeploys work straight from the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
