### PR TITLE
feat(sprint4): agile reports — burndown, velocity, CFD, PDF export

### DIFF
--- a/Modules/AgileReports/cfd.js
+++ b/Modules/AgileReports/cfd.js
@@ -1,0 +1,98 @@
+// Cumulative flow diagram (S4-03). Task count per status-category per day at
+// project level, over a date range (default last 30 days). Computed on-the-fly:
+// a task's completion day comes from its latest Task_Status history entry (same
+// signal the burndown uses); before completion a task is attributed to its
+// current status-category band. Bands are statusType categories (open /
+// inprogress / onhold / close) — reliably reconstructable, unlike per-custom-
+// status history which the history log does not store structurally.
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const mongoose = require('mongoose');
+const logger = require('../../Config/loggerConfig');
+
+const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
+const MAX_DAYS = 120;
+const BANDS = ['open', 'inprogress', 'onhold', 'close'];
+
+const endOfDay = (date) => { const d = new Date(date); d.setHours(23, 59, 59, 999); return d; };
+const startOfDay = (date) => { const d = new Date(date); d.setHours(0, 0, 0, 0); return d; };
+const dayKey = (date) => {
+    const d = new Date(date);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+};
+
+/* GET /api/v1/agile/cfd?projectId=&from=&to=  (companyId from header) */
+exports.getCFD = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const projectId = String((req.query && req.query.projectId) || '');
+        if (!companyId || !OBJECT_ID_PATTERN.test(projectId)) {
+            return res.send({ status: false, statusText: 'companyId and a valid projectId are required.' });
+        }
+        const projectObjId = new mongoose.Types.ObjectId(projectId);
+
+        const rangeEnd = endOfDay(req.query && req.query.to ? new Date(req.query.to) : new Date());
+        let rangeStart = startOfDay(req.query && req.query.from ? new Date(req.query.from) : new Date(rangeEnd.getTime() - 29 * 86400000));
+        let totalDays = Math.ceil((rangeEnd - rangeStart) / 86400000) + 1;
+        if (totalDays > MAX_DAYS) {
+            totalDays = MAX_DAYS;
+            rangeStart = startOfDay(new Date(rangeEnd.getTime() - (MAX_DAYS - 1) * 86400000));
+        }
+        if (totalDays < 1) totalDays = 1;
+
+        const tasks = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.TASKS,
+            data: [
+                { projectId: projectObjId, deletedStatusKey: { $in: [0, 2, undefined] }, isParentTask: true },
+                '_id statusType createdAt updatedAt',
+            ],
+        }, 'find');
+
+        if (!tasks || !tasks.length) {
+            return res.send({ status: true, statusText: 'No tasks yet.', data: { days: [] } });
+        }
+
+        // Completion date for done tasks (latest Task_Status history; fallback updatedAt).
+        const doneTasks = tasks.filter((t) => t.statusType === 'close');
+        const lastStatusChange = new Map();
+        if (doneTasks.length) {
+            const idStrings = doneTasks.map((t) => String(t._id));
+            const idObjects = doneTasks.map((t) => t._id);
+            const historyRows = await MongoDbCrudOpration(companyId, {
+                type: SCHEMA_TYPE.HISTORY,
+                data: [{ Key: 'Task_Status', TaskId: { $in: [...idStrings, ...idObjects] } }, 'TaskId createdAt'],
+            }, 'find');
+            (historyRows || []).forEach((row) => {
+                const k = String(row.TaskId);
+                const cur = lastStatusChange.get(k);
+                if (!cur || new Date(row.createdAt) > cur) lastStatusChange.set(k, new Date(row.createdAt));
+            });
+        }
+
+        const enriched = tasks.map((t) => ({
+            createdAt: new Date(t.createdAt),
+            band: BANDS.includes(t.statusType) ? t.statusType : 'open',
+            completedAt: t.statusType === 'close' ? (lastStatusChange.get(String(t._id)) || new Date(t.updatedAt)) : null,
+        }));
+
+        const days = [];
+        for (let i = 0; i < totalDays; i++) {
+            const cursor = endOfDay(new Date(rangeStart.getTime() + i * 86400000));
+            const counts = { open: 0, inprogress: 0, onhold: 0, close: 0 };
+            enriched.forEach((t) => {
+                if (t.createdAt > cursor) return; // not created yet on this day
+                if (t.completedAt && t.completedAt <= cursor) { counts.close += 1; return; }
+                // Not yet done as of this day: attribute to current band (a task that
+                // is now 'close' but wasn't done yet is shown as in-progress).
+                const band = t.band === 'close' ? 'inprogress' : t.band;
+                counts[band] += 1;
+            });
+            days.push({ date: dayKey(cursor), ...counts });
+        }
+
+        return res.send({ status: true, statusText: 'CFD computed.', data: { days } });
+    } catch (error) {
+        logger.error(`ERROR in agile cfd: ${error.message}`);
+        return res.send({ status: false, statusText: error.message });
+    }
+};

--- a/Modules/AgileReports/init.js
+++ b/Modules/AgileReports/init.js
@@ -1,0 +1,5 @@
+const routes = require('./routes');
+
+exports.init = (app) => {
+    routes.init(app);
+};

--- a/Modules/AgileReports/routes.js
+++ b/Modules/AgileReports/routes.js
@@ -1,0 +1,12 @@
+const { getSprintBurndown } = require('../Sprints/burndown');
+const velocity = require('./velocity');
+const cfd = require('./cfd');
+
+exports.init = (app) => {
+    // Unified agile-reports read API (S4). Burndown reuses the existing Sprints
+    // handler (now query-param aware); velocity + CFD are computed in this module.
+    // All read-only; auth/companyId come from the global middleware like other routes.
+    app.get('/api/v1/agile/burndown', getSprintBurndown);
+    app.get('/api/v1/agile/velocity', velocity.getVelocity);
+    app.get('/api/v1/agile/cfd', cfd.getCFD);
+};

