### PR TITLE
fix: show AI-created sprints and tasks live without reload (AHE-3777)

### DIFF
--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -310,7 +310,7 @@
                                 @defaultMonth="defaultMonth"
                             />
                             <!-- AI Assist (AHE-3777): project-level AI task generation, opened from the toolbar. -->
-                            <AiTaskCreator v-if="projectData && projectData._id" v-model="showAiTaskCreator" :projectId="String(projectData._id)" />
+                            <AiTaskCreator v-if="projectData && projectData._id" v-model="showAiTaskCreator" :projectId="String(projectData._id)" @done="onAiTasksCreated" />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
                                 :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView' && activeTab !== 'MapView'}]"
@@ -746,6 +746,37 @@ function closeSidebar(value) {
 const openAiCreator = () => {
     isActiveAiCreator.value = true;
 };
+// AI Assist creates the sprints + tasks server-side; there is no sprint socket,
+// so the live refresh is a forced re-fetch. getSprintData caches per project and
+// would otherwise skip the GET, so the AI sprints only showed after a full
+// reload (empty store). We pass forceRefresh=true to bypass that guard, rebuild
+// the project's sprint tree, and give projectData a fresh reference so the list
+// watcher re-runs. We retry briefly until the expected new sprints arrive
+// (totals.sprints from the 'done' event); each rendered sprint loads its tasks.
+async function onAiTasksCreated(totals) {
+    const proj = projectData.value;
+    if (!proj || !proj._id || !projectList.value || typeof projectList.value.getSprintFolderData !== 'function') return;
+    const pid = String(proj._id);
+    const sprintCount = () => {
+        const p = getters['projectData/projects']?.data?.find((x) => x._id === pid);
+        return p && p.sprintsObj ? Object.keys(p.sprintsObj).length : 0;
+    };
+    const expectedNew = (totals && Number(totals.sprints)) || 0;
+    const target = sprintCount() + expectedNew;
+    let prev = -1;
+    for (let attempt = 0; attempt < 10; attempt++) {
+        await projectList.value.getSprintFolderData(pid, true, true);
+        const fresh = getters['projectData/projects']?.data?.find((p) => p._id === pid);
+        if (fresh) projectData.value = { ...fresh };
+        const now = sprintCount();
+        // Stop once the expected new sprints have arrived; if totals is missing,
+        // stop when the count stops growing across two consecutive fetches.
+        if (expectedNew ? now >= target : (attempt > 0 && now === prev)) break;
+        prev = now;
+        await new Promise((r) => setTimeout(r, 600));
+    }
+}
+
 async function onAiProjectCreated({ projectId }) {
     if (!projectId) {
         isActiveAiCreator.value = false;

--- a/frontend/src/views/Projects/ProjectsListing/ProjectListing.vue
+++ b/frontend/src/views/Projects/ProjectsListing/ProjectListing.vue
@@ -334,10 +334,10 @@ const loadMoreProjects = () => {
 
 
 
-function getSprintData(id) {
+function getSprintData(id, forceRefresh = false) {
     return new Promise((resolve, reject) => {
         try {
-            if(Object.keys(getters["projectData/sprints"]).includes(id)){
+            if(!forceRefresh && Object.keys(getters["projectData/sprints"]).includes(id)){
                 if(!sprintData.value || !Object.keys(sprintData.value || {}).length){
                     sprintData.value = getters["projectData/sprints"][id];
                 }
@@ -418,14 +418,14 @@ function getFolderData(id) {
     })
 }
 
-const getSprintFolderData = async (id,isUpdate = false) => {
+const getSprintFolderData = async (id,isUpdate = false, forceRefresh = false) => {
     try {
         if(!isUpdate){
             loadingData.value[id] = true;
             emit('update:sprintLoading', true);
         }
         if (search.value === '' || projectSearch.value) {
-            Promise.allSettled([getSprintData(id), getFolderData(id)])
+            await Promise.allSettled([getSprintData(id, forceRefresh), getFolderData(id)])
             .then((results) => {
                 const resolvedPromises = results.filter((result) => result.status === 'fulfilled');
                 if (resolvedPromises.length === 2) {
@@ -632,7 +632,7 @@ function handleSearchUpdateProject (searchValues) {
 // user clicking a project in the sidebar triggers — commit-to-Vuex,
 // route push with the right tab query, and `update:projectData` emit
 // so the parent's watchers load sprints / tasks.
-defineExpose({toggleSidebar, mutateCurrentProjectDetails})
+defineExpose({toggleSidebar, mutateCurrentProjectDetails, getSprintFolderData})
 </script>
 
 <style>


### PR DESCRIPTION
## Summary

After AI Assist creates sprints/tasks into the currently-open project, they only showed up after a **manual reload**. This makes them appear **live**.

**Root cause:** `getSprintData` caches per project and **skips the GET** when the project's sprints are already loaded in the store. So the in-session refresh never re-fetched the newly-created sprints — a full reload "worked" only because it starts from an empty store. (There is no sprint socket either, so nothing arrived live.)

**Fix**
- `ProjectListing.vue` — add a `forceRefresh` flag to `getSprintData` / `getSprintFolderData` that bypasses the cache guard; make `getSprintFolderData` awaitable and expose it.
- `Projects.vue` — on `AiTaskCreator`'s `done`, force-refetch the project's sprints and give `projectData` a fresh reference so the list watcher rebuilds; retry briefly until the expected new sprints (`totals.sprints`) arrive. Each rendered sprint then loads its own tasks.

**Safety:** `forceRefresh` defaults to `false`, so the store-watchers, project-click, and `onAiProjectCreated` are all unchanged — only the AI-done path forces a refetch, and there's no re-fetch loop. Frontend build verified.

## Test plan
- Open a project → AI Assist → create sprints + tasks → new sprints + tasks appear **live**, no reload.
- Regression: open/switch projects, create a sprint manually, expand/collapse a project — all behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
