### PR TITLE
feat: show subtask completion percentage badge on parent tasks (AHE-3776)

### DIFF
--- a/.claude/test-cases/AHE-3776-subtask-percent-badge.md
+++ b/.claude/test-cases/AHE-3776-subtask-percent-badge.md
@@ -1,0 +1,113 @@
+# AHE-3776 — Subtask completion percentage badge on parent tasks
+
+**Sprint:** v14.6.0 - Main
+**Type:** Feature (frontend-only)
+**Status:** Implemented locally — pending manual test (not committed)
+
+---
+
+## Summary
+
+A parent task that has subtasks shows a **completion-percentage badge** computed from
+how many of its subtasks are done. Example: a task with "Sub 1" (done) + "Sub 2"
+(not done) shows **50%**.
+
+The badge appears in **three places**:
+
+- **A — Task-detail header:** a compact ring + `%` pill, placed just before the
+  attachment icon (top-right of the task header).
+- **C — Subtask section header:** a mini progress bar + `%` + `done/total` count,
+  directly above the subtask list.
+- **D — List view parent row:** the same compact ring + `%` pill, right after the
+  subtask-count badge.
+
+On the task-detail view, A and C read **one shared value**, so they never disagree.
+The List-view pill (D) shows on **every** parent row, including collapsed ones: each parent
+fetches a lightweight done/total count on load, then uses the live subtask list once expanded.
+
+---
+
+## How it works
+
+- **Completed = `(status?.type || statusType) === 'close'`** — the same predicate the
+  rest of the app uses for "done" (e.g. CanvasView, LinkedTasks). Covers both the
+  "Done" and "Complete" board columns (both are status type `close`).
+- **Percentage = `round(completed / total × 100)`**, where `total` = non-deleted
+  subtasks (`deletedStatusKey` is `0` or `undefined`).
+- **Single source of truth:** computed in `TaskDetail.vue` from the `subTasks` list
+  the detail view already loads, then `provide`d to both the header
+  (`TaskDetailAction.vue`) and the subtask section (`SubTasks.vue`).
+- **Live:** `TaskDetail.getQueryFun()` reloads the subtasks on every subtask socket
+  update, so the badge recomputes automatically when a subtask is completed, added,
+  or removed — no page refresh.
+- **Colour states:** `0%` = gray (not started), `1–99%` = blue (in progress),
+  `100%` = green (done).
+
+### Files changed
+| File | Change |
+|------|--------|
+| `frontend/src/components/atom/SubtaskProgressBadge/SubtaskProgressBadge.vue` | **New** — presentational badge (props: `completed`, `total`, `variant`). |
+| `frontend/src/views/TaskDetail/TaskDetail.vue` | Added `subtaskCompletion` computed + `provide`. |
+| `frontend/src/components/molecules/TaskDetailAction/TaskDetailAction.vue` | Renders the `pill` badge (A) before the attachment icon. |
+| `frontend/src/components/organisms/SubTasks/SubTasks.vue` | Renders the `bar` badge (C) in the section header. |
+| `frontend/src/components/organisms/Task/Task.vue` | Renders the `pill` badge (D) after the subtask-count badge in the List view. |
+
+---
+
+## Test cases
+
+> Run the frontend dev server (`cd frontend && npm run serve`, default `:8080`) against
+> a backend on `:4000`. Open any project task.
+
+### TC-1 — Parent with mixed subtasks shows the right %
+1. Open a task and add two subtasks: `Sub 1`, `Sub 2`.
+2. Move `Sub 1` to a Done/Complete status.
+3. **Expect:** header pill = `50%` (blue); subtask section header = bar at 50% + `50%` + `1/2`.
+
+### TC-2 — All subtasks complete → 100% (green)
+1. Move `Sub 2` to Done as well.
+2. **Expect:** both badges update to `100%` in green, bar full, count `2/2` — **without a manual refresh**.
+
+### TC-3 — No subtasks complete → 0% (gray)
+1. On a parent with 2 open subtasks (none done).
+2. **Expect:** both badges show `0%` in gray; ring shows only the faint track; bar empty; count `0/2`.
+
+### TC-4 — Task with no subtasks shows NO badge
+1. Open a plain task (no subtasks) and a subtask opened on its own.
+2. **Expect:** no badge in the header, no badge in the (empty) subtask section. Header icon row looks exactly as before.
+
+### TC-5 — Live update on add / delete
+1. With a parent at `1/2` (50%), add a third open subtask.
+2. **Expect:** badge recomputes to `33%` and `1/3` (denominator changed).
+3. Delete a subtask.
+4. **Expect:** badge recomputes accordingly.
+
+### TC-6 — Rounding
+1. Parent with 3 subtasks, 1 done.
+2. **Expect:** `33%` (round(33.33)). With 2 of 3 done → `67%`.
+
+### TC-7 — No regression
+- Header attachment / audio / more-menu / watchers / close icons all still work and are correctly spaced.
+- Subtask section: "Suggest Subtasks" and "+ Add Subtask" still aligned to the right; list, scroll, and create still work.
+- Opening a task detail with the badge present does not throw any console errors.
+
+### TC-8 — List view badge (D)
+1. In the project **List view** with rows **collapsed**, reload the page.
+2. **Expect:** each parent with subtasks shows a `%` pill right after the subtask-count badge (e.g. Task 1 → `67%`) — without expanding.
+3. Expand a parent and change a subtask's status → the pill updates live from the loaded subtasks.
+4. A parent with no subtasks shows no pill; the row layout is otherwise unchanged.
+5. **Note:** the collapsed badge is a load-time snapshot (refreshes on reload / on expand); while expanded it updates live.
+
+---
+
+## Notes / scope
+- Counts subtasks one level deep (the current single-level subtask model).
+- Percentage reflects the loaded subtask set (detail view loads up to 35); parents with
+  more than 35 subtasks — which do not occur in practice — would reflect the loaded set.
+- **List view (D):** each parent fetches a one-time, read-only done/total count on mount via
+  the existing `/task/find` aggregate endpoint (no backend change), so the pill shows on
+  collapsed rows right after reload; once expanded it switches to the live subtask list. The
+  collapsed value is a load-time snapshot (refreshes on reload / expand), not live while
+  collapsed. One lightweight grouped query per parent that has subtasks.
+- No backend, schema, or API changes — purely additive frontend, so existing
+  functionality is unaffected.

