### PR TITLE
feat(webhooks): add Slack and Discord delivery format presets

### DIFF
--- a/Modules/Webhooks/controller.js
+++ b/Modules/Webhooks/controller.js
@@ -14,6 +14,7 @@ const maskHook = (hook) => ({
     url: hook.url,
     events: hook.events,
     active: hook.active !== false,
+    format: hook.format || 'json',
     createdBy: hook.createdBy || '',
     lastStatus: hook.lastStatus,
     lastDeliveredAt: hook.lastDeliveredAt,
@@ -29,11 +30,11 @@ exports.listEvents = (req, res) => {
 exports.createWebhook = async (req, res) => {
     try {
         const companyId = req.headers['companyid'] || '';
-        const { name, url, events, userData } = req.body || {};
+        const { name, url, events, format, userData } = req.body || {};
         if (!companyId) {
             return res.send({ status: false, statusText: 'companyId is required.' });
         }
-        const check = validateWebhookInput({ name, url, events });
+        const check = validateWebhookInput({ name, url, events, format });
         if (!check.valid) {
             return res.send({ status: false, statusText: check.reason });
         }
@@ -47,6 +48,7 @@ exports.createWebhook = async (req, res) => {
                 events,
                 secret,
                 active: true,
+                format: format || 'json',
                 createdBy: userData && (userData.id || userData._id) ? String(userData.id || userData._id) : '',
             },
         }, 'save');
@@ -86,13 +88,14 @@ exports.updateWebhook = async (req, res) => {
         if (!companyId || !isObjectIdString(id)) {
             return res.send({ status: false, statusText: 'companyId and a valid webhook id are required.' });
         }
-        const { name, url, events, active } = req.body || {};
+        const { name, url, events, active, format } = req.body || {};
         const update = {};
-        if (name !== undefined || url !== undefined || events !== undefined) {
+        if (name !== undefined || url !== undefined || events !== undefined || format !== undefined) {
             const check = validateWebhookInput({
                 name: name !== undefined ? name : 'placeholder',
                 url: url !== undefined ? url : 'https://placeholder.invalid',
                 events: events !== undefined ? events : ['*'],
+                format,
             });
             if (!check.valid) {
                 return res.send({ status: false, statusText: check.reason });
@@ -100,6 +103,7 @@ exports.updateWebhook = async (req, res) => {
             if (name !== undefined) update.name = String(name).trim();
             if (url !== undefined) update.url = String(url).trim();
             if (events !== undefined) update.events = events;
+            if (format !== undefined) update.format = format;
         }
         if (active !== undefined) update.active = active === true;
         if (!Object.keys(update).length) {

--- a/Modules/Webhooks/dispatcher.js
+++ b/Modules/Webhooks/dispatcher.js
@@ -3,7 +3,7 @@ const { SCHEMA_TYPE } = require('../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
 const logger = require('../../Config/loggerConfig');
 const socketEmitter = require('../../event/socketEventEmitter');
-const { subscribesTo, classifyTaskEvent, trimTaskForDelivery, signPayload } = require('./helpers/webhookRules');
+const { subscribesTo, classifyTaskEvent, trimTaskForDelivery, signPayload, formatForTarget } = require('./helpers/webhookRules');
 
 // Webhook dispatcher. Piggybacks on the namespaced socketEmitter events that
 // every task mutation already fires, so no write path needed changes:
@@ -66,7 +66,9 @@ async function logDelivery(companyId, webhookId, entry) {
 }
 
 async function deliverToHook(companyId, hook, body, attempt) {
-    const bodyString = JSON.stringify(body);
+    // Shape the payload for the hook's target (raw json / Slack / Discord).
+    // The signature covers exactly what we send; body.event is kept for logging.
+    const bodyString = JSON.stringify(formatForTarget(hook.format, body));
     const startedAt = Date.now();
     try {
         const response = await axios.post(hook.url, bodyString, {

--- a/Modules/Webhooks/helpers/webhookRules.js
+++ b/Modules/Webhooks/helpers/webhookRules.js
@@ -16,6 +16,18 @@ const WILDCARD = '*';
 const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
 const MAX_NAME_LENGTH = 80;
 
+// Outbound payload shapes. 'json' ships the raw envelope; 'slack' and
+// 'discord' render the event into that platform's incoming-webhook format.
+const WEBHOOK_FORMATS = Object.freeze(['json', 'slack', 'discord']);
+
+const EVENT_LABELS = Object.freeze({
+    'task.created': 'Task created',
+    'task.updated': 'Task updated',
+    'task.deleted': 'Task deleted',
+    'task.archived': 'Task archived',
+    'task.restored': 'Task restored',
+});
+
 const isObjectIdString = (id) => OBJECT_ID_PATTERN.test(String(id || ''));
 
 const isValidUrl = (value) => {
@@ -28,7 +40,7 @@ const isValidUrl = (value) => {
 };
 
 /* Validate create/update input. Returns { valid, reason }. */
-const validateWebhookInput = ({ name, url, events }) => {
+const validateWebhookInput = ({ name, url, events, format }) => {
     if (!name || !String(name).trim() || String(name).length > MAX_NAME_LENGTH) {
         return { valid: false, reason: `A name up to ${MAX_NAME_LENGTH} characters is required.` };
     }
@@ -42,7 +54,50 @@ const validateWebhookInput = ({ name, url, events }) => {
     if (unknown.length) {
         return { valid: false, reason: `Unknown events: ${unknown.join(', ')}.` };
     }
+    if (format !== undefined && !WEBHOOK_FORMATS.includes(String(format))) {
+        return { valid: false, reason: `format must be one of: ${WEBHOOK_FORMATS.join(', ')}.` };
+    }
     return { valid: true, reason: '' };
+};
+
+const normalizeFormat = (format) => (WEBHOOK_FORMATS.includes(String(format)) ? String(format) : 'json');
+
+// Best-effort human status label from the trimmed task (status may be an
+// object, a string, or absent).
+const statusLabel = (task) => {
+    const s = task.status;
+    return String((s && (s.text || s.statusName || s.name)) || task.statusType || '—');
+};
+
+/* Render the canonical delivery body into the target platform's shape.
+ * Slack expects { text, blocks }; Discord expects { embeds }. 'json' (and
+ * anything unknown) ships the raw envelope unchanged. Pure — no I/O. */
+const formatForTarget = (format, body) => {
+    const fmt = normalizeFormat(format);
+    if (fmt === 'json') return body;
+
+    const task = body.data || {};
+    const label = EVENT_LABELS[body.event] || body.event;
+    const title = `${task.TaskKey ? task.TaskKey + ' — ' : ''}${task.TaskName || 'Task'}`;
+    const meta = `Status: ${statusLabel(task)} · Priority: ${task.Task_Priority || '—'}${task.DueDate ? ' · Due: ' + task.DueDate : ''}`;
+
+    if (fmt === 'slack') {
+        return {
+            text: `${label}: ${title}`,
+            blocks: [
+                { type: 'section', text: { type: 'mrkdwn', text: `*${label}*\n*${task.TaskKey || ''}* ${task.TaskName || ''}`.trim() } },
+                { type: 'context', elements: [{ type: 'mrkdwn', text: meta }] },
+            ],
+        };
+    }
+
+    // discord
+    const fields = [
+        { name: 'Status', value: statusLabel(task), inline: true },
+        { name: 'Priority', value: String(task.Task_Priority || '—'), inline: true },
+    ];
+    if (task.DueDate) fields.push({ name: 'Due', value: String(task.DueDate), inline: true });
+    return { embeds: [{ title, description: label, fields }] };
 };
 
 /* Does a webhook's subscription cover this event? */
@@ -96,6 +151,7 @@ const generateSecret = () => crypto.randomBytes(24).toString('hex');
 module.exports = {
     EVENT_TYPES,
     WILDCARD,
+    WEBHOOK_FORMATS,
     isObjectIdString,
     isValidUrl,
     validateWebhookInput,
@@ -104,4 +160,6 @@ module.exports = {
     trimTaskForDelivery,
     signPayload,
     generateSecret,
+    normalizeFormat,
+    formatForTarget,
 };

--- a/tests/webhook-rules.test.js
+++ b/tests/webhook-rules.test.js
@@ -9,6 +9,7 @@
 const {
     EVENT_TYPES,
     WILDCARD,
+    WEBHOOK_FORMATS,
     isValidUrl,
     validateWebhookInput,
     subscribesTo,
@@ -16,7 +17,58 @@ const {
     trimTaskForDelivery,
     signPayload,
     generateSecret,
+    normalizeFormat,
+    formatForTarget,
 } = require('../Modules/Webhooks/helpers/webhookRules');
+
+describe('webhook format presets', () => {
+    const body = {
+        event: 'task.updated',
+        companyId: 'c1',
+        data: { TaskKey: 'AHE-1', TaskName: 'Fix login', status: { text: 'In Progress' }, Task_Priority: 'HIGH', DueDate: '2026-07-01' },
+    };
+
+    test('normalizeFormat falls back to json for unknown/empty', () => {
+        expect(normalizeFormat('slack')).toBe('slack');
+        expect(normalizeFormat('discord')).toBe('discord');
+        expect(normalizeFormat('teams')).toBe('json');
+        expect(normalizeFormat(undefined)).toBe('json');
+    });
+
+    test('json format returns the raw envelope unchanged', () => {
+        expect(formatForTarget('json', body)).toBe(body);
+        expect(formatForTarget(undefined, body)).toBe(body);
+    });
+
+    test('slack format produces text + blocks with the task details', () => {
+        const out = formatForTarget('slack', body);
+        expect(out.text).toContain('AHE-1');
+        expect(Array.isArray(out.blocks)).toBe(true);
+        const rendered = JSON.stringify(out);
+        expect(rendered).toContain('Task updated');
+        expect(rendered).toContain('In Progress');
+        expect(rendered).toContain('HIGH');
+    });
+
+    test('discord format produces an embed with status/priority/due fields', () => {
+        const out = formatForTarget('discord', body);
+        expect(Array.isArray(out.embeds)).toBe(true);
+        expect(out.embeds[0].title).toContain('Fix login');
+        const names = out.embeds[0].fields.map((f) => f.name);
+        expect(names).toEqual(expect.arrayContaining(['Status', 'Priority', 'Due']));
+    });
+
+    test('validateWebhookInput rejects an unknown format but accepts a valid one', () => {
+        const base = { name: 'h', url: 'https://x.test', events: ['*'] };
+        expect(validateWebhookInput({ ...base, format: 'teams' }).valid).toBe(false);
+        expect(validateWebhookInput({ ...base, format: 'slack' }).valid).toBe(true);
+        expect(validateWebhookInput(base).valid).toBe(true); // format optional
+    });
+
+    test('WEBHOOK_FORMATS lists the three supported shapes', () => {
+        expect(WEBHOOK_FORMATS).toEqual(['json', 'slack', 'discord']);
+    });
+});
 
 describe('🪝 WEBHOOKS - Rules', () => {
 

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -436,6 +436,14 @@ const schema = {
             default: true,
             required: false,
         },
+        // Outbound payload shape: 'json' (raw, default), 'slack' (Block Kit),
+        // or 'discord' (embed) — lets a hook target a Slack/Discord incoming
+        // webhook directly without a transform service.
+        format: {
+            type: String,
+            default: "json",
+            required: false,
+        },
         createdBy: {
             type: String,
             required: false,


### PR DESCRIPTION
﻿## S2-01 / S2-03 (phase 1) — Slack & Discord webhook presets

Lets an outgoing webhook target a **Slack or Discord incoming webhook directly**, with no transform/middleware service.

- New `format` field on the webhook (`json` default · `slack` · `discord`), declared on the strict `webhooks` schema, validated on create/update, and returned in the (masked) hook responses.
- The dispatcher renders each task event into the target shape before signing/sending:
  - **Slack** → `{ text, blocks }` (Block Kit: event + task key/name, status · priority · due context line)
  - **Discord** → `{ embeds: [...] }` (title + status/priority/due fields)
  - **json** (and anything unknown) → the raw envelope unchanged
- The transformer (`formatForTarget`) is a **pure function** in `webhookRules.js`, covered by unit tests; the HMAC signature now covers exactly the bytes sent.

Usage: `POST /api/v2/webhooks` with `{ name, url: <slack/discord incoming-webhook URL>, events, format: "slack" }`.

## Verification
- Full jest suite passes (incl. new format-preset tests); webhooks module runtime-loads with `STORAGE_TYPE` set; transformer output spot-checked.

Note: this is backend-only (webhooks have no settings UI yet) — a webhook is configured via the API. A "Send to Slack/Discord" UI toggle can come with the webhooks settings page later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
