### PR TITLE
ci: inject OAuth client ids and flags into the frontend build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,20 @@ jobs:
           # ── App configuration ────────────────────────────────────────
           VUE_APP_STORAGE_TYPE:      ${{ secrets.VUE_APP_STORAGE_TYPE }}
           VUE_APP_AFFILIATEON:       ${{ secrets.VUE_APP_AFFILIATEON }}
+          # ── OAuth / social login ─────────────────────────────────────
+          # Client ids + enable flags are inlined into the bundle here, so
+          # they must come from GitHub secrets — the server-side frontend/.env
+          # is NOT used (the bundle is built on this runner, not the VPS).
+          # Set these in GitHub → Settings → Secrets and variables → Actions.
+          # Base URLs are constant for github.com / gitlab.com SaaS.
+          VUE_APP_IS_GOOGLE_LOGIN:       ${{ secrets.VUE_APP_IS_GOOGLE_LOGIN }}
+          VUE_APP_GOOGLE_CLIENT_ID:      ${{ secrets.VUE_APP_GOOGLE_CLIENT_ID }}
+          VUE_APP_IS_GITHUB_LOGIN:       ${{ secrets.VUE_APP_IS_GITHUB_LOGIN }}
+          VUE_APP_GITHUB_CLIENT_ID:      ${{ secrets.VUE_APP_GITHUB_CLIENT_ID }}
+          VUE_APP_GITHUB_BASE_OAUTH_URL: "https://github.com/login/oauth"
+          VUE_APP_IS_GITLAB_LOGIN:       ${{ secrets.VUE_APP_IS_GITLAB_LOGIN }}
+          VUE_APP_GITLAB_CLIENT_ID:      ${{ secrets.VUE_APP_GITLAB_CLIENT_ID }}
+          VUE_APP_GITLAB_BASE_OAUTH_URL: "https://gitlab.com/oauth"
 
       # ---------------------------------
       # Create Frontend Artifact


### PR DESCRIPTION
﻿## Root cause

The Google/GitHub/GitLab buttons never appeared on **staging** even though they work locally. Reason: the frontend bundle is built on the **GitHub Actions runner** (the `validate` job runs `npm run build`, then the artifact is shipped to the VPS). `frontend/.env` is gitignored, so on the runner the only `VUE_APP_*` values are the ones explicitly mapped from secrets in the build step — and the **OAuth vars were missing** from that map. So the shipped bundle had every `VUE_APP_IS_*_LOGIN` flag `undefined` → no buttons. Editing `frontend/.env` on the server has no effect, because the server never builds the bundle.

## Fix

Map the OAuth enable-flags and client ids from GitHub secrets in the build step (same pattern as the Firebase vars), and pin the constant `github.com` / `gitlab.com` OAuth base URLs.

## ⚠️ Required before buttons appear — set these GitHub repository secrets
Settings → Secrets and variables → Actions → **New repository secret**:

| Secret | Value |
|---|---|
| `VUE_APP_IS_GOOGLE_LOGIN` | `true` |
| `VUE_APP_GOOGLE_CLIENT_ID` | the Google client id used for **staging** |
| `VUE_APP_IS_GITHUB_LOGIN` | `true` |
| `VUE_APP_GITHUB_CLIENT_ID` | the GitHub client id used for **staging** |
| `VUE_APP_IS_GITLAB_LOGIN` | `true` |
| `VUE_APP_GITLAB_CLIENT_ID` | the GitLab application id used for **staging** |

Note: the OAuth apps must also list the staging origin/redirect (`https://staging-app.alianhub.com`). GitHub OAuth Apps allow only one callback URL, so staging likely needs its **own** GitHub app (separate client id) — Google/GitLab can add staging as an extra redirect on the same app.

After the secrets are set, trigger a redeploy (Actions → Run workflow, enabled by #236) to rebuild with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
