### PR TITLE
fix(reports): hide closed/deleted/archived projects from module pickers

### DIFF
--- a/Modules/Portfolio/controller.js
+++ b/Modules/Portfolio/controller.js
@@ -88,7 +88,7 @@ exports.getRollup = async (req, res) => {
         const projectDocs = projectIds.length
             ? await MongoDbCrudOpration(companyId, {
                 type: SCHEMA_TYPE.PROJECTS,
-                data: [{ _id: { $in: projectIds.map(oid) }, deletedStatusKey: { $nin: [1] } }, 'ProjectName status statusType DueDate'],
+                data: [{ _id: { $in: projectIds.map(oid) }, deletedStatusKey: { $nin: [1, 2] }, status: { $ne: 'close' } }, 'ProjectName status statusType DueDate'],
             }, 'find')
             : [];
         const projById = {};

--- a/frontend/src/views/CustomReports/CustomReports.vue
+++ b/frontend/src/views/CustomReports/CustomReports.vue
@@ -176,7 +176,9 @@ const runPreview = async () => {
 const loadProjects = async () => {
     try {
         const body = (await apiRequest('get', env.PROJECT))?.data;
-        projects.value = Array.isArray(body) ? body : (body && body.data) || [];
+        const list = Array.isArray(body) ? body : (body && body.data) || [];
+        // Active projects only — hide closed / deleted / archived from the picker.
+        projects.value = list.filter((p) => p && p.status !== 'close' && p.deletedStatusKey !== 1 && p.deletedStatusKey !== 2);
     } catch (e) { projects.value = []; }
 };
 const loadSaved = async (s) => {

--- a/frontend/src/views/Integrations/IntegrationsHub.vue
+++ b/frontend/src/views/Integrations/IntegrationsHub.vue
@@ -303,7 +303,9 @@ const webhookUrl = (token) => `${window.location.origin}${env.EMAIL_IN}/${token}
 const loadProjects = async () => {
     try {
         const body = (await apiRequest('get', env.PROJECT))?.data;
-        projects.value = Array.isArray(body) ? body : (body && body.data) || [];
+        const list = Array.isArray(body) ? body : (body && body.data) || [];
+        // Active projects only — hide closed / deleted / archived from the pickers.
+        projects.value = list.filter((p) => p && p.status !== 'close' && p.deletedStatusKey !== 1 && p.deletedStatusKey !== 2);
     } catch (e) { projects.value = []; }
 };
 const loadInboxes = async () => {

--- a/frontend/src/views/Portfolio/Portfolio.vue
+++ b/frontend/src/views/Portfolio/Portfolio.vue
@@ -125,7 +125,9 @@ const loadPortfolios = async () => {
 const loadProjects = async () => {
     try {
         const body = (await apiRequest('get', env.PROJECT))?.data;
-        allProjects.value = Array.isArray(body) ? body : (body && body.data) || [];
+        const list = Array.isArray(body) ? body : (body && body.data) || [];
+        // Active projects only — hide closed / deleted / archived from the picker.
+        allProjects.value = list.filter((p) => p && p.status !== 'close' && p.deletedStatusKey !== 1 && p.deletedStatusKey !== 2);
     } catch (e) { allProjects.value = []; }
 };
 const select = async (p) => {

--- a/frontend/src/views/VarianceReport/VarianceReport.vue
+++ b/frontend/src/views/VarianceReport/VarianceReport.vue
@@ -91,7 +91,9 @@ const varClass = (v) => (v > 0 ? 'over' : (v < 0 ? 'under' : ''));
 const loadProjects = async () => {
     try {
         const b = (await apiRequest('get', env.PROJECT))?.data;
-        projects.value = Array.isArray(b) ? b : (b && b.data) || [];
+        const list = Array.isArray(b) ? b : (b && b.data) || [];
+        // Active projects only — hide closed / deleted / archived from the picker.
+        projects.value = list.filter((p) => p && p.status !== 'close' && p.deletedStatusKey !== 1 && p.deletedStatusKey !== 2);
     } catch (e) { projects.value = []; }
 };
 const load = async () => {


### PR DESCRIPTION
## Hide closed/deleted projects from the new modules' project lists

`GET /api/v1/project` only filters out **deleted** projects (`deletedStatusKey: 1`) — it still returns **closed** (`status: 'close'`) and **archived** (`deletedStatusKey: 2`) ones. Those were showing in the new modules' project pickers and the portfolio rollup.

### Fix (scoped to the new modules — shared endpoint untouched)
| Module | Change |
|--------|--------|
| **Custom Report** | picker filters to active projects only |
| **Variance Report** | picker filters to active projects only |
| **Portfolio** | picker filters + **rollup query** tightened (`deletedStatusKey ∉ [1,2]`, `status ≠ 'close'`) |
| **Integrations** | picker filters to active (email-to-task, calendar, automations) |
| **Capacity Planning** | no project picker — nothing to change |

Active = `status !== 'close'` **and** `deletedStatusKey ∉ [1, 2]` (excludes closed, deleted, and archived — treating archived as inactive too).

- Frontend build clean (0 errors); Portfolio controller syntax-checked.
- No change to the shared `/api/v1/project` endpoint or the main Projects page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
