### PR TITLE
fix(gantt): render on direct reload + Sprint 2-5 QA test cases

### DIFF
--- a/.claude/test-cases/CsvImporter.md
+++ b/.claude/test-cases/CsvImporter.md
@@ -1,0 +1,24 @@
+# CSV Importer — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Import CSV · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Import Flow
+
+| ID      | Title                              | Precondition                                                            | Steps                                                                                              | Expected Result                                                                          | Actual Result | Status |
+|---------|------------------------------------|-------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|---------------|--------|
+| CSV_001 | Import a valid CSV                 | A CSV with a header row (Task Name, Status, Priority, Due Date, Description); a sprint to import into | 1. Open `...` → Import CSV  2. Upload the file  3. Confirm the auto-detected column mapping  4. Pick the target sprint  5. Import | Success message with created count; tasks appear in the sprint with mapped name/status/priority/due |               | ⏳     |
+| CSV_002 | Manual column-mapping override     | A CSV whose headers differ (e.g. "Summary" not "Task Name")             | 1. Upload  2. Adjust the column-mapping dropdowns manually  3. Import                              | Import respects the manual mapping                                                       |               | ⏳     |
+| CSV_003 | Row missing a task name is skipped | A CSV where one row has no task name                                    | 1. Import                                                                                          | That row is skipped; created count excludes it; import does not abort                    |               | ⏳     |
+| CSV_004 | Unknown status falls back          | A CSV with a status not configured in the project                       | 1. Import                                                                                          | Task falls back to the project's first status                                            |               | ⏳     |
+| CSV_005 | Priority mapping                   | A CSV with Highest / High / Medium / Low                                | 1. Import  2. Open the tasks                                                                       | Priorities mapped (e.g. Highest→Urgent, High→High, Medium→Normal)                        |               | ⏳     |
+| CSV_006 | XLSX upload                        | An `.xlsx` file with the same columns                                   | 1. Upload the .xlsx and import                                                                     | Parses and imports the same as CSV                                                       |               | ⏳     |
+| CSV_007 | Import history                     | A completed import                                                      | 1. Re-open the import modal / import history                                                       | Job listed as source "csv" with total / processed / created counts                       |               | ⏳     |
+| CSV_008 | Invalid file handled               | Import modal open                                                       | 1. Try an empty file  2. Try a non-CSV renamed to `.csv`                                           | Readable error in both cases; nothing created; modal stays usable                        |               | ⏳     |
+
+---
+
+**Total:** 8 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/CumulativeFlowDiagram.md
+++ b/.claude/test-cases/CumulativeFlowDiagram.md
@@ -1,0 +1,19 @@
+# Cumulative Flow Diagram — Test Cases
+
+**Location:** Project → `+ View` → Reports → Cumulative Flow · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Chart Rendering
+
+| ID      | Title                         | Precondition                                | Steps                                       | Expected Result                                                                                  | Actual Result | Status |
+|---------|-------------------------------|---------------------------------------------|---------------------------------------------|--------------------------------------------------------------------------------------------------|---------------|--------|
+| CFD_001 | CFD renders                   | Reports view added; project with tasks across statuses | 1. Open Reports → Cumulative Flow           | Stacked-area chart of task counts by status band (To do / In progress / On hold / Done) over ~30 days |               | ⏳     |
+| CFD_002 | Done band reflects completions | Some tasks completed over recent days       | 1. Observe the "Done" band over time        | The Done band grows on the dates tasks were completed                                            |               | ⏳     |
+| CFD_003 | Empty state handled           | A project with no tasks                     | 1. Open Reports → Cumulative Flow           | Renders an empty/zero state — no crash                                                            |               | ⏳     |
+
+---
+
+**Total:** 3 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/GanttView.md
+++ b/.claude/test-cases/GanttView.md
@@ -1,0 +1,44 @@
+# Gantt / Timeline View — Test Cases
+
+**Location:** Project → `+ View` → Gantt · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+>
+> **Setup:** run `cd frontend && npm install` once (adds `dhtmlx-gantt`); add the **Gantt** view to the project via `+ View`.
+
+---
+
+## Rendering & Scheduling
+
+| ID      | Title                       | Precondition                              | Steps                                                          | Expected Result                                                            | Actual Result | Status |
+|---------|-----------------------------|-------------------------------------------|----------------------------------------------------------------|----------------------------------------------------------------------------|---------------|--------|
+| GNT_001 | Add the Gantt view          | dhtmlx-gantt installed; project open      | 1. `+ View` → Gantt → Add                                      | Gantt tab appears and opens                                                |               | ⏳     |
+| GNT_002 | Bars render                 | Tasks with both a start and a due date    | 1. Open the Gantt tab                                          | Those tasks render as bars on the timeline                                 |               | ⏳     |
+| GNT_003 | Drag to reschedule          | A scheduled task                          | 1. Drag a bar to new dates  2. Reload + open List/Table        | Start/due updated and persisted everywhere                                 |               | ⏳     |
+| GNT_004 | Resize duration             | A scheduled task                          | 1. Drag a bar's edge                                           | Due date changes and persists                                              |               | ⏳     |
+| GNT_005 | Zoom presets                | Gantt open                                | 1. Switch Day / Week / Month                                   | Timeline scale changes accordingly                                         |               | ⏳     |
+| GNT_006 | Unscheduled tray → schedule | A task with no start/due dates            | 1. In the Unscheduled tray click **Schedule** on the task      | Task gets today→+1 day and appears as a bar                                |               | ⏳     |
+| GNT_007 | Milestones shown            | Project with milestones                   | 1. Open the Gantt                                              | Milestones render as read-only diamond markers                            |               | ⏳     |
+
+---
+
+## Dependencies, Sync & Permissions
+
+| ID      | Title                          | Precondition                                | Steps                                                       | Expected Result                                                          | Actual Result | Status |
+|---------|--------------------------------|---------------------------------------------|-------------------------------------------------------------|--------------------------------------------------------------------------|---------------|--------|
+| GNT_008 | Draw + delete a dependency     | Two scheduled tasks                         | 1. Drag from one bar's edge to another  2. Then delete the link | A "blocks" relation is created (visible in the task's Linked Tasks — see TaskRelations) then removed |               | ⏳     |
+| GNT_009 | Live sync across sessions      | Same project Gantt open in two browsers     | 1. Drag a bar in window 1                                   | Window 2 updates within a couple of seconds without reload               |               | ⏳     |
+| GNT_010 | Read-only without edit rights  | User lacking task-edit permission           | 1. Open the Gantt                                          | Read-only (no drag / no link drawing); "View only" badge shown            |               | ⏳     |
+
+---
+
+## Regression (fixes)
+
+| ID      | Title                                   | Precondition                       | Steps                                                                 | Expected Result                                                  | Actual Result | Status |
+|---------|-----------------------------------------|------------------------------------|-----------------------------------------------------------------------|------------------------------------------------------------------|---------------|--------|
+| GNT_011 | Reload with Gantt as the active view    | Gantt tab is currently active      | 1. Reload the page (do NOT visit another view first)                  | Bars render — Gantt loads the task store itself (no empty chart) |               | ⏳     |
+| GNT_012 | Repeated view switching doesn't crash   | —                                  | 1. Switch List → Table → Gantt and back several times                 | No error; Gantt re-renders cleanly each time (no "tasksStore" crash) |               | ⏳     |
+
+---
+
+**Total:** 12 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/Integrations.md
+++ b/.claude/test-cases/Integrations.md
@@ -1,0 +1,42 @@
+# Integrations (Slack & Discord) — Test Cases
+
+**Location:** Settings → Integrations → Add a webhook · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Setup & Connection — Slack
+
+| ID       | Title                                      | Precondition                          | Steps                                                                                                                                                                                 | Expected Result                                                                 | Actual Result | Status |
+|----------|--------------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|---------------|--------|
+| INTG_001 | Create a Slack incoming webhook (3rd-party) | A Slack workspace you can administer  | 1. Go to api.slack.com/apps → Create New App → From scratch → pick workspace  2. Features → Incoming Webhooks → toggle On  3. Add New Webhook to Workspace → choose channel → Allow  4. Copy the URL (`https://hooks.slack.com/services/…`) | A valid Slack incoming-webhook URL is obtained                                  |               | ⏳     |
+| INTG_002 | Connect Slack in AlianHub                  | INTG_001 done                         | 1. Settings → Integrations → Add a webhook  2. Select the **Slack** tab  3. Enter a name, paste the webhook URL, tick events (e.g. Task created, Task updated)  4. Save               | Webhook saved + listed; a one-time signing secret is shown (only once)          |               | ⏳     |
+| INTG_003 | Slack message on task creation             | Slack webhook configured (INTG_002)   | 1. Create a task in any project                                                                                                                                                       | Slack channel shows "Task created": `TaskKey — TaskName` with assignees/priority/due, within ~2 s |               | ⏳     |
+| INTG_004 | Slack message on status change             | INTG_002 done                         | 1. Change a task's status                                                                                                                                                             | Slack shows "Status changed" with `old → new`                                   |               | ⏳     |
+
+---
+
+## Setup & Connection — Discord
+
+| ID       | Title                                       | Precondition                             | Steps                                                                                                                            | Expected Result                                                              | Actual Result | Status |
+|----------|---------------------------------------------|------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|---------------|--------|
+| INTG_005 | Create a Discord channel webhook (3rd-party) | A Discord server/channel you can manage  | 1. Discord: Server → target Channel → Edit Channel (gear) → Integrations → Webhooks → New Webhook  2. Name it, pick channel  3. Copy Webhook URL (`https://discord.com/api/webhooks/…`) | A valid Discord webhook URL is obtained                                      |               | ⏳     |
+| INTG_006 | Connect Discord in AlianHub                 | INTG_005 done                            | 1. Settings → Integrations → Add a webhook  2. Select the **Discord** tab  3. Name + paste URL + select events  4. Save          | Webhook saved + listed                                                       |               | ⏳     |
+| INTG_007 | Discord embed on task event                 | INTG_006 done                            | 1. Create or update a task                                                                                                       | Discord channel receives an embed (title `TaskKey — TaskName`, headline, status/priority fields) |               | ⏳     |
+
+---
+
+## Events, Filtering & Delivery
+
+| ID       | Title                          | Precondition                               | Steps                                                                  | Expected Result                                                  | Actual Result | Status |
+|----------|--------------------------------|--------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------|---------------|--------|
+| INTG_008 | Event filtering                | A webhook subscribed only to "Task created" | 1. Update an existing task  2. Create a new task                       | Update → no message; create → message                            |               | ⏳     |
+| INTG_009 | Pause / disable a webhook      | An active webhook                          | 1. Toggle the webhook Off  2. Create a task  3. Toggle On  4. Create a task | Off → no message; On → messages resume                       |               | ⏳     |
+| INTG_010 | Delivery logs                  | A webhook that has fired                   | 1. Open the webhook's delivery logs                                    | Each delivery shows status code, duration, attempt count          |               | ⏳     |
+| INTG_011 | Payload is HMAC-signed         | A configured webhook + a request inspector | 1. Inspect a delivered request                                         | Request carries an `X-AlianHub-Signature` (HMAC-SHA256) header    |               | ⏳     |
+| INTG_012 | Invalid URL / no events rejected | Add-webhook form open                    | 1. Try a non-HTTPS / malformed URL  2. Try saving with zero events     | Save rejected with a readable validation message                  |               | ⏳     |
+
+---
+
+**Total:** 12 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/Mentions.md
+++ b/.claude/test-cases/Mentions.md
@@ -1,0 +1,20 @@
+# @Mentions in Comments — Test Cases
+
+**Location:** Task detail → Comments · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Mention & Notify
+
+| ID      | Title                          | Precondition                          | Steps                                                                            | Expected Result                                                                | Actual Result | Status |
+|---------|--------------------------------|---------------------------------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------------------|---------------|--------|
+| MNT_001 | Mention a user in a comment    | A task with other project members     | 1. Open a task → Comments  2. Type `@` in the comment box  3. Pick a user from the suggestions  4. Post | Comment posts with the mention; the mentioned user gets a notification (bell + email) |               | ⏳     |
+| MNT_002 | Notification links back        | MNT_001 done                          | 1. As the mentioned user, open the notification                                  | It links back to the task / comment                                            |               | ⏳     |
+| MNT_003 | Multiple mentions              | Project with ≥2 other members         | 1. Mention two users in one comment  2. Post                                     | Each mentioned user is notified                                                |               | ⏳     |
+| MNT_004 | No mention → no mention notice | —                                     | 1. Post a comment with no `@` mention                                            | No mention notification is sent                                                |               | ⏳     |
+
+---
+
+**Total:** 4 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/RecurringTasks.md
+++ b/.claude/test-cases/RecurringTasks.md
@@ -1,0 +1,25 @@
+# Recurring Tasks — Test Cases
+
+**Location:** Project → `+ View` → Recurring Tasks · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+>
+> **Setup:** add the **Recurring Tasks** view to the project via `+ View`.
+
+---
+
+## Definitions & Execution
+
+| ID      | Title                          | Precondition                                                       | Steps                                                                                                                  | Expected Result                                                          | Actual Result | Status |
+|---------|--------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|---------------|--------|
+| REC_001 | Create a recurring definition  | Recurring Tasks view added                                         | 1. `+ View` → Recurring Tasks  2. `+ New`  3. Fill definition name, task title, frequency (daily/weekly/monthly), interval, time, priority  4. Create | Definition appears in the list with a computed **Next run**              |               | ⏳     |
+| REC_002 | Run now creates a task         | REC_001 done                                                       | 1. Click **Run now** on a definition  2. Open the project task list                                                    | A task is created immediately; the definition's **Runs** count increments |               | ⏳     |
+| REC_003 | Pause / resume                 | An enabled definition                                              | 1. Click Pause  2. Click Resume                                                                                        | Enabled flag toggles; paused rows are dimmed and won't auto-run          |               | ⏳     |
+| REC_004 | Delete a definition            | A definition exists                                                | 1. Click Delete                                                                                                        | Definition is removed from the list                                      |               | ⏳     |
+| REC_005 | Skip if previous still open    | A definition with "Skip if previous still open" and an open prior instance | 1. Run now once (leave the created task open)  2. Run now again                                                | Second run is skipped ("previous instance still open")                   |               | ⏳     |
+| REC_006 | Weekly schedule summary        | —                                                                  | 1. Create a weekly definition with specific weekdays + time                                                           | Schedule summary and **Next run** reflect the chosen day/time            |               | ⏳     |
+| REC_007 | Scheduled auto-creation        | A due definition (nextRunAt ≤ now)                                 | 1. Production: wait for the 15-min cron. Local: `POST /api/v1/recurring-tasks/run-due`                                 | Due definitions instantiate tasks on schedule (cron is production-only; use Run now / run-due locally) |               | ⏳     |
+
+---
+
+**Total:** 7 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/ReportsPdfExport.md
+++ b/.claude/test-cases/ReportsPdfExport.md
@@ -1,0 +1,19 @@
+# Reports PDF Export — Test Cases
+
+**Location:** Project → `+ View` → Reports → (any chart) → Export PDF · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Export
+
+| ID      | Title                          | Precondition                                          | Steps                                      | Expected Result                                                                  | Actual Result | Status |
+|---------|--------------------------------|-------------------------------------------------------|--------------------------------------------|----------------------------------------------------------------------------------|---------------|--------|
+| PDF_001 | Export burndown to PDF         | `pdfmake` installed server-side; Reports → Burndown rendered | 1. Click **Export PDF** on the burndown chart | A branded PDF downloads containing the chart image + a data table matching the report |               | ⏳     |
+| PDF_002 | Export velocity / CFD to PDF   | Velocity or CFD chart rendered                        | 1. Click **Export PDF** on the chart       | PDF downloads with that chart image + its data table                             |               | ⏳     |
+| PDF_003 | Missing pdfmake degrades safely | Server where `pdfmake` is NOT installed              | 1. Start the app  2. Open a report  3. Click Export PDF | App starts and reports still render (lazy-loaded); only the export fails gracefully (no crash) |               | ⏳     |
+
+---
+
+**Total:** 3 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/StoryPoints.md
+++ b/.claude/test-cases/StoryPoints.md
@@ -1,0 +1,21 @@
+# Story Points & Estimation Scale — Test Cases
+
+**Location:** Task detail → Story Points · Project → estimation-scale config · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Estimation
+
+| ID     | Title                              | Precondition                              | Steps                                                                  | Expected Result                                                  | Actual Result | Status |
+|--------|------------------------------------|-------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------|---------------|--------|
+| SP_001 | Set story points on a task         | A task open                               | 1. Open a task  2. Set story points via the picker  3. Reload          | The value persists on the task                                   |               | ⏳     |
+| SP_002 | Picker reflects the project scale  | Project has an estimation scale set        | 1. Open the story-points picker                                        | Offered values match the project's scale (e.g. Fibonacci)        |               | ⏳     |
+| SP_003 | Change the project estimation scale | Admin on the project                      | 1. Open the project's estimation-scale config modal  2. Change scale  3. Save | The picker's available values update to the new scale            |               | ⏳     |
+| SP_004 | Story-points rollup in List view   | A sprint with several pointed tasks       | 1. Open the List view for the sprint                                   | A story-points rollup (sum per group/sprint) is shown            |               | ⏳     |
+| SP_005 | Points feed the reports            | Pointed + some completed tasks            | 1. Open Reports → Burndown and Velocity                               | Points are reflected in burndown "remaining" and in velocity      |               | ⏳     |
+
+---
+
+**Total:** 5 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/TrelloImporter.md
+++ b/.claude/test-cases/TrelloImporter.md
@@ -1,0 +1,31 @@
+# Trello Importer — Test Cases
+
+**Location:** Project board toolbar → `...` (More) → Import Trello · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Setup & Basic Import
+
+| ID      | Title                                    | Precondition                                                                                          | Steps                                                                                                                        | Expected Result                                                              | Actual Result | Status |
+|---------|------------------------------------------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|---------------|--------|
+| TRL_001 | Export a Trello board to JSON (3rd-party) | A Trello board with lists + cards; for rich-import coverage add a checklist, comment, label, attachment and a member to a card | 1. Open the board → board menu (`⋯` / "Show menu")  2. "Print, export, and share" → "Export as JSON"  3. Save the `.json` file | A Trello board JSON export file is obtained (no API key/token needed)        |               | ⏳     |
+| TRL_002 | Import the board                         | TRL_001 done; a sprint to import into                                                                | 1. Project → `...` → Import Trello  2. Upload the `.json`  3. Confirm the "X lists, Y cards" preview  4. Pick a sprint  5. Import | Lists → statuses, cards → tasks in the sprint; card name / description / due-date mapped |               | ⏳     |
+
+---
+
+## Rich Import (S3-01)
+
+| ID      | Title                          | Precondition                                            | Steps                                  | Expected Result                                                                       | Actual Result | Status |
+|---------|--------------------------------|---------------------------------------------------------|----------------------------------------|---------------------------------------------------------------------------------------|---------------|--------|
+| TRL_003 | Checklists imported            | A card with a checklist                                 | 1. Import  2. Open the task            | Task has the checklist with items in order and correct checked/unchecked state        |               | ⏳     |
+| TRL_004 | Comments imported              | A card with comments                                    | 1. Import  2. Open the task comments   | Comments imported as task comments (author + text)                                    |               | ⏳     |
+| TRL_005 | Labels folded into description | A card with labels                                      | 1. Import  2. Open the task            | Labels appended to the description ("Labels: …")                                       |               | ⏳     |
+| TRL_006 | Attachments as link references | A card with attachments                                 | 1. Import  2. Open the task            | Attachments imported as link references (filename + URL; not re-downloaded)           |               | ⏳     |
+| TRL_007 | Member email → assignee        | A card whose member email matches an AlianHub user      | 1. Import  2. Open the task            | That user added as a task assignee (best-effort; only when the export includes emails) |               | ⏳     |
+| TRL_008 | Closed / nameless skipped      | A board with closed lists/cards + a nameless card       | 1. Import                              | Closed and nameless items are skipped; valid cards still import                        |               | ⏳     |
+
+---
+
+**Total:** 8 test cases · **All status:** ⏳ Pending

