### PR TITLE
feat(stickies): add personal sticky notes

### DIFF
--- a/Config/collections.js
+++ b/Config/collections.js
@@ -59,6 +59,7 @@ const dbCollections = {
     WEBHOOKS: "webhooks",
     WEBHOOK_LOGS: "webhookLogs",
     RECENTVISITS: "recentVisits",
+    STICKIES: "stickies",
     API_TOKENS: "apiTokens",
     API_ACTIVITY_LOGS: "apiActivityLogs",
     EXPORT_JOBS: "exportJobs",

--- a/Config/schemaType.js
+++ b/Config/schemaType.js
@@ -58,6 +58,7 @@ const SCHEMA_TYPE = {
     WEBHOOKS: "webhooks",
     WEBHOOK_LOGS: "webhookLogs",
     RECENTVISITS: "recentVisits",
+    STICKIES: "stickies",
     API_TOKENS: "apiTokens",
     API_ACTIVITY_LOGS: "apiActivityLogs",
     EXPORT_JOBS: "exportJobs",

--- a/Modules/Stickies/controller.js
+++ b/Modules/Stickies/controller.js
@@ -1,0 +1,177 @@
+const { SCHEMA_TYPE } = require("../../Config/schemaType");
+const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries");
+const mongoose = require("mongoose");
+const logger = require("../../Config/loggerConfig");
+const {
+    MAX_NOTES_PER_USER,
+    isObjectId,
+    validateStickyPayload,
+    validateReorder,
+} = require("./helpers/stickyRules");
+
+// Personal sticky notes — one document per note, scoped to the company
+// database AND the owning userId. Every query filters on userId, so a user
+// can only ever read or mutate their own notes. Content is stored as plain
+// text and rendered as text on the client (no HTML).
+
+// Resolve the acting user from the various shapes the clients send.
+const getUserId = (req) => {
+    const fromBody = req.body && (req.body.userId || (req.body.userData && (req.body.userData.id || req.body.userData._id)));
+    const fromQuery = req.query && req.query.uid;
+    return String(fromBody || fromQuery || '');
+};
+
+/* GET /api/v2/stickies?uid=<userId> — the user's notes, pinned first. */
+exports.listStickies = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const userId = getUserId(req);
+        if (!companyId || !userId) {
+            return res.send({ status: false, statusText: 'companyId and uid are required.' });
+        }
+
+        const stickies = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.STICKIES,
+            data: [{ userId }, null, { sort: { isPinned: -1, sortIndex: 1, updatedAt: -1 } }],
+        }, 'find');
+
+        return res.send({ status: true, statusText: 'Stickies fetched.', data: stickies || [] });
+    } catch (error) {
+        logger.error(`ERROR in list stickies: ${error.message}`);
+        return res.send({ status: false, statusText: error.message });
+    }
+};
+
+/* POST /api/v2/stickies  body: { content?, color?, userData } */
+exports.createSticky = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const userId = getUserId(req);
+        if (!companyId || !userId) {
+            return res.send({ status: false, statusText: 'companyId and userId are required.' });
+        }
+
+        const check = validateStickyPayload(req.body || {}, { partial: false });
+        if (!check.valid) {
+            return res.send({ status: false, statusText: check.reason });
+        }
+
+        // Per-user count cap (abuse guard).
+        const count = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.STICKIES,
+            data: [{ userId }],
+        }, 'countDocuments');
+        if (count >= MAX_NOTES_PER_USER) {
+            return res.send({ status: false, statusText: `You can keep at most ${MAX_NOTES_PER_USER} sticky notes.` });
+        }
+
+        const created = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.STICKIES,
+            data: {
+                userId,
+                title: check.data.title,
+                content: check.data.content,
+                color: check.data.color,
+                sortIndex: 0,
+                isPinned: false,
+            },
+        }, 'save');
+
+        return res.send({ status: true, statusText: 'Sticky created.', data: created });
+    } catch (error) {
+        logger.error(`ERROR in create sticky: ${error.message}`);
+        return res.send({ status: false, statusText: error.message });
+    }
+};
+
+/* PUT /api/v2/stickies/:id  body: { content?, color?, isPinned?, userData } */
+exports.updateSticky = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const userId = getUserId(req);
+        const { id } = req.params;
+        if (!companyId || !userId || !isObjectId(id)) {
+            return res.send({ status: false, statusText: 'companyId, userId and a valid id are required.' });
+        }
+
+        const check = validateStickyPayload(req.body || {}, { partial: true });
+        if (!check.valid) {
+            return res.send({ status: false, statusText: check.reason });
+        }
+
+        const updated = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.STICKIES,
+            data: [
+                { _id: new mongoose.Types.ObjectId(id), userId },
+                { $set: check.data },
+                { returnDocument: 'after' },
+            ],
+        }, 'findOneAndUpdate');
+
+        if (!updated) {
+            return res.send({ status: false, statusText: 'Sticky not found.' });
+        }
+        return res.send({ status: true, statusText: 'Sticky updated.', data: updated });
+    } catch (error) {
+        logger.error(`ERROR in update sticky: ${error.message}`);
+        return res.send({ status: false, statusText: error.message });
+    }
+};
+
+/* DELETE /api/v2/stickies/:id?uid=<userId> */
+exports.deleteSticky = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const userId = getUserId(req);
+        const { id } = req.params;
+        if (!companyId || !userId || !isObjectId(id)) {
+            return res.send({ status: false, statusText: 'companyId, userId and a valid id are required.' });
+        }
+
+        const deleted = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.STICKIES,
+            data: [{ _id: new mongoose.Types.ObjectId(id), userId }],
+        }, 'findOneAndDelete');
+
+        if (!deleted) {
+            return res.send({ status: false, statusText: 'Sticky not found.' });
+        }
+        return res.send({ status: true, statusText: 'Sticky deleted.', data: { _id: id } });
+    } catch (error) {
+        logger.error(`ERROR in delete sticky: ${error.message}`);
+        return res.send({ status: false, statusText: error.message });
+    }
+};
+
+/* PUT /api/v2/stickies/reorder  body: { ids: [..], userData } */
+exports.reorderStickies = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const userId = getUserId(req);
+        if (!companyId || !userId) {
+            return res.send({ status: false, statusText: 'companyId and userId are required.' });
+        }
+
+        const check = validateReorder(req.body && req.body.ids);
+        if (!check.valid) {
+            return res.send({ status: false, statusText: check.reason });
+        }
+
+        // Each note is updated only when it belongs to the user (userId in
+        // the filter), so a forged id for someone else's note is a no-op.
+        for (let index = 0; index < check.ids.length; index += 1) {
+            await MongoDbCrudOpration(companyId, {
+                type: SCHEMA_TYPE.STICKIES,
+                data: [
+                    { _id: new mongoose.Types.ObjectId(check.ids[index]), userId },
+                    { $set: { sortIndex: index } },
+                ],
+            }, 'updateOne');
+        }
+
+        return res.send({ status: true, statusText: 'Stickies reordered.' });
+    } catch (error) {
+        logger.error(`ERROR in reorder stickies: ${error.message}`);
+        return res.send({ status: false, statusText: error.message });
+    }
+};