--- a/frontend/src/components/atom/SubtaskProgressBadge/SubtaskProgressBadge.vue
+++ b/frontend/src/components/atom/SubtaskProgressBadge/SubtaskProgressBadge.vue
@@ -1,0 +1,191 @@
+<template>
+    <!--
+        Subtask completion badge (AHE-3776).
+        Shows how far a parent task has progressed based on its subtasks.
+        Renders nothing unless there is at least one subtask, so tasks without
+        subtasks are completely unaffected.
+
+        variant "pill" — compact ring + percent, for the task-detail header.
+        variant "bar"  — mini progress bar + percent + "done/total", for the
+                         subtask section header.
+
+        Purely presentational: it owns no data and makes no requests; the caller
+        passes `completed` and `total` and this component only formats them.
+    -->
+    <span
+        v-if="hasSubtasks"
+        class="subtask-progress"
+        :class="[`subtask-progress--${variant}`, `subtask-progress--${state}`]"
+        :title="tooltip"
+        role="img"
+        :aria-label="tooltip"
+    >
+        <!-- compact ring (pill variant) -->
+        <svg
+            v-if="variant === 'pill'"
+            class="subtask-progress__ring"
+            width="14"
+            height="14"
+            viewBox="0 0 18 18"
+            aria-hidden="true"
+        >
+            <circle cx="9" cy="9" r="7" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="3" />
+            <circle
+                v-if="percent > 0"
+                cx="9"
+                cy="9"
+                r="7"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+                stroke-linecap="round"
+                :stroke-dasharray="`${dash} ${circumference}`"
+                transform="rotate(-90 9 9)"
+            />
+        </svg>
+
+        <!-- mini bar (bar variant) -->
+        <span v-else class="subtask-progress__track" aria-hidden="true">
+            <span class="subtask-progress__fill" :style="{ width: percent + '%' }"></span>
+        </span>
+
+        <span class="subtask-progress__percent">{{ percent }}%</span>
+        <span v-if="variant === 'bar'" class="subtask-progress__count">{{ safeCompleted }}/{{ total }}</span>
+    </span>
+</template>
+
+<script setup>
+import { computed, defineProps } from 'vue';
+
+const props = defineProps({
+    // Number of completed subtasks (statusType === 'close').
+    completed: {
+        type: Number,
+        default: 0
+    },
+    // Total number of (non-deleted) subtasks.
+    total: {
+        type: Number,
+        default: 0
+    },
+    // 'pill' (header) or 'bar' (subtask section header).
+    variant: {
+        type: String,
+        default: 'pill'
+    }
+});
+
+const hasSubtasks = computed(() => Number(props.total) > 0);
+
+// Clamp completed into [0, total] so a stale/partial count can never produce a
+// nonsensical percentage like 120%.
+const safeCompleted = computed(() => {
+    const total = Number(props.total) || 0;
+    const completed = Number(props.completed) || 0;
+    return Math.max(0, Math.min(completed, total));
+});
+
+const percent = computed(() => {
+    const total = Number(props.total) || 0;
+    if (total <= 0) return 0;
+    return Math.round((safeCompleted.value / total) * 100);
+});
+
+// 0% = not started (gray), 100% = done (green), anything between = in progress (blue).
+const state = computed(() => {
+    if (percent.value >= 100) return 'done';
+    if (percent.value <= 0) return 'empty';
+    return 'progress';
+});
+
+// SVG ring geometry: r = 7 → circumference ≈ 43.98, rounded to 44.
+const circumference = 44;
+const dash = computed(() => Math.round((percent.value / 100) * circumference));
+
+const tooltip = computed(() => `${safeCompleted.value} of ${props.total} subtasks complete (${percent.value}%)`);
+</script>
+
+<style scoped>
+.subtask-progress {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border-radius: 999px;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+/* Compact pill for the task-detail header (option A). */
+.subtask-progress--pill {
+    padding: 3px 9px 3px 7px;
+    font-size: 12px;
+}
+.subtask-progress--pill .subtask-progress__ring {
+    flex: 0 0 auto;
+}
+
+/* Mini bar for the subtask section header (option C). */
+.subtask-progress--bar {
+    padding: 3px 10px;
+    font-size: 12px;
+    background: #f1f2f4;
+    border: 1px solid #e0e2e6;
+    color: #5e6c84;
+    gap: 7px;
+}
+.subtask-progress__track {
+    display: inline-block;
+    width: 60px;
+    height: 6px;
+    border-radius: 999px;
+    background: #dfe1e6;
+    overflow: hidden;
+    position: relative;
+    flex: 0 0 auto;
+}
+.subtask-progress__fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    border-radius: 999px;
+    transition: width 0.25s ease;
+}
+.subtask-progress__count {
+    color: #5e6c84;
+}
+
+/* Colour states. */
+.subtask-progress--empty {
+    color: #8993a4;
+}
+.subtask-progress--empty.subtask-progress--pill {
+    background: #f1f2f4;
+}
+.subtask-progress--progress.subtask-progress--pill {
+    background: #e6f0fb;
+    color: #185fa5;
+}
+.subtask-progress--done.subtask-progress--pill {
+    background: #e1f5ee;
+    color: #0f6e56;
+}
+
+.subtask-progress--empty .subtask-progress__fill {
+    background: #b4b2a9;
+}
+.subtask-progress--progress .subtask-progress__fill {
+    background: #378add;
+}
+.subtask-progress--done .subtask-progress__fill {
+    background: #1d9e75;
+}
+.subtask-progress--progress .subtask-progress__percent {
+    color: #185fa5;
+}
+.subtask-progress--done .subtask-progress__percent {
+    color: #0f6e56;
+}
+</style>

