### PR TITLE
fix(deps): make samlify xsd validator optional so deploy npm ci survives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.96.0",
-        "@authenio/samlify-xsd-schema-validator": "^1.0.5",
         "@aws-sdk/client-iam": "3.864.0",
         "@aws-sdk/client-s3": "3.864.0",
         "@aws-sdk/client-ses": "^3.1045.0",
@@ -63,6 +62,9 @@
       },
       "engines": {
         "node": "20.x"
+      },
+      "optionalDependencies": {
+        "@authenio/samlify-xsd-schema-validator": "^1.0.5"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -131,6 +133,7 @@
       "resolved": "https://registry.npmjs.org/@authenio/samlify-xsd-schema-validator/-/samlify-xsd-schema-validator-1.0.5.tgz",
       "integrity": "sha512-HJjmjM1WbeB/z4nVbYEcmtIWTLPKqjrqRGEpC9lu7s03Usc4nxxfrJGjHgh3M8MvBJy4neVUoeM9rP4ym3GLgg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@authenio/xsd-schema-validator": "^0.7.3"
       },
@@ -166,7 +169,8 @@
       "resolved": "https://registry.npmjs.org/@authenio/xsd-schema-validator/-/xsd-schema-validator-0.7.3.tgz",
       "integrity": "sha512-Jhc/Hxv90bacZr0Fv+u+PEb440zPh4mO6rw+bzEAIBiFLKCtRa/BvKGRxPdCAwsGRPuwl2hFqQGF+Lfz6Q8kFg==",
       "hasInstallScript": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "nodemailer": "6.9.16",
     "openid-client": "^5.7.0",
     "samlify": "^2.8.10",
-    "@authenio/samlify-xsd-schema-validator": "^1.0.5",
     "otplib": "^12.0.1",
     "pdf-parse": "^2.4.5",
     "pdfmake": "^0.2.7",
@@ -87,6 +86,9 @@
     "winston-daily-rotate-file": "^5.0.0",
     "xlsx": "^0.18.5",
     "zod": "^4.4.3"
+  },
+  "optionalDependencies": {
+    "@authenio/samlify-xsd-schema-validator": "^1.0.5"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
## Production-priority: staging deploy was failing

**Symptom:** `npm ci` aborted with `code 127` →

```
npm error path .../node_modules/@authenio/xsd-schema-validator
npm error command sh -c javac support/XMLValidator.java
npm error sh: 1: javac: not found
```

…so `node_modules` was never populated and the app crashed on boot with `Cannot find module 'express'`.

**Root cause:** `@authenio/samlify-xsd-schema-validator` (added for SAML SSO, SEC-02) transitively depends on `@authenio/xsd-schema-validator`, whose **postinstall compiles a Java validator with `javac`**. The deploy host has no JDK.

**Fix:** move `@authenio/samlify-xsd-schema-validator` to **`optionalDependencies`** + regenerate the lockfile (both validator entries now `"optional": true`). npm treats an optional dep's build failure as non-fatal, so:
- Java-less hosts: the subtree is skipped, `npm ci` succeeds, **express + all required deps install, app boots**.
- Hosts with a JDK: still install fully (XSD validation intact).
- Also unblocks the CI "Lint PR title & commits" job, which runs `npm ci`.

**SAML safety:** unchanged at boot — `Modules/SSO/saml.js` lazy-requires the validator inside `ensureValidator()` (per SAML request) and already fails that request gracefully if absent. Signature validation (the primary control) is untouched. Strict XSD validation on Java-less hosts is a documented follow-up.

Only `package.json` + `package-lock.json` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)