--- a/Modules/Stickies/helpers/stickyRules.js
+++ b/Modules/Stickies/helpers/stickyRules.js
@@ -1,0 +1,89 @@
+// Pure validation/normalization rules for sticky notes — NO I/O, so the
+// jest suite can import this file directly without dragging in mongoose,
+// controllers, or any module that trips the Babel parser on legacy files.
+
+const STICKY_COLORS = ['yellow', 'green', 'blue', 'pink', 'orange', 'purple', 'gray'];
+const DEFAULT_COLOR = 'yellow';
+const MAX_TITLE_LENGTH = 200;
+const MAX_CONTENT_LENGTH = 2000;
+const MAX_NOTES_PER_USER = 200;
+const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
+
+const isObjectId = (value) => OBJECT_ID_PATTERN.test(String(value || ''));
+
+// Notes are plain text rendered as text (never HTML) on the client, so we
+// only bound the length and coerce to a string here — no markup stripping.
+const normalizeContent = (content) => String(content == null ? '' : content);
+
+const normalizeColor = (color) => (STICKY_COLORS.includes(String(color)) ? String(color) : DEFAULT_COLOR);
+
+// Validate a create/update payload. `partial: true` (update) only checks the
+// fields that are present; create requires the note to be within limits.
+const validateStickyPayload = (payload = {}, { partial = false } = {}) => {
+    const out = {};
+
+    if (!partial || payload.title !== undefined) {
+        const title = normalizeContent(payload.title);
+        if (title.length > MAX_TITLE_LENGTH) {
+            return { valid: false, reason: `Title exceeds ${MAX_TITLE_LENGTH} characters.` };
+        }
+        out.title = title;
+    }
+
+    if (!partial || payload.content !== undefined) {
+        const content = normalizeContent(payload.content);
+        if (content.length > MAX_CONTENT_LENGTH) {
+            return { valid: false, reason: `Content exceeds ${MAX_CONTENT_LENGTH} characters.` };
+        }
+        out.content = content;
+    }
+
+    if (!partial || payload.color !== undefined) {
+        out.color = normalizeColor(payload.color);
+    }
+
+    if (payload.isPinned !== undefined) {
+        out.isPinned = Boolean(payload.isPinned);
+    }
+
+    if (payload.sortIndex !== undefined) {
+        const n = Number(payload.sortIndex);
+        if (!Number.isFinite(n)) {
+            return { valid: false, reason: 'sortIndex must be a number.' };
+        }
+        out.sortIndex = n;
+    }
+
+    if (partial && Object.keys(out).length === 0) {
+        return { valid: false, reason: 'No valid fields to update.' };
+    }
+
+    return { valid: true, data: out };
+};
+
+// Validate a reorder request: an array of sticky ids in their new order.
+const validateReorder = (ids) => {
+    if (!Array.isArray(ids) || !ids.length) {
+        return { valid: false, reason: 'ids must be a non-empty array.' };
+    }
+    if (ids.length > MAX_NOTES_PER_USER) {
+        return { valid: false, reason: 'Too many ids.' };
+    }
+    if (!ids.every(isObjectId)) {
+        return { valid: false, reason: 'Every id must be a valid ObjectId.' };
+    }
+    return { valid: true, ids: ids.map(String) };
+};
+
+module.exports = {
+    STICKY_COLORS,
+    DEFAULT_COLOR,
+    MAX_TITLE_LENGTH,
+    MAX_CONTENT_LENGTH,
+    MAX_NOTES_PER_USER,
+    isObjectId,
+    normalizeContent,
+    normalizeColor,
+    validateStickyPayload,
+    validateReorder,
+};