--- a/frontend/src/components/molecules/TaskDetailAction/TaskDetailAction.vue
+++ b/frontend/src/components/molecules/TaskDetailAction/TaskDetailAction.vue
@@ -1,6 +1,16 @@
 <template>
     <div class="task-detail-action">
         <ul class="task-detail-action-ul">
+            <!-- Subtask completion badge (AHE-3776): at-a-glance % of this parent's
+                 subtasks that are done. Hidden when the task has no subtasks. -->
+            <!-- width:auto so the pill isn't clipped by the shared `li { width:30px }` icon sizing. -->
+            <li v-if="subtaskCompletion && subtaskCompletion.total" style="display:flex; align-items:center; width:auto;">
+                <SubtaskProgressBadge
+                    :completed="subtaskCompletion.completed"
+                    :total="subtaskCompletion.total"
+                    variant="pill"
+                />
+            </li>
             <li>
                 <Skelaton v-if="isSpinner" style="height: 30px;" class="w-30px border-radius-6-px"/>
                 <img v-else @click="$emit('open', 'filesLinks')" src="@/assets/images/svg/Fileslinks.svg" />
@@ -206,6 +216,7 @@
     import ConvertToList from '@/components/molecules/ConvertToList/ConvertToList.vue';
     import ConfirmationSidebar from "@/components/molecules/ConfirmationSidebar/ConfirmationSidebar.vue"
     import WasabiIamgeCompp from '@/components/atom/WasabiIamgeCompp/WasabiIamgeCompp.vue';
