### PR TITLE
fix(projects): make project view-tabs responsive and readable

### DIFF
--- a/frontend/src/components/atom/ViewsList/ViewsList.vue
+++ b/frontend/src/components/atom/ViewsList/ViewsList.vue
@@ -13,7 +13,8 @@
            <span class="gray81">{{$t(`ViewList.${item.name}`)}}</span>
            <img :src="active ? activePin : pin" v-if="item?.isPin && item.isPin" class="ml-10px active__pin-condition">
            <span class="notification-tick blinking position-sti ml-7px" v-if="item?.isPrivate"></span>
-           <DropDown :id="item._id" @isVisible="isDropDownVisible" :zIndex="6" v-if="checkPermission('project.view_list',project.isGlobalPermission) === true">
+           <div class="view-list__menu" v-if="checkPermission('project.view_list',project.isGlobalPermission) === true">
+           <DropDown :id="item._id" @isVisible="isDropDownVisible" :zIndex="6">
                 <template #button>
                     <img :src="dots" class="dots ml-5px" :ref="item._id">
                 </template>
@@ -36,6 +37,7 @@
                     </div>
                 </template>
             </DropDown>
+            </div>
             <ConfirmationSidebar
                 v-model="isDelete"
                 :title="$t('Projects.deleteview')"