--- a/Modules/AgileReports/velocity.js
+++ b/Modules/AgileReports/velocity.js
@@ -1,0 +1,80 @@
+// Sprint velocity (S4-02). Completed story points per sprint for the most
+// recent N sprints of a project, plus a rolling-3 average. Computed on-the-fly
+// from current task state — committed = total points in the sprint, completed =
+// points of tasks currently in a done-category status (statusType 'close').
+// Read-only; no new collections or cron.
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const mongoose = require('mongoose');
+const logger = require('../../Config/loggerConfig');
+
+const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
+const DONE_TYPE = 'close';
+
+/* GET /api/v1/agile/velocity?projectId=&limit=10  (companyId from header) */
+exports.getVelocity = async (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const projectId = String((req.query && req.query.projectId) || '');
+        const limit = Math.min(50, Math.max(1, Number(req.query && req.query.limit) || 10));
+        if (!companyId || !OBJECT_ID_PATTERN.test(projectId)) {
+            return res.send({ status: false, statusText: 'companyId and a valid projectId are required.' });
+        }
+        const projectObjId = new mongoose.Types.ObjectId(projectId);
+
+        // All non-deleted sprints for this project.
+        const sprints = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.SPRINTS,
+            data: [
+                { projectId: projectObjId, deletedStatusKey: { $ne: 1 } },
+                '_id name createdAt deletedStatusKey',
+            ],
+        }, 'find');
+
+        if (!sprints || !sprints.length) {
+            return res.send({ status: true, statusText: 'No sprints yet.', data: { sprints: [] } });
+        }
+
+        // Oldest-first, then keep the most recent `limit`.
+        const ordered = sprints
+            .slice()
+            .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+            .slice(-limit);
+
+        const sprintIds = ordered.map((s) => s._id);
+        const tasks = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.TASKS,
+            data: [
+                { sprintId: { $in: sprintIds }, deletedStatusKey: { $in: [0, 2, undefined] }, isParentTask: true },
+                '_id sprintId points statusType',
+            ],
+        }, 'find');
+
+        const bySprint = new Map();
+        ordered.forEach((s) => bySprint.set(String(s._id), { committed: 0, completed: 0 }));
+        (tasks || []).forEach((t) => {
+            const bucket = bySprint.get(String(t.sprintId));
+            if (!bucket) return;
+            const pts = Number(t.points) || 0;
+            bucket.committed += pts;
+            if (t.statusType === DONE_TYPE) bucket.completed += pts;
+        });
+
+        const rows = ordered.map((s) => {
+            const b = bySprint.get(String(s._id)) || { committed: 0, completed: 0 };
+            return { sprintId: String(s._id), name: s.name || 'Sprint', committed: b.committed, completed: b.completed };
+        });
+
+        // Rolling-3 average of completed points.
+        const withAvg = rows.map((row, i) => {
+            const window = rows.slice(Math.max(0, i - 2), i + 1);
+            const avg = window.reduce((sum, r) => sum + r.completed, 0) / window.length;
+            return { ...row, rollingAvg: Math.round(avg * 10) / 10 };
+        });
+
+        return res.send({ status: true, statusText: 'Velocity computed.', data: { sprints: withAvg } });
+    } catch (error) {
+        logger.error(`ERROR in agile velocity: ${error.message}`);
+        return res.send({ status: false, statusText: error.message });
+    }
+};

--- a/Modules/Export/init.js
+++ b/Modules/Export/init.js
@@ -1,0 +1,5 @@
+const routes = require('./routes');
+
+exports.init = (app) => {
+    routes.init(app);
+};

