### PR TITLE
style(ai): match "Write with AI" description button to the Suggest Tasks link

### DIFF
--- a/frontend/src/components/atom/Description/Description.vue
+++ b/frontend/src/components/atom/Description/Description.vue
@@ -9,10 +9,10 @@
         </div>
         <div class="editor-container description_componenet" v-show="!noDescription">
             <div v-if="editPermission && checkAiProject && checkAiDescription" class="ai-write-desc-bar">
-                <button type="button" class="ai-write-desc-btn" @click="openAiWriteDescription()">
-                    <span class="ai-write-desc-spark">&#10024;</span>
-                    {{ $t('AI.ai_write_description') }}
-                </button>
+                <div class="d-flex align-items-center cursor-pointer" @click="openAiWriteDescription()">
+                    <img :src="aiIcon" class="mr-3px" alt="ai" />
+                    <span class="font-size-14 font-weight-500 ai-color ai-border-bottom">{{ $t('AI.ai_write_description') }}</span>
+                </div>
             </div>
             <div v-show="contentLoaded" id="editorjs" :class="{'ml-10px mr-10-px': clientWidth < 767, 'show_hide_class': !isShow}" @click="isShow = true"></div>
             <Transition>
@@ -81,6 +81,7 @@ import * as env from '@/config/env';
 import { useCustomComposable } from '@/composable';
 import Skelaton from '@/components/atom/Skelaton/Skelaton.vue';
 import taskClass from '@/utils/TaskOperations';
+const aiIcon = require('@/assets/images/svg/ai_image.svg');
 
 
 defineComponent({

--- a/frontend/src/components/atom/Description/style.css
+++ b/frontend/src/components/atom/Description/style.css
@@ -222,28 +222,7 @@ max-width: 100% !important;
     justify-content: flex-end;
     padding: 0 4px 6px;
 }
-.ai-write-desc-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    height: 28px;
-    padding: 0 12px;
-    background: #ffffff;
-    border: 1px solid #2f3990;
-    border-radius: 6px;
-    color: #2f3990;
-    font-size: 12px;
-    font-weight: 500;
-    cursor: pointer;
-    font-family: 'Roboto', sans-serif;
-    transition: background 0.15s ease;
-}
-.ai-write-desc-btn:hover {
-    background: #f2f3fb;
-}
-.ai-write-desc-spark {
-    font-size: 13px;
-    line-height: 1;
-}
+/* The trigger reuses the shared AI link style (.ai-color gradient text +
+   .ai-border-bottom), matching "Suggest Tasks"/"Suggest Subtasks". */
 
 


### PR DESCRIPTION
Restyles the description **"Write with AI"** trigger to the shared AI-link style — the `ai_image.svg` sparkle + `.ai-color` gradient text + `.ai-border-bottom` underline — matching **"Suggest Tasks" / "Suggest Subtasks"**. Reuses the existing shared classes (no new styles; removes the old bordered-button CSS). Frontend-only, additive; build clean (0 errors).