+    import SubtaskProgressBadge from '@/components/atom/SubtaskProgressBadge/SubtaskProgressBadge.vue';
 
     import { computed, defineProps,defineEmits, ref, inject, watch } from 'vue';
     import taskClass from "@/utils/TaskOperations"
@@ -261,6 +272,8 @@
     const userId = inject('$userId')
     const companyId = inject('$companyId')
     const clientWidth = inject('$clientWidth');
+    // Provided by TaskDetail.vue — { total, completed } for the subtask % badge.
+    const subtaskCompletion = inject('subtaskCompletion', null);
     const openConvertSubTaskSidebar = ref(false);
     const converrtToListSidebar = ref(false);
     const openMoveSidebar = ref(false);

--- a/frontend/src/components/organisms/SubTasks/SubTasks.vue
+++ b/frontend/src/components/organisms/SubTasks/SubTasks.vue
@@ -6,7 +6,18 @@
         </div> -->
         <div class="overflow-auto style-scroll mobile__bg--withPadding mt-10px">
             <div class="w-100 d-flex align-items-center justify-content-between">
-                <span :class="{'font-size-16 font-weight-600' : clientWidth <= 767 , 'font-size-14 font-weight-700' : clientWidth > 767 }" class="font-weight-700 font-size-14">{{$t('ProjectDetails.subtask')}}</span>
+                <div class="d-flex align-items-center">
+                    <span :class="{'font-size-16 font-weight-600' : clientWidth <= 767 , 'font-size-14 font-weight-700' : clientWidth > 767 }" class="font-weight-700 font-size-14">{{$t('ProjectDetails.subtask')}}</span>
+                    <!-- Subtask completion badge (AHE-3776): % of subtasks done, with a
+                         mini progress bar and done/total count, right above the list. -->
+                    <SubtaskProgressBadge
+                        v-if="subtaskCompletion && subtaskCompletion.total"
+                        :completed="subtaskCompletion.completed"
+                        :total="subtaskCompletion.total"
+                        variant="bar"
+                        class="ml-10px"
+                    />
+                </div>
                 <div class="d-flex align-items-center">
                     <div class="d-flex align-items-center" @click="sugestSubTask()" v-if="checkApps('AI',project) && checkPermission('task.sub_task_create',project?.isGlobalPermission) === true">
                         <img :src="aiIcon" class="mr-3px" />
@@ -92,6 +103,7 @@ import {computed,defineProps, inject, nextTick, ref,watch} from "vue";
 import SubTaskItem from "@/components/molecules/SubTaskItem/SubTaskItem.vue"
 import CreateTask from "@/components/atom/CreateTask/CreateTask.vue"
 import SpinnerComp from '@/components/atom/SpinnerComp/SpinnerComp'
+import SubtaskProgressBadge from '@/components/atom/SubtaskProgressBadge/SubtaskProgressBadge.vue'
 import { useCustomComposable } from "@/composable";
 import { useToast } from "vue-toast-notification";
 import taskClass from "@/utils/TaskOperations"
@@ -136,6 +148,8 @@ const skip = ref(0);
 const limit = ref(35);
 const clientWidth = inject("$clientWidth");
 const project = inject("selectedProject");