--- a/.claude/test-cases/VelocityChart.md
+++ b/.claude/test-cases/VelocityChart.md
@@ -1,0 +1,19 @@
+# Velocity Chart — Test Cases
+
+**Location:** Project → `+ View` → Reports → Velocity · **Last updated:** 2026-06-18
+
+> **Status legend:** ⏳ Pending · ✅ Pass · ❌ Fail · ⚠️ Blocked · 🔄 Flaky
+
+---
+
+## Chart Rendering
+
+| ID      | Title                         | Precondition                                  | Steps                                            | Expected Result                                                                       | Actual Result | Status |
+|---------|-------------------------------|-----------------------------------------------|--------------------------------------------------|---------------------------------------------------------------------------------------|---------------|--------|
+| VEL_001 | Velocity renders              | Reports view added; project with ≥2 sprints carrying story points | 1. Open Reports → Velocity                       | Per-sprint **committed vs completed** point columns plus a rolling 3-sprint average line |               | ⏳     |
+| VEL_002 | Ordering & counts are correct | VEL_001 done                                  | 1. Observe the sprint order and bar values       | Sprints shown oldest → newest; committed/completed match each sprint's points          |               | ⏳     |
+| VEL_003 | Empty state handled           | A project with no pointed/closed sprints      | 1. Open Reports → Velocity                       | Renders an empty/zero state — no crash                                                 |               | ⏳     |
+
+---
+
+**Total:** 3 test cases · **All status:** ⏳ Pending