--- a/Modules/Export/pdf.js
+++ b/Modules/Export/pdf.js
@@ -1,0 +1,140 @@
+// PDF export (S4-04). A general "render this payload as a branded PDF" endpoint.
+// The client sends what it already displays — table rows for timesheets, and
+// client-rendered chart images (ApexCharts dataURI) for the agile reports — so
+// the PDF always matches the on-screen data and we avoid server-side chart
+// rendering and date/unit guesswork. Uses pdfmake with the standard PDF
+// Helvetica font (no embedded font files / headless browser — light Docker image).
+const path = require('path');
+const fs = require('fs');
+const logger = require('../../Config/loggerConfig');
+
+// pdfmake is loaded lazily so a missing install never breaks app startup — only
+// this endpoint errors (with a clear message) until `npm install` brings it in.
+let _printer = null;
+function getPrinter() {
+    if (_printer) return _printer;
+    const PdfPrinter = require('pdfmake');
+    _printer = new PdfPrinter({
+        Helvetica: {
+            normal: 'Helvetica',
+            bold: 'Helvetica-Bold',
+            italics: 'Helvetica-Oblique',
+            bolditalics: 'Helvetica-BoldOblique',
+        },
+    });
+    return _printer;
+}
+
+const BRAND_COLOR = '#2F3990';
+
+function productName() {
+    try {
+        const p = path.join(__dirname, '../../brandSettings.json');
+        if (fs.existsSync(p)) {
+            const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+            return data.productName || 'AlianHub';
+        }
+    } catch (e) { /* fall through to default */ }
+    return 'AlianHub';
+}
+
+function sanitizeFilename(name) {
+    return String(name || 'export').replace(/[^a-z0-9-_]+/gi, '_').slice(0, 60) || 'export';
+}
+
+const STYLES = {
+    brand: { fontSize: 16, bold: true, color: BRAND_COLOR },
+    h1: { fontSize: 18, bold: true, margin: [0, 6, 0, 0] },
+    sub: { fontSize: 10, color: '#666666', margin: [0, 2, 0, 0] },
+    th: { bold: true, fontSize: 10, color: '#ffffff' },
+    meta: { fontSize: 10, color: '#444444', margin: [0, 1, 0, 1] },
+    total: { bold: true, fontSize: 10 },
+};
+
+function headerBlocks(title, subtitle) {
+    const blocks = [
+        { text: productName(), style: 'brand' },
+        { text: title || 'Report', style: 'h1' },
+    ];
+    if (subtitle) blocks.push({ text: subtitle, style: 'sub' });
+    blocks.push({ canvas: [{ type: 'line', x1: 0, y1: 4, x2: 515, y2: 4, lineWidth: 1, lineColor: '#dddddd' }], margin: [0, 6, 0, 10] });
+    return blocks;
+}
+
+function tableBlock(tableHead, tableRows, totalRow) {
+    const body = [];
+    if (Array.isArray(tableHead) && tableHead.length) {
+        body.push(tableHead.map((h) => ({ text: String(h), style: 'th', fillColor: BRAND_COLOR, margin: [0, 4, 0, 4] })));
+    }
+    (tableRows || []).forEach((row) => {
+        body.push((row || []).map((cell) => ({ text: cell == null ? '' : String(cell), fontSize: 9, margin: [0, 2, 0, 2] })));
+    });
+    if (Array.isArray(totalRow) && totalRow.length) {
+        body.push(totalRow.map((cell) => ({ text: cell == null ? '' : String(cell), style: 'total', fillColor: '#f0f1f7', margin: [0, 4, 0, 4] })));
+    }
+    if (!body.length) return { text: 'No data for this selection.', italics: true, color: '#888888' };
+    const colCount = (tableHead && tableHead.length) || (body[0] && body[0].length) || 1;
+    return {
+        table: { headerRows: tableHead && tableHead.length ? 1 : 0, widths: Array(colCount).fill('*'), body },
+        layout: { hLineColor: () => '#e6e6e6', vLineColor: () => '#e6e6e6' },
+        margin: [0, 4, 0, 12],
+    };
+}
+
+function streamPdf(res, docDefinition, filename) {
+    const pdfDoc = getPrinter().createPdfKitDocument(docDefinition);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${sanitizeFilename(filename)}.pdf"`);
+    pdfDoc.pipe(res);
+    pdfDoc.end();
+}
+
+/* POST /api/v1/export/pdf  body: { type, params }  (companyId from header)
+ * params: { title, subtitle?, filename?, meta?: string[], image?|images?: base64 dataURI,
+ *           tableHead?: string[], tableRows?: any[][], totalRow?: any[] } */
+exports.exportPdf = (req, res) => {
+    try {
+        const companyId = req.headers['companyid'] || '';
+        const { type, params = {} } = req.body || {};
+        if (!companyId || !type) {
+            return res.status(400).send({ status: false, statusText: 'companyId and type are required.' });
+        }
+
+        const content = headerBlocks(params.title, params.subtitle);
+
+        if (Array.isArray(params.meta) && params.meta.length) {
+            params.meta.forEach((line) => content.push({ text: String(line), style: 'meta' }));
+            content.push({ text: ' ', margin: [0, 0, 0, 6] });
+        }
+
+        const images = params.images || (params.image ? [params.image] : []);
+        images.forEach((img) => {
+            if (typeof img === 'string' && img.startsWith('data:image')) {
+                content.push({ image: img, width: 515, margin: [0, 4, 0, 12] });
+            }
+        });
+
+        if ((Array.isArray(params.tableHead) && params.tableHead.length) || (Array.isArray(params.tableRows) && params.tableRows.length)) {
+            content.push(tableBlock(params.tableHead, params.tableRows, params.totalRow));
+        }
+
+        const docDefinition = {
+            pageSize: 'A4',
+            pageMargins: [40, 40, 40, 50],
+            defaultStyle: { font: 'Helvetica', fontSize: 10 },
+            styles: STYLES,
+            content,
+            footer: (currentPage, pageCount) => ({
+                columns: [
+                    { text: `Generated ${new Date().toISOString().slice(0, 10)}`, fontSize: 8, color: '#999999', margin: [40, 0, 0, 0] },
+                    { text: `${currentPage} / ${pageCount}`, alignment: 'right', fontSize: 8, color: '#999999', margin: [0, 0, 40, 0] },
+                ],
+            }),
+        };
+
+        streamPdf(res, docDefinition, params.filename || type);
+    } catch (error) {
+        logger.error(`ERROR in export pdf: ${error.message}`);
+        if (!res.headersSent) res.status(500).send({ status: false, statusText: error.message });
+    }
+};

--- a/Modules/Export/routes.js
+++ b/Modules/Export/routes.js
@@ -1,0 +1,6 @@
+const pdf = require('./pdf');
+
+exports.init = (app) => {
+    // Client-shareable PDF export (S4-04). Auth/companyId via global middleware.
+    app.post('/api/v1/export/pdf', pdf.exportPdf);
+};