+// Provided by TaskDetail.vue — { total, completed } for the subtask % badge.
+const subtaskCompletion = inject('subtaskCompletion', null);
 const subTasksList = ref([]);
 const isSpinner = ref(false);
 const isSpinnerSuggest = ref(false);

--- a/frontend/src/components/organisms/Task/Task.vue
+++ b/frontend/src/components/organisms/Task/Task.vue
@@ -97,6 +97,15 @@
                                     {{myParentCounts > 99 ? "+99" : myParentCounts}}
                                 </div>
                             </div>
+                            <!-- Subtask completion % (AHE-3776), right after the subtask count.
+                                 Appears once the row's subtasks are loaded (parent expanded). -->
+                            <SubtaskProgressBadge
+                                v-if="data?.isParentTask && subtaskProgress.total"
+                                :completed="subtaskProgress.completed"
+                                :total="subtaskProgress.total"
+                                variant="pill"
+                                class="ml-5px"
+                            />
                         </template>
                         <!-- TASK OPTIONS -->
                         <div class="align-items-center justify-content-evenly task-options" :class="[{'d-flex':dropVisible, 'd-none' : !dropVisible }]" v-if="!showArchiveVar && !editTaskName && clientWidth > 768">
@@ -290,6 +299,9 @@ import CreateTagPopup from '@/components/molecules/TagList/CreateTagPopup.vue';
 import TagChip from '@/components/atom/TagChip/TagChip.vue';
 import ConvertToSubTaskSidebar from '@/components/molecules/ConvertToSubTaskSidebar/ConvertToSubTaskSidebar.vue';
 import ConvertToList from '@/components/molecules/ConvertToList/ConvertToList.vue';
+import SubtaskProgressBadge from '@/components/atom/SubtaskProgressBadge/SubtaskProgressBadge.vue';
+import { apiRequest } from '@/services';
+import * as env from '@/config/env';
 
 import TaskQuickMenu from './components/TaskQuickMenu.vue';
 import { useTaskActions } from './composables/useTaskActions';
@@ -397,6 +409,51 @@ const projectTaskType = computed(() => projectData.value.taskTypeCounts);
 const taskStatus = computed(() => projectData.value.taskStatusData.find((x) => x.key === task.value.statusKey));
 const taskType = computed(() => projectData.value.taskTypeCounts.find((x) => x.key === task.value.TaskTypeKey));
 