@@ -203,9 +205,35 @@ const editOptions = (type) =>{
 defineEmits(['click']);
 </script>
 <style scoped>
-.dots, .list__edit{
+.list__edit{
     height: 20px;
     width: 15px;
+}
+/* ⋯ menu: positioned OVER the tab's right edge (out of flow) so it never
+   reserves space or resizes the tab — it only appears on hover. */
+.view-list__menu{
+    position: absolute;
+    right: 2px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+}
+/* The trigger is a proper rounded button (white chip + soft shadow) so it
+   reads as a control and cleanly masks the sliver of label it overlaps. */
+.dots{
+    height: 24px;
+    width: 28px;
+    padding: 4px 6px;
+    border-radius: 6px;
+    box-sizing: border-box;
+    object-fit: contain;
+    cursor: pointer;
+    background: #fff;
+    box-shadow: 0 1px 4px rgba(16, 24, 40, 0.18);
+}
+.dots:hover{
+    background: #f1f2f4;
 }
 .count-block.comment__count{
    color: #eabb00 !important;

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -128,7 +128,7 @@
                                 </div>
                                 <div class="list-head-mid h-100" :class="{'desktop-view' : clientWidth > 767}" id="projectview_driver">
                                     <template v-if="clientWidth > 765">
-                                        <div class="d-flex align-items-center overflow-x-auto style-scroll view_list_scroll h-100">
+                                        <div class="d-flex align-items-center overflow-x-auto view_list_scroll h-100">
                                             <ViewsList
                                                 v-for="(view, index) in (viewsListArray)"
                                                 :key="view._id"

--- a/frontend/src/views/Projects/style.css
+++ b/frontend/src/views/Projects/style.css
@@ -31,6 +31,44 @@
   margin-left: 10px;
   /* margin-top: 6px; */
 }
+
+/* ── Project view-tabs: responsive + readable (AHE) ─────────────────────
+   With many views (List, Board, Table, Whiteboard, Canvas, Map, Reports,
+   Gantt, Recurring, Timeline …) the tab row overflowed the header. The strip
+   now fills the available width and scrolls horizontally (a flex item only
+   scrolls if it can shrink below its content — hence `min-width: 0`), tabs
+   get a gap, the right-side icon bar stays fully visible, and the scrollbar
+   is clearly visible so users know there are more views to scroll to. */
+.list-head-leftrightwrappper { min-width: 0; }
+.list-head-mid { min-width: 0; }
+/* Right-side action icons (files / audio / watchers): never shrink and don't
+   cap the width, so they're always clearly visible. !important overrides the
+   old base rule that capped this bar to ~15%. */
+.list-head-right { flex-shrink: 0; max-width: none !important; }
+/* Tab strip: fill remaining width, scroll horizontally, gap between tabs. */
+.view_list_scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 800px;
+  /* Horizontal scroll only (the tall active tab must not trigger a vertical
+     scrollbar), and offset the 6px scrollbar with matching top padding so the
+     tab labels stay vertically centered in the row while it's showing. */
+  overflow-y: hidden;
+  padding-top: 6px;
+  box-sizing: border-box;
+  scrollbar-width: thin;            /* Firefox */
+  scrollbar-color: #b4b8c0 #eef0f2; /* Firefox: thumb / track */
+}
+.view-list-wrapper { flex-shrink: 0; }
+.project__requirementcomponent-wrapper { flex-shrink: 0; }
+/* Clearly-visible 6px horizontal scrollbar (the strip no longer uses the
+   2px `style-scroll` utility). */
+.view_list_scroll::-webkit-scrollbar { height: 6px; }
+.view_list_scroll::-webkit-scrollbar-track { background: #eef0f2; border-radius: 6px; }
+.view_list_scroll::-webkit-scrollbar-thumb { background: #b4b8c0; border-radius: 6px; }
+.view_list_scroll::-webkit-scrollbar-thumb:hover { background: #969ba6; }
+/* Per-tab "⋯" menu shows on hover only; it's positioned over the tab's right
+   edge in ViewsList (out of flow) so it never reserves space or resizes. */
 .list-head-right {
   max-width: 15%;
   display: flex;
@@ -82,7 +120,10 @@
   width: 0px;
 }
 .view-list {
-  padding: 0 9.15px 0 9.15px;
+  /* Symmetric padding gives each name breathing room and centers the
+     border-right divider between two tabs (no flex `gap`, which would only
+     pad one side of the divider). */
+  padding: 0 18px 0 18px;
   justify-content: center;
 }
 .list-head-midmobile {
@@ -184,11 +225,12 @@
 }
 
 .dots{
-  display: none;
-  width: 15px;
+  /* Reserve the ⋯ slot in layout via `visibility` (NOT `display:none`) so the
+     tab width never jumps when the menu appears on hover. */
+  visibility: hidden;
 }
 .wrapper:hover .dots{
-  display: block;
+  visibility: visible;
 }
 .search__in-dropdown {
   border: 0 !important;
@@ -215,7 +257,7 @@
     justify-content: center;
 }
 @media(max-width: 1890px){
-  .wrapper:hover .dots{display: block;min-width: 15px;}
+  .wrapper:hover .dots{visibility: visible;}
 }
 @media (max-width: 1820px) {
   .list-head-left {max-width: 50%;}


### PR DESCRIPTION
## What
Resolves the UI / responsive issues on the project **view-tabs row** (List, Board, Table, Whiteboard, Canvas, Map, Reports, Gantt, Recurring Tasks, Timeline, …) — the tabs overflowed the header on smaller screens and crowded the right-side action icons.

## Changes
- **Horizontal scroll, not overflow** — the tab strip fills the available width and scrolls horizontally (the flex chain needed `min-width: 0`), capped at `max-width: 800px`.
- **Right-side icons always visible** — the files / audio / watchers bar was capped at `max-width: 15%`; uncapped it + `flex-shrink: 0` so it never gets squeezed.
- **Visible scrollbar** — a clear 6px horizontal scrollbar (replacing the near-invisible 2px `style-scroll`) so it's obvious there are more views to scroll to.
- **Readable dividers + names** — symmetric per-tab padding (removed the lopsided flex `gap`) so each divider sits centered between two tabs.
- **"⋯" per-tab menu** — moved out of flow to a hover button pinned over the tab's right edge: no width jump on hover, no reserved gap, proper rounded button styling.
- **Vertical centering with scrollbar** — `overflow-y: hidden` + a matching top-padding offset so the tab labels stay vertically centered while the scrollbar is showing.

## Files
- `frontend/src/views/Projects/style.css`
- `frontend/src/views/Projects/Projects.vue` (dropped `style-scroll` from the strip)
- `frontend/src/components/atom/ViewsList/ViewsList.vue` (the ⋯ button)

## Testing
CSS + a small markup/class tweak only — no logic changes. Reviewed iteratively in the browser (hot-reload) across each item above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
