### PR TITLE
fix(i18n): close Stickies object in en.js so the frontend builds

### DIFF
--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -2668,6 +2668,7 @@ export default {
         pin: "Pin",
         unpin: "Unpin",
         drag_hint: "Drag to reorder",
+    },
     Demo: {
         banner: "You're on the AlianHub live demo — data may reset periodically.",
         login_with: "Log in with",


### PR DESCRIPTION
PR #239 added the Stickies locale block immediately before the existing Demo block but omitted its closing brace. That nested Demo inside Stickies and left the locale object one brace short, breaking the frontend build:

  SyntaxError: src/locales/en.js: Unexpected token, expected "," (2677:1)

Fix: add the missing brace to close Stickies, restoring Demo as a top-level sibling. Verified the file parses with @babel/parser (sourceType: module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)