### PR TITLE
refactor(frontend): group navbar menus under Reports and Workspace

### DIFF
--- a/frontend/src/components/organisms/Header/Header.vue
+++ b/frontend/src/components/organisms/Header/Header.vue
@@ -181,7 +181,7 @@
                             <div :key="'nested-item-'+index" v-else>
                                 <DropDown :id="'nav_menu'+index" :title="$t(`Header.${item.name}`)">
                                     <template #button>
-                                        <div :class="{'active-list-mobile': item.name==='Time_Sheet' ? $route.name.toLowerCase().includes('timesheet') : $route.name.toLowerCase().includes('report')}" class="hover-white p-1 cursor-pointer border-radius-7-px mobile-menu-list mobile-menu-list-arrow">
+                                        <div :class="{'active-list-mobile': item.submenu.some((s) => s.to && s.to.path && $route.path.startsWith(s.to.path))}" class="hover-white p-1 cursor-pointer border-radius-7-px mobile-menu-list mobile-menu-list-arrow">
                                             {{ $t(`Header.${item.name}`) }}
                                         </div>
                                     </template>

--- a/frontend/src/components/organisms/Header/helper.js
+++ b/frontend/src/components/organisms/Header/helper.js
@@ -23,39 +23,26 @@ export function useHelper() {
             isActive: true
         },
         {
-            name: "Portfolio",
-            to: {path: `/${companyId.value}/portfolio`},
+            // Workspace — oversight + planning + apps grouped under one menu.
+            name: "Workspace",
             show: true,
-            submenu: [],
-            isActive: true
-        },
-        {
-            name: "Custom_Report",
-            to: {path: `/${companyId.value}/custom-reports`},
-            show: true,
-            submenu: [],
-            isActive: true
-        },
-        {
-            name: "Variance_Report",
-            to: {path: `/${companyId.value}/reports/variance`},
-            show: true,
-            submenu: [],
-            isActive: true
-        },
-        {
-            name: "Capacity_Planning",
-            to: {path: `/${companyId.value}/reports/capacity`},
-            show: true,
-            submenu: [],
-            isActive: true
-        },
-        {
-            name: "Integrations",
-            to: {path: `/${companyId.value}/integrations`},
-            show: true,
-            submenu: [],
-            isActive: true
+            submenu: [
+                {
+                    name: "Portfolio",
+                    to: {path: `/${companyId.value}/portfolio`},
+                    show: true
+                },
+                {
+                    name: "Capacity_Planning",
+                    to: {path: `/${companyId.value}/reports/capacity`},
+                    show: true
+                },
+                {
+                    name: "Integrations",
+                    to: {path: `/${companyId.value}/integrations`},
+                    show: true
+                }
+            ]
         },
         {
             name: "Time_Sheet",
@@ -109,13 +96,24 @@ export function useHelper() {
             ]
         },
         {
+            // Reports — Milestone (permission-gated) + the always-on Custom & Variance reports.
             name: "Reports",
-            show:checkPermission('sheet_settings.milestone_report') !== null,
+            show: true,
             submenu: [
                 {
                     name: "Milestone_Report",
                     to: {path: `/${companyId.value}/report/milestone`},
                     show:checkPermission('sheet_settings.milestone_report') !== null
+                },
+                {
+                    name: "Custom_Report",
+                    to: {path: `/${companyId.value}/custom-reports`},
+                    show: true
+                },
+                {
+                    name: "Variance_Report",
+                    to: {path: `/${companyId.value}/reports/variance`},
+                    show: true
                 }
             ]
         }

--- a/frontend/src/components/organisms/NavLinks/NavLinks.vue
+++ b/frontend/src/components/organisms/NavLinks/NavLinks.vue
@@ -7,7 +7,7 @@
                 </router-link>
 
             <!-- FOR SUB MENU -->
-            <div :key="'nested-item-'+index+item.name" v-else class="link-item link-dropdown-menu" :class="{'active': item.name==='Time_Sheet' ? $route.name.toLowerCase().includes('timesheet') : $route.name.toLowerCase().includes('report')}">
+            <div :key="'nested-item-'+index+item.name" v-else class="link-item link-dropdown-menu" :class="{'active': isDropdownActive(item)}">
                 <DropDown :id="'nav_menu2'+index+item.name" :title="item.name">
                     <template #button>
                         <div class="cursor-pointer dropdown_wrapper h-100" :id="item.id ? item.id : ''">
@@ -57,6 +57,13 @@ defineProps({
 const handleItemClick = (value,idex)  =>{
     document.getElementById(`list_dropdown_header${value}${idex}`).click()
 }
+
+// A dropdown is active when the current route matches any of its submenu paths.
+// Generalizes the old hardcoded Time_Sheet/Reports check so the Workspace menu
+// (Portfolio / Capacity / Integrations) highlights correctly too.
+const isDropdownActive = (item) => (item.submenu || []).some(
+    (s) => s && s.to && s.to.path && route.path.startsWith(s.to.path)
+);
 
 </script>
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -523,6 +523,7 @@ export default {
         Variance_Report: "Variance Report",
         Capacity_Planning: "Capacity Planning",
         Integrations: "Integrations",
+        Workspace: "Workspace",
         Time_Sheet: "Time Sheet",
         User_Timesheet: "User Timesheet",
         project_Timesheet: "Project Timesheet",


### PR DESCRIPTION
## Navbar menu refactor

The top nav had accumulated several flat items as v14.5.0 features landed. This groups them into dropdowns (per request, from the current-nav screenshot):

**Before:** Projects · Portfolio · Custom Report · Variance Report · Capacity Planning · Integrations · Time Sheet · Reports

**After:** Projects · **Workspace ▾** · Time Sheet ▾ · **Reports ▾**
- **Reports ▾** → Milestone Report (permission-gated) · Custom Report · Variance Report
- **Workspace ▾** → Portfolio · Capacity Planning · Integrations

### Notes
- Menu **config only** (`Header/helper.js`) — routes, pages and i18n keys unchanged; added one label `Header.Workspace`.
- Reports now always shows (it previously hid without the milestone-report permission); Milestone stays permission-gated, Custom/Variance are always available.
- Dropdown active-highlight generalized to "current route matches any submenu path" (desktop `NavLinks` + mobile `Header`), replacing the old hardcoded timesheet-vs-report check so the new Workspace menu highlights correctly.
- Frontend build clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