--- a/frontend/src/views/Projects/GanttView/GanttView.vue
+++ b/frontend/src/views/Projects/GanttView/GanttView.vue
@@ -52,6 +52,7 @@ import { useCustomComposable } from '@/composable';
 import { apiRequest } from '@/services';
 import * as env from '@/config/env';
 import taskClass from '@/utils/TaskOperations';
+import { taskListHelper } from '@/views/Projects/helper.js';
 
 const props = defineProps({
     projectData: { type: Object, default: () => ({}) },
@@ -60,6 +61,7 @@ const props = defineProps({
 
 const { getters } = useStore();
 const { checkPermission } = useCustomComposable();
+const { groupBy } = taskListHelper();
 const selectedProject = inject('selectedProject', ref({}));
 
 const ganttEl = ref(null);
@@ -249,7 +251,23 @@ function setZoom(level) {
 }
 
 /* ----------------------------------- lifecycle ---------------------------------- */
+// Ensure the project's task list is in the store. Other views (List/Table/Board) trigger
+// this load via taskListHelper on mount; Gantt must too — otherwise a direct reload INTO
+// the Gantt tab finds an empty store and renders nothing (it only worked when another view
+// had already populated it). Mirrors ListView's onMounted loader (state.tasks via Mongo).
+function ensureTasksLoaded() {
+    if (tasks.value.length) return; // already loaded (e.g. arrived here from another view)
+    const proj = (selectedProject.value && selectedProject.value._id) ? selectedProject.value : props.projectData;
+    if (!proj || !proj._id || !Array.isArray(props.sprints) || !props.sprints.length) return;
+    try {
+        groupBy(0, true, proj, props.sprints, ref([]), false, 'list', false, true, () => {});
+    } catch (e) {
+        console.error('Gantt: task-load trigger failed', e);
+    }
+}
+
 onMounted(async () => {
+    ensureTasksLoaded();
     let mod;
     try {
         mod = await import(/* webpackChunkName: "dhtmlx-gantt" */ 'dhtmlx-gantt');
@@ -323,6 +341,9 @@ watch(readOnly, (ro) => {
     gantt.config.drag_links = !ro;
     gantt.render();
 });
+
+// Sprints can arrive after mount on a fresh reload — trigger the load once they're present.
+watch(() => props.sprints, () => ensureTasksLoaded(), { deep: true });
 
 onBeforeUnmount(() => {
     try {


### PR DESCRIPTION
Two related changes from the Sprint 5 QA pass.

## Fix — Gantt renders on direct reload  (commit 6e9cc3a)
**Bug:** reloading the page with the **Gantt** tab active showed an empty chart (0 scheduled + empty Unscheduled tray); reaching Gantt via List worked.
**Cause:** the project task list is loaded into the Vuex store by whichever task view (List/Table/Board) mounts, via `taskListHelper().groupBy(...)`. Gantt only *read* the store, so a direct reload into the Gantt tab left it empty.
**Fix:** `GanttView` triggers the same loader on mount **only when the store is empty** for the project+sprint (no double-fetch when arriving from another view), and retries if `sprints` arrive late; the existing reactive watch renders once the data lands. Retains the earlier reopen-crash fix (dhtmlx singleton, no `destructor()`, guarded `init()`).

## Docs — Sprint 2–5 feature test cases  (commit cd6b4cc)
10 per-feature files in `.claude/test-cases/`, matching the folder's existing template (`ID | Title | Precondition | Steps | Expected | Actual | Status`):
Integrations (Slack + Discord), CSV importer, Trello importer, story points, @mentions, velocity, CFD, reports PDF export, Gantt, recurring tasks.
- Third-party **setup steps** are written as the first "configure" case (Slack app → Incoming Webhook, Discord channel webhook, Trello board → Export as JSON).
- The Gantt file includes **regression cases** for the fix above.
- Skips `BurndownChart.md` (S4-01, already present); excludes n8n (not implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