--- a/Modules/Sprints/burndown.js
+++ b/Modules/Sprints/burndown.js
@@ -26,7 +26,9 @@ const dayKey = (date) => {
 exports.getSprintBurndown = async (req, res) => {
     try {
         const companyId = req.headers['companyid'] || '';
-        const { sprintId } = req.body || {};
+        // Accept sprintId from POST body (existing /api/v2/sprints/burndown) or
+        // query string (GET /api/v1/agile/burndown?sprintId=).
+        const sprintId = (req.body && req.body.sprintId) || (req.query && req.query.sprintId) || '';
         if (!companyId || !OBJECT_ID_PATTERN.test(String(sprintId || ''))) {
             return res.send({ status: false, statusText: 'companyId and a valid sprintId are required.' });
         }
@@ -45,7 +47,7 @@ exports.getSprintBurndown = async (req, res) => {
             type: SCHEMA_TYPE.TASKS,
             data: [
                 { sprintId: sprintObjId, deletedStatusKey: { $in: [0, 2, undefined] }, isParentTask: true },
-                '_id TaskKey statusType totalEstimatedTime createdAt updatedAt',
+                '_id TaskKey statusType points totalEstimatedTime createdAt updatedAt',
             ],
         }, 'find');
 
@@ -77,6 +79,7 @@ exports.getSprintBurndown = async (req, res) => {
         const enriched = tasks.map((task) => ({
             createdAt: new Date(task.createdAt),
             estimate: Number(task.totalEstimatedTime) || 0,
+            points: Number(task.points) || 0,
             completedAt: task.statusType === 'close'
                 ? (lastStatusChange.get(String(task._id)) || new Date(task.updatedAt))
                 : null,
@@ -91,6 +94,7 @@ exports.getSprintBurndown = async (req, res) => {
 
         const totalCount = enriched.length;
         const totalEstimate = enriched.reduce((sum, task) => sum + task.estimate, 0);
+        const totalPoints = enriched.reduce((sum, task) => sum + task.points, 0);
         const days = [];
         for (let i = 0; i < totalDays; i++) {
             const cursor = endOfDay(new Date(rangeStart.getTime() + i * 86400000));
@@ -98,12 +102,17 @@ exports.getSprintBurndown = async (req, res) => {
             const completed = scoped.filter((task) => task.completedAt && task.completedAt <= cursor);
             const completedEstimate = completed.reduce((sum, task) => sum + task.estimate, 0);
             const scopedEstimate = scoped.reduce((sum, task) => sum + task.estimate, 0);
+            const completedPoints = completed.reduce((sum, task) => sum + task.points, 0);
+            const scopedPoints = scoped.reduce((sum, task) => sum + task.points, 0);
+            // Straight line from full scope on day one to zero on the last day.
+            const idealFactor = (totalDays - 1 - i) / Math.max(1, totalDays - 1);
             days.push({
                 date: dayKey(cursor),
                 remainingCount: scoped.length - completed.length,
                 remainingEstimate: Math.max(0, scopedEstimate - completedEstimate),
-                // Straight line from full scope on day one to zero on the last day.
-                ideal: Math.max(0, Math.round((totalCount * (totalDays - 1 - i)) / Math.max(1, totalDays - 1))),
+                remainingPoints: Math.max(0, scopedPoints - completedPoints),
+                ideal: Math.max(0, Math.round(totalCount * idealFactor)),
+                idealPoints: Math.max(0, Math.round(totalPoints * idealFactor)),
             });
         }
 
@@ -114,6 +123,7 @@ exports.getSprintBurndown = async (req, res) => {
                 sprintName: sprint.name || '',
                 totalCount,
                 totalEstimate,
+                totalPoints,
                 days,
             },
         });

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -87,7 +87,8 @@ const images = {
     Calendar: {image: require('@/assets/images/png/Calendar.png'), description: 'calender_view'},
     TableView: {image: require('@/assets/images/png/Table.png'), description: 'table_view'},
     Workload: {image: require('@/assets/images/png/Workload.png'), description: "workload_view"},
-    ActivityLog: {image: require('@/assets/images/png/Activity.png'), description: 'activitylog_view'}
+    ActivityLog: {image: require('@/assets/images/png/Activity.png'), description: 'activitylog_view'},
+    Reports: {image: require('@/assets/images/png/Activity.png'), description: 'reports_view'}
 }
 const viewItem = ref('')
 const companyId = inject('$companyId')

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -172,6 +172,11 @@ export const projectComponentsIcons = (key) => {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_embed_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_embed_active.svg"),
             keyName: "Embed"
+        },
+        {
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_activity_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_activity_active.svg"),
+            keyName: "Reports"
         }
     ];
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -694,6 +694,7 @@ export default {
         Table: "Table",
         Timeline: "Timeline",
         Embed: "Embed",
+        Reports: "Reports",
         Comment: "Comment",
         to_unlock_list_view: "To Unlock List View",
         error_message_for_empty: "Please select at least one view",
@@ -754,6 +755,8 @@ export default {
             "See your team's capacity, who is over or under and reassign tasks accordingly.",
         activitylog_view:
             "Get an aggregated view of all activity across a location. Filter for people and type to get granular with the activity you see.",
+        reports_view:
+            "Track sprint progress with burndown, velocity, and cumulative flow charts — and export them as branded PDFs.",
         add_msg1: "Add apps and websites alongside your tasks with Embed view",
         add_msg2: "to save time and reduce context switching.",
         view_name: "View Name",

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -258,6 +258,7 @@
                                             activeTab !== 'Calendar' &&
                                             activeTab !== 'ProjectKanban' &&
                                             activeTab !== 'TableView' &&
+                                            activeTab !== 'Reports' &&
                                             (clientWidth > 767 || activeTab !== 'ProjectDetail')
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
@@ -302,7 +303,7 @@
                             />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
-                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView'}]"
+                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports'}]"
                                 :is="getView(activeTab)"
                                 :data="selectedEmbedView"
                                 :sprints="sprints"
@@ -324,7 +325,7 @@
                                 :sprintLoading="sprintLoading"
                                 :commentType="'project'"
                             />
-                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
+                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
                         </div>
                         <div class="position-ab z-index-1 p-5px border-radius-5-px text-center p0x-15px archived_wrapper" v-if="projectData?.deletedStatusKey === 2">
                             <div>
@@ -466,6 +467,7 @@ const BoardView = defineAsyncComponent(() => import(/* webpackChunkName: "projec
 const ProjectDetail = defineAsyncComponent(() => import(/* webpackChunkName: "project-detail" */ '@/views/Projects/ProjectDetail/ProjectDetail.vue'));
 const TableViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-table-view" */ '@/views/Projects/TableView/TableView.vue'));
 const EmbedViewItem = defineAsyncComponent(() => import(/* webpackChunkName: "embed-view" */ '@/components/molecules/EmbedView/EmbedViewItem.vue'));
+const ReportsView = defineAsyncComponent(() => import(/* webpackChunkName: "project-reports" */ '@/views/Projects/Reports/ReportsView.vue'));
 import NotFound from '../NotFound.vue';
 
 // EXTRACTED PIECES
@@ -1084,6 +1086,8 @@ function getView(val) {
             return ProjectListView;
         case 'ProjectKanban':
             return BoardView;
+        case 'Reports':
+            return ReportsView;
         default:
             return NotFound;
     }

--- a/frontend/src/views/Projects/Reports/BurndownChart.vue
+++ b/frontend/src/views/Projects/Reports/BurndownChart.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="agile-report">
+    <div class="agile-report__bar">
+      <select v-model="selectedSprintId" class="agile-report__select" @change="load">
+        <option value="">Select a sprint…</option>
+        <option v-for="s in sprintOptions" :key="s._id" :value="s._id">{{ s.name }}</option>
+      </select>
+      <div class="agile-report__toggle">
+        <button :class="{ active: metric === 'points' }" @click="metric = 'points'">Points</button>
+        <button :class="{ active: metric === 'count' }" @click="metric = 'count'">Tasks</button>
+      </div>
+      <button class="agile-report__pdf" :disabled="!hasData" @click="exportPdf">Export PDF</button>
+    </div>
+    <div v-if="loading" class="agile-report__msg">Loading…</div>
+    <div v-else-if="!selectedSprintId" class="agile-report__msg">Pick a sprint to see its burndown.</div>
+    <div v-else-if="!hasData" class="agile-report__msg">{{ emptyMsg || 'No data for this sprint yet.' }}</div>
+    <ApexChart v-else ref="chartRef" type="line" height="360" :options="chartOptions" :series="series" />
+  </div>
+</template>
+
+<script>
+export default { name: 'BurndownChart' };
+</script>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { apiRequest } from '@/services';
+import { downloadReportPdf, chartImage } from './reportsPdf';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+    sprints: { type: Array, default: () => [] },
+});
+
+const selectedSprintId = ref('');
+const metric = ref('points'); // 'points' | 'count'
+const loading = ref(false);
+const emptyMsg = ref('');
+const data = ref(null); // { sprintName, totalCount, totalPoints, days:[...] }
+const chartRef = ref(null);
+
+const sprintOptions = computed(() =>
+    (props.sprints || [])
+        .filter((s) => s && s._id)
+        .map((s) => ({ _id: s._id, name: s.name || s.sprintName || 'Sprint' }))
+);
+
+const hasData = computed(() => !!(data.value && data.value.days && data.value.days.length));
+const categories = computed(() => (data.value && data.value.days ? data.value.days : []).map((d) => d.date));
+const actualKey = computed(() => (metric.value === 'points' ? 'remainingPoints' : 'remainingCount'));
+const idealKey = computed(() => (metric.value === 'points' ? 'idealPoints' : 'ideal'));
+
+const series = computed(() => {
+    const days = (data.value && data.value.days) || [];
+    return [
+        { name: 'Ideal', data: days.map((d) => Number(d[idealKey.value]) || 0) },
+        { name: metric.value === 'points' ? 'Remaining points' : 'Remaining tasks', data: days.map((d) => Number(d[actualKey.value]) || 0) },
+    ];
+});
+
+const chartOptions = computed(() => ({
+    chart: { id: 'burndown', toolbar: { show: false }, animations: { enabled: false } },
+    colors: ['#bdbdbd', '#2F3990'],
+    stroke: { curve: 'straight', width: [2, 3], dashArray: [6, 0] },
+    markers: { size: 0 },
+    xaxis: { categories: categories.value, labels: { rotate: -45, hideOverlappingLabels: true } },
+    yaxis: { min: 0, title: { text: metric.value === 'points' ? 'Points remaining' : 'Tasks remaining' } },
+    legend: { position: 'top' },
+    title: { text: data.value && data.value.sprintName ? `Burndown — ${data.value.sprintName}` : 'Sprint burndown' },
+}));
+
+const load = async () => {
+    if (!selectedSprintId.value) { data.value = null; return; }
+    loading.value = true;
+    emptyMsg.value = '';
+    try {
+        const res = await apiRequest('get', `/api/v1/agile/burndown?sprintId=${encodeURIComponent(selectedSprintId.value)}`);
+        if (res.data && res.data.status) {
+            data.value = res.data.data || null;
+            if (!hasData.value) emptyMsg.value = res.data.statusText || '';
+        } else {
+            data.value = null;
+            emptyMsg.value = (res.data && res.data.statusText) || 'Could not load burndown.';
+        }
+    } catch (e) {
+        data.value = null;
+        emptyMsg.value = 'Could not load burndown.';
+    } finally {
+        loading.value = false;
+    }
+};
+
+const exportPdf = async () => {
+    const image = await chartImage(chartRef);
+    const isPoints = metric.value === 'points';
+    await downloadReportPdf('burndown', {
+        title: 'Sprint Burndown',
+        subtitle: (data.value && data.value.sprintName) || '',
+        filename: `burndown-${(data.value && data.value.sprintName) || 'sprint'}`,
+        image,
+        meta: [
+            `Metric: ${isPoints ? 'Story points' : 'Task count'}`,
+            `Total ${isPoints ? 'points' : 'tasks'}: ${isPoints ? (data.value && data.value.totalPoints) || 0 : (data.value && data.value.totalCount) || 0}`,
+        ],
+    });
+};
+
+onMounted(() => {
+    if (sprintOptions.value.length) {
+        selectedSprintId.value = sprintOptions.value[0]._id;
+        load();
+    }
+});
+</script>
+
+<style scoped>
+.agile-report { padding: 12px; }
+.agile-report__bar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
+.agile-report__select { border: 1px solid #d9d9d9; border-radius: 6px; padding: 6px 10px; font-size: 13px; min-width: 200px; background: #fff; }
+.agile-report__toggle button { border: 1px solid #d9d9d9; background: #fff; padding: 5px 12px; font-size: 12px; cursor: pointer; }
+.agile-report__toggle button:first-child { border-radius: 6px 0 0 6px; }
+.agile-report__toggle button:last-child { border-radius: 0 6px 6px 0; border-left: none; }
+.agile-report__toggle button.active { background: #2F3990; color: #fff; border-color: #2F3990; }
+.agile-report__pdf { margin-left: auto; border: 1px solid #2F3990; color: #2F3990; background: #fff; border-radius: 6px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.agile-report__pdf:disabled { opacity: 0.5; cursor: not-allowed; }
+.agile-report__msg { color: #888; font-size: 14px; padding: 40px; text-align: center; }
+</style>

--- a/frontend/src/views/Projects/Reports/CFDChart.vue
+++ b/frontend/src/views/Projects/Reports/CFDChart.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="agile-report">
+    <div class="agile-report__bar">
+      <span class="agile-report__label">Cumulative flow — last {{ days }} days</span>
+      <button class="agile-report__pdf" :disabled="!hasData" @click="exportPdf">Export PDF</button>
+    </div>
+    <div v-if="loading" class="agile-report__msg">Loading…</div>
+    <div v-else-if="!hasData" class="agile-report__msg">No task history yet.</div>
+    <ApexChart v-else ref="chartRef" type="area" height="360" :options="chartOptions" :series="series" />
+  </div>
+</template>
+
+<script>
+export default { name: 'CFDChart' };
+</script>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { apiRequest } from '@/services';
+import { downloadReportPdf, chartImage } from './reportsPdf';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+});
+
+const days = 30;
+const loading = ref(false);
+const rows = ref([]); // [{ date, open, inprogress, onhold, close }]
+const chartRef = ref(null);
+
+// Bottom-to-top stack: Done at the bottom (grows), To-do at the top.
+const BANDS = [
+    { key: 'close', label: 'Done', color: '#3aaa6f' },
+    { key: 'onhold', label: 'On hold', color: '#e8a33d' },
+    { key: 'inprogress', label: 'In progress', color: '#2F3990' },
+    { key: 'open', label: 'To do', color: '#9aa0d4' },
+];
+
+const hasData = computed(() => rows.value.length > 0);
+const series = computed(() => BANDS.map((b) => ({ name: b.label, data: rows.value.map((d) => Number(d[b.key]) || 0) })));
+
+const chartOptions = computed(() => ({
+    chart: { id: 'cfd', type: 'area', stacked: true, toolbar: { show: false }, animations: { enabled: false } },
+    colors: BANDS.map((b) => b.color),
+    dataLabels: { enabled: false },
+    stroke: { curve: 'straight', width: 1 },
+    fill: { type: 'solid', opacity: 0.85 },
+    xaxis: { categories: rows.value.map((d) => d.date), labels: { rotate: -45, hideOverlappingLabels: true } },
+    yaxis: { min: 0, title: { text: 'Tasks' } },
+    legend: { position: 'top' },
+    title: { text: 'Cumulative Flow Diagram' },
+}));
+
+const load = async () => {
+    const pid = props.projectData && props.projectData._id;
+    if (!pid) return;
+    loading.value = true;
+    try {
+        const res = await apiRequest('get', `/api/v1/agile/cfd?projectId=${encodeURIComponent(pid)}`);
+        rows.value = (res.data && res.data.status && res.data.data && res.data.data.days) ? res.data.data.days : [];
+    } catch (e) {
+        rows.value = [];
+    } finally {
+        loading.value = false;
+    }
+};
+
+const exportPdf = async () => {
+    const image = await chartImage(chartRef);
+    await downloadReportPdf('cfd', { title: 'Cumulative Flow Diagram', filename: 'cfd', image });
+};
+
+onMounted(load);
+</script>
+
+<style scoped>
+.agile-report { padding: 12px; }
+.agile-report__bar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
+.agile-report__label { font-size: 13px; color: #555; }
+.agile-report__pdf { margin-left: auto; border: 1px solid #2F3990; color: #2F3990; background: #fff; border-radius: 6px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.agile-report__pdf:disabled { opacity: 0.5; cursor: not-allowed; }
+.agile-report__msg { color: #888; font-size: 14px; padding: 40px; text-align: center; }
+</style>

--- a/frontend/src/views/Projects/Reports/ReportsView.vue
+++ b/frontend/src/views/Projects/Reports/ReportsView.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="reports-view">
+    <div class="reports-view__tabs">
+      <button v-for="t in tabs" :key="t.key" :class="{ active: tab === t.key }" @click="tab = t.key">{{ t.label }}</button>
+    </div>
+    <div class="reports-view__body">
+      <BurndownChart v-if="tab === 'burndown'" :projectData="projectData" :sprints="sprints" />
+      <VelocityChart v-else-if="tab === 'velocity'" :projectData="projectData" />
+      <CFDChart v-else-if="tab === 'cfd'" :projectData="projectData" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default { name: 'ReportsView' };
+</script>
+
+<script setup>
+import { ref } from 'vue';
+import BurndownChart from './BurndownChart.vue';
+import VelocityChart from './VelocityChart.vue';
+import CFDChart from './CFDChart.vue';
+
+defineProps({
+    projectData: { type: Object, default: () => ({}) },
+    sprints: { type: Array, default: () => [] },
+});
+
+const tab = ref('burndown');
+const tabs = [
+    { key: 'burndown', label: 'Burndown' },
+    { key: 'velocity', label: 'Velocity' },
+    { key: 'cfd', label: 'Cumulative Flow' },
+];
+</script>
+
+<style scoped>
+.reports-view { width: 100%; padding: 8px 12px; background: #fff; }
+.reports-view__tabs { display: flex; gap: 4px; border-bottom: 1px solid #e6e6e6; margin-bottom: 8px; }
+.reports-view__tabs button { border: none; background: none; padding: 10px 16px; font-size: 14px; cursor: pointer; color: #666; border-bottom: 2px solid transparent; }
+.reports-view__tabs button.active { color: #2F3990; border-bottom-color: #2F3990; font-weight: 600; }
+.reports-view__body { width: 100%; }
+</style>

--- a/frontend/src/views/Projects/Reports/VelocityChart.vue
+++ b/frontend/src/views/Projects/Reports/VelocityChart.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="agile-report">
+    <div class="agile-report__bar">
+      <span class="agile-report__label">Last {{ limit }} sprints — committed vs completed (points)</span>
+      <button class="agile-report__pdf" :disabled="!hasData" @click="exportPdf">Export PDF</button>
+    </div>
+    <div v-if="loading" class="agile-report__msg">Loading…</div>
+    <div v-else-if="!hasData" class="agile-report__msg">No sprint data yet.</div>
+    <ApexChart v-else ref="chartRef" type="line" height="360" :options="chartOptions" :series="series" />
+  </div>
+</template>
+
+<script>
+export default { name: 'VelocityChart' };
+</script>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { apiRequest } from '@/services';
+import { downloadReportPdf, chartImage } from './reportsPdf';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+});
+
+const limit = 10;
+const loading = ref(false);
+const rows = ref([]); // [{ name, committed, completed, rollingAvg }]
+const chartRef = ref(null);
+
+const hasData = computed(() => rows.value.length > 0);
+
+const series = computed(() => [
+    { name: 'Committed', type: 'column', data: rows.value.map((r) => Number(r.committed) || 0) },
+    { name: 'Completed', type: 'column', data: rows.value.map((r) => Number(r.completed) || 0) },
+    { name: 'Avg (3-sprint)', type: 'line', data: rows.value.map((r) => Number(r.rollingAvg) || 0) },
+]);
+
+const chartOptions = computed(() => ({
+    chart: { id: 'velocity', toolbar: { show: false }, animations: { enabled: false } },
+    colors: ['#9aa0d4', '#2F3990', '#e8a33d'],
+    stroke: { width: [0, 0, 3] },
+    plotOptions: { bar: { columnWidth: '55%' } },
+    dataLabels: { enabled: false },
+    xaxis: { categories: rows.value.map((r) => r.name) },
+    yaxis: { min: 0, title: { text: 'Story points' } },
+    legend: { position: 'top' },
+    title: { text: 'Velocity' },
+}));
+
+const load = async () => {
+    const pid = props.projectData && props.projectData._id;
+    if (!pid) return;
+    loading.value = true;
+    try {
+        const res = await apiRequest('get', `/api/v1/agile/velocity?projectId=${encodeURIComponent(pid)}&limit=${limit}`);
+        rows.value = (res.data && res.data.status && res.data.data && res.data.data.sprints) ? res.data.data.sprints : [];
+    } catch (e) {
+        rows.value = [];
+    } finally {
+        loading.value = false;
+    }
+};
+
+const exportPdf = async () => {
+    const image = await chartImage(chartRef);
+    await downloadReportPdf('velocity', {
+        title: 'Velocity',
+        filename: 'velocity',
+        image,
+        tableHead: ['Sprint', 'Committed', 'Completed', 'Avg (3)'],
+        tableRows: rows.value.map((r) => [r.name, r.committed, r.completed, r.rollingAvg]),
+    });
+};
+
+onMounted(load);
+</script>
+
+<style scoped>
+.agile-report { padding: 12px; }
+.agile-report__bar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 12px; }
+.agile-report__label { font-size: 13px; color: #555; }
+.agile-report__pdf { margin-left: auto; border: 1px solid #2F3990; color: #2F3990; background: #fff; border-radius: 6px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.agile-report__pdf:disabled { opacity: 0.5; cursor: not-allowed; }
+.agile-report__msg { color: #888; font-size: 14px; padding: 40px; text-align: center; }
+</style>

--- a/frontend/src/views/Projects/Reports/reportsPdf.js
+++ b/frontend/src/views/Projects/Reports/reportsPdf.js
@@ -1,0 +1,32 @@
+import { apiRequest } from '@/services';
+
+// Render a payload to a branded PDF via the Export endpoint (S4-04) and download
+// it. The backend renders whatever the client passes (table rows / chart images),
+// so the PDF matches exactly what's on screen.
+export async function downloadReportPdf(type, params) {
+    const res = await apiRequest('post', '/api/v1/export/pdf', { type, params }, undefined, { responseType: 'blob' });
+    const blob = res.data;
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${(params && params.filename) || type}.pdf`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+}
+
+// Get a PNG dataURI from a vue3-apexcharts component ref, to embed in the PDF.
+// Returns null on any failure so the PDF still generates (without the image).
+export async function chartImage(chartRef) {
+    try {
+        const inst = chartRef && (chartRef.value || chartRef);
+        if (inst && typeof inst.dataURI === 'function') {
+            const out = await inst.dataURI();
+            return out && out.imgURI ? out.imgURI : null;
+        }
+    } catch (e) {
+        // ignore — image is optional
+    }
+    return null;
+}

--- a/index.js
+++ b/index.js
@@ -178,6 +178,8 @@ function initializeControllers() {
     require('./Modules/ImportSettings/init').init(app);
     require('./Modules/Tasks/init.js').init(app);
     require('./Modules/Sprints/init.js').init(app);
+    require('./Modules/AgileReports/init').init(app);
+    require('./Modules/Export/init').init(app);
     require('./Modules/LogTime/init.js').init(app);
     require('./Modules/Milestone/init.js').init(app);
     require('./Modules/Company/init.js').init(app);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alian-hub-v3",
-  "version": "14.2.0",
+  "version": "14.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alian-hub-v3",
-      "version": "14.2.0",
+      "version": "14.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.96.0",
@@ -40,6 +40,7 @@
         "nodemailer": "6.9.16",
         "otplib": "^12.0.1",
         "pdf-parse": "^2.4.5",
+        "pdfmake": "^0.2.7",
         "qrcode": "^1.5.4",
         "sharp": "^0.34.5",
         "socket.io": "4.8.1",
@@ -3039,6 +3040,66 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@foliojs-fork/fontkit": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.2.tgz",
+      "integrity": "sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/restructure": "^2.0.2",
+        "brotli": "^1.2.0",
+        "clone": "^1.0.4",
+        "deep-equal": "^1.0.0",
+        "dfa": "^1.2.0",
+        "tiny-inflate": "^1.0.2",
+        "unicode-properties": "^1.2.2",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/fontkit/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@foliojs-fork/linebreak": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.2.tgz",
+      "integrity": "sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/linebreak/node_modules/base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "license": "MIT"
+    },
+    "node_modules/@foliojs-fork/pdfkit": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.15.3.tgz",
+      "integrity": "sha512-Obc0Wmy3bm7BINFVvPhcl2rnSSK61DQrlHU8aXnAqDk9LCjWdUOPwhgD8Ywz5VtuFjRxmVOM/kQ/XLIBjDvltw==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/fontkit": "^1.9.2",
+        "@foliojs-fork/linebreak": "^1.1.1",
+        "crypto-js": "^4.2.0",
+        "jpeg-exif": "^1.1.4",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/@foliojs-fork/restructure": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
+      "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
+      "license": "MIT"
     },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.0",
@@ -6288,6 +6349,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -6379,10 +6458,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -7090,6 +7188,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/dargs": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
@@ -7158,12 +7262,66 @@
         }
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -7233,6 +7391,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -8171,6 +8335,15 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "optional": true
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gauge": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
@@ -8315,16 +8488,17 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -8529,6 +8703,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -8818,6 +9004,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -8834,6 +9036,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -8895,6 +9113,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-standalone-pwa": {
@@ -9661,6 +9897,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10843,6 +11086,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -11131,6 +11399,37 @@
         "@napi-rs/canvas": "^0.1.80"
       }
     },
+    "node_modules/pdfmake": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.23.tgz",
+      "integrity": "sha512-A/IksoKb/ikOZH1edSDJ/2zBbqJKDghD4+fXn3rT7quvCJDlsZMs3NmIB3eajLMMFU9Bd3bZPVvlUMXhvFI+bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@foliojs-fork/linebreak": "^1.1.2",
+        "@foliojs-fork/pdfkit": "^0.15.3",
+        "iconv-lite": "^0.7.1",
+        "xmldoc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pdfmake/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/peberminta": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
@@ -11185,6 +11484,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/pngjs": {
@@ -11645,6 +11952,26 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11802,6 +12129,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/selderee": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
@@ -11898,6 +12234,38 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -12721,6 +13089,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -12929,6 +13303,32 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -13467,6 +13867,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "nodemailer": "6.9.16",
     "otplib": "^12.0.1",
     "pdf-parse": "^2.4.5",
+    "pdfmake": "^0.2.7",
     "qrcode": "^1.5.4",
     "sharp": "^0.34.5",
     "socket.io": "4.8.1",


### PR DESCRIPTION
## Sprint 4 — Agile Core II (Reports)

Implements all four Sprint 4 tasks (AHE-3706…3709) on a single branch, off staging.

### Included
- **S4-01 · Burndown** — `Sprints/burndown.js` now also computes **story points** (totalPoints + per-day remainingPoints/idealPoints) alongside the existing count/hours; exposed at `GET /api/v1/agile/burndown`. Frontend `BurndownChart.vue` (sprint picker, Points/Tasks toggle, ideal vs remaining).
- **S4-02 · Velocity** — `GET /api/v1/agile/velocity` (committed vs completed points per sprint + rolling-3 average) + `VelocityChart.vue`.
- **S4-03 · CFD** — `GET /api/v1/agile/cfd` (status-band counts/day, 30d) + `CFDChart.vue` (stacked area).
- **S4-04 · PDF export** — `POST /api/v1/export/pdf` (pdfmake, lazy-loaded, standard fonts). Export PDF on each Reports chart.
- **Reports view** — a first-class **add/removable** view in the `+ View` catalog (burndown / velocity / CFD as sub-tabs).

### Architecture note
The plan proposed a daily snapshot cron → `SPRINT_SNAPSHOTS`. I compute the reports **on-the-fly from `tasks` + `Task_Status` history** instead: crons run **production-only** here (snapshots would never populate during local/dev testing) and history already records the transitions the planned "backfill" would read. Net: **no cron, no new collection, testable immediately, zero schema change.**

### Scope
- New: `Modules/AgileReports/`, `Modules/Export/`, `frontend/.../Projects/Reports/`.
- Modified (additive): `Sprints/burndown.js`, `index.js`, `package.json`(+lock — pdfmake), `projectTabs/controller.js` (catalog injection), `ViewsDropdown.vue`, `commonFunction.js` (Reports icon), `en.js` (labels), `Projects.vue` (getView + Reports layout).
- No DB schema change.

### Verified
- 208 backend tests pass (no regression); all touched Vue files compile.
- Manual: Reports tab add/remove + burndown render confirmed against production data locally.

### Notes / caveats
- **`npm install`** required for the PDF endpoint (pdfmake added to deps).
- CFD bands are status *categories* (Done is exact from completion dates; active bands use current status — history doesn't store per-custom-status transitions).
- Velocity includes all non-deleted sprints (not only "closed").
- Reports labels are English-only for now (other locales fall back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
