### PR TITLE
docs: add ROADMAP with a free-stays-free commitment

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,64 @@
+# AlianHub Roadmap
+
+This page sets out two things: our **commitment on what stays free**, and where the project is **heading next**.
+
+---
+
+## Our promise: free stays free
+
+Everything that works in AlianHub today — and everything marked _planned_ below — is and will remain **free and open-source under AGPL-3.0**. We will **not** move a feature that works today behind a paywall. This is a deliberate, public commitment so teams can adopt AlianHub without fear of a future bait-and-switch.
+
+### Always free
+
+- **All project views** — List, Board (Kanban), Table, Calendar, Workload — and the upcoming **Gantt / timeline**
+- **Time tracking** — timesheets plus optional screenshots / activity capture, and the desktop tracker
+- **Custom fields**, **custom roles**, and per-company **RBAC**
+- **Dashboards & widgets**
+- **Sprints, milestones & reports**
+- **AI** task / sub-task / project generation (using your own provider API key)
+- **Built-in chat & channels**, real-time sync
+- **Webhooks, importers, public share links, API tokens**
+- **Self-hosting** with full data ownership — no per-seat pricing, no telemetry lock-in
+
+### What may become paid (new enterprise add-ons)
+
+To fund sustained development, some **enterprise-grade** capabilities may ship as paid add-ons. These are needs that teams without compliance or large-scale governance requirements generally don't miss — and they are **new** capabilities, never a take-back of what's free today:
+
+- **SAML / SCIM / LDAP** single sign-on & user provisioning
+- **Audit-log API** & advanced governance / retention controls
+- **Managed cloud hosting** (we run it for you)
+- **SLA-backed priority support**
+
+> If a future paid add-on is ever built on top of something free today, the free version keeps working. The boundary moves _up_ (new enterprise features), never _down_.
+
+---
+
+## Where we're heading
+
+This is direction, not a dated commitment. For what *just* shipped, see [CHANGELOG.md](CHANGELOG.md).
+
+### 🔭 Now
+- Third-party sign-in hardening and additional OAuth providers
+- Platform integration surface (webhooks, API tokens, public REST API)
+
+### 🛠 Next
+- **Gantt / timeline view** with dependencies and milestones — the most-requested missing view
+- Velocity & cumulative-flow reports on top of sprints
+- More first-class integrations (Slack/Discord presets, n8n)
+
+### 💡 Later / exploring
+- Additional importers (Trello, Jira)
+- Recurring tasks
+- Guest / client role + read-only public boards
+- Deeper automation rules
+
+---
+
+## Suggest something
+
+Have an idea or a need? We prioritize from real demand:
+
+- 💬 [Start a discussion](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/discussions)
+- 🚀 [Open a feature request](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/issues/new?template=feature_request.yml)
+
+_This roadmap is a living document and will change as priorities and community feedback evolve. The "free stays free" commitment above will not._


### PR DESCRIPTION
﻿## S0-05 — Free/paid boundary + public roadmap (+ CLA steps)

Restores **ROADMAP.md** (it was removed earlier, leaving broken README links) with the Sprint-0 "irreversibility insurance":

- **Free stays free** commitment — everything that works today (all views incl. upcoming Gantt, time tracking + screenshots, custom fields, custom roles, dashboards, AI with your key, webhooks, importers, sprints, milestones, chat) stays free under AGPL-3.0.
- **What may become paid** — only *new* enterprise add-ons (SAML/SCIM/LDAP, audit-log API, managed cloud, SLA support), never a take-back of free features.
- **Now / Next / Later** direction section + how to suggest features.

This also makes the README roadmap references resolve again (PR #241 temporarily pointed them at Discussions; once both merge they can point back to ROADMAP.md).

### Remaining S0-05 steps that are external (not repo PRs) — for you to action
1. **Pin** the "free stays free" statement as a GitHub Discussion (Announcements).
2. **CLA** — this is a legal decision I deliberately did **not** commit:
   - **Recommended:** install the [CLA Assistant GitHub App](https://cla-assistant.io) and paste a standard Individual CLA granting Aliansoftware relicensing rights (needed if an enterprise edition is on the table).
   - **Lighter alternative:** enable DCO sign-offs via the `dco` GitHub App.
   - Tell me which and I can add the matching workflow/`CLA.md` in a follow-up PR.
3. **Public Project board** — convert the sprint backlog into a public GitHub Project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
