### PR TITLE
feat(estimate): historical-actuals grounding + calibration for AI time estimate

### DIFF
--- a/Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md
+++ b/Modules/AIProjectGenerator/prompts/project-plan/task-time-estimate.md
@@ -1,8 +1,11 @@
 # What you produce
 
-A single integer estimate of how many minutes an AI coding agent
-(Claude Code) needs to complete this task end-to-end, with NO manual
-human implementation work.
+A calibrated estimate of how many minutes the work in this task takes,
+expressed as a three-point range (optimistic / likely / pessimistic) plus
+a confidence level. The estimate is for the {{ESTIMATE_TARGET_LABEL}}
+described below — estimate THAT worker's effort, nothing else.
+
+{{ESTIMATE_TARGET_GUIDANCE}}
 
 # Accuracy matters
 
@@ -17,6 +20,11 @@ Two failure modes ruin estimates equally:
 
 Your job is to extract the **actual unique work** from the
 description and estimate that — nothing more, nothing less.
+
+If "Comparable past tasks" are provided below, they are the single most
+important signal you have: they show how long THIS team actually takes for
+similar work. Anchor your numbers to them. If your instinct disagrees with
+the actuals, trust the actuals and adjust.
 
 # How you make the estimate
 
@@ -62,6 +70,10 @@ Bad items: "Make the system better", "Improve user experience",
 "Polish the UI" — these are too vague to be a single deliverable;
 either translate them into concrete items or drop them.
 
+If subtasks are listed below, treat each as work that must be accounted
+for in the total — fold them into your work-item list (deduplicating
+against the description) rather than ignoring them.
+
 ## Phase 3 — Estimate each unique work item
 
 For EACH item on your list (not for the whole description), judge:
@@ -78,27 +90,46 @@ For EACH item on your list (not for the whole description), judge:
    tests, third-party services. More surface = more time.
 
 3. **Clarity.** Specific requirements estimate tighter than vague
-   ones. If an item leaves open questions the agent will have to
-   resolve mid-task, add time for that exploration.
+   ones. If an item leaves open questions that have to be resolved
+   mid-task, add time for that exploration.
 
 4. **Verification.** Pure internal refactors verify by running
    tests. Anything touching data, auth, payments, or UI needs a
    real verification loop (run, click, observe, iterate).
 
-5. **Iteration overhead.** The agent typically writes, runs, sees
-   a failure, and fixes — 1-2 iteration loops on anything
+5. **Iteration overhead.** Real work is rarely right the first time —
+   write, run, see a failure, fix: 1-2 iteration loops on anything
    non-trivial. Bake that in per item.
 
-## Phase 4 — Sum and return
+6. **Who is doing it.** If an assignee with a known role/seniority is
+   given below, calibrate to them: a senior engineer on familiar work
+   is faster; a junior or someone new to the area needs more time and
+   iteration.
 
-Add up the per-item estimates. If two items genuinely share setup
-(e.g. both touch the same new file), don't double-count the setup.
-The final number is the sum of the unique work, not the sum of every
-line in the description.
+## Phase 4 — Produce the three-point range
+
+Add up the per-item estimates into a single **likely** figure. If two
+items genuinely share setup (e.g. both touch the same new file), don't
+double-count the setup. The likely number is the sum of the unique work,
+not the sum of every line in the description.
+
+Then bracket it:
+
+- **optimistic** — everything goes smoothly, no surprises, requirements
+  are exactly as clear as they look. Strictly ≤ likely.
+- **pessimistic** — realistic bad case: hidden complexity surfaces,
+  extra iteration, a tricky edge case. Strictly ≥ likely.
+- **confidence** — `high` when the work is well-specified and you have
+  good anchors; `medium` when there's moderate ambiguity; `low` when the
+  description is vague, the work is novel, or you have no anchors.
+
+The spread between optimistic and pessimistic should reflect the genuine
+uncertainty: tight for a well-specified copy tweak, wide for a vague
+integration.
 
 # Scope of the estimate
 
-The number represents the AI agent's wall-clock time:
+The numbers represent hands-on working time on the task:
 
 - Reading the task and locating the relevant code.
 - Planning the change.
@@ -108,19 +139,18 @@ The number represents the AI agent's wall-clock time:
 
 Do NOT include:
 
-- Human review or approval time.
+- Review or approval time by someone else.
 - Waiting for CI queues, deploys, or external systems.
 - Meetings, handoffs, or status updates.
 
 # Bounds
 
-- Minimum: 5 minutes.
+- Minimum: 5 minutes (applies to every figure).
 - Maximum: 10080 minutes (7 days). Anything that would genuinely
   take longer should have been split into multiple tasks.
 
-Pick a specific integer based on the work items. Do not default to
-round numbers like 60 / 120 / 240 unless the math actually lands
-there.
+Pick specific integers based on the work items. Do not default to
+round numbers like 60 / 120 / 240 unless the math actually lands there.
 
 # Worked examples
 