--- a/Modules/Stickies/init.js
+++ b/Modules/Stickies/init.js
@@ -1,0 +1,5 @@
+const routes = require('./routes');
+
+exports.init = (app) => {
+    routes.init(app);
+}

--- a/Modules/Stickies/routes.js
+++ b/Modules/Stickies/routes.js
@@ -1,0 +1,9 @@
+const ctrl = require('./controller');
+
+exports.init = (app) => {
+    app.get('/api/v2/stickies', ctrl.listStickies);
+    app.post('/api/v2/stickies', ctrl.createSticky);
+    app.put('/api/v2/stickies/reorder', ctrl.reorderStickies);
+    app.put('/api/v2/stickies/:id', ctrl.updateSticky);
+    app.delete('/api/v2/stickies/:id', ctrl.deleteSticky);
+}

--- a/frontend/src/assets/images/svg/sticky_note_icon.svg
+++ b/frontend/src/assets/images/svg/sticky_note_icon.svg
@@ -1,0 +1,5 @@
+<svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 3.75h14A1.25 1.25 0 0 1 20.25 5v9.19a1.25 1.25 0 0 1-.366.884l-4.81 4.81a1.25 1.25 0 0 1-.884.366H5A1.25 1.25 0 0 1 3.75 19V5A1.25 1.25 0 0 1 5 3.75Z" stroke="#ffffff" stroke-width="1.5"/>
+  <path d="M13.75 20v-5a1.25 1.25 0 0 1 1.25-1.25h5" stroke="#ffffff" stroke-width="1.5"/>
+  <path d="M7.5 8h9M7.5 11h6" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/components/molecules/Stickies/StickiesPanel.vue
+++ b/frontend/src/components/molecules/Stickies/StickiesPanel.vue
@@ -1,0 +1,436 @@
+<template>
+    <div v-if="modelValue" class="stickies__overlay" @click.self="close">
+        <div class="stickies__panel" @click="openMenuId = null">
+            <div class="d-flex align-items-center justify-content-between stickies__head">
+                <span class="font-size-16 font-weight-700">{{ $t('Stickies.title') }}</span>
+                <div class="d-flex align-items-center">
+                    <button class="btn-primary font-size-12 mr-10px" :disabled="isBusy" @click="addNote">+ {{ $t('Stickies.add') }}</button>
+                    <span class="cursor-pointer font-size-16 stickies__close" @click="close">&#10005;</span>
+                </div>
+            </div>
+
+            <div v-if="isLoading" class="gray81 font-size-12 stickies__empty">{{ $t('Stickies.loading') }}</div>
+            <div v-else-if="!notes.length" class="gray81 font-size-12 stickies__empty">{{ $t('Stickies.empty') }}</div>
+
+            <Draggable
+                v-else
+                class="stickies__grid"
+                :list="notes"
+                item-key="_id"
+                handle=".stickies__note-head"
+                @end="onReorder"
+            >
+                <template #item="{ element: note }">
+                    <div
+                        class="stickies__note"
+                        :class="{ 'stickies__note--menu-open': openMenuId === note._id, 'stickies__note--pinned': note.isPinned }"
+                        :style="{ background: colorBg(note.color) }"
+                    >
+                        <!-- Head doubles as the drag handle so the textarea below stays editable. -->
+                        <div class="stickies__note-head" :title="$t('Stickies.drag_hint')">
+                            <span class="stickies__head-left">
+                                <img :src="dragGrip" alt="" class="stickies__drag-grip">
+                                <span v-if="note.isPinned" class="stickies__pin">&#128204;</span>
+                            </span>
+                            <button class="stickies__menu-btn" :title="$t('Stickies.options')" @click.stop="toggleMenu(note)">
+                                <img :src="horizontalDots" alt="options" class="vertical-middle">
+                            </button>
+                        </div>
+
+                        <!-- Per-note actions menu (pin / expand / color / delete live here
+                             so new options can be added without crowding the card). -->
+                        <div v-if="openMenuId === note._id" class="stickies__menu" @click.stop>
+                            <div class="stickies__menu-item" @click="togglePin(note)">{{ note.isPinned ? $t('Stickies.unpin') : $t('Stickies.pin') }}</div>
+                            <div class="stickies__menu-item" @click="expand(note)">{{ $t('Stickies.expand') }}</div>
+                            <div class="stickies__menu-colors">
+                                <span
+                                    v-for="c in colors"
+                                    :key="note._id + '-' + c"
+                                    class="stickies__dot"
+                                    :class="{ 'stickies__dot--active': note.color === c }"
+                                    :style="{ background: colorBg(c) }"
+                                    :title="c"
+                                    @click="setColor(note, c)"
+                                ></span>
+                            </div>
+                            <div class="stickies__menu-item stickies__menu-item--danger" @click="remove(note)">{{ $t('Stickies.delete') }}</div>
+                        </div>
+
+                        <input
+                            v-model="note.title"
+                            class="stickies__title"
+                            :placeholder="$t('Stickies.title_placeholder')"
+                            @input="scheduleSave(note)"
+                            @blur="saveNow(note)"
+                        />
+                        <textarea
+                            v-model="note.content"
+                            class="stickies__text"
+                            :placeholder="$t('Stickies.placeholder')"
+                            rows="5"
+                            @input="scheduleSave(note)"
+                            @blur="saveNow(note)"
+                        ></textarea>
+                    </div>
+                </template>
+            </Draggable>
+        </div>
+
+        <!-- Expanded single-note view. -->
+        <div v-if="expandedNote" class="stickies__expand-overlay" @click.self="closeExpand">
+            <div class="stickies__expand-card" :style="{ background: colorBg(expandedNote.color) }">
+                <div class="d-flex align-items-center justify-content-between stickies__expand-head">
+                    <div class="d-flex align-items-center">
+                        <span
+                            v-for="c in colors"
+                            :key="'exp-' + c"
+                            class="stickies__dot"
+                            :class="{ 'stickies__dot--active': expandedNote.color === c }"
+                            :style="{ background: colorBg(c) }"
+                            :title="c"
+                            @click="setColor(expandedNote, c)"
+                        ></span>
+                    </div>
+                    <span class="cursor-pointer font-size-16 stickies__close" @click="closeExpand">&#10005;</span>
+                </div>
+                <input
+                    v-model="expandedNote.title"
+                    class="stickies__expand-title"
+                    :placeholder="$t('Stickies.title_placeholder')"
+                    @input="scheduleSave(expandedNote)"
+                    @blur="saveNow(expandedNote)"
+                />
+                <textarea
+                    v-model="expandedNote.content"
+                    class="stickies__expand-text"
+                    :placeholder="$t('Stickies.placeholder')"
+                    @input="scheduleSave(expandedNote)"
+                    @blur="saveNow(expandedNote)"
+                ></textarea>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+// PACKAGES
+import { defineProps, inject, ref, watch } from "vue";
+import { useToast } from "vue-toast-notification";
+import { useI18n } from "vue-i18n";
+
+// COMPONENTS
+import Draggable from 'vuedraggable';
+
+// IMAGE
+import horizontalDots from "@/assets/images/svg/horizontalDots.svg";
+import dragGrip from "@/assets/images/svg/4DotsDrag.svg";
+
+// UTILS
+import { apiRequest } from '@/services';
+
+const { t } = useI18n();
+const $toast = useToast();
+const userId = inject('$userId');
+
+const props = defineProps({
+    modelValue: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const colors = ['yellow', 'green', 'blue', 'pink', 'orange', 'purple', 'gray'];
+const COLOR_BG = {
+    yellow: '#fff3b0', green: '#c8e6c9', blue: '#bbdefb', pink: '#f8bbd0',
+    orange: '#ffe0b2', purple: '#e1bee7', gray: '#e6e6e6',
+};
+const SAVE_DEBOUNCE_MS = 600;
+
+const notes = ref([]);
+const isLoading = ref(false);
+const isBusy = ref(false);
+const openMenuId = ref(null);
+const expandedNote = ref(null);
+const saveTimers = {};
+
+const colorBg = (color) => COLOR_BG[color] || COLOR_BG.yellow;
+
+function close() {
+    emit('update:modelValue', false);
+}
+
+watch(() => props.modelValue, (open) => {
+    if (open) {
+        openMenuId.value = null;
+        expandedNote.value = null;
+        fetchStickies();
+    }
+});
+
+function toggleMenu(note) {
+    openMenuId.value = openMenuId.value === note._id ? null : note._id;
+}
+
+function expand(note) {
+    openMenuId.value = null;
+    expandedNote.value = note;
+}
+
+function closeExpand() {
+    saveNow(expandedNote.value);
+    expandedNote.value = null;
+}
+
+function fetchStickies() {
+    isLoading.value = true;
+    apiRequest('get', `/api/v2/stickies?uid=${encodeURIComponent(userId.value)}`)
+    .then((response) => {
+        notes.value = response.data?.status ? (response.data.data || []) : [];
+    })
+    .catch((error) => console.error('ERROR in fetch stickies: ', error))
+    .finally(() => { isLoading.value = false; });
+}
+
+function addNote() {
+    if (isBusy.value) return;
+    isBusy.value = true;
+    apiRequest('post', '/api/v2/stickies', { content: '', color: 'yellow', userData: { id: userId.value } })
+    .then((response) => {
+        if (response.data?.status) {
+            notes.value.unshift(response.data.data);
+        } else {
+            $toast.error(response.data?.statusText || t('Toast.something_went_wrong'), { position: 'top-right' });
+        }
+    })
+    .catch((error) => console.error('ERROR in add sticky: ', error))
+    .finally(() => { isBusy.value = false; });
+}
+
+// Debounced per-note content save (keyed by id so editing one note never
+// cancels a pending save on another).
+function scheduleSave(note) {
+    if (saveTimers[note._id]) clearTimeout(saveTimers[note._id]);
+    saveTimers[note._id] = setTimeout(() => saveNow(note), SAVE_DEBOUNCE_MS);
+}
+
+function saveNow(note) {
+    if (!note) return;
+    if (saveTimers[note._id]) {
+        clearTimeout(saveTimers[note._id]);
+        delete saveTimers[note._id];
+    }
+    apiRequest('put', `/api/v2/stickies/${note._id}`, { title: note.title, content: note.content, userData: { id: userId.value } })
+    .catch((error) => console.error('ERROR in save sticky: ', error));
+}
+
+function setColor(note, color) {
+    note.color = color;
+    apiRequest('put', `/api/v2/stickies/${note._id}`, { color, userData: { id: userId.value } })
+    .catch((error) => console.error('ERROR in set sticky color: ', error));
+}
+
+// Re-sort to match the server order: pinned first, then sortIndex, then newest.
+function resort() {
+    notes.value = [...notes.value].sort((a, b) =>
+        (Number(b.isPinned) - Number(a.isPinned))
+        || ((a.sortIndex || 0) - (b.sortIndex || 0))
+        || (new Date(b.updatedAt) - new Date(a.updatedAt))
+    );
+}
+
+function togglePin(note) {
+    openMenuId.value = null;
+    note.isPinned = !note.isPinned;
+    apiRequest('put', `/api/v2/stickies/${note._id}`, { isPinned: note.isPinned, userData: { id: userId.value } })
+    .then(() => resort())
+    .catch((error) => console.error('ERROR in toggle pin: ', error));
+}
+
+// Persist the new manual order after a drag (vuedraggable has already
+// reordered `notes` in place); write sequential sortIndex values.
+function onReorder() {
+    const ids = notes.value.map((n) => n._id);
+    notes.value.forEach((n, i) => { n.sortIndex = i; });
+    apiRequest('put', '/api/v2/stickies/reorder', { ids, userData: { id: userId.value } })
+    .catch((error) => console.error('ERROR in reorder stickies: ', error));
+}
+
+function remove(note) {
+    openMenuId.value = null;
+    apiRequest('delete', `/api/v2/stickies/${note._id}?uid=${encodeURIComponent(userId.value)}`)
+    .then((response) => {
+        if (response.data?.status) {
+            if (expandedNote.value && expandedNote.value._id === note._id) expandedNote.value = null;
+            notes.value = notes.value.filter((n) => n._id !== note._id);
+        } else {
+            $toast.error(response.data?.statusText || t('Toast.something_went_wrong'), { position: 'top-right' });
+        }
+    })
+    .catch((error) => console.error('ERROR in delete sticky: ', error));
+}
+</script>
+
+<style scoped>
+.stickies__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 1000;
+    display: flex;
+    justify-content: flex-end;
+}
+.stickies__panel {
+    background: #fff;
+    width: min(400px, 92vw);
+    height: 100%;
+    padding: 16px 18px;
+    overflow-y: auto;
+    box-shadow: -8px 0 30px rgba(0, 0, 0, 0.18);
+}
+.stickies__head { margin-bottom: 14px; }
+.stickies__close { color: #9a9a9a; }
+.stickies__close:hover { color: #e84a4a; }
+.stickies__empty { padding: 32px 12px; text-align: center; }
+.stickies__grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    /* start (not stretch) so resizing one note doesn't stretch its row sibling */
+    align-items: start;
+}
+.stickies__note {
+    position: relative;
+    border-radius: 8px;
+    padding: 10px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+}
+.stickies__note--menu-open { z-index: 5; }
+.stickies__note--pinned { box-shadow: 0 0 0 2px rgba(91, 91, 107, 0.4), 0 1px 4px rgba(0, 0, 0, 0.12); }
+.stickies__note-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: grab;
+    margin-bottom: 2px;
+}
+.stickies__note-head:active { cursor: grabbing; }
+.stickies__head-left { display: flex; align-items: center; gap: 4px; }
+.stickies__drag-grip { width: 14px; height: 14px; opacity: 0.4; }
+.stickies__pin { font-size: 12px; }
+.stickies__menu-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0 2px;
+    line-height: 1;
+}
+.stickies__menu {
+    position: absolute;
+    top: 26px;
+    right: 8px;
+    z-index: 10;
+    background: #fff;
+    border: 1px solid #e6e6e6;
+    border-radius: 8px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+    padding: 6px;
+    min-width: 150px;
+}
+.stickies__menu-item {
+    font-size: 13px;
+    color: #3a3a3a;
+    padding: 7px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+.stickies__menu-item:hover { background: #f5f6fa; }
+.stickies__menu-item--danger { color: #e84a4a; }
+.stickies__menu-colors {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 6px 8px;
+    border-top: 1px solid #f0f0f0;
+    border-bottom: 1px solid #f0f0f0;
+    margin: 2px 0;
+}
+.stickies__dot {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    cursor: pointer;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    display: inline-block;
+    margin-right: 4px;
+}
+.stickies__dot--active { outline: 2px solid #555; outline-offset: 1px; }
+.stickies__title {
+    background: transparent;
+    border: none;
+    outline: none;
+    width: 100%;
+    font-size: 13px;
+    font-weight: 700;
+    color: #2b2b2b;
+    margin-bottom: 4px;
+}
+.stickies__text {
+    background: transparent;
+    border: none;
+    resize: vertical;
+    outline: none;
+    width: 100%;
+    font-size: 13px;
+    color: #3a3a3a;
+    line-height: 1.4;
+    min-height: 84px;
+}
+/* Expanded single-note view */
+.stickies__expand-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 1100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.stickies__expand-card {
+    border-radius: 10px;
+    width: min(680px, 92vw);
+    height: min(70vh, 640px);
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.28);
+}
+.stickies__expand-head { margin-bottom: 10px; }
+.stickies__expand-title {
+    background: transparent;
+    border: none;
+    outline: none;
+    width: 100%;
+    font-size: 16px;
+    font-weight: 700;
+    color: #2b2b2b;
+    margin-bottom: 8px;
+}
+.stickies__expand-text {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    resize: none;
+    width: 100%;
+    font-size: 15px;
+    color: #3a3a3a;
+    line-height: 1.5;
+}
+@media (max-width: 480px) {
+    .stickies__grid { grid-template-columns: 1fr; }
+}
+</style>

--- a/frontend/src/components/organisms/Header/Header.vue
+++ b/frontend/src/components/organisms/Header/Header.vue
@@ -62,6 +62,9 @@
                 <img src="@/assets/images/comment_mention.png" class="cursor-pointer" id="mention_driver" @click="getMentions(!mentions.length), showNotification = 1, notificationVisible = true">
                 <span :class="{'notification-tick': totalMentions > 0}" class="blinking"></span>
             </div>
+            <div class="position-re" :class="{'mr-2' : clientWidth > 1440, 'mr-1' : clientWidth<=1440}" v-if="rules && Object.keys(rules).length">
+                <img src="@/assets/images/svg/sticky_note_icon.svg" class="cursor-pointer" id="stickies_driver" :title="$t('Stickies.title')" @click="stickiesVisible = true">
+            </div>
             <div class="position-re" :class="{'pr-2' : clientWidth > 1440, 'pr-1' : clientWidth<=1440}" v-if="rules && Object.keys(rules).length && (companyUser.roleType === 1 || companyUser.roleType === 2)">
                 <img src="@/assets/images/svg/tour_image.svg" class="cursor-pointer" id="tour_icon" @click="getTourDetails(),tourVisible = true">
             </div>
@@ -99,6 +102,8 @@
                 v{{version}}
             </span>
         </div>
+
+        <StickiesPanel v-model="stickiesVisible" />
 
         <Sidebar
             title="Test"
@@ -334,6 +339,7 @@ import { useCustomComposable, useGetterFunctions } from "@/composable/index.js";
 import NavLinks from "@/components/organisms/NavLinks/NavLinks.vue";
 import WasabiIamgeCompp from "@/components/atom/WasabiIamgeCompp/WasabiIamgeCompp.vue"
 import Sidebar from "@/components/molecules/Sidebar/Sidebar.vue";
+import StickiesPanel from "@/components/molecules/Stickies/StickiesPanel.vue";
 import DropDown from "@/components/molecules/DropDown/DropDown.vue";
 import DropDownOption from "@/components/molecules/DropDownOption/DropDownOption.vue";
 import DropDownRouterOption from "@/components/molecules/DropDownRouterOption/DropDownRouterOption.vue";
@@ -436,6 +442,7 @@ const visible = ref(false);
 const showNotification = ref(0);
 const notificationVisible = ref(false);
 const tourVisible = ref(false);
+const stickiesVisible = ref(false);
 const myCounts = computed(() => getters["users/myCounts"]?.data || {})
 const totalNotification = computed(() => myCounts.value?.notification_counts);
 const totalMentions = computed(() => myCounts.value?.mention_counts)

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -2655,4 +2655,18 @@ export default {
         load_failed: "Couldn't load the changelog.",
         retry: "Retry",
     },
+    Stickies: {
+        title: "Sticky Notes",
+        add: "Add note",
+        loading: "Loading your notes…",
+        empty: "No notes yet. Click \"Add note\" to jot something down.",
+        placeholder: "Write a quick note…",
+        title_placeholder: "Title",
+        delete: "Delete note",
+        options: "Options",
+        expand: "Expand",
+        pin: "Pin",
+        unpin: "Unpin",
+        drag_hint: "Drag to reorder",
+    },
 };

--- a/index.js
+++ b/index.js
@@ -212,6 +212,7 @@ function initializeControllers() {
     require('./Modules/Webhooks/init').init(app);
     require('./Modules/Reactions/init').init(app);
     require('./Modules/RecentVisits/init').init(app);
+    require('./Modules/Stickies/init').init(app);
     require('./Modules/GlobalSearch/init').init(app);
     require('./Modules/Epics/init').init(app);
     require('./Modules/ExportJobs/init').init(app);

--- a/tests/sticky-rules.test.js
+++ b/tests/sticky-rules.test.js
@@ -1,0 +1,101 @@
+const {
+    STICKY_COLORS,
+    DEFAULT_COLOR,
+    MAX_TITLE_LENGTH,
+    MAX_CONTENT_LENGTH,
+    MAX_NOTES_PER_USER,
+    isObjectId,
+    normalizeColor,
+    validateStickyPayload,
+    validateReorder,
+} = require('../Modules/Stickies/helpers/stickyRules');
+
+describe('sticky rules — color', () => {
+    test('keeps a valid palette color', () => {
+        STICKY_COLORS.forEach((c) => expect(normalizeColor(c)).toBe(c));
+    });
+    test('falls back to the default for an unknown color', () => {
+        expect(normalizeColor('chartreuse')).toBe(DEFAULT_COLOR);
+        expect(normalizeColor(undefined)).toBe(DEFAULT_COLOR);
+        expect(normalizeColor('')).toBe(DEFAULT_COLOR);
+    });
+});
+
+describe('sticky rules — isObjectId', () => {
+    test('accepts a 24-hex id and rejects junk', () => {
+        expect(isObjectId('6a1d613984fa1ecb8175b7bf')).toBe(true);
+        expect(isObjectId('not-an-id')).toBe(false);
+        expect(isObjectId('')).toBe(false);
+        expect(isObjectId(null)).toBe(false);
+    });
+});
+
+describe('sticky rules — validateStickyPayload (create)', () => {
+    test('defaults title and content to empty and color to default', () => {
+        const r = validateStickyPayload({});
+        expect(r.valid).toBe(true);
+        expect(r.data.title).toBe('');
+        expect(r.data.content).toBe('');
+        expect(r.data.color).toBe(DEFAULT_COLOR);
+    });
+    test('accepts a title and rejects one over the max length', () => {
+        expect(validateStickyPayload({ title: 'Groceries' }).data.title).toBe('Groceries');
+        expect(validateStickyPayload({ title: 'x'.repeat(MAX_TITLE_LENGTH + 1) }).valid).toBe(false);
+    });
+    test('accepts content within the limit and a valid color', () => {
+        const r = validateStickyPayload({ content: 'call vendor at 3pm', color: 'blue' });
+        expect(r.valid).toBe(true);
+        expect(r.data.content).toBe('call vendor at 3pm');
+        expect(r.data.color).toBe('blue');
+    });
+    test('rejects content over the max length', () => {
+        const r = validateStickyPayload({ content: 'x'.repeat(MAX_CONTENT_LENGTH + 1) });
+        expect(r.valid).toBe(false);
+    });
+    test('coerces an unknown color to the default rather than failing', () => {
+        const r = validateStickyPayload({ content: 'note', color: 'neon' });
+        expect(r.valid).toBe(true);
+        expect(r.data.color).toBe(DEFAULT_COLOR);
+    });
+});
+
+describe('sticky rules — validateStickyPayload (partial update)', () => {
+    test('updates only the provided fields', () => {
+        const r = validateStickyPayload({ color: 'green' }, { partial: true });
+        expect(r.valid).toBe(true);
+        expect(r.data).toEqual({ color: 'green' });
+    });
+    test('accepts isPinned and numeric sortIndex', () => {
+        const r = validateStickyPayload({ isPinned: true, sortIndex: 3 }, { partial: true });
+        expect(r.valid).toBe(true);
+        expect(r.data.isPinned).toBe(true);
+        expect(r.data.sortIndex).toBe(3);
+    });
+    test('rejects a non-numeric sortIndex', () => {
+        const r = validateStickyPayload({ sortIndex: 'abc' }, { partial: true });
+        expect(r.valid).toBe(false);
+    });
+    test('rejects an empty partial update', () => {
+        const r = validateStickyPayload({}, { partial: true });
+        expect(r.valid).toBe(false);
+    });
+});
+
+describe('sticky rules — validateReorder', () => {
+    test('accepts an array of valid ids', () => {
+        const ids = ['6a1d613984fa1ecb8175b7bf', '6a1d613a84fa1ecb8175b7c2'];
+        const r = validateReorder(ids);
+        expect(r.valid).toBe(true);
+        expect(r.ids).toEqual(ids);
+    });
+    test('rejects an empty array', () => {
+        expect(validateReorder([]).valid).toBe(false);
+    });
+    test('rejects an array containing a bad id', () => {
+        expect(validateReorder(['6a1d613984fa1ecb8175b7bf', 'nope']).valid).toBe(false);
+    });
+    test('rejects more than the per-user cap', () => {
+        const many = new Array(MAX_NOTES_PER_USER + 1).fill('6a1d613984fa1ecb8175b7bf');
+        expect(validateReorder(many).valid).toBe(false);
+    });
+});

--- a/utils/mongo-handler/createSchema.js
+++ b/utils/mongo-handler/createSchema.js
@@ -90,6 +90,9 @@ const recentVisitsSchema = new Schema(schema.recentVisits, {strict: true, timest
 // recents: one doc per user+entity, always read newest-first per user.
 recentVisitsSchema.index({ userId: 1, visitedAt: -1 });
 recentVisitsSchema.index({ userId: 1, entityType: 1, entityId: 1 }, { unique: true });
+const stickiesSchema = new Schema(schema.stickies, {strict: true, timestamps: true});
+// stickies: per-user board, read in pin-then-order sequence for that user.
+stickiesSchema.index({ userId: 1, isPinned: -1, sortIndex: 1 });
 const apiTokensSchema = new Schema(schema.apiTokens, {strict: true, timestamps: true});
 apiTokensSchema.index({ tokenHash: 1 });
 apiTokensSchema.index({ userId: 1 });
@@ -179,6 +182,7 @@ module.exports = {
     webhooksSchema,
     webhookLogsSchema,
     recentVisitsSchema,
+    stickiesSchema,
     apiTokensSchema,
     apiActivityLogsSchema,
     exportJobsSchema,

--- a/utils/mongo-handler/mongoQueries.js
+++ b/utils/mongo-handler/mongoQueries.js
@@ -57,6 +57,7 @@ const {
     webhooksSchema,
     webhookLogsSchema,
     recentVisitsSchema,
+    stickiesSchema,
     apiTokensSchema,
     apiActivityLogsSchema,
     exportJobsSchema,
@@ -184,6 +185,8 @@ exports.checkType = (type) => {
             return webhookLogsSchema
         case SCHEMA_TYPE.RECENTVISITS:
             return recentVisitsSchema
+        case SCHEMA_TYPE.STICKIES:
+            return stickiesSchema
         case SCHEMA_TYPE.API_TOKENS:
             return apiTokensSchema
         case SCHEMA_TYPE.API_ACTIVITY_LOGS:
@@ -324,6 +327,8 @@ exports.tableType = (type) => {
                 return `${dbCollections.WEBHOOK_LOGS}`
         case SCHEMA_TYPE.RECENTVISITS:
                 return `${dbCollections.RECENTVISITS}`
+        case SCHEMA_TYPE.STICKIES:
+                return `${dbCollections.STICKIES}`
         case SCHEMA_TYPE.API_TOKENS:
                 return `${dbCollections.API_TOKENS}`
         case SCHEMA_TYPE.API_ACTIVITY_LOGS:

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -304,6 +304,40 @@ const schema = {
             required: true,
         },
     },
+    // Personal sticky notes — per-user quick-capture scratchpad,
+    // company-DB-scoped and private to the owning user. Managed by
+    // Modules/Stickies. Content is plain text (rendered as text, never HTML).
+    stickies: {
+        userId: {
+            type: String,
+            required: true,
+        },
+        title: {
+            type: String,
+            required: false,
+            default: "",
+        },
+        content: {
+            type: String,
+            required: false,
+            default: "",
+        },
+        color: {
+            type: String,
+            required: false,
+            default: "yellow",
+        },
+        sortIndex: {
+            type: Number,
+            required: false,
+            default: 0,
+        },
+        isPinned: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
+    },
     // Personal API tokens (hashed at rest; prefix shown for identification)
     // — managed by Modules/ApiTokens
     apiTokens: {


### PR DESCRIPTION
﻿## What & why

Adds **Sticky Notes** — a personal quick-capture scratchpad (closes the Plane "Stickies" gap). Per-user notes that are always one click away from a header icon, for jotting reminders/ideas that don''t yet belong to a formal task.

### Frontend
- Header **sticky-note icon** → right-side slide-over panel (`StickiesPanel.vue`).
- Grid of colored note cards, each with a **bold title** + body, **debounced auto-save** (on input + blur).
- Per-note **"..." menu** (extensible): **Pin/Unpin**, **Expand** (large single-note view), **color** picker, **Delete**.
- **Drag-to-reorder** via a grip handle (uses the app''s `vuedraggable`); the textareas stay editable.
- Pinned notes float to the top with a 📌 + ring. i18n added.

### Backend — `Modules/Stickies/`
- CRUD + reorder endpoints (`/api/v2/stickies`), every query scoped by **company DB + `userId`** (ownership enforced in the filter).
- Pure `stickyRules.js` (title/content length caps, color-enum, reorder validation) + unit tests.
- `stickies` collection wired through **all five** schema-registration points (schema / createSchema / mongoQueries ×3 / schemaType / collections); per-user count cap (200); content rendered as text (no HTML).

## Verification
- ESLint clean; full jest suite passes (incl. new `sticky-rules` tests); backend module runtime-loads and the schema registers; `index.js` parses.
- Manually tested: create / title+body autosave / color / pin / expand / delete / drag-reorder / per-user isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