+// Subtask completion (AHE-3776) for the list-row badge shown after the subtask
+// count. When the row is expanded its subtasks are loaded into `subtaskArray`
+// (used live); when collapsed they aren't loaded, so we fetch a lightweight
+// done/total count once on mount (`fetchedProgress`) and fall back to it — that
+// way the badge shows on a collapsed row right after reload. A subtask is done
+// when statusType is 'close'; only non-deleted subtasks count.
+const fetchedProgress = ref({ total: 0, completed: 0 });
+
+const subtaskProgress = computed(() => {
+    const loaded = Array.isArray(task.value?.subtaskArray)
+        ? task.value.subtaskArray.filter((s) => s && (s.deletedStatusKey === 0 || s.deletedStatusKey === undefined))
+        : [];
+    if (loaded.length) {
+        const completed = loaded.filter((s) => (s?.status?.type || s?.statusType) === 'close').length;
+        return { total: loaded.length, completed };
+    }
+    // Collapsed row — subtasks not loaded; use the count fetched on mount.
+    return fetchedProgress.value;
+});
+
+// One-time, read-only count of this parent's subtasks (done vs total) so the
+// badge can show on a COLLAPSED row right after reload. Uses the existing
+// /task/find aggregate endpoint (no backend change). Best-effort: any failure
+// just leaves the badge hidden. Skipped for non-parents, parents with no
+// subtasks, or rows whose subtasks are already loaded (expanded).
+function fetchSubtaskProgress() {
+    if (!task.value?.isParentTask) return;
+    if ((Number(task.value?.subTasks) || 0) <= 0) return;
+    if (Array.isArray(task.value?.subtaskArray) && task.value.subtaskArray.length) return;
+    const findQuery = [
+        { $match: { ParentTaskId: String(task.value._id), deletedStatusKey: { $in: [0, undefined] } } },
+        { $group: { _id: null, total: { $sum: 1 }, completed: { $sum: { $cond: [{ $eq: ['$statusType', 'close'] }, 1, 0] } } } },
+    ];
+    apiRequest('post', `${env.TASK}/find`, { findQuery })
+        .then((response) => {
+            const row = response?.data && response.data[0];
+            if (row) {
+                fetchedProgress.value = { total: Number(row.total) || 0, completed: Number(row.completed) || 0 };
+            }
+        })
+        .catch((error) => {
+            console.error('ERROR in fetchSubtaskProgress: ', error);
+        });
+}
+
 const sprintData = computed(() => {
     let sprintData = false;
     if (projectData.value && props.data) {
@@ -471,7 +528,9 @@ watch(() => getters['settings/finalCustomFields'], (newVal) => {
 const taskCollapsed = inject('taskCollapsed');
 onMounted(() => {
     if (taskCollapsed.value !== undefined && !taskCollapsed.value) {
-        emit('toggle');
+        emit('toggle');   // auto-expand mode → subtasks load, badge uses them live
+    } else {
+        fetchSubtaskProgress();   // collapsed → fetch the count so the badge shows on reload
     }
     manageCustomField(customFieldList.value);
 });

--- a/frontend/src/views/TaskDetail/TaskDetail.vue
+++ b/frontend/src/views/TaskDetail/TaskDetail.vue
@@ -185,6 +185,20 @@
         return getters["projectData/gettaskDetailData"];
     })
 
+    // Subtask completion (AHE-3776): how many of this parent's loaded subtasks
+    // are done (statusType 'close'), used by the progress badge in the task
+    // header and the subtask section. Derived from the same reactive `subTasks`
+    // the detail view already loads, so it stays live — getQueryFun() reloads
+    // the subtasks on every subtask socket update. Only non-deleted subtasks
+    // count; a task with no subtasks yields total 0 and the badge hides itself.
+    const subtaskCompletion = computed(() => {
+        const list = Array.isArray(subTasks.value) ? subTasks.value : [];
+        const valid = list.filter((s) => s && (s.deletedStatusKey === 0 || s.deletedStatusKey === undefined));
+        const total = valid.length;
+        const completed = valid.filter((s) => (s?.status?.type || s?.statusType) === 'close').length;
+        return { total, completed };
+    });
+
     const currentUserId = inject("$userId");
     const user = getUser(currentUserId.value);
     const isSpinner = ref(true);
@@ -514,6 +528,9 @@
         document.removeEventListener('visibilitychange', visibilityHandler);
     })
     provide("selectedProject", projectData);
+    // Shared so both the header badge (TaskDetailAction) and the subtask section
+    // header (SubTasks) read one identical value and never disagree.
+    provide("subtaskCompletion", subtaskCompletion);
 
     function getParentTask() {
         if(task?.value?.ParentTaskId) {


### PR DESCRIPTION
## What
A parent task with subtasks now shows a **completion-percentage badge** based on its subtasks' status.

- **Completed** = subtask `statusType === 'close'` (the project's done/close column — project-agnostic, matching how the rest of the app defines "completed", not the editable status name).
- **Percentage** = round(completed ÷ total non-deleted subtasks × 100).

## Where — 3 surfaces, one shared `SubtaskProgressBadge` atom
- **A — Task-detail header:** compact ring + `%` pill, before the attachment icon.
- **C — Subtask section header:** mini progress bar + `%` + `done/total`.
- **D — List view parent row:** `%` pill after the subtask-count badge. Shows on collapsed rows after reload (lightweight grouped count via the existing `/api/v1/task/find` aggregate); uses the live subtask array when expanded.

`TaskDetail.vue` computes the value once and `provide`s it to A + C so they never disagree.

## Notes
- **Frontend-only** — no backend / API / schema changes.
- Colour states: gray `0%` · blue `1–99%` · green `100%`. No badge when a task has no subtasks.
- Verified: `npm --prefix frontend run build` clean; `vue-cli-service lint` clean.

## Test
Full cases in `.claude/test-cases/AHE-3776-subtask-percent-badge.md`. Quick: task with Sub1 done + Sub2 not done → **50%**; all done → **100%** green; live update on subtask status change; no badge when there are no subtasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)