@@ -154,6 +184,10 @@ Shape:
 ```
 {
   "work_items": ["<item 1>", "<item 2>", ...],
+  "optimistic": <integer>,
+  "likely": <integer>,
+  "pessimistic": <integer>,
+  "confidence": "low" | "medium" | "high",
   "minutes": <integer>,
   "reasoning": "<one short sentence>"
 }
@@ -162,6 +196,11 @@ Shape:
 - `work_items` is the deduplicated list of distinct deliverables you
   extracted in Phase 2. Each entry is a short, concrete phrase.
   Keep this list to the items that actually drove the estimate.
-- `minutes` is an integer between 5 and 10080.
+- `optimistic`, `likely`, `pessimistic` are integers in [5, 10080] with
+  `optimistic` ≤ `likely` ≤ `pessimistic`.
+- `confidence` is one of `low`, `medium`, `high`.
+- `minutes` is your single best point estimate as an integer in
+  [5, 10080] — normally equal to `likely`. (It is kept for backward
+  compatibility; the caller may recompute a PERT point from the range.)
 - `reasoning` is one short sentence (under 25 words) naming the
   concrete factors that drove the number.

--- a/Modules/EstimatedTime/aiTaskEstimator.js
+++ b/Modules/EstimatedTime/aiTaskEstimator.js
@@ -1,12 +1,23 @@
 /**
  * AI-powered task time estimator.
  *
- * Given a freshly-created task, asks the configured LLM (Anthropic preferred,
- * OpenAI fallback — reuses the AIProjectGenerator/llmProvider factory) for an
- * estimated completion time assuming an AI coding agent (Claude Code) does
- * the work end-to-end with no human implementation effort. The estimate is
- * persisted to `tasks.totalEstimatedTime` (minutes) and broadcast over
+ * Given a task, asks the configured LLM (Anthropic preferred, OpenAI/DeepSeek
+ * fallback — reuses the AIProjectGenerator/llmProvider factory) for an
+ * estimated completion time. By default the target is a human DEVELOPER's
+ * effort (configurable via ESTIMATE_TARGET=human|agent). The point estimate
+ * is persisted to `tasks.totalEstimatedTime` (minutes) and broadcast over
  * Socket.io so connected clients see the value appear without a refresh.
+ *
+ * Accuracy is improved in three additive, fully optional layers — each wrapped
+ * so a failure degrades gracefully to the original single-call behaviour:
+ *
+ *   1. Historical grounding — completed similar tasks (same project + type)
+ *      and their ACTUAL logged minutes are injected as few-shot anchors.
+ *   2. Calibration — a clamped median(actual ÷ estimate) multiplier corrects
+ *      a systematic over/under bias for this team.
+ *   3. Range + confidence + self-consistency — the model returns a 3-point
+ *      range; a PERT point is computed, calibrated, and the model is sampled
+ *      N times (median combined) for stability.
  *
  * Designed to be invoked fire-and-forget right after task creation: it never
  * throws, never blocks the caller, and silently no-ops when no LLM provider
@@ -29,6 +40,16 @@ try {
     providerFactory = null;
 }
 
+// Historical-actuals grounding + calibration (additive). Loaded defensively
+// so a missing/renamed module can never break the base estimate — grounding
+// just no-ops (empty anchors, multiplier 1.0).
+let grounding = null;
+try {
+    grounding = require('./estimateGrounding');
+} catch (_e) {
+    grounding = null;
+}
+
 // Task activity-log + minute-formatting helpers, loaded defensively (same
 // pattern as providerFactory above) so a missing/renamed module can never
 // break the estimator — the activity-log entry just silently no-ops.
@@ -46,7 +67,7 @@ try {
 const AI_ACTOR_NAME = 'AlianHub AI';
 
 // Bounds chosen so a malformed LLM response can't write nonsense.
-// 5 minutes — smallest meaningful "AI does the task end-to-end" unit.
+// 5 minutes — smallest meaningful unit of work.
 // 7 days  — anything larger should be broken into subtasks.
 const MIN_MINUTES = 5;
 const MAX_MINUTES = 60 * 24 * 7;
@@ -58,11 +79,59 @@ const MAX_MINUTES = 60 * 24 * 7;
 const REQUEST_TIMEOUT_MS = 120_000;
 const DESCRIPTION_CHAR_CAP = 4000;
 
+// Estimate target: whose effort are we estimating?
+//   'human' (default) — a developer does the work by hand.
+//   'agent'           — an AI coding agent (Claude Code) does it end-to-end.
+// Config-only (env var); NO settings UI. Anything other than 'agent' is
+// treated as 'human' so a typo can never silently pick the agent calibration.
+const ESTIMATE_TARGET = (() => {
+    const raw = (process.env.ESTIMATE_TARGET || '').trim().toLowerCase();
+    return raw === 'agent' ? 'agent' : 'human';
+})();
+
+// Self-consistency: how many times to sample the model and combine (median
+// of the PERT points). Default 2 — cheap but smooths out a single unlucky
+// draw. Tunable via ESTIMATE_SAMPLES; clamped to [1, 5] so a bad env value
+// can't fan out an unbounded number of LLM calls.
+const ESTIMATE_SAMPLES = (() => {
+    const n = parseInt(process.env.ESTIMATE_SAMPLES, 10);
+    if (!Number.isFinite(n)) return 2;
+    if (n < 1) return 1;
+    if (n > 5) return 5;
+    return n;
+})();
+
+// Per-target prompt framing. Substituted into the {{ESTIMATE_TARGET_LABEL}}
+// and {{ESTIMATE_TARGET_GUIDANCE}} placeholders in the prompt .md so the
+// same pipeline serves both targets without two prompt files.
+const TARGET_FRAGMENTS = {
+    human: {
+        label: 'human software developer who will implement the work by hand',
+        guidance:
+            'Estimate a competent human developer\'s hands-on working time: '
+            + 'reading the task, locating code, designing the change, writing it, '
+            + 'running it, fixing what breaks, and self-verifying. Assume normal '
+            + 'human pace with realistic context-switching and iteration — not an '
+            + 'idealised uninterrupted sprint, and not an AI agent.',
+    },
+    agent: {
+        label: 'AI coding agent (Claude Code) doing the work end-to-end with no manual human implementation',
+        guidance:
+            'Estimate the AI agent\'s wall-clock time to complete the task '
+            + 'end-to-end with no human implementation effort: reading the task, '
+            + 'planning, editing files, running commands/builds/tests, and '
+            + 'self-verifying.',
+    },
+};
+
 // Load the system prompt from the shared AIProjectGenerator prompts dir so
 // it lives alongside the other model-facing prompts and can be edited
 // without a code change. Read once at module load (require() caches this
 // module) — zero file I/O per estimate call. BOM stripped and CRLF
 // normalized so files authored on different OSes produce identical bytes.
+// The {{ESTIMATE_TARGET_*}} placeholders are substituted for the configured
+// target; if the template ever lacks them (older prompt), the substitution
+// is a harmless no-op and the prompt still works.
 const SYSTEM_PROMPT = (() => {
     const promptPath = path.join(
         __dirname,
@@ -73,7 +142,11 @@ const SYSTEM_PROMPT = (() => {
         'task-time-estimate.md',
     );
     const raw = fs.readFileSync(promptPath, 'utf8');
-    return raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').trim();
+    const cleaned = raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').trim();
+    const frag = TARGET_FRAGMENTS[ESTIMATE_TARGET] || TARGET_FRAGMENTS.human;
+    return cleaned
+        .replace(/\{\{ESTIMATE_TARGET_LABEL\}\}/g, frag.label)
+        .replace(/\{\{ESTIMATE_TARGET_GUIDANCE\}\}/g, frag.guidance);
 })();
 
 function extractDescription(task) {
@@ -148,7 +221,60 @@ function normalizeDescriptionForPrompt(text) {
     return out.join('\n').trim();
 }
 
-function buildUserMessage(task) {
+/**
+ * Render assignee role/seniority cheaply IF it's already on the task doc.
+ * We do NOT make extra DB calls here — only use fields the caller passed.
+ * Returns '' when nothing useful is available (so the prompt is unchanged).
+ */
+function describeAssignee(task) {
+    if (!task) return '';
+    // Accept a few shapes defensively — different call sites attach assignee
+    // metadata differently, and we only want it when it's cheaply present.
+    const a = task.assigneeInfo || task.primaryAssignee || null;
+    if (a && typeof a === 'object') {
+        const role = a.role || a.Designation || a.title || a.seniority || '';
+        const name = a.name || a.Employee_Name || '';
+        const desc = [name, role].filter(Boolean).join(' — ');
+        if (desc) return desc;
+    }
+    if (typeof task.assigneeRole === 'string' && task.assigneeRole.trim()) {
+        return task.assigneeRole.trim();
+    }
+    return '';
+}
+
+/** Compact list of subtask titles for parent tasks (already fetched). */
+function describeSubtasks(task) {
+    const subs = task && Array.isArray(task.subtaskTitles) ? task.subtaskTitles : null;
+    if (!subs || !subs.length) return '';
+    const titles = subs
+        .map((s) => (typeof s === 'string' ? s : (s && s.TaskName) || ''))
+        .filter((t) => typeof t === 'string' && t.trim())
+        .slice(0, 25);
+    if (!titles.length) return '';
+    return titles.map((t) => `- ${t}`).join('\n');
+}
+
+/** Normalize tags to a short comma-joined string (defensive about shape). */
+function describeTags(task) {
+    const tags = task && Array.isArray(task.tagsArray) ? task.tagsArray : null;
+    if (!tags || !tags.length) return '';
+    const names = [];
+    for (const t of tags) {
+        if (typeof t === 'string' && t.trim()) names.push(t.trim());
+        else if (t && typeof t.name === 'string' && t.name.trim()) names.push(t.name.trim());
+        else if (t && typeof t.title === 'string' && t.title.trim()) names.push(t.title.trim());
+    }
+    return names.slice(0, 20).join(', ');
+}
+
+/**
+ * Build the user message. `anchorsBlock` (optional) is the rendered
+ * comparable-past-tasks block from the grounding helper — appended verbatim
+ * when present, omitted entirely when absent so the no-history prompt is
+ * identical to before.
+ */
+function buildUserMessage(task, anchorsBlock = '') {
     const title = (task && task.TaskName) ? String(task.TaskName) : '(no title)';
     const priority = (task && task.Task_Priority) ? String(task.Task_Priority) : 'MEDIUM';
     const taskType = (task && task.TaskType) ? String(task.TaskType) : 'task';
@@ -157,17 +283,34 @@ function buildUserMessage(task) {
     if (description.length > DESCRIPTION_CHAR_CAP) {
         description = `${description.slice(0, DESCRIPTION_CHAR_CAP)}…`;
     }
-    return [
+
+    const lines = [
         `Task title: ${title}`,
         `Task type: ${taskType}`,
         `Priority: ${priority}`,
         `Is parent task: ${isParent ? 'yes' : 'no (subtask)'}`,
-        '',
-        'Description:',
-        description || '(no description provided — estimate from the title only)',
+    ];
+
+    const tags = describeTags(task);
+    if (tags) lines.push(`Tags: ${tags}`);
+
+    const assignee = describeAssignee(task);
+    if (assignee) lines.push(`Assignee: ${assignee}`);
+
+    lines.push('', 'Description:', description || '(no description provided — estimate from the title only)');
+
+    const subtasks = describeSubtasks(task);
+    if (subtasks) {
+        lines.push('', 'Subtasks (account for each in the total):', subtasks);
+    }
+
+    if (anchorsBlock) lines.push(anchorsBlock);
+
+    lines.push(
         '',
         'Follow the four-phase pipeline in the system prompt. Deduplicate before estimating; do not double-count overlapping requirements.',
-    ].join('\n');
+    );
+    return lines.join('\n');
 }
 
 function clampMinutes(value) {
@@ -179,7 +322,19 @@ function clampMinutes(value) {
     return rounded;
 }
 
-function parseMinutes(content) {
+const VALID_CONFIDENCE = new Set(['low', 'medium', 'high']);
+
+function normalizeConfidence(value) {
+    if (typeof value !== 'string') return null;
+    const v = value.trim().toLowerCase();
+    return VALID_CONFIDENCE.has(v) ? v : null;
+}
+
+/**
+ * Strip code fences and parse the model's JSON, tolerating prose around it.
+ * Returns the parsed object or null.
+ */
+function parseJsonLoose(content) {
     if (typeof content !== 'string') return null;
     const trimmed = content.trim();
     if (!trimmed) return null;
@@ -189,62 +344,284 @@ function parseMinutes(content) {
         .trim();
     try {
         const parsed = JSON.parse(stripped);
-        if (parsed && typeof parsed === 'object') {
-            if ('minutes' in parsed) return clampMinutes(parsed.minutes);
-            if ('estimate' in parsed) return clampMinutes(parsed.estimate);
-            if ('totalEstimatedTime' in parsed) return clampMinutes(parsed.totalEstimatedTime);
-        }
+        if (parsed && typeof parsed === 'object') return parsed;
     } catch (_e) {
-        // Fall through to regex rescue below.
+        // Try to rescue the first {...} block from surrounding prose.
+        const match = stripped.match(/\{[\s\S]*\}/);
+        if (match) {
+            try {
+                const parsed = JSON.parse(match[0]);
+                if (parsed && typeof parsed === 'object') return parsed;
+            } catch (_e2) { /* fall through */ }
+        }
     }
-    const keyMatch = stripped.match(/"minutes"\s*:\s*(-?\d+(?:\.\d+)?)/);
-    if (keyMatch) return clampMinutes(keyMatch[1]);
-    const bareNumber = stripped.match(/^\s*(-?\d+(?:\.\d+)?)\s*$/);
-    return bareNumber ? clampMinutes(bareNumber[1]) : null;
+    return null;
 }
 
-async function callProvider(task) {
+/**
+ * Backward-compatible point parser. Returns a single integer (minutes) or
+ * null. Kept for the original contract / unit tests: accepts the old
+ * { minutes } shape AND the new ranged shape, and even a bare number.
+ */
+function parseMinutes(content) {
+    const parsed = parseJsonLoose(content);
+    if (parsed) {
+        if ('minutes' in parsed) {
+            const m = clampMinutes(parsed.minutes);
+            if (m != null) return m;
+        }
+        if ('likely' in parsed) {
+            const m = clampMinutes(parsed.likely);
+            if (m != null) return m;
+        }
+        if ('estimate' in parsed) {
+            const m = clampMinutes(parsed.estimate);
+            if (m != null) return m;
+        }
+        if ('totalEstimatedTime' in parsed) {
+            const m = clampMinutes(parsed.totalEstimatedTime);
+            if (m != null) return m;
+        }
+    }
+    if (typeof content === 'string') {
+        const stripped = content.trim()
+            .replace(/^```(?:json)?\s*/i, '').replace(/```$/i, '').trim();
+        const keyMatch = stripped.match(/"(?:minutes|likely)"\s*:\s*(-?\d+(?:\.\d+)?)/);
+        if (keyMatch) return clampMinutes(keyMatch[1]);
+        const bareNumber = stripped.match(/^\s*(-?\d+(?:\.\d+)?)\s*$/);
+        if (bareNumber) return clampMinutes(bareNumber[1]);
+    }
+    return null;
+}
+
+/**
+ * Parse the full ranged estimate from one model response. Returns a normalized
+ * sample object, or null when nothing usable could be extracted.
+ *
+ *   { point, optimistic, likely, pessimistic, confidence, work_items, reasoning }
+ *
+ * `point` is the PERT estimate (O + 4·likely + P)/6 when a full range is
+ * present, otherwise the single point — always clamped. The ranged fields
+ * fall back to the point when the model omitted them, so a model that still
+ * answers the OLD { minutes } shape produces a valid (degenerate) sample.
+ */
+function parseEstimateSample(content) {
+    const parsed = parseJsonLoose(content);
+
+    // Fallback: no JSON object → reuse the legacy point parser (handles bare
+    // numbers / regex rescue) and synthesize a degenerate sample.
+    if (!parsed) {
+        const point = parseMinutes(content);
+        if (point == null) return null;
+        return {
+            point,
+            optimistic: point,
+            likely: point,
+            pessimistic: point,
+            confidence: null,
+            work_items: [],
+            reasoning: '',
+        };
+    }
+
+    const likely = clampMinutes(parsed.likely != null ? parsed.likely : parsed.minutes);
+    const optimisticRaw = clampMinutes(parsed.optimistic);
+    const pessimisticRaw = clampMinutes(parsed.pessimistic);
+    const pointFallback = clampMinutes(parsed.minutes != null ? parsed.minutes : parsed.likely);
+
+    // Need at least one usable number.
+    if (likely == null && pointFallback == null && optimisticRaw == null && pessimisticRaw == null) {
+        return null;
+    }
+
+    const base = likely != null ? likely : pointFallback;
+    let optimistic = optimisticRaw != null ? optimisticRaw : base;
+    let pessimistic = pessimisticRaw != null ? pessimisticRaw : base;
+    const mid = base != null ? base : Math.round((optimistic + pessimistic) / 2);
+
+    // Enforce optimistic ≤ likely ≤ pessimistic (models occasionally swap).
+    optimistic = Math.min(optimistic, mid);
+    pessimistic = Math.max(pessimistic, mid);
+
+    // PERT point estimate from the (sanitized) three-point range.
+    const pert = clampMinutes((optimistic + 4 * mid + pessimistic) / 6);
+    const point = pert != null ? pert : (pointFallback != null ? pointFallback : mid);
+
+    const workItems = Array.isArray(parsed.work_items)
+        ? parsed.work_items.filter((w) => typeof w === 'string' && w.trim()).slice(0, 50)
+        : [];
+    const reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning.trim().slice(0, 500) : '';
+
+    return {
+        point,
+        optimistic,
+        likely: mid,
+        pessimistic,
+        confidence: normalizeConfidence(parsed.confidence),
+        work_items: workItems,
+        reasoning,
+    };
+}
+
+/** Median of a numeric array; null on empty. */
+function medianOf(nums) {
+    const arr = (nums || []).filter((n) => Number.isFinite(n));
+    if (!arr.length) return null;
+    const sorted = arr.slice().sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/** Pick the most common confidence among samples (ties → highest present). */
+function combineConfidence(samples) {
+    const order = ['low', 'medium', 'high'];
+    const counts = { low: 0, medium: 0, high: 0 };
+    let any = false;
+    for (const s of samples) {
+        if (s && s.confidence && counts[s.confidence] != null) { counts[s.confidence] += 1; any = true; }
+    }
+    if (!any) return null;
+    let best = null;
+    let bestCount = -1;
+    for (const level of order) {
+        if (counts[level] >= bestCount) { bestCount = counts[level]; best = level; }
+    }
+    return best;
+}
+
+/** Resolve the provider once (or null when none is configured). */
+function resolveProvider() {
     if (!providerFactory || typeof providerFactory.getProvider !== 'function') return null;
     if (typeof providerFactory.isAnyProviderConfigured === 'function'
         && !providerFactory.isAnyProviderConfigured()) {
         return null;
     }
-    let provider;
     try {
-        provider = providerFactory.getProvider();
+        return providerFactory.getProvider();
     } catch (_e) {
         return null;
     }
-    const userMessage = buildUserMessage(task);
-    const chatPromise = provider.chat({
-        systemPrompt: SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: userMessage }],
-        jsonMode: true,
-        // Low temperature pulls the model toward deterministic, calibrated
-        // numbers — accuracy depends on the model NOT being creative here.
-        temperature: 0.15,
-        // The visible JSON answer (work_items[] + minutes + reasoning) is
-        // tiny — ~300-500 tokens — so 1024 was fine for non-thinking models
-        // (GPT-4.1, Claude, deepseek-chat). But THINKING models
-        // (deepseek-reasoner, deepseek-v4-pro, OpenAI o-series) spend their
-        // output budget on hidden chain-of-thought BEFORE the visible JSON.
-        // At 1024 the reasoning consumed the entire budget and the model
-        // emitted an EMPTY answer (finish_reason="length") → parseMinutes
-        // returned null → no estimate was ever saved. 8192 gives the
-        // reasoning ample room while the model still self-terminates
-        // (finish_reason="stop") at ~1000-1300 tokens, so non-thinking
-        // models pay nothing for the larger ceiling.
-        maxTokens: 8192,
-    });
-    const result = await Promise.race([
-        chatPromise,
-        new Promise((_, reject) => setTimeout(
-            () => reject(new Error('AI estimate request timed out')),
-            REQUEST_TIMEOUT_MS,
-        )),
-    ]);
-    if (!result || typeof result.content !== 'string') return null;
-    return parseMinutes(result.content);
+}
+
+/** One model call → one parsed sample (or null). Never throws. */
+async function callOnce(provider, userMessage) {
+    try {
+        const chatPromise = provider.chat({
+            systemPrompt: SYSTEM_PROMPT,
+            messages: [{ role: 'user', content: userMessage }],
+            jsonMode: true,
+            // Low temperature pulls the model toward deterministic, calibrated
+            // numbers — accuracy depends on the model NOT being creative here.
+            temperature: 0.15,
+            // The visible JSON answer (work_items[] + range + minutes +
+            // reasoning) is small — ~400-600 tokens — but THINKING models
+            // (deepseek-reasoner, deepseek-v4-pro, OpenAI o-series) spend their
+            // output budget on hidden chain-of-thought BEFORE the visible JSON.
+            // 8192 gives the reasoning ample room while non-thinking models
+            // (GPT-4.1, Claude, deepseek-chat) self-terminate well under it.
+            maxTokens: 8192,
+        });
+        const result = await Promise.race([
+            chatPromise,
+            new Promise((_, reject) => setTimeout(
+                () => reject(new Error('AI estimate request timed out')),
+                REQUEST_TIMEOUT_MS,
+            )),
+        ]);
+        if (!result || typeof result.content !== 'string') return null;
+        return parseEstimateSample(result.content);
+    } catch (e) {
+        logger.error(`AI estimate sample failed: ${e && e.message ? e.message : e}`);
+        return null;
+    }
+}
+
+/**
+ * Run the estimate: build the message (with optional grounding anchors),
+ * sample the model ESTIMATE_SAMPLES times, combine by median of the PERT
+ * points, apply the calibration multiplier, and return the full estimate
+ * object — or null when every sample failed.
+ *
+ * @returns {Promise<null | {
+ *   minutes:number, optimistic:number, likely:number, pessimistic:number,
+ *   confidence:(string|null), work_items:string[], reasoning:string,
+ *   basedOnSamples:number, calibrationMultiplier:number, modelSamples:number
+ * }>}
+ */
+async function runEstimate(companyId, task) {
+    const provider = resolveProvider();
+    if (!provider) return null;
+
+    // --- Grounding (additive, best-effort) ---
+    let anchorsBlock = '';
+    let multiplier = 1;
+    let basedOnSamples = 0;
+    try {
+        if (grounding && typeof grounding.buildGrounding === 'function' && companyId) {
+            const g = await grounding.buildGrounding(companyId, task);
+            if (g) {
+                multiplier = (typeof g.multiplier === 'number' && g.multiplier > 0) ? g.multiplier : 1;
+                basedOnSamples = Number.isFinite(g.sampleCount) ? g.sampleCount : 0;
+                if (typeof grounding.renderAnchorsForPrompt === 'function') {
+                    anchorsBlock = grounding.renderAnchorsForPrompt(g.anchors) || '';
+                }
+            }
+        }
+    } catch (e) {
+        // Grounding failure must never break the estimate.
+        logger.error(`AI estimate grounding step failed: ${e && e.message ? e.message : e}`);
+        anchorsBlock = '';
+        multiplier = 1;
+        basedOnSamples = 0;
+    }
+
+    const userMessage = buildUserMessage(task, anchorsBlock);
+
+    // --- Sample the model (self-consistency) ---
+    const samples = [];
+    for (let i = 0; i < ESTIMATE_SAMPLES; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        const sample = await callOnce(provider, userMessage);
+        if (sample) samples.push(sample);
+    }
+    if (!samples.length) return null;
+
+    // Combine: median of the per-sample PERT points, plus median of each
+    // range bound, then apply the calibration multiplier to the points.
+    const rawPoint = medianOf(samples.map((s) => s.point));
+    const rawOptimistic = medianOf(samples.map((s) => s.optimistic));
+    const rawLikely = medianOf(samples.map((s) => s.likely));
+    const rawPessimistic = medianOf(samples.map((s) => s.pessimistic));
+
+    const minutes = clampMinutes((rawPoint != null ? rawPoint : rawLikely) * multiplier);
+    if (minutes == null) return null;
+
+    const optimistic = clampMinutes((rawOptimistic != null ? rawOptimistic : rawPoint) * multiplier);
+    const likely = clampMinutes((rawLikely != null ? rawLikely : rawPoint) * multiplier);
+    const pessimistic = clampMinutes((rawPessimistic != null ? rawPessimistic : rawPoint) * multiplier);
+
+    // Re-assert ordering after independent clamping.
+    const o = Math.min(optimistic != null ? optimistic : minutes, minutes);
+    const p = Math.max(pessimistic != null ? pessimistic : minutes, minutes);
+    const l = likely != null ? Math.min(Math.max(likely, o), p) : minutes;
+
+    // Prefer the richest sample's work_items/reasoning (most work items).
+    const richest = samples.reduce((best, s) => (
+        (s.work_items.length > (best ? best.work_items.length : -1)) ? s : best
+    ), null) || samples[0];
+
+    return {
+        minutes,
+        optimistic: o,
+        likely: l,
+        pessimistic: p,
+        confidence: combineConfidence(samples),
+        work_items: richest.work_items || [],
+        reasoning: richest.reasoning || '',
+        basedOnSamples,
+        calibrationMultiplier: multiplier,
+        modelSamples: samples.length,
+    };
 }
 
 async function persistEstimate(companyId, taskId, minutes, opts = {}) {
@@ -332,7 +709,10 @@ function logEstimateHistory({ companyId, result, taskId, minutes, userData, prev
  * @param {object} [params.userData]  Optional actor for the activity-log entry
  *                                    ({ id, Employee_Name }). Defaults to the
  *                                    "AlianHub AI" actor when omitted.
- * @returns {Promise<{status: boolean, minutes?: number, reason?: string}>}
+ * @returns {Promise<{status: boolean, minutes?: number, optimistic?: number,
+ *   likely?: number, pessimistic?: number, confidence?: (string|null),
+ *   work_items?: string[], reasoning?: string, basedOnSamples?: number,
+ *   reason?: string}>}
  */
 async function estimateAndPersist({ companyId, taskId, task, force = false, userData } = {}) {
     try {
@@ -357,12 +737,26 @@ async function estimateAndPersist({ companyId, taskId, task, force = false, user
         const previousMinutes = (typeof task.totalEstimatedTime === 'number')
             ? task.totalEstimatedTime
             : null;
-        const minutes = await callProvider(task);
-        if (minutes == null) {
+
+        const estimate = await runEstimate(companyId, task);
+        if (!estimate || estimate.minutes == null) {
             return { status: false, reason: 'no estimate returned' };
         }
-        await persistEstimate(companyId, taskId, minutes, { userData, previousMinutes });
-        return { status: true, minutes };
+
+        // Persist the SAME stored field, same shape, as always.
+        await persistEstimate(companyId, taskId, estimate.minutes, { userData, previousMinutes });
+
+        return {
+            status: true,
+            minutes: estimate.minutes,
+            optimistic: estimate.optimistic,
+            likely: estimate.likely,
+            pessimistic: estimate.pessimistic,
+            confidence: estimate.confidence,
+            work_items: estimate.work_items,
+            reasoning: estimate.reasoning,
+            basedOnSamples: estimate.basedOnSamples,
+        };
     } catch (error) {
         logger.error(`AI task estimator failed for task ${taskId}: ${error && error.message ? error.message : error}`);
         return { status: false, reason: (error && error.message) || 'estimator error' };
@@ -375,9 +769,19 @@ module.exports = {
     _internal: {
         clampMinutes,
         parseMinutes,
+        parseEstimateSample,
+        parseJsonLoose,
         buildUserMessage,
         extractDescription,
         normalizeDescriptionForPrompt,
+        describeTags,
+        describeSubtasks,
+        describeAssignee,
+        medianOf,
+        combineConfidence,
+        normalizeConfidence,
+        ESTIMATE_TARGET,
+        ESTIMATE_SAMPLES,
         MIN_MINUTES,
         MAX_MINUTES,
     },

--- a/Modules/EstimatedTime/controller.js
+++ b/Modules/EstimatedTime/controller.js
@@ -93,7 +93,9 @@ exports.generateAiEstimate = async (req, res) => {
 
         // Fetch the task with just the fields the estimator needs so the
         // payload to the LLM is built from the canonical DB state — not
-        // from whatever stale shape the client happened to send.
+        // from whatever stale shape the client happened to send. ProjectID +
+        // tagsArray feed the historical-actuals grounding/calibration; the
+        // rest feed the prompt.
         const taskObj = {
             type: SCHEMA_TYPE.TASKS,
             data: [
@@ -106,12 +108,44 @@ exports.generateAiEstimate = async (req, res) => {
                     rawDescription: 1,
                     descriptionBlock: 1,
                     totalEstimatedTime: 1,
+                    ProjectID: 1,
+                    tagsArray: 1,
                 },
             ],
         };
-        const taskDoc = await MongoDbCrudOpration(companyId, taskObj, 'findOne');
-        if (!taskDoc || !taskDoc._id) {
+        const taskDocRaw = await MongoDbCrudOpration(companyId, taskObj, 'findOne');
+        if (!taskDocRaw || !taskDocRaw._id) {
             return res.status(404).json({ status: false, statusText: 'task not found' });
+        }
+        // Work with a plain object so we can attach derived fields (e.g.
+        // subtaskTitles) that aren't part of the task schema — a Mongoose doc
+        // would silently drop unknown-path assignments.
+        const taskDoc = (typeof taskDocRaw.toObject === 'function')
+            ? taskDocRaw.toObject()
+            : taskDocRaw;
+
+        // Subtask rollup (richer input): if this is a parent task, attach its
+        // subtasks' titles so the model accounts for the work they represent.
+        // Best-effort and capped — a failure here must not block the estimate.
+        if (taskDoc.isParentTask !== false) {
+            try {
+                const subs = await MongoDbCrudOpration(companyId, {
+                    type: SCHEMA_TYPE.TASKS,
+                    data: [
+                        {
+                            ParentTaskId: String(taskId),
+                            deletedStatusKey: { $in: [0, undefined] },
+                        },
+                        { TaskName: 1 },
+                        { limit: 50 },
+                    ],
+                }, 'find').catch(() => []);
+                if (Array.isArray(subs) && subs.length) {
+                    taskDoc.subtaskTitles = subs
+                        .map((s) => (s && s.TaskName ? String(s.TaskName) : ''))
+                        .filter(Boolean);
+                }
+            } catch (_e) { /* subtask rollup is best-effort */ }
         }
 
         // Actor for the activity-log entry the estimator writes. The client
@@ -138,10 +172,24 @@ exports.generateAiEstimate = async (req, res) => {
                 statusText: result.reason || 'estimate not generated',
             });
         }
+        // Return the full ranged estimate so the UI can surface the
+        // optimistic/likely/pessimistic range + confidence. `totalEstimatedTime`
+        // (the persisted point estimate) is kept exactly as before for any
+        // existing consumer of this response.
         return res.status(200).json({
             status: true,
             statusText: 'Estimate generated successfully',
-            data: { totalEstimatedTime: result.minutes },
+            data: {
+                totalEstimatedTime: result.minutes,
+                minutes: result.minutes,
+                optimistic: result.optimistic,
+                likely: result.likely,
+                pessimistic: result.pessimistic,
+                confidence: result.confidence,
+                work_items: result.work_items,
+                reasoning: result.reasoning,
+                basedOnSamples: result.basedOnSamples,
+            },
         });
     } catch (error) {
         loggerConfig.error(`generateAiEstimate error: ${error && error.message ? error.message : error}`);

--- a/Modules/EstimatedTime/estimateGrounding.js
+++ b/Modules/EstimatedTime/estimateGrounding.js
@@ -1,0 +1,306 @@
+/**
+ * Historical-actuals grounding + calibration for the AI time estimator.
+ *
+ * Everything here is ADDITIVE and READ-ONLY. It is called at estimate time
+ * to make the LLM's number more accurate by:
+ *
+ *   1. Finding the company's COMPLETED tasks that are "similar" to the one
+ *      being estimated (same project + same TaskType, preferring overlapping
+ *      tags) and pairing each with its ACTUAL logged minutes (summed from the
+ *      timesheet) and its prior estimate. These become few-shot anchors in
+ *      the prompt ("comparable past tasks — title, est, actual").
+ *
+ *   2. Computing a calibration multiplier = median(actual ÷ estimate) over
+ *      those comparable pairs, clamped to a sane range, applied to the
+ *      model's raw estimate to correct a systematic over/under bias.
+ *
+ * NON-NEGOTIABLE: none of this may break the base estimate. Every query is
+ * wrapped so a failure (no provider, no history, slow/broken query) yields
+ * empty anchors + a no-op multiplier (1.0), and the caller falls back to the
+ * exact single-call behaviour that shipped before.
+ *
+ * Units: timesheet `LogTimeDuration` is stored in MINUTES (see
+ * Modules/LogTime/controllerV2/manualLogtime.js — `diffMin = h*60 + m`), the
+ * same unit as `tasks.totalEstimatedTime`, so logged time and estimates are
+ * directly comparable with no conversion.
+ */
+'use strict';
+
+const mongoose = require('mongoose');
+const logger = require('../../Config/loggerConfig');
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+
+// Cap how many completed tasks we scan and how many anchors we surface, so
+// the grounding queries stay cheap on large companies. We over-fetch a few
+// candidates (CANDIDATE_LIMIT) then rank them by similarity and keep the best
+// ANCHOR_LIMIT for the prompt / calibration.
+const CANDIDATE_LIMIT = 40;
+const ANCHOR_LIMIT = 5;
+
+// Calibration needs a minimum signal before it's trustworthy — with fewer
+// than this many (estimate, actual) pairs the multiplier stays 1.0 (no-op).
+const MIN_PAIRS_FOR_CALIBRATION = 3;
+
+// Clamp the multiplier so a handful of wildly-off historical tasks can't
+// blow up (or zero out) a fresh estimate. 0.5–2.0 = "trust history to halve
+// or double the model, no more".
+const CALIBRATION_MIN = 0.5;
+const CALIBRATION_MAX = 2.0;
+
+// Status types that mean "this task is finished" (see utils/Tempates/
+// task_status.js — the done/complete column carries type "close").
+const COMPLETED_STATUS_TYPES = ['close'];
+
+function toObjectIdString(value) {
+    return value == null ? '' : String(value);
+}
+
+/**
+ * Sum logged minutes per task from the timesheet collection for a set of
+ * task ids, in a single grouped aggregate. Returns a Map<taskId, minutes>.
+ *
+ * `LogTimeDuration` is minutes (see file header). `TicketID` is stored as a
+ * string id, so we match on string ids. Best-effort: any failure resolves to
+ * an empty Map so the caller simply gets no actuals.
+ */
+async function sumLoggedMinutesByTask(companyId, taskIds) {
+    const ids = (taskIds || []).map(toObjectIdString).filter(Boolean);
+    if (!ids.length) return new Map();
+    try {
+        const rows = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.TIMESHEET,
+            data: [
+                [
+                    { $match: { TicketID: { $in: ids } } },
+                    {
+                        $group: {
+                            _id: '$TicketID',
+                            minutes: { $sum: '$LogTimeDuration' },
+                        },
+                    },
+                ],
+            ],
+        }, 'aggregate').catch(() => []);
+        const map = new Map();
+        for (const row of (rows || [])) {
+            if (!row || row._id == null) continue;
+            const minutes = Number(row.minutes);
+            if (Number.isFinite(minutes) && minutes > 0) {
+                map.set(String(row._id), minutes);
+            }
+        }
+        return map;
+    } catch (_e) {
+        return new Map();
+    }
+}
+
+/**
+ * Fetch completed, non-deleted tasks in the same project + same TaskType as
+ * the target task. Read-only, company-scoped, capped at CANDIDATE_LIMIT and
+ * sorted most-recent-first. Returns [] on any failure or missing inputs.
+ */
+async function fetchCompletedSimilarTasks(companyId, task) {
+    if (!task || !task.ProjectID) return [];
+    let projectId;
+    try {
+        projectId = new mongoose.Types.ObjectId(String(task.ProjectID));
+    } catch (_e) {
+        return [];
+    }
+    const taskType = task.TaskType ? String(task.TaskType) : null;
+    const selfId = toObjectIdString(task._id);
+
+    const filter = {
+        ProjectID: projectId,
+        statusType: { $in: COMPLETED_STATUS_TYPES },
+        deletedStatusKey: { $in: [0, undefined] },
+    };
+    if (taskType) filter.TaskType = taskType;
+    if (selfId) {
+        try {
+            filter._id = { $ne: new mongoose.Types.ObjectId(selfId) };
+        } catch (_e) { /* ignore — self-exclusion is best-effort */ }
+    }
+
+    try {
+        const rows = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.TASKS,
+            data: [
+                filter,
+                {
+                    _id: 1, TaskName: 1, TaskType: 1, tagsArray: 1,
+                    totalEstimatedTime: 1, updatedAt: 1,
+                },
+                { sort: { updatedAt: -1, _id: -1 }, limit: CANDIDATE_LIMIT },
+            ],
+        }, 'find').catch(() => []);
+        return Array.isArray(rows) ? rows : [];
+    } catch (_e) {
+        return [];
+    }
+}
+
+/** Normalize a task's tags to a lowercase string array (defensive). */
+function normalizeTags(tagsArray) {
+    if (!Array.isArray(tagsArray)) return [];
+    const out = [];
+    for (const t of tagsArray) {
+        if (typeof t === 'string' && t.trim()) out.push(t.trim().toLowerCase());
+        else if (t && typeof t.name === 'string' && t.name.trim()) out.push(t.name.trim().toLowerCase());
+        else if (t && typeof t.title === 'string' && t.title.trim()) out.push(t.title.trim().toLowerCase());
+    }
+    return out;
+}
+
+/** Count how many tags two normalized tag-lists share. */
+function tagOverlapCount(aTags, bTags) {
+    if (!aTags.length || !bTags.length) return 0;
+    const set = new Set(aTags);
+    let n = 0;
+    for (const t of bTags) if (set.has(t)) n += 1;
+    return n;
+}
+
+/**
+ * Build the grounding payload for a task:
+ *   { anchors: [{ title, estimate, actual }], multiplier, sampleCount }
+ *
+ * anchors    — up to ANCHOR_LIMIT comparable completed tasks, each with a
+ *              numeric estimate and/or actual logged minutes, ranked by tag
+ *              overlap then recency. Used as few-shot examples in the prompt.
+ * multiplier — calibration factor in [CALIBRATION_MIN, CALIBRATION_MAX], or
+ *              1.0 when there are < MIN_PAIRS_FOR_CALIBRATION (estimate,
+ *              actual) pairs. Multiply the model's raw minutes by this.
+ * sampleCount— number of comparable tasks that contributed (for the API
+ *              response `basedOnSamples`).
+ *
+ * NEVER throws. On any failure returns the safe no-op shape
+ * { anchors: [], multiplier: 1, sampleCount: 0 } so the estimator falls back
+ * to today's behaviour.
+ */
+async function buildGrounding(companyId, task) {
+    const EMPTY = { anchors: [], multiplier: 1, sampleCount: 0 };
+    try {
+        if (!companyId || !task) return EMPTY;
+
+        const candidates = await fetchCompletedSimilarTasks(companyId, task);
+        if (!candidates.length) return EMPTY;
+
+        // Rank by tag overlap with the target, then keep a generous slice to
+        // look up actuals for. (We still cap anchors below.)
+        const targetTags = normalizeTags(task.tagsArray);
+        const ranked = candidates
+            .map((c) => ({
+                doc: c,
+                overlap: tagOverlapCount(targetTags, normalizeTags(c.tagsArray)),
+            }))
+            .sort((a, b) => b.overlap - a.overlap);
+
+        const idsForActuals = ranked.map((r) => toObjectIdString(r.doc._id)).filter(Boolean);
+        const actualsByTask = await sumLoggedMinutesByTask(companyId, idsForActuals);
+
+        // Assemble comparable records: keep only those with a usable estimate
+        // and/or actual. Prefer ones that have BOTH (they drive calibration).
+        const comparables = [];
+        for (const { doc } of ranked) {
+            const id = toObjectIdString(doc._id);
+            const estimate = Number(doc.totalEstimatedTime);
+            const actual = actualsByTask.get(id);
+            const hasEstimate = Number.isFinite(estimate) && estimate > 0;
+            const hasActual = Number.isFinite(actual) && actual > 0;
+            if (!hasEstimate && !hasActual) continue;
+            comparables.push({
+                title: doc.TaskName ? String(doc.TaskName) : '(untitled task)',
+                estimate: hasEstimate ? Math.round(estimate) : null,
+                actual: hasActual ? Math.round(actual) : null,
+            });
+        }
+
+        if (!comparables.length) return EMPTY;
+
+        // Calibration: median(actual ÷ estimate) over pairs that have BOTH a
+        // positive estimate and positive actual.
+        const ratios = [];
+        for (const c of comparables) {
+            if (c.estimate && c.actual) ratios.push(c.actual / c.estimate);
+        }
+        const multiplier = computeCalibrationMultiplier(ratios);
+
+        // Anchors: the most-similar comparable tasks (already ranked), capped.
+        const anchors = comparables.slice(0, ANCHOR_LIMIT);
+
+        return { anchors, multiplier, sampleCount: comparables.length };
+    } catch (e) {
+        logger.error(`estimate grounding failed: ${e && e.message ? e.message : e}`);
+        return EMPTY;
+    }
+}
+
+/** Median of a numeric array (sorted copy); null on empty. */
+function median(nums) {
+    if (!nums || !nums.length) return null;
+    const sorted = nums.slice().sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[mid - 1] + sorted[mid]) / 2
+        : sorted[mid];
+}
+
+/**
+ * Calibration multiplier from a list of actual/estimate ratios.
+ * - < MIN_PAIRS_FOR_CALIBRATION ratios → 1.0 (no-op; not enough signal).
+ * - otherwise median(ratios) clamped to [CALIBRATION_MIN, CALIBRATION_MAX].
+ */
+function computeCalibrationMultiplier(ratios) {
+    const valid = (ratios || []).filter((r) => Number.isFinite(r) && r > 0);
+    if (valid.length < MIN_PAIRS_FOR_CALIBRATION) return 1;
+    const med = median(valid);
+    if (!Number.isFinite(med) || med <= 0) return 1;
+    if (med < CALIBRATION_MIN) return CALIBRATION_MIN;
+    if (med > CALIBRATION_MAX) return CALIBRATION_MAX;
+    return med;
+}
+
+/**
+ * Render the anchors as a compact, model-friendly block to append to the user
+ * message. Returns '' when there are no anchors (so the prompt is byte-for-byte
+ * identical to today when there's no history).
+ */
+function renderAnchorsForPrompt(anchors) {
+    if (!Array.isArray(anchors) || !anchors.length) return '';
+    const lines = [
+        '',
+        'Comparable past tasks from this team (completed, same project/type):',
+        'Use these as calibration anchors — they reflect how long this team',
+        'actually takes. "est" is the prior estimate, "actual" is real logged',
+        'time, both in minutes. Weight actuals over estimates when they differ.',
+    ];
+    for (const a of anchors) {
+        const parts = [];
+        if (a.estimate != null) parts.push(`est ${a.estimate}m`);
+        if (a.actual != null) parts.push(`actual ${a.actual}m`);
+        lines.push(`- "${a.title}" — ${parts.join(', ')}`);
+    }
+    return lines.join('\n');
+}
+
+module.exports = {
+    buildGrounding,
+    renderAnchorsForPrompt,
+    // Exposed for unit tests / debugging — not part of the runtime contract.
+    _internal: {
+        computeCalibrationMultiplier,
+        median,
+        normalizeTags,
+        tagOverlapCount,
+        sumLoggedMinutesByTask,
+        fetchCompletedSimilarTasks,
+        MIN_PAIRS_FOR_CALIBRATION,
+        CALIBRATION_MIN,
+        CALIBRATION_MAX,
+        ANCHOR_LIMIT,
+        CANDIDATE_LIMIT,
+    },
+};


### PR DESCRIPTION
Improves the **accuracy** of the AI "estimate time" feature. Backend-only, **additive**, and the existing estimate keeps working unchanged in the fallback case.

## What changed
- **Right target:** the prompt now estimates **human-developer effort** (was calibrated to an AI agent). `ESTIMATE_TARGET` env, default `human` (`agent` still possible).
- **Historical-actuals grounding** (`Modules/EstimatedTime/estimateGrounding.js` — read-only, company-scoped, capped at 40 candidates / 5 anchors, never throws): pulls the team's **completed similar tasks** (same project + type, tag-ranked) with their **actual logged minutes** (summed from the timesheet) and injects them as few-shot anchors.
- **On-demand calibration:** multiplier = `median(actual ÷ estimate)` clamped **0.5–2.0**, no-op under 3 pairs, applied to the model's raw number. Computed at estimate time — **no task-completion hooks, no new storage.**
- **Richer inputs:** tags, assignee, and **subtask rollup** added to the prompt.
- **Range + confidence + self-consistency:** the model returns optimistic/likely/pessimistic + confidence; a **PERT** point estimate is computed; the model is sampled `ESTIMATE_SAMPLES` times (default **2**, median-combined). The range/confidence/work-items/reasoning are **returned in the API response** (available for a future UI) — there is **no UI change in this PR**.

## Safety / non-regression
- `persistEstimate` still writes **only** `task.totalEstimatedTime` (the PERT point, int, clamped) with the **same** socket emit + history key — stored shape unchanged.
- Every new step is wrapped: **no provider / no history / query failure / all samples fail → falls back to the prior single-call estimate**. The degenerate case (1 sample, no history, multiplier 1) == today's behavior.
- All queries company-scoped + capped; timesheet unit (minutes) verified.
- Verified: backend **`node --check` OK**, **jest 541 pass / 49 suites**. No frontend change; no new npm dependency.

## Notes
- `ESTIMATE_SAMPLES=2` doubles LLM calls per estimate (set `1` to revert to single-call cost). Needs an LLM provider configured.
- Accuracy scales with historical logged-time data; with none it still works (retargeted to human, multiplier 1).
- The range/confidence **display** UI was intentionally left out (to be designed separately).