### PR TITLE
feat(views): project views & canvas — timeline, mind map, whiteboard, canvas, map

### DIFF
--- a/.claude/test-cases/VIEW-01-timeline.md
+++ b/.claude/test-cases/VIEW-01-timeline.md
@@ -1,0 +1,35 @@
+# Test Cases — VIEW-01 Timeline view (AHE-3742)
+
+A first-class **project view** (keyName `TimelineView`) that plots tasks with a
+start + due date as bars on a shared date axis. Read-only, lightweight (no external
+library), reads from the same live Vuex task store the List/Gantt views use (so
+socket updates flow in automatically).
+
+**Registration (6 spots):** TimelineView.vue · Projects.vue (`getView` + 3 full-width
+layout conditions) · commonFunction `projectComponentsIcons` (reuses `comp_timeline_*` icons) ·
+ViewsDropdown `images` · en.js `ViewList.TimelineView` + `ViewListdescription.timeline_view` ·
+utils/data.js new-company seed (keyName `TimelineView`, sortIndex 12).
+
+> **Catalog note:** added to the new-company seed; for EXISTING companies a `PROJECT_TAB_COMPONENTS`
+> record (`{keyName:'TimelineView', name, sortIndex, viewStatus:true}`) must be added + the
+> `ProjectTabs:<companyId>` cache cleared (per the maintained-catalog process). keyName is
+> `TimelineView` (not `Timeline`, which the catalog hard-filters).
+
+## Manual / integration test cases
+
+| # | Scenario | Steps | Expected |
+|---|----------|-------|----------|
+| M1 | View appears | Add the catalog record → open a project → "+ View" | "Timeline" is listed with its icon/preview |
+| M2 | Bars render | Open Timeline on a project with dated tasks | Tasks with start+due show as bars positioned on the date axis; month ticks across the top |
+| M3 | Status colour | tasks of different statuses | bars coloured: To Do (grey), In Progress (blue), Done (green) |
+| M4 | Unscheduled tray | tasks without start/due | listed in the "Unscheduled" side tray, not on the axis |
+| M5 | Empty | project with no dated tasks | friendly empty-state message |
+| M6 | Live sync | change a task's dates in another view | Timeline reflects it (shared store) |
+| M7 | Single-day task | start == due | bar still visible (min width + 1-day axis pad) |
+| M8 | Sort | — | rows ordered by start date |
+
+## Guards / non-regression
+- **Read-only** — no writes, no drag, no persistence; purely a visualization. Can't affect task data.
+- **No external dependency** (unlike Gantt's dhtmlx) — pure CSS/computed; works offline.
+- Reuses the proven GanttView data harness (`pickTasks` from the store + `ensureTasksLoaded` via `taskListHelper.groupBy`) so a direct reload into the tab still loads tasks.
+- Additive: a new view + registration only; no existing view, route, or schema changed. `deletedStatusKey ∈ [0,2]` (active/archived) tasks shown, deleted excluded — consistent with other views.

--- a/.claude/test-cases/VIEW-02-mindmap.md
+++ b/.claude/test-cases/VIEW-02-mindmap.md
@@ -1,0 +1,29 @@
+# Test Cases — VIEW-02 Mind Map view (AHE-3743)
+
+A first-class **project view** (keyName `MindMapView`) rendering the project →
+parent-task → subtask hierarchy as an SVG node tree. Read-only, lightweight (no
+external lib), reads the same live Vuex task store as the other views.
+
+**Registration:** MindMapView.vue · Projects.vue (`getView` + 3 full-width layout conditions) ·
+commonFunction `projectComponentsIcons` · ViewsDropdown `images` · en.js `ViewList.MindMapView` +
+`ViewListdescription.mindmap_view` · utils/data.js seed (keyName `MindMapView`, sortIndex 13).
+Existing companies need the `PROJECT_TAB_COMPONENTS` catalog record added (maintained-catalog process).
+
+## Manual / integration test cases
+
+| # | Scenario | Steps | Expected |
+|---|----------|-------|----------|
+| M1 | View appears | add catalog record → "+ View" | "Mind Map" listed with icon/preview |
+| M2 | Tree renders | open Mind Map | Root = project name; parent tasks branch from it; subtasks branch from their parent; curved connectors |
+| M3 | Status colour | mixed statuses | node borders/text reflect To Do / In Progress (blue) / Done (green); root filled navy |
+| M4 | Subtask nesting | task with subtasks | subtasks appear as 3rd-level nodes off their parent |
+| M5 | Empty | project with no tasks | friendly empty-state |
+| M6 | Live sync | add/rename a task elsewhere | mind map reflects it (shared store) |
+| M7 | Long names | task name > 24 chars | truncated with ellipsis in the node |
+| M8 | Scroll | large project | SVG scrolls within the panel (width/height grow with the tree) |
+
+## Guards / non-regression
+- Read-only visualization — no writes, no persistence.
+- No external dependency — pure SVG + a bottom-up tidy-tree layout (leaves placed sequentially, parents centered on their children).
+- Reuses the GanttView data harness (`pickTasks` + `ensureTasksLoaded`); deleted tasks excluded (`deletedStatusKey ∈ [0,2]`).
+- Additive: new view + registration only; nothing existing changed.

--- a/.claude/test-cases/VIEW-03-whiteboard.md
+++ b/.claude/test-cases/VIEW-03-whiteboard.md
@@ -1,0 +1,33 @@
+# Test Cases — VIEW-03 Whiteboard view (AHE-3744)
+
+A first-class **project view** (keyName `WhiteboardView`) showing tasks as freely
+draggable cards on a gridded board. Positions persist **per user** via localStorage
+(keyed by project+sprint) as the v1; shared/server-persisted positions are a noted
+follow-up. Reads the same live Vuex task store.
+
+**Registration:** WhiteboardView.vue · Projects.vue (`getView` + 3 full-width layout conditions) ·
+commonFunction `projectComponentsIcons` (reuses `comp_board_*`) · ViewsDropdown `images` ·
+en.js `ViewList.WhiteboardView` + `ViewList["Whiteboard View"]` (catalog name) + `ViewListdescription.whiteboard_view` ·
+utils/data.js seed (keyName `WhiteboardView`, sortIndex 14). Existing companies need the catalog DB record added.
+
+## Manual / integration test cases
+
+| # | Scenario | Steps | Expected |
+|---|----------|-------|----------|
+| M1 | View appears | add catalog record → "+ View" | "Whiteboard" listed; label resolves (not raw key) |
+| M2 | Cards render | open Whiteboard | each task is a card on the board, auto-laid in a grid; status colour on the left edge |
+| M3 | Drag | drag a card | it follows the cursor; drops where released |
+| M4 | Persistence | move cards, reload the view | positions restored (localStorage, same browser/user) |
+| M5 | Auto-arrange | click "Auto-arrange" | cards snap back to a tidy grid; saved |
+| M6 | New task | add a task elsewhere | appears as a new card (default grid slot) |
+| M7 | Empty | no tasks | friendly empty-state |
+| M8 | Scroll | many cards / dragged far | board scrolls; drag accounts for scroll offset |
+
+## Guards / non-regression
+- Does **not** mutate task data — only card positions, stored client-side (localStorage). No backend, no schema, no new collection.
+- Lightweight: custom pointer-drag (no external lib); global mousemove/up listeners cleaned up on unmount.
+- Reuses the GanttView data harness; deleted tasks excluded.
+- Additive: new view + registration only.
+
+## Follow-up
+Shared/server-persisted positions (a per-project board layout) so arrangements are the same for everyone — deferred to keep this view lightweight + backend-free.

--- a/.claude/test-cases/VIEW-04-canvas.md
+++ b/.claude/test-cases/VIEW-04-canvas.md
@@ -1,0 +1,29 @@
+# Test Cases — VIEW-04 Canvas / dynamic layouts (AHE-3745)
+
+A first-class **project view** (keyName `CanvasView`): a configurable mini-dashboard
+of project insight widgets (Summary, By status, By priority, Overdue, Upcoming),
+computed live from the task store. Which widgets show is toggleable + persisted per
+user (localStorage). Lightweight, no external lib.
+
+**Registration:** CanvasView.vue · Projects.vue (`getView` + 3 layout conditions) ·
+commonFunction `projectComponentsIcons` · ViewsDropdown `images` · en.js `ViewList.CanvasView` +
+`ViewList["Canvas View"]` + `ViewListdescription.canvas_view` · utils/data.js seed (keyName `CanvasView`, sortIndex 15).
+Existing companies need the catalog DB record added.
+
+## Manual / integration test cases
+
+| # | Scenario | Steps | Expected |
+|---|----------|-------|----------|
+| M1 | View appears | add catalog record → "+ View" | "Canvas" listed; label resolves |
+| M2 | Widgets render | open Canvas | Summary (total + % complete), By status, By priority bars, Overdue count, Upcoming list — all from live tasks |
+| M3 | Completion % | mark tasks done | Summary % + Done bar update |
+| M4 | Overdue | task past due & open | counted in Overdue (red if > 0) |
+| M5 | Upcoming | task due within 7 days & open | listed (date-sorted, top 6) |
+| M6 | Toggle widget | click a chip off/on | widget hides/shows; choice persists on reload (localStorage) |
+| M7 | Empty | no tasks | friendly empty-state |
+| M8 | Live sync | change tasks elsewhere | widgets recompute |
+
+## Guards / non-regression
+- Read-only — derives stats from the store; no writes, no schema, no backend, no new collection. Widget on/off stored client-side.
+- Reuses the GanttView data harness; deleted tasks excluded; done = status type 'close'.
+- Additive: new view + registration only.

--- a/.claude/test-cases/VIEW-05-map.md
+++ b/.claude/test-cases/VIEW-05-map.md
@@ -1,0 +1,44 @@
+# Test Cases — VIEW-05 Map view (AHE-3746)
+
+A first-class **project view** (keyName `MapView`): pin tasks onto a world map to see
+where work happens. Dependency-free and **fully offline** — a custom SVG equirectangular
+world canvas (no Leaflet, no external map tiles), honoring AlianHub's self-hosted /
+data-residency / Offline-Mode identity. Task placements are personal and saved to the
+browser (localStorage), like the Whiteboard view's card positions.
+
+**Why no Leaflet/OSM tiles:** fetching map tiles from a third party on every render would
+add a runtime network + CSP dependency that none of the other views have and that
+contradicts the product's offline/self-hosted posture (AHE-3763 Offline Mode). The SVG
+canvas plots real lat/lng via an equirectangular projection with zero external calls.
+
+**Registration:** MapView.vue · Projects.vue (`getView` + 3 layout conditions) ·
+commonFunction `projectComponentsIcons` · ViewsDropdown `images` · en.js `ViewList.MapView` +
+`ViewList["Map View"]` + `ViewListdescription.map_view` · utils/data.js seed (keyName `MapView`, sortIndex 16).
+Existing companies need the catalog DB record added (user-maintained process).
+
+## Projection
+- `project(lat,lng)` → `x = (lng+180)/360 · W`, `y = (90-lat)/180 · H` (W=1000, H=500, 2:1).
+- `unproject(x,y)` inverts it. Click → unproject → clamp to [-90,90]/[-180,180].
+
+## Manual / integration test cases
+
+| # | Scenario | Steps | Expected |
+|---|----------|-------|----------|
+| M1 | View appears | add catalog record → "+ View" | "Map" listed; label + description resolve (no raw `ViewList.*`) |
+| M2 | Canvas renders | open Map | ocean background, 30° graticule, bold equator + prime meridian, edge degree labels (N/S/E/W) |
+| M3 | Place a task | click **Place** on a tray task → click the map | a colored pin drops at the clicked point; task leaves the tray; selected-card shows its lat/lng |
+| M4 | Cancel placing | click Place → "cancel" in the banner | placing mode ends, no pin added |
+| M5 | Pin color = status | tasks in to-do / in-progress / done | grey / amber / green pins |
+| M6 | Select pin | click a placed pin | side card shows name, key, coords, **Remove from map**; pin outlined |
+| M7 | Remove | open a pin → Remove from map | pin gone; task back in the "To place" tray |
+| M8 | Persistence | place a few, reload | placements restored (localStorage `map:{pid}:{sid}`) |
+| M9 | Clear all | click **Clear all** | all pins removed; all tasks back in tray |
+| M10 | Per-sprint | switch sprint | placements scoped per project+sprint key; no bleed across sprints |
+| M11 | Empty | sprint with no tasks | "No tasks in this sprint yet." |
+| M12 | Live sync | task added/closed elsewhere | tray/pin set + pin colors recompute from the store |
+
+## Guards / non-regression
+- **Zero backend** — no schema change, no endpoint, no socket, no new collection. Placements live in localStorage only (per-browser, per user/device), documented as the known v1 limitation; a shared server-side `location` field is the natural enhancement.
+- Reuses the GanttView data harness (`pickTasks` + `ensureTasksLoaded` via `groupBy`); deleted tasks excluded (`deletedStatusKey ∈ {0,2,undefined,null}`); done = status type `close`.
+- No external network at runtime (no tiles, no geocoding) — works fully offline.
+- Additive: new view + registration + seed only; no existing view or core path touched.

--- a/.claude/test-cases/VIEW-fix-icon-fallback.md
+++ b/.claude/test-cases/VIEW-fix-icon-fallback.md
@@ -1,0 +1,30 @@
+# Test Cases — "+ View" icon-fallback crash fix
+
+**Bug:** Clicking **+ View** threw `Cannot read properties of undefined (reading 'icon')`
+and white-screened the dropdown. Root cause: `projectComponentsIcons(keyName)`
+(commonFunction.js) returned `undefined` when a catalog record's `keyName` was not in
+its hardcoded icon array, and callers read `.icon` / `.activeIcon` directly. Since the
+PROJECT_TAB_COMPONENTS catalog is user-maintained (records added to existing companies),
+the frontend must not assume every keyName is known.
+
+**Fix:** `projectComponentsIcons()` now returns a default-icon fallback object
+(`{ icon, activeIcon, keyName }`) instead of `undefined` — one change that protects every
+caller (the "+ View" dropdown, the active tab strip, and the template / project-creation /
+project-settings catalogs, ~10 call sites total). Added optional-chaining at the two
+directly affected spots (ViewsDropdown, ViewsList) as belt-and-suspenders.
+
+## Manual / regression test cases
+
+| # | Scenario | Steps | Expected |
+|---|----------|-------|----------|
+| R1 | Known views | open "+ View" with all 5 new views in the catalog | dropdown renders; each view shows its proper icon; no console error |
+| R2 | Unknown keyName | catalog record with a keyName not in the icon array | dropdown still renders; that row shows the default icon; **no crash** |
+| R3 | Tab strip | a project with a view whose keyName is unknown | the horizontal view tab renders with the default icon, not a blank/crash |
+| R4 | Template / settings catalogs | open Template detail, Create Project view-picker, Project listing settings | all render with icons or the default; no `reading 'icon'` error |
+| R5 | Add a view | "+ View" → pick a new view → Add | adds normally; tab appears with correct label + icon |
+
+## Guards / non-regression
+- Pure hardening: the helper's contract changes from "may return undefined" to "always
+  returns an icon object". No behavior change for known keyNames (same icons as before).
+- Fallback icon is `comp_gantt_*` (guaranteed present); no new assets.
+- Frontend-only; no backend, schema, or catalog change.

--- a/frontend/src/assets/images/svg/component-active-icons/comp_canvas_active.svg
+++ b/frontend/src/assets/images/svg/component-active-icons/comp_canvas_active.svg
@@ -1,0 +1,6 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.2" y="1.2" width="6.2" height="6.2" rx="1" fill="#2F3990"/>
+<rect x="8.6" y="1.2" width="4.2" height="2.7" rx="0.8" fill="#2F3990"/>
+<rect x="8.6" y="4.7" width="4.2" height="2.7" rx="0.8" fill="#2F3990"/>
+<rect x="1.2" y="8.6" width="11.6" height="4.2" rx="1" fill="#2F3990"/>
+</svg>

--- a/frontend/src/assets/images/svg/component-active-icons/comp_map_active.svg
+++ b/frontend/src/assets/images/svg/component-active-icons/comp_map_active.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7 1.2C4.51 1.2 2.6 3.11 2.6 5.6C2.6 9 7 12.8 7 12.8C7 12.8 11.4 9 11.4 5.6C11.4 3.11 9.49 1.2 7 1.2ZM7 7.2C6.12 7.2 5.4 6.48 5.4 5.6C5.4 4.72 6.12 4 7 4C7.88 4 8.6 4.72 8.6 5.6C8.6 6.48 7.88 7.2 7 7.2Z" fill="#2F3990"/>
+</svg>

--- a/frontend/src/assets/images/svg/component-active-icons/comp_mindmap_active.svg
+++ b/frontend/src/assets/images/svg/component-active-icons/comp_mindmap_active.svg
@@ -1,0 +1,7 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.4 6.4L9.5 3.2M4.7 7H9.3M4.4 7.6L9.5 10.8" stroke="#2F3990" stroke-width="1" stroke-linecap="round"/>
+<circle cx="2.6" cy="7" r="2.1" fill="#2F3990"/>
+<circle cx="11" cy="3" r="1.7" fill="#2F3990"/>
+<circle cx="11" cy="7" r="1.7" fill="#2F3990"/>
+<circle cx="11" cy="11" r="1.7" fill="#2F3990"/>
+</svg>

--- a/frontend/src/assets/images/svg/component-active-icons/comp_whiteboard_active.svg
+++ b/frontend/src/assets/images/svg/component-active-icons/comp_whiteboard_active.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.1" y="2.1" width="11.8" height="9.8" rx="1.4" stroke="#2F3990" stroke-width="1.2"/>
+<rect x="3" y="4" width="3.6" height="3.6" rx="0.6" fill="#2F3990"/>
+<rect x="7.6" y="6.4" width="3.4" height="3.4" rx="0.6" fill="#2F3990"/>
+</svg>

--- a/frontend/src/assets/images/svg/component-inactive-icons/comp_canvas_inactive.svg
+++ b/frontend/src/assets/images/svg/component-inactive-icons/comp_canvas_inactive.svg
@@ -1,0 +1,6 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.2" y="1.2" width="6.2" height="6.2" rx="1" fill="#818181"/>
+<rect x="8.6" y="1.2" width="4.2" height="2.7" rx="0.8" fill="#818181"/>
+<rect x="8.6" y="4.7" width="4.2" height="2.7" rx="0.8" fill="#818181"/>
+<rect x="1.2" y="8.6" width="11.6" height="4.2" rx="1" fill="#818181"/>
+</svg>

--- a/frontend/src/assets/images/svg/component-inactive-icons/comp_map_inactive.svg
+++ b/frontend/src/assets/images/svg/component-inactive-icons/comp_map_inactive.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7 1.2C4.51 1.2 2.6 3.11 2.6 5.6C2.6 9 7 12.8 7 12.8C7 12.8 11.4 9 11.4 5.6C11.4 3.11 9.49 1.2 7 1.2ZM7 7.2C6.12 7.2 5.4 6.48 5.4 5.6C5.4 4.72 6.12 4 7 4C7.88 4 8.6 4.72 8.6 5.6C8.6 6.48 7.88 7.2 7 7.2Z" fill="#818181"/>
+</svg>

--- a/frontend/src/assets/images/svg/component-inactive-icons/comp_mindmap_inactive.svg
+++ b/frontend/src/assets/images/svg/component-inactive-icons/comp_mindmap_inactive.svg
@@ -1,0 +1,7 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.4 6.4L9.5 3.2M4.7 7H9.3M4.4 7.6L9.5 10.8" stroke="#818181" stroke-width="1" stroke-linecap="round"/>
+<circle cx="2.6" cy="7" r="2.1" fill="#818181"/>
+<circle cx="11" cy="3" r="1.7" fill="#818181"/>
+<circle cx="11" cy="7" r="1.7" fill="#818181"/>
+<circle cx="11" cy="11" r="1.7" fill="#818181"/>
+</svg>

--- a/frontend/src/assets/images/svg/component-inactive-icons/comp_whiteboard_inactive.svg
+++ b/frontend/src/assets/images/svg/component-inactive-icons/comp_whiteboard_inactive.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.1" y="2.1" width="11.8" height="9.8" rx="1.4" stroke="#818181" stroke-width="1.2"/>
+<rect x="3" y="4" width="3.6" height="3.6" rx="0.6" fill="#818181"/>
+<rect x="7.6" y="6.4" width="3.4" height="3.4" rx="0.6" fill="#818181"/>
+</svg>

--- a/frontend/src/components/atom/ViewsList/ViewsList.vue
+++ b/frontend/src/components/atom/ViewsList/ViewsList.vue
@@ -9,7 +9,7 @@
         :style="{ height: active ? '48px' : 'auto' }">
            <span v-if="commentCount" class="count-block comment__count white position-ab">{{commentCount <= 99 ? commentCount : '+99'}}</span> 
            <img class="position-ab list_make_as_defaultimg" v-if="item.setAsDefault" :src="viewDefaultIcon" />
-           <img :src="active ? projectComponentsIcons(item.keyName).activeIcon : projectComponentsIcons(item.keyName)?.icon" :alt="item.name" class="mr-10px">
+           <img :src="active ? projectComponentsIcons(item.keyName)?.activeIcon : projectComponentsIcons(item.keyName)?.icon" :alt="item.name" class="mr-10px">
            <span class="gray81">{{$t(`ViewList.${item.name}`)}}</span>
            <img :src="active ? activePin : pin" v-if="item?.isPin && item.isPin" class="ml-10px active__pin-condition">
            <span class="notification-tick blinking position-sti ml-7px" v-if="item?.isPrivate"></span>

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -5,7 +5,7 @@
                 {{$t('Projects.task_view')}}
             </span>
             <div v-for="(item, index) in navOptions" :key="index">
-                <DropDownOption :class="{'activeView': item.name == viewItem.name}" class="options" :style="`${clientWidth <= 767 ? 'padding: 5px 0px !important;' : ''}`" :item="{label:$t(`ViewList.${item.name}`), image: projectComponentsIcons(item.keyName).icon}"  @click="viewItem = {...item}"/>
+                <DropDownOption :class="{'activeView': item.name == viewItem.name}" class="options" :style="`${clientWidth <= 767 ? 'padding: 5px 0px !important;' : ''}`" :item="{label:$t(`ViewList.${item.name}`), image: projectComponentsIcons(item.keyName)?.icon}"  @click="viewItem = {...item}"/>
                 <div  v-if="index == 3 && clientWidth > 767" class="p0x-10px">
                     <div class="comments__divider"></div>
                 </div>

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -91,7 +91,8 @@ const images = {
     Reports: {image: require('@/assets/images/png/Activity.png'), description: 'reports_view'},
     GanttView: {image: require('@/assets/images/png/Table.png'), description: 'gantt_view'},
     RecurringTasks: {image: require('@/assets/images/png/Calendar.png'), description: 'recurring_view'},
-    TimelineView: {image: require('@/assets/images/png/Table.png'), description: 'timeline_view'}
+    TimelineView: {image: require('@/assets/images/png/Table.png'), description: 'timeline_view'},
+    MindMapView: {image: require('@/assets/images/png/Activity.png'), description: 'mindmap_view'}
 }
 const viewItem = ref('')
 const companyId = inject('$companyId')

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -90,7 +90,8 @@ const images = {
     ActivityLog: {image: require('@/assets/images/png/Activity.png'), description: 'activitylog_view'},
     Reports: {image: require('@/assets/images/png/Activity.png'), description: 'reports_view'},
     GanttView: {image: require('@/assets/images/png/Table.png'), description: 'gantt_view'},
-    RecurringTasks: {image: require('@/assets/images/png/Calendar.png'), description: 'recurring_view'}
+    RecurringTasks: {image: require('@/assets/images/png/Calendar.png'), description: 'recurring_view'},
+    TimelineView: {image: require('@/assets/images/png/Table.png'), description: 'timeline_view'}
 }
 const viewItem = ref('')
 const companyId = inject('$companyId')

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -119,6 +119,16 @@ onMounted(() => {
         const data = response.data;
         navOptions.value = data.map((item) => { return {...item ,image: (images[item?.keyName])?.image , description : (images[item?.keyName])?.description , sortIndex: item?.sortIndex != 6 && item?.sortIndex != 9 ? item?.sortIndex : (item?.sortIndex == 9 ? 6 : 9 ) }})
         navOptions.value = (navOptions.value.filter((element) => element?.keyName != 'Gantt' && element?.keyName != 'Timeline')).sort((a,b) => (a.sortIndex < b.sortIndex) ? -1 : 1 )
+        // Collapse duplicate catalog records that resolve to the same view label — an
+        // existing company can carry a legacy "Timeline" record alongside the new
+        // "Timeline View" (both display as "Timeline"). Keep the first after sort.
+        const seenViewLabels = new Set();
+        navOptions.value = navOptions.value.filter((element) => {
+            const label = t(`ViewList.${element?.name}`);
+            if (seenViewLabels.has(label)) return false;
+            seenViewLabels.add(label);
+            return true;
+        });
         viewItem.value = {...navOptions.value[0]}
     })
     companyUser.value = (companyUserData.value.filter((item) => userId.value === item.userId )[0])

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -94,7 +94,8 @@ const images = {
     TimelineView: {image: require('@/assets/images/png/Table.png'), description: 'timeline_view'},
     MindMapView: {image: require('@/assets/images/png/Activity.png'), description: 'mindmap_view'},
     WhiteboardView: {image: require('@/assets/images/png/Board.png'), description: 'whiteboard_view'},
-    CanvasView: {image: require('@/assets/images/png/Activity.png'), description: 'canvas_view'}
+    CanvasView: {image: require('@/assets/images/png/Activity.png'), description: 'canvas_view'},
+    MapView: {image: require('@/assets/images/png/Workload.png'), description: 'map_view'}
 }
 const viewItem = ref('')
 const companyId = inject('$companyId')

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -92,7 +92,8 @@ const images = {
     GanttView: {image: require('@/assets/images/png/Table.png'), description: 'gantt_view'},
     RecurringTasks: {image: require('@/assets/images/png/Calendar.png'), description: 'recurring_view'},
     TimelineView: {image: require('@/assets/images/png/Table.png'), description: 'timeline_view'},
-    MindMapView: {image: require('@/assets/images/png/Activity.png'), description: 'mindmap_view'}
+    MindMapView: {image: require('@/assets/images/png/Activity.png'), description: 'mindmap_view'},
+    WhiteboardView: {image: require('@/assets/images/png/Board.png'), description: 'whiteboard_view'}
 }
 const viewItem = ref('')
 const companyId = inject('$companyId')

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -93,7 +93,8 @@ const images = {
     RecurringTasks: {image: require('@/assets/images/png/Calendar.png'), description: 'recurring_view'},
     TimelineView: {image: require('@/assets/images/png/Table.png'), description: 'timeline_view'},
     MindMapView: {image: require('@/assets/images/png/Activity.png'), description: 'mindmap_view'},
-    WhiteboardView: {image: require('@/assets/images/png/Board.png'), description: 'whiteboard_view'}
+    WhiteboardView: {image: require('@/assets/images/png/Board.png'), description: 'whiteboard_view'},
+    CanvasView: {image: require('@/assets/images/png/Activity.png'), description: 'canvas_view'}
 }
 const viewItem = ref('')
 const companyId = inject('$companyId')

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -216,7 +216,14 @@ export const projectComponentsIcons = (key) => {
     ];
 
     const result = data.filter(x => x.keyName === key);
-    return result[0];
+    // Fallback so an unknown / just-added catalog keyName never returns undefined —
+    // callers read .icon/.activeIcon directly (e.g. the "+ View" dropdown renders the
+    // whole catalog), and a missing entry must degrade to a default icon, not crash.
+    return result[0] || {
+        icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
+        activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
+        keyName: key
+    };
 }
 
 export const projectAppsIcons = (key) => {

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -197,6 +197,11 @@ export const projectComponentsIcons = (key) => {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
             keyName: "MindMapView"
+        },
+        {
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_board_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_board_active.svg"),
+            keyName: "WhiteboardView"
         }
     ];
 

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -194,23 +194,23 @@ export const projectComponentsIcons = (key) => {
             keyName: "TimelineView"
         },
         {
-            icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
-            activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_mindmap_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_mindmap_active.svg"),
             keyName: "MindMapView"
         },
         {
-            icon: require("@/assets/images/svg/component-inactive-icons/comp_board_inactive.svg"),
-            activeIcon: require("@/assets/images/svg/component-active-icons/comp_board_active.svg"),
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_whiteboard_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_whiteboard_active.svg"),
             keyName: "WhiteboardView"
         },
         {
-            icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
-            activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_canvas_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_canvas_active.svg"),
             keyName: "CanvasView"
         },
         {
-            icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
-            activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_map_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_map_active.svg"),
             keyName: "MapView"
         }
     ];

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -192,6 +192,11 @@ export const projectComponentsIcons = (key) => {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_timeline_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_timeline_active.svg"),
             keyName: "TimelineView"
+        },
+        {
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
+            keyName: "MindMapView"
         }
     ];
 

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -187,6 +187,11 @@ export const projectComponentsIcons = (key) => {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_calender_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_calender_active.svg"),
             keyName: "RecurringTasks"
+        },
+        {
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_timeline_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_timeline_active.svg"),
+            keyName: "TimelineView"
         }
     ];
 

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -207,6 +207,11 @@ export const projectComponentsIcons = (key) => {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
             keyName: "CanvasView"
+        },
+        {
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
+            keyName: "MapView"
         }
     ];
 

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -202,6 +202,11 @@ export const projectComponentsIcons = (key) => {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_board_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_board_active.svg"),
             keyName: "WhiteboardView"
+        },
+        {
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
+            keyName: "CanvasView"
         }
     ];
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -908,6 +908,7 @@ export default {
         MindMapView: "Mind Map",
         WhiteboardView: "Whiteboard",
         CanvasView: "Canvas",
+        MapView: "Map",
         // The "+ View" catalog labels off the DB record's `name` field
         // ($t(`ViewList.${item.name}`)), so these keys must match those names verbatim.
         "Gantt View": "Gantt View",
@@ -969,6 +970,8 @@ export default {
             "Arrange tasks as free-floating cards on a board — drag them anywhere to map out your thinking.",
         canvas_view:
             "A configurable dashboard of project widgets — status, priority, progress, overdue and upcoming work.",
+        map_view:
+            "Pin tasks onto a world map to see where your work happens — placements are saved to your browser.",
         list_view:
             "Use List view to organize your tasks in anyway imaginable – sort, filter, group, and customize columns.",
         kanban_view:

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -909,15 +909,16 @@ export default {
         WhiteboardView: "Whiteboard",
         CanvasView: "Canvas",
         MapView: "Map",
-        // The "+ View" catalog labels off the DB record's `name` field
-        // ($t(`ViewList.${item.name}`)), so these keys must match those names verbatim.
-        "Gantt View": "Gantt View",
+        // The catalog/tab labels key off the DB record's `name` field
+        // ($t(`ViewList.${item.name}`)), so the KEYS must match those names verbatim.
+        // The VALUES are the short display labels (no "View" suffix).
+        "Gantt View": "Gantt",
         "Recurring Tasks": "Recurring Tasks",
-        "Timeline View": "Timeline View",
-        "Mind Map View": "Mind Map View",
-        "Whiteboard View": "Whiteboard View",
-        "Canvas View": "Canvas View",
-        "Map View": "Map View",
+        "Timeline View": "Timeline",
+        "Mind Map View": "Mind Map",
+        "Whiteboard View": "Whiteboard",
+        "Canvas View": "Canvas",
+        "Map View": "Map",
         Comment: "Comment",
         to_unlock_list_view: "To Unlock List View",
         error_message_for_empty: "Please select at least one view",

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -904,6 +904,7 @@ export default {
         Reports: "Reports",
         GanttView: "Gantt",
         RecurringTasks: "Recurring Tasks",
+        TimelineView: "Timeline",
         Comment: "Comment",
         to_unlock_list_view: "To Unlock List View",
         error_message_for_empty: "Please select at least one view",
@@ -948,6 +949,8 @@ export default {
         to_unlock_embed_view: "To Unlock Embed View",
     },
     ViewListdescription: {
+        timeline_view:
+            "See your scheduled tasks laid out on a shared date axis to spot overlaps and gaps at a glance.",
         list_view:
             "Use List view to organize your tasks in anyway imaginable – sort, filter, group, and customize columns.",
         kanban_view:

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -905,6 +905,7 @@ export default {
         GanttView: "Gantt",
         RecurringTasks: "Recurring Tasks",
         TimelineView: "Timeline",
+        MindMapView: "Mind Map",
         Comment: "Comment",
         to_unlock_list_view: "To Unlock List View",
         error_message_for_empty: "Please select at least one view",
@@ -951,6 +952,8 @@ export default {
     ViewListdescription: {
         timeline_view:
             "See your scheduled tasks laid out on a shared date axis to spot overlaps and gaps at a glance.",
+        mindmap_view:
+            "Visualize the project as a mind map — parent tasks branching into their subtasks.",
         list_view:
             "Use List view to organize your tasks in anyway imaginable – sort, filter, group, and customize columns.",
         kanban_view:

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -906,6 +906,15 @@ export default {
         RecurringTasks: "Recurring Tasks",
         TimelineView: "Timeline",
         MindMapView: "Mind Map",
+        // The "+ View" catalog labels off the DB record's `name` field
+        // ($t(`ViewList.${item.name}`)), so these keys must match those names verbatim.
+        "Gantt View": "Gantt View",
+        "Recurring Tasks": "Recurring Tasks",
+        "Timeline View": "Timeline View",
+        "Mind Map View": "Mind Map View",
+        "Whiteboard View": "Whiteboard View",
+        "Canvas View": "Canvas View",
+        "Map View": "Map View",
         Comment: "Comment",
         to_unlock_list_view: "To Unlock List View",
         error_message_for_empty: "Please select at least one view",

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -907,6 +907,7 @@ export default {
         TimelineView: "Timeline",
         MindMapView: "Mind Map",
         WhiteboardView: "Whiteboard",
+        CanvasView: "Canvas",
         // The "+ View" catalog labels off the DB record's `name` field
         // ($t(`ViewList.${item.name}`)), so these keys must match those names verbatim.
         "Gantt View": "Gantt View",
@@ -966,6 +967,8 @@ export default {
             "Visualize the project as a mind map — parent tasks branching into their subtasks.",
         whiteboard_view:
             "Arrange tasks as free-floating cards on a board — drag them anywhere to map out your thinking.",
+        canvas_view:
+            "A configurable dashboard of project widgets — status, priority, progress, overdue and upcoming work.",
         list_view:
             "Use List view to organize your tasks in anyway imaginable – sort, filter, group, and customize columns.",
         kanban_view:

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -906,6 +906,7 @@ export default {
         RecurringTasks: "Recurring Tasks",
         TimelineView: "Timeline",
         MindMapView: "Mind Map",
+        WhiteboardView: "Whiteboard",
         // The "+ View" catalog labels off the DB record's `name` field
         // ($t(`ViewList.${item.name}`)), so these keys must match those names verbatim.
         "Gantt View": "Gantt View",
@@ -963,6 +964,8 @@ export default {
             "See your scheduled tasks laid out on a shared date axis to spot overlaps and gaps at a glance.",
         mindmap_view:
             "Visualize the project as a mind map — parent tasks branching into their subtasks.",
+        whiteboard_view:
+            "Arrange tasks as free-floating cards on a board — drag them anywhere to map out your thinking.",
         list_view:
             "Use List view to organize your tasks in anyway imaginable – sort, filter, group, and customize columns.",
         kanban_view:

--- a/frontend/src/views/Projects/CanvasView/CanvasView.vue
+++ b/frontend/src/views/Projects/CanvasView/CanvasView.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="cv-view">
+    <div class="cv-view__bar">
+      <span class="cv-view__title">Canvas</span>
+      <div class="cv-view__chips">
+        <button
+          v-for="w in WIDGETS"
+          :key="w.key"
+          type="button"
+          class="cv-view__chip"
+          :class="{ on: enabled.includes(w.key) }"
+          @click="toggle(w.key)"
+        >{{ w.label }}</button>
+      </div>
+    </div>
+
+    <div class="cv-view__board">
+      <div v-if="!hasTasks" class="cv-view__empty">No tasks yet — widgets fill in as the project grows.</div>
+      <div v-else class="cv-view__grid">
+        <template v-for="w in WIDGETS">
+          <div v-if="enabled.includes(w.key)" :key="w.key" class="cv-card" :class="'cv-card--' + w.key">
+            <div class="cv-card__head">{{ w.label }}</div>
+
+            <div v-if="w.key === 'summary'" class="cv-card__big">
+              <div class="cv-card__num">{{ stats.total }}</div>
+              <div class="cv-card__sub">{{ stats.donePct }}% complete</div>
+              <div class="cv-bar"><div class="cv-bar__fill is-done" :style="{ width: stats.donePct + '%' }"></div></div>
+            </div>
+
+            <div v-else-if="w.key === 'status'" class="cv-card__rows">
+              <div v-for="s in stats.status" :key="s.key" class="cv-row">
+                <span class="cv-row__label">{{ s.label }}</span>
+                <div class="cv-bar"><div class="cv-bar__fill" :class="s.cls" :style="{ width: barPct(s.count) + '%' }"></div></div>
+                <span class="cv-row__val">{{ s.count }}</span>
+              </div>
+            </div>
+
+            <div v-else-if="w.key === 'priority'" class="cv-card__rows">
+              <div v-for="p in stats.priority" :key="p.key" class="cv-row">
+                <span class="cv-row__label">{{ p.label }}</span>
+                <div class="cv-bar"><div class="cv-bar__fill" :class="p.cls" :style="{ width: barPct(p.count) + '%' }"></div></div>
+                <span class="cv-row__val">{{ p.count }}</span>
+              </div>
+            </div>
+
+            <div v-else-if="w.key === 'overdue'" class="cv-card__big">
+              <div class="cv-card__num" :class="{ danger: stats.overdue > 0 }">{{ stats.overdue }}</div>
+              <div class="cv-card__sub">overdue & open</div>
+            </div>
+
+            <div v-else-if="w.key === 'upcoming'" class="cv-card__list">
+              <div v-if="!stats.upcoming.length" class="cv-card__muted">Nothing due in the next 7 days.</div>
+              <div v-for="t in stats.upcoming" :key="t.id" class="cv-up">
+                <span class="cv-up__name" :title="t.name">{{ t.name }}</span>
+                <span class="cv-up__date">{{ t.due }}</span>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default { name: 'CanvasView' };
+</script>
+
+<script setup>
+// VIEW-04 — Canvas / dynamic layouts. A configurable mini-dashboard of project
+// insight widgets (summary, status, priority, overdue, upcoming) computed live
+// from the task store. Which widgets show is toggleable + persisted per user
+// (localStorage). Lightweight, no external lib.
+import { ref, computed, onMounted, inject, watch } from 'vue';
+import { useStore } from 'vuex';
+import { taskListHelper } from '@/views/Projects/helper.js';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+    sprints: { type: Array, default: () => [] },
+});
+
+const { getters } = useStore();
+const { groupBy } = taskListHelper();
+const selectedProject = inject('selectedProject', ref({}));
+
+const WIDGETS = [
+    { key: 'summary', label: 'Summary' },
+    { key: 'status', label: 'By status' },
+    { key: 'priority', label: 'By priority' },
+    { key: 'overdue', label: 'Overdue' },
+    { key: 'upcoming', label: 'Upcoming' },
+];
+
+const sprintId = computed(() => props.sprints?.[0]?.id || props.sprints?.[0]?._id || '');
+function pickTasks(map) {
+    const pid = props.projectData?._id;
+    const sid = sprintId.value;
+    if (!pid || !sid || !map || !map[pid] || !map[pid][sid]) return null;
+    const node = map[pid][sid];
+    return Array.isArray(node.tasks) ? node.tasks : null;
+}
+const tasks = computed(() => pickTasks(getters['projectData/tasks']) || pickTasks(getters['projectData/tableTasks']) || []);
+const active = computed(() => tasks.value.filter((t) => t && [0, 2, undefined, null].includes(t.deletedStatusKey)));
+const hasTasks = computed(() => active.value.length > 0);
+
+const isDone = (t) => (t?.status?.type || t?.statusType) === 'close';
+const isProgress = (t) => (t?.status?.type || t?.statusType) === 'inprogress';
+
+const stats = computed(() => {
+    const list = active.value;
+    const total = list.length;
+    const done = list.filter(isDone).length;
+    const inprog = list.filter(isProgress).length;
+    const todo = total - done - inprog;
+    const prio = (p) => list.filter((t) => (t.Task_Priority || '').toUpperCase() === p).length;
+    const now = Date.now();
+    const soon = now + 7 * 86400000;
+    const dated = list.filter((t) => t.DueDate && !isDone(t) && !isNaN(new Date(t.DueDate)));
+    const overdue = dated.filter((t) => new Date(t.DueDate).getTime() < now).length;
+    const upcoming = dated
+        .filter((t) => { const d = new Date(t.DueDate).getTime(); return d >= now && d <= soon; })
+        .sort((a, b) => new Date(a.DueDate) - new Date(b.DueDate))
+        .slice(0, 6)
+        .map((t) => ({ id: String(t._id), name: t.TaskName || t.TaskKey || 'Task', due: new Date(t.DueDate).toLocaleDateString() }));
+    return {
+        total,
+        donePct: total ? Math.round((done / total) * 100) : 0,
+        status: [
+            { key: 'todo', label: 'To Do', count: todo, cls: 'is-todo' },
+            { key: 'inprog', label: 'In Progress', count: inprog, cls: 'is-progress' },
+            { key: 'done', label: 'Done', count: done, cls: 'is-done' },
+        ],
+        priority: [
+            { key: 'high', label: 'High', count: prio('HIGH'), cls: 'is-high' },
+            { key: 'med', label: 'Medium', count: prio('MEDIUM'), cls: 'is-med' },
+            { key: 'low', label: 'Low', count: prio('LOW'), cls: 'is-low' },
+        ],
+        overdue,
+        upcoming,
+    };
+});
+const maxStat = computed(() => Math.max(1, ...stats.value.status.map((s) => s.count), ...stats.value.priority.map((p) => p.count)));
+const barPct = (n) => Math.round((n / maxStat.value) * 100);
+
+const storeKey = computed(() => `canvas:${props.projectData?._id || 'p'}:${sprintId.value || 's'}`);
+const enabled = ref(WIDGETS.map((w) => w.key));
+function loadEnabled() {
+    try { const saved = JSON.parse(localStorage.getItem(storeKey.value) || 'null'); if (Array.isArray(saved)) enabled.value = saved; } catch (e) { /* noop */ }
+}
+function toggle(key) {
+    enabled.value = enabled.value.includes(key) ? enabled.value.filter((k) => k !== key) : [...enabled.value, key];
+    try { localStorage.setItem(storeKey.value, JSON.stringify(enabled.value)); } catch (e) { /* noop */ }
+}
+
+function ensureTasksLoaded() {
+    if (tasks.value.length) return;
+    const proj = (selectedProject.value && selectedProject.value._id) ? selectedProject.value : props.projectData;
+    if (!proj || !proj._id || !Array.isArray(props.sprints) || !props.sprints.length) return;
+    try { groupBy(0, true, proj, props.sprints, ref([]), false, 'list', false, true, () => {}); } catch (e) { /* noop */ }
+}
+onMounted(() => { ensureTasksLoaded(); loadEnabled(); });
+watch(() => props.sprints, () => ensureTasksLoaded(), { deep: true });
+</script>
+
+<style scoped>
+.cv-view { display: flex; flex-direction: column; width: 100%; height: 100%; background: #f7f8fc; }
+.cv-view__bar { display: flex; align-items: center; gap: 14px; padding: 8px 14px; border-bottom: 1px solid #e6e7ee; background: #fff; flex: 0 0 auto; flex-wrap: wrap; }
+.cv-view__title { font-size: 14px; font-weight: 700; color: #2b2f44; }
+.cv-view__chips { display: flex; gap: 6px; flex-wrap: wrap; }
+.cv-view__chip { border: 1px solid #d8d8e0; background: #fff; color: #777; border-radius: 14px; padding: 3px 11px; font-size: 12px; cursor: pointer; }
+.cv-view__chip.on { background: #eef0ff; border-color: #c7ccf5; color: #2f3a8f; }
+.cv-view__board { flex: 1 1 auto; overflow: auto; padding: 16px; }
+.cv-view__empty { text-align: center; color: #999; font-size: 14px; padding: 40px; }
+.cv-view__grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 14px; }
+.cv-card { background: #fff; border: 1px solid #e6e7ee; border-radius: 12px; padding: 14px 16px; min-height: 120px; }
+.cv-card__head { font-size: 11.5px; text-transform: uppercase; letter-spacing: .04em; color: #9aa0b4; margin-bottom: 10px; }
+.cv-card__big { text-align: center; }
+.cv-card__num { font-size: 36px; font-weight: 700; color: #2b2f44; line-height: 1; }
+.cv-card__num.danger { color: #c0392b; }
+.cv-card__sub { font-size: 12px; color: #6b7280; margin-top: 4px; }
+.cv-card__rows { display: flex; flex-direction: column; gap: 9px; }
+.cv-row { display: flex; align-items: center; gap: 8px; }
+.cv-row__label { width: 78px; font-size: 12px; color: #555; }
+.cv-row__val { width: 24px; text-align: right; font-size: 12px; color: #333; font-weight: 600; }
+.cv-bar { flex: 1; height: 9px; background: #eef0f6; border-radius: 4px; overflow: hidden; }
+.cv-bar__fill { height: 100%; background: #8a93b5; }
+.cv-bar__fill.is-todo { background: #8a93b5; }
+.cv-bar__fill.is-progress { background: #2f6fed; }
+.cv-bar__fill.is-done { background: #1c9b5e; }
+.cv-bar__fill.is-high { background: #e6593f; }
+.cv-bar__fill.is-med { background: #e2a23b; }
+.cv-bar__fill.is-low { background: #6c9bd2; }
+.cv-card__big + .cv-bar, .cv-card__big .cv-bar { margin-top: 10px; }
+.cv-card__list { display: flex; flex-direction: column; gap: 7px; }
+.cv-card__muted { font-size: 12px; color: #9aa0b4; }
+.cv-up { display: flex; justify-content: space-between; gap: 8px; font-size: 12.5px; }
+.cv-up__name { color: #33384a; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cv-up__date { color: #9aa0b4; white-space: nowrap; }
+</style>

--- a/frontend/src/views/Projects/MapView/MapView.vue
+++ b/frontend/src/views/Projects/MapView/MapView.vue
@@ -1,0 +1,333 @@
+<template>
+  <div class="map-view">
+    <div class="map-view__bar">
+      <span class="map-view__count">
+        {{ placedTasks.length }} placed<template v-if="unplaced.length"> · {{ unplaced.length }} to place</template>
+      </span>
+      <span v-if="placingTask" class="map-view__hint">
+        Click anywhere on the map to place <b>{{ placingTask.TaskName || placingTask.TaskKey }}</b>
+        <button type="button" class="map-view__hint-x" @click="placingId = ''">cancel</button>
+      </span>
+      <button
+        v-if="placedTasks.length"
+        type="button"
+        class="map-view__clear"
+        @click="clearAll"
+      >Clear all</button>
+    </div>
+
+    <div class="map-view__main">
+      <div class="map-view__canvas" :class="{ 'is-placing': !!placingId }">
+        <svg
+          ref="svgEl"
+          class="map-view__svg"
+          :viewBox="`0 0 ${W} ${H}`"
+          preserveAspectRatio="xMidYMid meet"
+          @click="onMapClick"
+        >
+          <defs>
+            <linearGradient id="mvOcean" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#eef4fb" />
+              <stop offset="100%" stop-color="#dde9f6" />
+            </linearGradient>
+          </defs>
+
+          <!-- ocean -->
+          <rect x="0" y="0" :width="W" :height="H" fill="url(#mvOcean)" stroke="#c7d6e8" />
+
+          <!-- graticule -->
+          <g class="map-view__grid">
+            <line
+              v-for="ln in lngLines"
+              :key="'lng' + ln.deg"
+              :x1="ln.x" y1="0" :x2="ln.x" :y2="H"
+              :class="{ 'is-prime': ln.deg === 0 }"
+            />
+            <line
+              v-for="lt in latLines"
+              :key="'lat' + lt.deg"
+              x1="0" :y1="lt.y" :x2="W" :y2="lt.y"
+              :class="{ 'is-equator': lt.deg === 0 }"
+            />
+          </g>
+
+          <!-- degree labels -->
+          <g class="map-view__labels">
+            <text v-for="ln in lngLines" :key="'lngL' + ln.deg" :x="ln.x" :y="H - 4" text-anchor="middle">{{ lngLabel(ln.deg) }}</text>
+            <text v-for="lt in latLines" :key="'latL' + lt.deg" x="4" :y="lt.y - 3">{{ latLabel(lt.deg) }}</text>
+          </g>
+
+          <!-- pins -->
+          <g
+            v-for="p in placedTasks"
+            :key="p._id"
+            class="map-view__pin"
+            :class="{ 'is-selected': selectedId === String(p._id) }"
+            :transform="`translate(${p.x}, ${p.y})`"
+            @click.stop="selectMarker(p._id)"
+          >
+            <path
+              class="map-view__pin-body"
+              :fill="p.color"
+              d="M0,0 C-9,-14 -7,-26 0,-26 C7,-26 9,-14 0,0 Z"
+            />
+            <circle class="map-view__pin-dot" cx="0" cy="-18" r="4.5" fill="#fff" />
+            <title>{{ p.TaskName || p.TaskKey }} — {{ fmtLatLng(p.lat, p.lng) }}</title>
+          </g>
+        </svg>
+
+        <div v-if="!activeTasks.length" class="map-view__empty">
+          No tasks in this sprint yet.
+        </div>
+      </div>
+
+      <aside class="map-view__side">
+        <div v-if="selectedTask" class="map-view__card">
+          <div class="map-view__card-head">
+            <span class="map-view__dot" :style="{ background: statusColor(selectedTask) }"></span>
+            <span class="map-view__card-name" :title="selectedTask.TaskName">{{ selectedTask.TaskName || selectedTask.TaskKey }}</span>
+            <button type="button" class="map-view__card-x" @click="selectedId = ''">×</button>
+          </div>
+          <div class="map-view__card-meta">
+            <span v-if="selectedTask.TaskKey" class="map-view__key">{{ selectedTask.TaskKey }}</span>
+            <span class="map-view__coord">{{ fmtLatLng(placements[selectedId].lat, placements[selectedId].lng) }}</span>
+          </div>
+          <button type="button" class="map-view__remove" @click="removePlacement(selectedId)">Remove from map</button>
+        </div>
+
+        <h4 class="map-view__side-title">To place ({{ unplaced.length }})</h4>
+        <ul class="map-view__list">
+          <li
+            v-for="t in unplaced"
+            :key="t._id"
+            class="map-view__item"
+            :class="{ 'is-active': placingId === String(t._id) }"
+          >
+            <span class="map-view__dot" :style="{ background: statusColor(t) }"></span>
+            <span class="map-view__item-name" :title="t.TaskName">{{ t.TaskName || t.TaskKey }}</span>
+            <button type="button" class="map-view__place" @click="startPlacing(t._id)">
+              {{ placingId === String(t._id) ? 'Placing…' : 'Place' }}
+            </button>
+          </li>
+          <li v-if="!unplaced.length" class="map-view__all-placed">All tasks placed.</li>
+        </ul>
+      </aside>
+    </div>
+  </div>
+</template>
+
+<script>
+export default { name: 'MapView' };
+</script>
+
+<script setup>
+import { ref, computed, onMounted, watch, inject } from 'vue';
+import { useStore } from 'vuex';
+import { taskListHelper } from '@/views/Projects/helper.js';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+    sprints: { type: Array, default: () => [] },
+});
+
+const { getters } = useStore();
+const { groupBy } = taskListHelper();
+const selectedProject = inject('selectedProject', ref({}));
+
+// equirectangular world canvas (2:1)
+const W = 1000;
+const H = 500;
+
+const svgEl = ref(null);
+const placingId = ref('');
+const selectedId = ref('');
+// { [taskId]: { lat, lng } } — personal, per-browser (localStorage)
+const placements = ref({});
+
+/* ----------------------- data in: from the live Vuex store ----------------------- */
+const sprintId = computed(() => props.sprints?.[0]?.id || props.sprints?.[0]?._id || '');
+
+function pickTasks(map) {
+    const pid = props.projectData?._id;
+    const sid = sprintId.value;
+    if (!pid || !sid || !map || !map[pid] || !map[pid][sid]) return null;
+    const node = map[pid][sid];
+    return Array.isArray(node.tasks) ? node.tasks : null;
+}
+const tasks = computed(() =>
+    pickTasks(getters['projectData/tasks']) || pickTasks(getters['projectData/tableTasks']) || []
+);
+// active = not deleted (0 active, 2 archived, undefined legacy)
+const activeTasks = computed(() => tasks.value.filter((t) => t && [0, 2, undefined, null].includes(t.deletedStatusKey)));
+
+/* --------------------------------- projection ---------------------------------- */
+function project(lat, lng) {
+    return { x: ((Number(lng) + 180) / 360) * W, y: ((90 - Number(lat)) / 180) * H };
+}
+function unproject(x, y) {
+    return { lng: (x / W) * 360 - 180, lat: 90 - (y / H) * 180 };
+}
+
+/* ----------------------------------- status ------------------------------------ */
+function statusColor(task) {
+    const type = task?.status?.type || task?.statusType;
+    if (type === 'close') return '#27ae60';
+    if (type === 'inprogress') return '#f1a33a';
+    return '#9aa3b2';
+}
+
+/* ------------------------------- placed / unplaced ------------------------------ */
+const placedTasks = computed(() =>
+    activeTasks.value
+        .filter((t) => placements.value[String(t._id)])
+        .map((t) => {
+            const loc = placements.value[String(t._id)];
+            const pt = project(loc.lat, loc.lng);
+            return { ...t, lat: loc.lat, lng: loc.lng, x: pt.x, y: pt.y, color: statusColor(t) };
+        })
+);
+const unplaced = computed(() => activeTasks.value.filter((t) => !placements.value[String(t._id)]));
+
+const placingTask = computed(() => activeTasks.value.find((t) => String(t._id) === placingId.value) || null);
+const selectedTask = computed(() => {
+    if (!selectedId.value || !placements.value[selectedId.value]) return null;
+    return activeTasks.value.find((t) => String(t._id) === selectedId.value) || null;
+});
+
+/* ----------------------------------- labels ------------------------------------ */
+const lngLines = computed(() => {
+    const out = [];
+    for (let d = -180; d <= 180; d += 30) out.push({ deg: d, x: project(0, d).x });
+    return out;
+});
+const latLines = computed(() => {
+    const out = [];
+    for (let d = -90; d <= 90; d += 30) out.push({ deg: d, y: project(d, 0).y });
+    return out;
+});
+function lngLabel(d) { return d === 0 ? '0°' : `${Math.abs(d)}°${d > 0 ? 'E' : 'W'}`; }
+function latLabel(d) { return d === 0 ? '0°' : `${Math.abs(d)}°${d > 0 ? 'N' : 'S'}`; }
+function fmtLatLng(lat, lng) {
+    const la = Number(lat); const ln = Number(lng);
+    return `${Math.abs(la).toFixed(2)}°${la >= 0 ? 'N' : 'S'}, ${Math.abs(ln).toFixed(2)}°${ln >= 0 ? 'E' : 'W'}`;
+}
+
+/* ----------------------------------- actions ----------------------------------- */
+function startPlacing(id) {
+    placingId.value = placingId.value === String(id) ? '' : String(id);
+    selectedId.value = '';
+}
+function selectMarker(id) {
+    selectedId.value = selectedId.value === String(id) ? '' : String(id);
+}
+function onMapClick(e) {
+    if (!placingId.value || !svgEl.value) { selectedId.value = ''; return; }
+    const rect = svgEl.value.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    // the svg is letterboxed (xMidYMid meet) into a 2:1 box, but the canvas itself is 2:1,
+    // so the rendered area matches the viewBox aspect — straight ratio mapping is correct.
+    const sx = ((e.clientX - rect.left) / rect.width) * W;
+    const sy = ((e.clientY - rect.top) / rect.height) * H;
+    const { lat, lng } = unproject(sx, sy);
+    placements.value = {
+        ...placements.value,
+        [placingId.value]: { lat: Math.max(-90, Math.min(90, lat)), lng: Math.max(-180, Math.min(180, lng)) },
+    };
+    selectedId.value = placingId.value;
+    placingId.value = '';
+}
+function removePlacement(id) {
+    const next = { ...placements.value };
+    delete next[String(id)];
+    placements.value = next;
+    if (selectedId.value === String(id)) selectedId.value = '';
+}
+function clearAll() {
+    placements.value = {};
+    selectedId.value = '';
+    placingId.value = '';
+}
+
+/* --------------------------------- persistence --------------------------------- */
+function storeKey() {
+    return `map:${props.projectData?._id || ''}:${sprintId.value || ''}`;
+}
+function loadPlacements() {
+    try {
+        const raw = localStorage.getItem(storeKey());
+        placements.value = raw ? (JSON.parse(raw) || {}) : {};
+    } catch (e) { placements.value = {}; }
+}
+watch(placements, (val) => {
+    try { localStorage.setItem(storeKey(), JSON.stringify(val || {})); } catch (e) { /* quota / private mode */ }
+}, { deep: true });
+watch(sprintId, () => { selectedId.value = ''; placingId.value = ''; loadPlacements(); });
+
+/* ----------------------------------- lifecycle --------------------------------- */
+// Mirror the other views: make sure the project's task list is in the store on a
+// direct load into this tab (otherwise the store is empty and nothing plots).
+function ensureTasksLoaded() {
+    if (tasks.value.length) return;
+    const proj = (selectedProject.value && selectedProject.value._id) ? selectedProject.value : props.projectData;
+    if (!proj || !proj._id || !Array.isArray(props.sprints) || !props.sprints.length) return;
+    try {
+        groupBy(0, true, proj, props.sprints, ref([]), false, 'list', false, true, () => {});
+    } catch (e) {
+        console.error('Map: task-load trigger failed', e);
+    }
+}
+
+onMounted(() => {
+    loadPlacements();
+    ensureTasksLoaded();
+});
+watch(() => props.sprints, () => ensureTasksLoaded(), { deep: true });
+</script>
+
+<style scoped>
+.map-view { display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
+.map-view__bar { display: flex; align-items: center; gap: 14px; padding: 8px 12px; border-bottom: 1px solid #eee; flex: 0 0 auto; }
+.map-view__count { font-size: 12px; color: #888; }
+.map-view__hint { font-size: 12px; color: #2F3990; background: #eef0ff; border: 1px solid #cdd2f5; border-radius: 4px; padding: 2px 8px; display: inline-flex; align-items: center; gap: 8px; }
+.map-view__hint-x { border: none; background: transparent; color: #2F3990; text-decoration: underline; cursor: pointer; font-size: 12px; padding: 0; }
+.map-view__clear { margin-left: auto; border: 1px solid #d8d8e0; background: #fff; color: #666; border-radius: 5px; font-size: 12px; padding: 3px 10px; cursor: pointer; }
+.map-view__clear:hover { border-color: #c0392b; color: #c0392b; }
+
+.map-view__main { position: relative; flex: 1 1 auto; display: flex; min-height: 380px; }
+.map-view__canvas { position: relative; flex: 1 1 auto; min-width: 0; padding: 12px; overflow: auto; }
+.map-view__canvas.is-placing { cursor: crosshair; }
+.map-view__svg { display: block; width: 100%; height: auto; max-height: 100%; border-radius: 6px; }
+
+.map-view__grid line { stroke: #c2d2e6; stroke-width: 1; }
+.map-view__grid line.is-prime,
+.map-view__grid line.is-equator { stroke: #9bb4d4; stroke-width: 1.4; }
+.map-view__labels text { fill: #8190a6; font-size: 11px; }
+
+.map-view__pin { cursor: pointer; }
+.map-view__pin-body { stroke: #fff; stroke-width: 1.5; transition: transform .1s ease; }
+.map-view__pin.is-selected .map-view__pin-body { stroke: #2F3990; stroke-width: 2.5; }
+.map-view__pin:hover .map-view__pin-body { transform: scale(1.12); }
+
+.map-view__empty { position: absolute; top: 50%; left: 0; right: 0; transform: translateY(-50%); text-align: center; color: #999; font-size: 14px; pointer-events: none; }
+
+.map-view__side { width: 230px; flex: 0 0 auto; border-left: 1px solid #eee; padding: 10px; overflow: auto; background: #fafafe; }
+.map-view__card { border: 1px solid #cdd2f5; background: #fff; border-radius: 6px; padding: 8px; margin-bottom: 12px; }
+.map-view__card-head { display: flex; align-items: center; gap: 6px; }
+.map-view__card-name { flex: 1 1 auto; font-size: 13px; font-weight: 600; color: #333; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.map-view__card-x { border: none; background: transparent; color: #999; font-size: 16px; line-height: 1; cursor: pointer; padding: 0 2px; }
+.map-view__card-meta { display: flex; align-items: center; gap: 8px; margin: 6px 0; flex-wrap: wrap; }
+.map-view__key { font-size: 11px; color: #2F3990; background: #eef0ff; border-radius: 3px; padding: 1px 6px; }
+.map-view__coord { font-size: 11px; color: #777; }
+.map-view__remove { width: 100%; border: 1px solid #e3b4ae; background: #fff; color: #c0392b; border-radius: 5px; font-size: 12px; padding: 4px; cursor: pointer; }
+.map-view__remove:hover { background: #c0392b; color: #fff; }
+
+.map-view__side-title { font-size: 12px; text-transform: uppercase; color: #999; margin: 0 0 8px; letter-spacing: .04em; }
+.map-view__list { list-style: none; margin: 0; padding: 0; }
+.map-view__item { display: flex; align-items: center; gap: 6px; padding: 6px 0; border-bottom: 1px dashed #eee; }
+.map-view__item.is-active { background: #f3f5ff; }
+.map-view__dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
+.map-view__item-name { flex: 1 1 auto; font-size: 13px; color: #444; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.map-view__place { border: 1px solid #2F3990; color: #2F3990; background: #fff; border-radius: 5px; font-size: 12px; padding: 3px 8px; cursor: pointer; white-space: nowrap; }
+.map-view__place:hover { background: #2F3990; color: #fff; }
+.map-view__all-placed { font-size: 12px; color: #aaa; padding: 8px 0; }
+</style>

--- a/frontend/src/views/Projects/MindMapView/MindMapView.vue
+++ b/frontend/src/views/Projects/MindMapView/MindMapView.vue
@@ -1,0 +1,143 @@
+<template>
+  <div class="mm-view">
+    <div class="mm-view__bar">
+      <span class="mm-view__title">Mind Map</span>
+      <span class="mm-view__count">{{ nodeCount }} nodes</span>
+    </div>
+    <div class="mm-view__main">
+      <div v-if="!hasTasks" class="mm-view__empty">No tasks yet — add tasks to see the project mind map.</div>
+      <div v-else class="mm-view__scroll">
+        <svg :width="dims.w" :height="dims.h" class="mm-view__svg">
+          <path v-for="(e, i) in edges" :key="'e' + i" :d="edgePath(e)" class="mm-view__edge" />
+          <g v-for="n in nodes" :key="n.id" :transform="`translate(${n.x}, ${n.y})`" class="mm-view__node" :class="n.kind">
+            <rect :width="NODE_W" :height="NODE_H" rx="7" />
+            <text :x="10" :y="NODE_H / 2 + 4">{{ trim(n.name) }}</text>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default { name: 'MindMapView' };
+</script>
+
+<script setup>
+// VIEW-02 — read-only Mind Map. Renders the project → parent-task → subtask
+// hierarchy as an SVG node tree. Lightweight (no external lib); reads the same
+// live Vuex task store the other views use.
+import { ref, computed, onMounted, inject, watch } from 'vue';
+import { useStore } from 'vuex';
+import { taskListHelper } from '@/views/Projects/helper.js';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+    sprints: { type: Array, default: () => [] },
+});
+
+const { getters } = useStore();
+const { groupBy } = taskListHelper();
+const selectedProject = inject('selectedProject', ref({}));
+
+const NODE_W = 190;
+const NODE_H = 34;
+const COL_W = 250;
+const ROW_H = 46;
+
+const sprintId = computed(() => props.sprints?.[0]?.id || props.sprints?.[0]?._id || '');
+function pickTasks(map) {
+    const pid = props.projectData?._id;
+    const sid = sprintId.value;
+    if (!pid || !sid || !map || !map[pid] || !map[pid][sid]) return null;
+    const node = map[pid][sid];
+    return Array.isArray(node.tasks) ? node.tasks : null;
+}
+const tasks = computed(() => pickTasks(getters['projectData/tasks']) || pickTasks(getters['projectData/tableTasks']) || []);
+const activeTasks = computed(() => tasks.value.filter((t) => t && [0, 2, undefined, null].includes(t.deletedStatusKey)));
+const hasTasks = computed(() => activeTasks.value.length > 0);
+
+const kindOf = (t) => {
+    const type = t?.status?.type || t?.statusType;
+    if (type === 'close') return 'is-done';
+    if (type === 'inprogress') return 'is-progress';
+    return 'is-todo';
+};
+
+// Build root → parent tasks → subtasks, then a bottom-up tidy layout.
+const layout = computed(() => {
+    const list = activeTasks.value;
+    const parents = list.filter((t) => !t.ParentTaskId);
+    const childrenOf = (pid) => list.filter((t) => t.ParentTaskId && String(t.ParentTaskId) === String(pid));
+    const root = {
+        id: 'root', name: props.projectData?.ProjectName || 'Project', kind: 'is-root',
+        children: parents.map((p) => ({
+            id: String(p._id), name: p.TaskName || p.TaskKey || 'Task', kind: kindOf(p),
+            children: childrenOf(p._id).map((c) => ({ id: String(c._id), name: c.TaskName || c.TaskKey || 'Task', kind: kindOf(c), children: [] })),
+        })),
+    };
+    let leaf = 0;
+    let maxDepth = 0;
+    const place = (node, depth) => {
+        node.x = depth * COL_W;
+        maxDepth = Math.max(maxDepth, depth);
+        if (node.children.length) {
+            node.children.forEach((c) => place(c, depth + 1));
+            node.y = (node.children[0].y + node.children[node.children.length - 1].y) / 2;
+        } else {
+            node.y = leaf * ROW_H;
+            leaf += 1;
+        }
+    };
+    place(root, 0);
+    const nodes = [];
+    const edges = [];
+    const walk = (node) => {
+        nodes.push({ id: node.id, name: node.name, x: node.x, y: node.y, kind: node.kind });
+        node.children.forEach((c) => {
+            edges.push({ x1: node.x + NODE_W, y1: node.y + NODE_H / 2, x2: c.x, y2: c.y + NODE_H / 2 });
+            walk(c);
+        });
+    };
+    walk(root);
+    return { nodes, edges, w: (maxDepth + 1) * COL_W + 40, h: Math.max(leaf, 1) * ROW_H + 20 };
+});
+
+const nodes = computed(() => layout.value.nodes);
+const edges = computed(() => layout.value.edges);
+const dims = computed(() => ({ w: layout.value.w, h: layout.value.h }));
+const nodeCount = computed(() => nodes.value.length);
+
+const edgePath = (e) => {
+    const mx = (e.x1 + e.x2) / 2;
+    return `M ${e.x1} ${e.y1} C ${mx} ${e.y1}, ${mx} ${e.y2}, ${e.x2} ${e.y2}`;
+};
+const trim = (s) => { const str = String(s || ''); return str.length > 24 ? `${str.slice(0, 23)}…` : str; };
+
+function ensureTasksLoaded() {
+    if (tasks.value.length) return;
+    const proj = (selectedProject.value && selectedProject.value._id) ? selectedProject.value : props.projectData;
+    if (!proj || !proj._id || !Array.isArray(props.sprints) || !props.sprints.length) return;
+    try { groupBy(0, true, proj, props.sprints, ref([]), false, 'list', false, true, () => {}); } catch (e) { /* noop */ }
+}
+onMounted(ensureTasksLoaded);
+watch(() => props.sprints, () => ensureTasksLoaded(), { deep: true });
+</script>
+
+<style scoped>
+.mm-view { display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
+.mm-view__bar { display: flex; align-items: center; gap: 14px; padding: 8px 14px; border-bottom: 1px solid #eee; flex: 0 0 auto; }
+.mm-view__title { font-size: 14px; font-weight: 700; color: #2b2f44; }
+.mm-view__count { margin-left: auto; font-size: 12px; color: #888; }
+.mm-view__main { position: relative; flex: 1 1 auto; min-height: 360px; overflow: hidden; }
+.mm-view__empty { position: absolute; top: 48px; left: 0; right: 0; text-align: center; color: #999; font-size: 14px; padding: 20px; }
+.mm-view__scroll { width: 100%; height: 100%; overflow: auto; padding: 16px; }
+.mm-view__edge { fill: none; stroke: #cfd4e6; stroke-width: 1.6; }
+.mm-view__node rect { fill: #fff; stroke: #8a93b5; stroke-width: 1.4; }
+.mm-view__node text { font-size: 12px; fill: #33384a; }
+.mm-view__node.is-root rect { fill: #2f3a8f; stroke: #2f3a8f; }
+.mm-view__node.is-root text { fill: #fff; font-weight: 700; }
+.mm-view__node.is-progress rect { stroke: #2f6fed; }
+.mm-view__node.is-done rect { stroke: #1c9b5e; }
+.mm-view__node.is-done text { fill: #1c7a43; }
+</style>

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -86,7 +86,7 @@
                                                             <img :src="activeTab !== 'EmbedView'
                                                                     ? projectComponentsIcons(projectData?.ProjectRequiredComponent?.find(x => x.keyName === activeTab)?.keyName)?.icon
                                                                     : projectComponentsIcons(projectData?.ProjectRequiredComponent?.find(x => x.name === embedViewName)?.type)?.icon" alt="list" class="mr-5px">
-                                                            {{activeTab !== 'EmbedView' ? projectData?.ProjectRequiredComponent?.find(x => x.keyName === activeTab)?.name || "N/A" : embedViewName || "N/A"}}
+                                                            {{activeTab !== 'EmbedView' ? viewLabel(projectData?.ProjectRequiredComponent?.find(x => x.keyName === activeTab)?.name) : embedViewName || "N/A"}}
                                                         </span>
                                                         <img :src="listDropIcon" alt="ListDropIcon" :style="[{marginLeft : clientWidth <=375 ? '2px' : '10px'}]"/>
                                                     </div>
@@ -504,7 +504,10 @@ import { useProjectsHelper } from './helper';
 
 // UTILS
 const { checkErrors } = useValidation();
-const { t } = useI18n();
+const { t, te } = useI18n();
+// Short display label for a view tab: the ViewList i18n value drops the "View"
+// suffix (e.g. "Map View" → "Map"); fall back to the raw name for custom/embed views.
+const viewLabel = (name) => (name && te(`ViewList.${name}`)) ? t(`ViewList.${name}`) : (name || 'N/A');
 const { projects, filteredProjects, dispatchProjects } = useProjectsHelper();
 const showArchivedProjects = ref(false);
 const isAdvanceFilterApplied = ref(false);

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -262,6 +262,7 @@
                                             activeTab !== 'GanttView' &&
                                             activeTab !== 'RecurringTasks' &&
                                             activeTab !== 'TimelineView' &&
+                                            activeTab !== 'MindMapView' &&
                                             (clientWidth > 767 || activeTab !== 'ProjectDetail')
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
@@ -306,7 +307,7 @@
                             />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
-                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView'}]"
+                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView'}]"
                                 :is="getView(activeTab)"
                                 :data="selectedEmbedView"
                                 :sprints="sprints"
@@ -328,7 +329,7 @@
                                 :sprintLoading="sprintLoading"
                                 :commentType="'project'"
                             />
-                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
+                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
                         </div>
                         <div class="position-ab z-index-1 p-5px border-radius-5-px text-center p0x-15px archived_wrapper" v-if="projectData?.deletedStatusKey === 2">
                             <div>
@@ -474,6 +475,7 @@ const ReportsView = defineAsyncComponent(() => import(/* webpackChunkName: "proj
 const GanttViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-gantt" */ '@/views/Projects/GanttView/GanttView.vue'));
 const RecurringTasksComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-recurring" */ '@/views/Projects/RecurringTasks/RecurringTasksManager.vue'));
 const TimelineViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-timeline" */ '@/views/Projects/TimelineView/TimelineView.vue'));
+const MindMapViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-mindmap" */ '@/views/Projects/MindMapView/MindMapView.vue'));
 import NotFound from '../NotFound.vue';
 
 // EXTRACTED PIECES
@@ -1100,6 +1102,8 @@ function getView(val) {
             return RecurringTasksComp;
         case 'TimelineView':
             return TimelineViewComp;
+        case 'MindMapView':
+            return MindMapViewComp;
         default:
             return NotFound;
     }

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -264,6 +264,7 @@
                                             activeTab !== 'TimelineView' &&
                                             activeTab !== 'MindMapView' &&
                                             activeTab !== 'WhiteboardView' &&
+                                            activeTab !== 'CanvasView' &&
                                             (clientWidth > 767 || activeTab !== 'ProjectDetail')
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
@@ -308,7 +309,7 @@
                             />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
-                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView'}]"
+                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView'}]"
                                 :is="getView(activeTab)"
                                 :data="selectedEmbedView"
                                 :sprints="sprints"
@@ -330,7 +331,7 @@
                                 :sprintLoading="sprintLoading"
                                 :commentType="'project'"
                             />
-                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
+                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
                         </div>
                         <div class="position-ab z-index-1 p-5px border-radius-5-px text-center p0x-15px archived_wrapper" v-if="projectData?.deletedStatusKey === 2">
                             <div>
@@ -478,6 +479,7 @@ const RecurringTasksComp = defineAsyncComponent(() => import(/* webpackChunkName
 const TimelineViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-timeline" */ '@/views/Projects/TimelineView/TimelineView.vue'));
 const MindMapViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-mindmap" */ '@/views/Projects/MindMapView/MindMapView.vue'));
 const WhiteboardViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-whiteboard" */ '@/views/Projects/WhiteboardView/WhiteboardView.vue'));
+const CanvasViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-canvas" */ '@/views/Projects/CanvasView/CanvasView.vue'));
 import NotFound from '../NotFound.vue';
 
 // EXTRACTED PIECES
@@ -1108,6 +1110,8 @@ function getView(val) {
             return MindMapViewComp;
         case 'WhiteboardView':
             return WhiteboardViewComp;
+        case 'CanvasView':
+            return CanvasViewComp;
         default:
             return NotFound;
     }

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -261,6 +261,7 @@
                                             activeTab !== 'Reports' &&
                                             activeTab !== 'GanttView' &&
                                             activeTab !== 'RecurringTasks' &&
+                                            activeTab !== 'TimelineView' &&
                                             (clientWidth > 767 || activeTab !== 'ProjectDetail')
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
@@ -305,7 +306,7 @@
                             />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
-                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks'}]"
+                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView'}]"
                                 :is="getView(activeTab)"
                                 :data="selectedEmbedView"
                                 :sprints="sprints"
@@ -327,7 +328,7 @@
                                 :sprintLoading="sprintLoading"
                                 :commentType="'project'"
                             />
-                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
+                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
                         </div>
                         <div class="position-ab z-index-1 p-5px border-radius-5-px text-center p0x-15px archived_wrapper" v-if="projectData?.deletedStatusKey === 2">
                             <div>
@@ -472,6 +473,7 @@ const EmbedViewItem = defineAsyncComponent(() => import(/* webpackChunkName: "em
 const ReportsView = defineAsyncComponent(() => import(/* webpackChunkName: "project-reports" */ '@/views/Projects/Reports/ReportsView.vue'));
 const GanttViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-gantt" */ '@/views/Projects/GanttView/GanttView.vue'));
 const RecurringTasksComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-recurring" */ '@/views/Projects/RecurringTasks/RecurringTasksManager.vue'));
+const TimelineViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-timeline" */ '@/views/Projects/TimelineView/TimelineView.vue'));
 import NotFound from '../NotFound.vue';
 
 // EXTRACTED PIECES
@@ -1096,6 +1098,8 @@ function getView(val) {
             return GanttViewComp;
         case 'RecurringTasks':
             return RecurringTasksComp;
+        case 'TimelineView':
+            return TimelineViewComp;
         default:
             return NotFound;
     }

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -265,6 +265,7 @@
                                             activeTab !== 'MindMapView' &&
                                             activeTab !== 'WhiteboardView' &&
                                             activeTab !== 'CanvasView' &&
+                                            activeTab !== 'MapView' &&
                                             (clientWidth > 767 || activeTab !== 'ProjectDetail')
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
@@ -309,7 +310,7 @@
                             />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
-                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView'}]"
+                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView' && activeTab !== 'MapView'}]"
                                 :is="getView(activeTab)"
                                 :data="selectedEmbedView"
                                 :sprints="sprints"
@@ -480,6 +481,7 @@ const TimelineViewComp = defineAsyncComponent(() => import(/* webpackChunkName: 
 const MindMapViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-mindmap" */ '@/views/Projects/MindMapView/MindMapView.vue'));
 const WhiteboardViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-whiteboard" */ '@/views/Projects/WhiteboardView/WhiteboardView.vue'));
 const CanvasViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-canvas" */ '@/views/Projects/CanvasView/CanvasView.vue'));
+const MapViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-map" */ '@/views/Projects/MapView/MapView.vue'));
 import NotFound from '../NotFound.vue';
 
 // EXTRACTED PIECES
@@ -1112,6 +1114,8 @@ function getView(val) {
             return WhiteboardViewComp;
         case 'CanvasView':
             return CanvasViewComp;
+        case 'MapView':
+            return MapViewComp;
         default:
             return NotFound;
     }

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -263,6 +263,7 @@
                                             activeTab !== 'RecurringTasks' &&
                                             activeTab !== 'TimelineView' &&
                                             activeTab !== 'MindMapView' &&
+                                            activeTab !== 'WhiteboardView' &&
                                             (clientWidth > 767 || activeTab !== 'ProjectDetail')
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
@@ -307,7 +308,7 @@
                             />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
-                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView'}]"
+                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView'}]"
                                 :is="getView(activeTab)"
                                 :data="selectedEmbedView"
                                 :sprints="sprints"
@@ -329,7 +330,7 @@
                                 :sprintLoading="sprintLoading"
                                 :commentType="'project'"
                             />
-                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
+                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
                         </div>
                         <div class="position-ab z-index-1 p-5px border-radius-5-px text-center p0x-15px archived_wrapper" v-if="projectData?.deletedStatusKey === 2">
                             <div>
@@ -476,6 +477,7 @@ const GanttViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "pr
 const RecurringTasksComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-recurring" */ '@/views/Projects/RecurringTasks/RecurringTasksManager.vue'));
 const TimelineViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-timeline" */ '@/views/Projects/TimelineView/TimelineView.vue'));
 const MindMapViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-mindmap" */ '@/views/Projects/MindMapView/MindMapView.vue'));
+const WhiteboardViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-whiteboard" */ '@/views/Projects/WhiteboardView/WhiteboardView.vue'));
 import NotFound from '../NotFound.vue';
 
 // EXTRACTED PIECES
@@ -1104,6 +1106,8 @@ function getView(val) {
             return TimelineViewComp;
         case 'MindMapView':
             return MindMapViewComp;
+        case 'WhiteboardView':
+            return WhiteboardViewComp;
         default:
             return NotFound;
     }

--- a/frontend/src/views/Projects/TimelineView/TimelineView.vue
+++ b/frontend/src/views/Projects/TimelineView/TimelineView.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="tl-view">
+    <div class="tl-view__bar">
+      <span class="tl-view__title">Timeline</span>
+      <span class="tl-view__count">
+        {{ scheduled.length }} scheduled<template v-if="unscheduled.length"> · {{ unscheduled.length }} unscheduled</template>
+      </span>
+    </div>
+
+    <div class="tl-view__main">
+      <div v-if="!scheduled.length" class="tl-view__empty">
+        No scheduled tasks yet — give a task a start &amp; due date to see it on the timeline.
+      </div>
+
+      <div v-else class="tl-view__chart">
+        <!-- month axis -->
+        <div class="tl-view__axis">
+          <div class="tl-view__axis-label"></div>
+          <div class="tl-view__axis-track">
+            <span v-for="(m, i) in monthTicks" :key="i" class="tl-view__tick" :style="{ left: m.left + '%' }">{{ m.label }}</span>
+          </div>
+        </div>
+
+        <!-- rows -->
+        <div v-for="t in scheduled" :key="t._id" class="tl-view__row">
+          <div class="tl-view__row-label" :title="t.TaskName || t.TaskKey">
+            <span class="tl-view__key" v-if="t.TaskKey">{{ t.TaskKey }}</span>{{ t.TaskName || 'Untitled' }}
+          </div>
+          <div class="tl-view__row-track">
+            <div
+              class="tl-view__barseg"
+              :class="statusClass(t)"
+              :style="{ left: barLeft(t) + '%', width: barWidth(t) + '%' }"
+              :title="`${fmt(t.startDate)} → ${fmt(t.DueDate)}`"
+            >
+              <span class="tl-view__barseg-text">{{ t.TaskName || t.TaskKey }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <aside v-if="unscheduled.length" class="tl-view__tray">
+        <h4 class="tl-view__tray-title">Unscheduled ({{ unscheduled.length }})</h4>
+        <ul class="tl-view__tray-list">
+          <li v-for="t in unscheduled" :key="t._id" class="tl-view__tray-item" :title="t.TaskName || t.TaskKey">
+            {{ t.TaskName || t.TaskKey }}
+          </li>
+        </ul>
+      </aside>
+    </div>
+  </div>
+</template>
+
+<script>
+export default { name: 'TimelineView' };
+</script>
+
+<script setup>
+// VIEW-01 — read-only Timeline. Plots tasks with a start + due date as bars on a
+// shared date axis. Lightweight (no external lib); reads tasks from the same live
+// Vuex store the List/Gantt views use, so socket updates flow in for free.
+import { ref, computed, onMounted, inject, watch } from 'vue';
+import { useStore } from 'vuex';
+import { taskListHelper } from '@/views/Projects/helper.js';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+    sprints: { type: Array, default: () => [] },
+});
+
+const { getters } = useStore();
+const { groupBy } = taskListHelper();
+const selectedProject = inject('selectedProject', ref({}));
+
+const sprintId = computed(() => props.sprints?.[0]?.id || props.sprints?.[0]?._id || '');
+function pickTasks(map) {
+    const pid = props.projectData?._id;
+    const sid = sprintId.value;
+    if (!pid || !sid || !map || !map[pid] || !map[pid][sid]) return null;
+    const node = map[pid][sid];
+    return Array.isArray(node.tasks) ? node.tasks : null;
+}
+const tasks = computed(() => pickTasks(getters['projectData/tasks']) || pickTasks(getters['projectData/tableTasks']) || []);
+const activeTasks = computed(() => tasks.value.filter((t) => t && [0, 2, undefined, null].includes(t.deletedStatusKey)));
+
+const scheduled = computed(() => activeTasks.value
+    .filter((t) => t.startDate && t.DueDate && !isNaN(new Date(t.startDate)) && !isNaN(new Date(t.DueDate)))
+    .slice()
+    .sort((a, b) => new Date(a.startDate) - new Date(b.startDate)));
+const unscheduled = computed(() => activeTasks.value.filter((t) => !(t.startDate && t.DueDate)));
+
+const range = computed(() => {
+    if (!scheduled.value.length) return { min: 0, max: 1 };
+    let min = Infinity; let max = -Infinity;
+    scheduled.value.forEach((t) => {
+        min = Math.min(min, new Date(t.startDate).getTime());
+        max = Math.max(max, new Date(t.DueDate).getTime());
+    });
+    if (min === max) max = min + 86400000; // 1-day pad so a single same-day task is visible
+    return { min, max };
+});
+const pct = (ms) => {
+    const { min, max } = range.value;
+    return Math.max(0, Math.min(100, ((ms - min) / (max - min)) * 100));
+};
+const barLeft = (t) => pct(new Date(t.startDate).getTime());
+const barWidth = (t) => Math.max(1.5, pct(new Date(t.DueDate).getTime()) - barLeft(t));
+
+const monthTicks = computed(() => {
+    const { min, max } = range.value;
+    if (!isFinite(min) || max <= min) return [];
+    const ticks = [];
+    const d = new Date(min);
+    d.setUTCDate(1); d.setUTCHours(0, 0, 0, 0);
+    let guard = 0;
+    while (d.getTime() <= max && guard++ < 60) {
+        const ms = d.getTime();
+        if (ms >= min) ticks.push({ left: pct(ms), label: d.toLocaleString('default', { month: 'short', year: '2-digit' }) });
+        d.setUTCMonth(d.getUTCMonth() + 1);
+    }
+    return ticks;
+});
+
+const statusClass = (t) => {
+    const type = t?.status?.type || t?.statusType;
+    if (type === 'close') return 'is-done';
+    if (type === 'inprogress') return 'is-progress';
+    return 'is-todo';
+};
+const fmt = (d) => (d ? new Date(d).toLocaleDateString() : '');
+
+function ensureTasksLoaded() {
+    if (tasks.value.length) return;
+    const proj = (selectedProject.value && selectedProject.value._id) ? selectedProject.value : props.projectData;
+    if (!proj || !proj._id || !Array.isArray(props.sprints) || !props.sprints.length) return;
+    try { groupBy(0, true, proj, props.sprints, ref([]), false, 'list', false, true, () => {}); } catch (e) { /* noop */ }
+}
+onMounted(ensureTasksLoaded);
+watch(() => props.sprints, () => ensureTasksLoaded(), { deep: true });
+</script>
+
+<style scoped>
+.tl-view { display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
+.tl-view__bar { display: flex; align-items: center; gap: 14px; padding: 8px 14px; border-bottom: 1px solid #eee; flex: 0 0 auto; }
+.tl-view__title { font-size: 14px; font-weight: 700; color: #2b2f44; }
+.tl-view__count { margin-left: auto; font-size: 12px; color: #888; }
+.tl-view__main { position: relative; flex: 1 1 auto; display: flex; min-height: 360px; overflow: hidden; }
+.tl-view__chart { flex: 1 1 auto; overflow: auto; padding-bottom: 12px; }
+.tl-view__empty { position: absolute; top: 48px; left: 0; right: 0; text-align: center; color: #999; font-size: 14px; padding: 20px; }
+.tl-view__axis { display: flex; position: sticky; top: 0; background: #fafbff; border-bottom: 1px solid #eee; z-index: 1; }
+.tl-view__axis-label { width: 240px; flex: 0 0 240px; }
+.tl-view__axis-track { position: relative; flex: 1 1 auto; height: 26px; }
+.tl-view__tick { position: absolute; top: 5px; font-size: 11px; color: #9aa0b4; transform: translateX(-50%); white-space: nowrap; }
+.tl-view__tick::before { content: ''; position: absolute; top: -5px; left: 50%; width: 1px; height: 100%; background: #eef0f6; }
+.tl-view__row { display: flex; align-items: center; border-bottom: 1px solid #f4f4f8; }
+.tl-view__row-label { width: 240px; flex: 0 0 240px; padding: 7px 12px; font-size: 13px; color: #3a3f52; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tl-view__key { color: #7b68ee; font-weight: 600; margin-right: 6px; }
+.tl-view__row-track { position: relative; flex: 1 1 auto; height: 34px; }
+.tl-view__barseg { position: absolute; top: 7px; height: 20px; border-radius: 5px; display: flex; align-items: center; padding: 0 8px; overflow: hidden; min-width: 6px; }
+.tl-view__barseg-text { font-size: 11px; color: #fff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tl-view__barseg.is-todo { background: #8a93b5; }
+.tl-view__barseg.is-progress { background: #2f6fed; }
+.tl-view__barseg.is-done { background: #1c9b5e; }
+.tl-view__tray { width: 210px; flex: 0 0 auto; border-left: 1px solid #eee; padding: 10px; overflow: auto; background: #fafafe; }
+.tl-view__tray-title { font-size: 12px; text-transform: uppercase; color: #999; margin: 0 0 8px; letter-spacing: .04em; }
+.tl-view__tray-list { list-style: none; margin: 0; padding: 0; }
+.tl-view__tray-item { padding: 6px 0; border-bottom: 1px dashed #eee; font-size: 13px; color: #444; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+</style>

--- a/frontend/src/views/Projects/WhiteboardView/WhiteboardView.vue
+++ b/frontend/src/views/Projects/WhiteboardView/WhiteboardView.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="wb-view">
+    <div class="wb-view__bar">
+      <span class="wb-view__title">Whiteboard</span>
+      <span class="wb-view__count">{{ cards.length }} cards</span>
+      <button class="wb-view__btn" type="button" @click="autoArrange">Auto-arrange</button>
+    </div>
+    <div ref="boardEl" class="wb-view__board">
+      <div v-if="!cards.length" class="wb-view__empty">No tasks yet — tasks appear here as movable cards.</div>
+      <div
+        v-for="c in cards"
+        :key="c.id"
+        class="wb-view__card"
+        :class="[c.kind, { dragging: dragId === c.id }]"
+        :style="pos[c.id] ? { left: pos[c.id].x + 'px', top: pos[c.id].y + 'px' } : { left: '16px', top: '16px' }"
+        @mousedown="startDrag(c.id, $event)"
+      >
+        <span v-if="c.key" class="wb-view__card-key">{{ c.key }}</span>
+        <span class="wb-view__card-name">{{ c.name }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default { name: 'WhiteboardView' };
+</script>
+
+<script setup>
+// VIEW-03 — Whiteboard. Tasks as freely draggable cards on a board. Positions are
+// saved per user (localStorage, keyed by project+sprint) as a v1; shared/persisted
+// positions are a documented follow-up. Reads the same live Vuex task store.
+import { ref, computed, reactive, onMounted, onBeforeUnmount, inject, watch } from 'vue';
+import { useStore } from 'vuex';
+import { taskListHelper } from '@/views/Projects/helper.js';
+
+const props = defineProps({
+    projectData: { type: Object, default: () => ({}) },
+    sprints: { type: Array, default: () => [] },
+});
+
+const { getters } = useStore();
+const { groupBy } = taskListHelper();
+const selectedProject = inject('selectedProject', ref({}));
+
+const boardEl = ref(null);
+const CARD_W = 180;
+const GAP = 16;
+const ROW_H = 92;
+
+const sprintId = computed(() => props.sprints?.[0]?.id || props.sprints?.[0]?._id || '');
+function pickTasks(map) {
+    const pid = props.projectData?._id;
+    const sid = sprintId.value;
+    if (!pid || !sid || !map || !map[pid] || !map[pid][sid]) return null;
+    const node = map[pid][sid];
+    return Array.isArray(node.tasks) ? node.tasks : null;
+}
+const tasks = computed(() => pickTasks(getters['projectData/tasks']) || pickTasks(getters['projectData/tableTasks']) || []);
+const activeTasks = computed(() => tasks.value.filter((t) => t && [0, 2, undefined, null].includes(t.deletedStatusKey)));
+const kindOf = (t) => { const ty = t?.status?.type || t?.statusType; return ty === 'close' ? 'is-done' : ty === 'inprogress' ? 'is-progress' : 'is-todo'; };
+const cards = computed(() => activeTasks.value.map((t) => ({ id: String(t._id), key: t.TaskKey, name: t.TaskName || 'Untitled', kind: kindOf(t) })));
+
+const storeKey = computed(() => `wb:${props.projectData?._id || 'p'}:${sprintId.value || 's'}`);
+const pos = reactive({});
+const perRow = () => Math.max(1, Math.floor(((boardEl.value && boardEl.value.clientWidth) || 900) / (CARD_W + GAP)));
+function gridPos(i) { const n = perRow(); return { x: (i % n) * (CARD_W + GAP) + GAP, y: Math.floor(i / n) * ROW_H + GAP }; }
+function loadPos() {
+    let saved = {};
+    try { saved = JSON.parse(localStorage.getItem(storeKey.value) || '{}') || {}; } catch (e) { saved = {}; }
+    cards.value.forEach((c, i) => { pos[c.id] = saved[c.id] || pos[c.id] || gridPos(i); });
+}
+function savePos() { try { localStorage.setItem(storeKey.value, JSON.stringify(pos)); } catch (e) { /* noop */ } }
+function autoArrange() { cards.value.forEach((c, i) => { pos[c.id] = gridPos(i); }); savePos(); }
+
+let dragId = null; let offX = 0; let offY = 0;
+const dragRef = ref(null);
+function startDrag(id, e) {
+    dragId = id; dragRef.value = id;
+    const r = e.currentTarget.getBoundingClientRect();
+    offX = e.clientX - r.left; offY = e.clientY - r.top;
+    window.addEventListener('mousemove', onDrag);
+    window.addEventListener('mouseup', endDrag);
+    e.preventDefault();
+}
+function onDrag(e) {
+    if (!dragId || !boardEl.value) return;
+    const b = boardEl.value.getBoundingClientRect();
+    pos[dragId] = {
+        x: Math.max(0, e.clientX - b.left - offX + boardEl.value.scrollLeft),
+        y: Math.max(0, e.clientY - b.top - offY + boardEl.value.scrollTop),
+    };
+}
+function endDrag() {
+    if (dragId) savePos();
+    dragId = null; dragRef.value = null;
+    window.removeEventListener('mousemove', onDrag);
+    window.removeEventListener('mouseup', endDrag);
+}
+
+function ensureTasksLoaded() {
+    if (tasks.value.length) return;
+    const proj = (selectedProject.value && selectedProject.value._id) ? selectedProject.value : props.projectData;
+    if (!proj || !proj._id || !Array.isArray(props.sprints) || !props.sprints.length) return;
+    try { groupBy(0, true, proj, props.sprints, ref([]), false, 'list', false, true, () => {}); } catch (e) { /* noop */ }
+}
+onMounted(() => { ensureTasksLoaded(); loadPos(); });
+watch(cards, () => loadPos());
+watch(() => props.sprints, () => ensureTasksLoaded(), { deep: true });
+onBeforeUnmount(() => { window.removeEventListener('mousemove', onDrag); window.removeEventListener('mouseup', endDrag); });
+</script>
+
+<style scoped>
+.wb-view { display: flex; flex-direction: column; width: 100%; height: 100%; background: #fff; }
+.wb-view__bar { display: flex; align-items: center; gap: 14px; padding: 8px 14px; border-bottom: 1px solid #eee; flex: 0 0 auto; }
+.wb-view__title { font-size: 14px; font-weight: 700; color: #2b2f44; }
+.wb-view__count { font-size: 12px; color: #888; }
+.wb-view__btn { margin-left: auto; border: 1px solid #d8d8e0; background: #fff; color: #444; border-radius: 6px; padding: 5px 12px; font-size: 12px; cursor: pointer; }
+.wb-view__btn:hover { background: #f2f3fb; }
+.wb-view__board { position: relative; flex: 1 1 auto; min-height: 360px; overflow: auto; background:
+    linear-gradient(#f4f5fa 1px, transparent 1px) 0 0 / 24px 24px,
+    linear-gradient(90deg, #f4f5fa 1px, transparent 1px) 0 0 / 24px 24px, #fff; }
+.wb-view__empty { position: absolute; top: 48px; left: 0; right: 0; text-align: center; color: #999; font-size: 14px; }
+.wb-view__card { position: absolute; width: 180px; min-height: 64px; box-sizing: border-box; background: #fff; border: 1px solid #e0e2ee; border-left: 4px solid #8a93b5; border-radius: 8px; padding: 8px 10px; box-shadow: 0 1px 4px rgba(0,0,0,.08); cursor: grab; user-select: none; }
+.wb-view__card.dragging { cursor: grabbing; box-shadow: 0 6px 18px rgba(0,0,0,.18); z-index: 5; }
+.wb-view__card.is-progress { border-left-color: #2f6fed; }
+.wb-view__card.is-done { border-left-color: #1c9b5e; }
+.wb-view__card-key { display: block; font-size: 11px; font-weight: 600; color: #7b68ee; margin-bottom: 3px; }
+.wb-view__card-name { font-size: 13px; color: #33384a; }
+</style>

--- a/utils/data.js
+++ b/utils/data.js
@@ -1885,6 +1885,14 @@ exports.importProjectTabComponents = (companyName) => {
             value: "timelineview",
             setAsDefault: false,
             viewStatus: false
+        },
+        {
+            name: "Mind Map View",
+            sortIndex: 13,
+            keyName: "MindMapView",
+            value: "mindmapview",
+            setAsDefault: false,
+            viewStatus: false
         }
     ];
     return new Promise(async (resolve, reject) => {

--- a/utils/data.js
+++ b/utils/data.js
@@ -1853,6 +1853,14 @@ exports.importProjectTabComponents = (companyName) => {
             value: "embed",
             setAsDefault: false,
             viewStatus: false
+        },
+        {
+            name: "Timeline View",
+            sortIndex: 12,
+            keyName: "TimelineView",
+            value: "timelineview",
+            setAsDefault: false,
+            viewStatus: false
         }
     ];
     return new Promise(async (resolve, reject) => {

--- a/utils/data.js
+++ b/utils/data.js
@@ -1893,6 +1893,14 @@ exports.importProjectTabComponents = (companyName) => {
             value: "mindmapview",
             setAsDefault: false,
             viewStatus: false
+        },
+        {
+            name: "Whiteboard View",
+            sortIndex: 14,
+            keyName: "WhiteboardView",
+            value: "whiteboardview",
+            setAsDefault: false,
+            viewStatus: false
         }
     ];
     return new Promise(async (resolve, reject) => {

--- a/utils/data.js
+++ b/utils/data.js
@@ -1901,6 +1901,14 @@ exports.importProjectTabComponents = (companyName) => {
             value: "whiteboardview",
             setAsDefault: false,
             viewStatus: false
+        },
+        {
+            name: "Canvas View",
+            sortIndex: 15,
+            keyName: "CanvasView",
+            value: "canvasview",
+            setAsDefault: false,
+            viewStatus: false
         }
     ];
     return new Promise(async (resolve, reject) => {

--- a/utils/data.js
+++ b/utils/data.js
@@ -1855,6 +1855,30 @@ exports.importProjectTabComponents = (companyName) => {
             viewStatus: false
         },
         {
+            name: "Reports",
+            sortIndex: 12,
+            keyName: "Reports",
+            value: "reports",
+            setAsDefault: false,
+            viewStatus: false
+        },
+        {
+            name: "Gantt View",
+            sortIndex: 12,
+            keyName: "GanttView",
+            value: "ganttview",
+            setAsDefault: false,
+            viewStatus: false
+        },
+        {
+            name: "Recurring Tasks",
+            sortIndex: 12,
+            keyName: "RecurringTasks",
+            value: "recurringtasks",
+            setAsDefault: false,
+            viewStatus: false
+        },       
+        {
             name: "Timeline View",
             sortIndex: 12,
             keyName: "TimelineView",

--- a/utils/data.js
+++ b/utils/data.js
@@ -1909,6 +1909,14 @@ exports.importProjectTabComponents = (companyName) => {
             value: "canvasview",
             setAsDefault: false,
             viewStatus: false
+        },
+        {
+            name: "Map View",
+            sortIndex: 16,
+            keyName: "MapView",
+            value: "mapview",
+            setAsDefault: false,
+            viewStatus: false
         }
     ];
     return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
## Project Views & Canvas (v14.5.0) — VIEW-01..05

Five new first-class project views, all lightweight, dependency-free and **fully offline** (custom SVG / CSS / localStorage — no new runtime libraries, no external network calls), built on the GanttView data-harness pattern so they read from the live task store and pick up socket updates for free.

### Views
- **VIEW-01 · Timeline** (`TimelineView`, AHE-3742) — read-only date-axis timeline; tasks as bars, month ticks, status colours, unscheduled tray.
- **VIEW-02 · Mind Map** (`MindMapView`, AHE-3743) — SVG tree (project → parent tasks → subtasks), tidy bottom-up layout, bezier edges.
- **VIEW-03 · Whiteboard** (`WhiteboardView`, AHE-3744) — draggable task cards, positions saved per project+sprint (localStorage), auto-arrange.
- **VIEW-04 · Canvas** (`CanvasView`, AHE-3745) — configurable widget dashboard (summary / status / priority / overdue / upcoming), toggles persisted per user.
- **VIEW-05 · Map** (`MapView`, AHE-3746) — pin tasks onto a custom SVG world canvas (equirectangular projection); placements saved per project+sprint. No Leaflet / OSM tiles, honouring the self-hosted / offline-mode posture.

### Registration
Each view is wired across the 6 standard spots (component, `Projects.vue` getView + layout conditions, `commonFunction` icons, `ViewsDropdown` images, en.js `ViewList` + description, `utils/data.js` new-company seed). Existing companies get the `PROJECT_TAB_COMPONENTS` catalog record via the maintained-catalog process (no controller-time injection).

### Fixes folded in (from review)
- **Tab labels** drop the "View" suffix — display Timeline / Mind Map / Whiteboard / Canvas / Map / Gantt.
- **"+ View" crash** (`Cannot read properties of undefined (reading 'icon')`) fixed: `projectComponentsIcons()` now returns a default-icon fallback so an unknown catalog keyName can never white-screen the dropdown (or the template / project-creation / settings catalogs).
- **Catalog de-dupe** — collapses records that resolve to the same view label, so a company carrying a legacy "Timeline" record alongside the new one shows a single Timeline.
- **Unique tab icons** for Mind Map / Whiteboard / Canvas / Map (new inactive/active SVGs; Timeline keeps `comp_timeline`).

### Notes
- No backend schema, endpoint, socket, or new collection — additive frontend only (plus the seed array).
- Per directive, **no time tracking** logged for this module.

### Verification
- Frontend build: clean (0 errors; per-view chunks emit).
- Backend jest suite: green.
- Test cases: `.claude/test-cases/VIEW-01-timeline.md` … `VIEW-05-map.md`, plus `VIEW-fix-icon-fallback.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
