### PR TITLE
feat(dashboard): dismiss recently-added project suggestions

### DIFF
--- a/frontend/src/components/molecules/CardFieldComponent/CardFieldComponent.vue
+++ b/frontend/src/components/molecules/CardFieldComponent/CardFieldComponent.vue
@@ -90,6 +90,7 @@
                         :projects="newlyAddedProjects"
                         :selectedIds="selectedProjects"
                         @toggle="toggleNewProject"
+                        @dismiss="dismissNewProject"
                     />
                 </template>
             </div>
@@ -263,6 +264,21 @@ const isNewlyAddedProject = (project) => {
     const threshold = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 2).getTime();
     return created > threshold;
 };
+// Projects the user explicitly dismissed (the X on a suggestion row). Persisted
+// in localStorage per user so a dismissed suggestion stays gone after the card
+// is closed and reopened — even without saving. Only ids still inside the "new"
+// window are retained (see dismissNewProject), so the stored list stays bounded.
+const dismissKey = () => `rap_dismissed_${userId?.value || 'anon'}`;
+const dismissedNewProjects = ref([]);
+const loadDismissedProjects = () => {
+    try {
+        const raw = localStorage.getItem(dismissKey());
+        dismissedNewProjects.value = raw ? (JSON.parse(raw) || []) : [];
+    } catch (e) {
+        dismissedNewProjects.value = [];
+    }
+};
+
 const newlyAddedProjects = computed(() => {
     if (props.componentId !== 'EmployeeWorkloadReportCard') return [];
     return (props.allProjectsArray || [])
@@ -271,6 +287,8 @@ const newlyAddedProjects = computed(() => {
         // to selectedProjects (what Save persists), so it drops out of this
         // list immediately and won't be suggested again on reopen.
         .filter((p) => !selectedProjects.value.includes(p._id))
+        // …and not ones the user dismissed with the X.
+        .filter((p) => !dismissedNewProjects.value.includes(p._id))
         .sort((a, b) => resolveCreatedMs(b?.createdAt) - resolveCreatedMs(a?.createdAt));
 });
 // Toggle a project in/out of the SAME selectedProjects array the Project
@@ -280,6 +298,26 @@ const toggleNewProject = (projectId) => {
     selectedProjects.value = selectedProjects.value.includes(projectId)
         ? selectedProjects.value.filter((id) => id !== projectId)
         : [...selectedProjects.value, projectId];
+};
+// Dismiss a suggestion (the X). Persist immediately so it survives the card
+// being closed and reopened, pruning to ids still in the "new" window to keep
+// the stored list bounded. Does NOT touch selectedProjects — only hides it.
+const dismissNewProject = (projectId) => {
+    if (!projectId) return;
+    const candidateIds = (props.allProjectsArray || [])
+        .filter(isNewlyAddedProject)
+        .map((p) => p._id);
+    const next = new Set(
+        dismissedNewProjects.value.filter((id) => candidateIds.includes(id))
+    );
+    next.add(projectId);
+    dismissedNewProjects.value = [...next];
+    try {
+        localStorage.setItem(dismissKey(), JSON.stringify(dismissedNewProjects.value));
+    } catch (e) {
+        // localStorage unavailable (private mode / quota) — the dismissal still
+        // applies for this session via the reactive ref above.
+    }
 };
 
 const error = ref('');
@@ -306,6 +344,7 @@ watch(()=>selectedProjects.value, (newValue) => {
 },{deep:true,immediate: true});
 
 onMounted(() =>{
+    loadDismissedProjects();
     initializeFormObject();
 });
 

--- a/frontend/src/components/molecules/RecentlyAddedProjects/RecentlyAddedProjects.vue
+++ b/frontend/src/components/molecules/RecentlyAddedProjects/RecentlyAddedProjects.vue
@@ -14,6 +14,20 @@
                 :class="{ 'rap-row-selected': isChecked(p._id) }"
                 @click="$emit('toggle', p._id)"
             >
+                <!-- Dismiss (X): removes this suggestion for good (the parent
+                     persists it so it won't come back). .stop keeps it from
+                     triggering the row's add-toggle. -->
+                <button
+                    type="button"
+                    class="rap-dismiss"
+                    :title="$t('dashboardCard.dismiss_recent_project')"
+                    @click.stop="$emit('dismiss', p._id)"
+                >
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M1.5 1.5l7 7m0-7l-7 7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                </button>
+
                 <!-- Project icon — mirrors the project dropdown / sidebar rendering -->
                 <span
                     v-if="p.projectIcon && p.projectIcon.type === 'color'"
@@ -56,7 +70,7 @@ const props = defineProps({
     selectedIds: { type: Array, default: () => [] },
 });
 
-defineEmits(['toggle']);
+defineEmits(['toggle', 'dismiss']);
 
 const isChecked = (id) => props.selectedIds.includes(id);
 
@@ -155,6 +169,27 @@ const createdLabel = (p) => {
     background: #F2F4FE;
     border-color: #C9D0F8;
     border-left-color: #3ba510;
+}
+/* Dismiss (X) — leftmost in the row, just inside the green marker. Subtle
+   grey by default, turns red on hover to read as a "remove" action. */
+.rap-dismiss {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: #B6BCC9;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+.rap-dismiss:hover {
+    background: #FDECEC;
+    color: #E5484D;
 }
 .rap-icon {
     display: inline-flex;

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -2575,6 +2575,7 @@ export default {
         recently_added_projects: "Recently Added Projects",
         recently_added_projects_hint: "New projects from the last 2 days — tick one to add it to this card.",
         new_badge: "New",
+        dismiss_recent_project: "Remove from suggestions",
         Today: "Today",
         Yesterday: "Yesterday",
         Tomorrow: "Tomorrow",


### PR DESCRIPTION
Adds a per-row dismiss control to the Recently Added Projects section of the Employee Workload Edit Card modal.

## What changed
- **RecentlyAddedProjects.vue**: an X button as the leftmost element of each row (just inside the green marker), grey by default and red on hover. Uses click.stop so it never triggers the row add-toggle. New dismiss emit.
- **CardFieldComponent.vue**: dismissed project ids are stored in localStorage per user, filtered out of newlyAddedProjects, loaded on mount, and written on dismiss. The stored list is pruned to the 2-day new-project window so it cannot grow unbounded.
- **en.js**: dashboardCard.dismiss_recent_project tooltip string.

## Behavior
- Clicking X removes the suggestion immediately and persists it, so it does not reappear after the card is closed and reopened, or after a page reload.
- Dismissing only hides the suggestion; it does NOT modify selectedProjects. The tick-to-add path, Save, and the main Project dropdown are unchanged. The project can still be added manually from the dropdown.

## Notes
- Scope is per-user, per-browser (localStorage), and global across Workload cards (the editor only knows the card type, not an instance id). Per-card or cross-device persistence would need a small backend field.

Verified all three files compile with @vue/compiler-sfc (parse + compileScript + compileTemplate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)