### PR TITLE
fix: keep list-view filter toolbar on a single line (AHE-3783)

### DIFF
--- a/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
+++ b/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
@@ -379,4 +379,23 @@ const groupIcon = require('@/assets/images/peopleGray.png');
     font-size: 13px;
     line-height: 1;
 }
+
+/* Keep the filter/action row on a single line (desktop). The global .mr-1
+   gap is 16px (1rem); with ~6 action buttons that was wide enough that adding
+   the "AI Assist" pill pushed the whole action group onto a second line.
+   Tighten the gaps to 8px, and stop the wrapper from wrapping the action group
+   below the search — the group already scrolls horizontally (overflow:auto)
+   when space is tight, so it stays on one line instead of dropping down. */
+@media (min-width: 768px) {
+    .task-filtersearchassignee-wrapper {
+        flex-wrap: nowrap !important;
+    }
+    .task-filter-assignee {
+        flex: 1 1 0%;
+        min-width: 0;
+    }
+    .task-filter-assignee > :deep(.mr-1) {
+        margin-right: 8px;
+    }
+}
 </style>


### PR DESCRIPTION
## Summary

Fixes AHE-3783 — on the project **List view**, the filter / action toolbar wrapped onto a second line instead of staying inline.

**Cause:** every action button uses the global `.mr-1` gap (16px / 1rem). With the buttons in the group, adding the "AI Assist" button (AHE-3777, #293) pushed the total width past the available space; because the toolbar wrapper is `flex-wrap`, the whole action group dropped below the Search box.

**Fix** — scoped to `ProjectFiltersToolbar.vue`, desktop (≥768px) only:
- Tighten the action-button gap from **16px → 8px**.
- `flex-wrap: nowrap` on the wrapper so the action group stays on the Search line.
- `flex: 1 / min-width: 0` on the action group so it scrolls horizontally (it already has `overflow:auto`) when space is tight, instead of wrapping to a new line.
- Mobile (≤767px) layout is untouched.

## Test plan
- Open a project → List view.
- Confirm Search + AI Assist · Write with AI · Group by · Subtask · ⋯ · Me/Assignee · Show Archive all sit on one line.
- Narrow the window — the action group should scroll horizontally rather than drop to a second line.
- Confirm mobile (≤767px) layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
