### PR TITLE
fix: force-hide list-view Suggest Tasks CTA in production

### DIFF
--- a/frontend/src/components/organisms/SprinstList/SprintsList.vue
+++ b/frontend/src/components/organisms/SprinstList/SprintsList.vue
@@ -856,9 +856,13 @@ function startTaskTour(key) {
 .ai-generated-task-div{
     border: 1px solid #DFE1E6;
 }
-/* Hide the per-sprint "Suggest Tasks" AI CTA in the list view */
+/* Hide the per-sprint "Suggest Tasks" AI CTA in the list view.
+   !important is required: the element also carries the `d-flex` utility
+   (display: flex), which has the same specificity (one class, no !important).
+   In the production CSS bundle `.d-flex` lands later and re-shows the button,
+   even though the component style wins in dev hot-reload. */
 .suggest-tasks-cta{
-    display: none;
+    display: none !important;
 }
 
 </style>


### PR DESCRIPTION
## Summary

The per-sprint "Suggest Tasks" CTA was hidden locally but **reappeared on staging**.

**Cause:** the hide rule `.suggest-tasks-cta { display: none }` and the element's `.d-flex` utility `{ display: flex }` (display.css) have **equal specificity** (one class each, no `!important`). With a specificity tie, CSS source order decides the winner — the component `<style>` wins in dev hot-reload (injected last), but in the production CSS bundle `.d-flex` lands later and re-shows the button. Not a deploy or browser-cache problem (every staging deploy succeeded and the source already had the hide).

**Fix:** `display: none !important` on `.suggest-tasks-cta`, so the hide wins regardless of bundle order.

## Test plan
- After merge + the staging redeploy, hard-refresh the List view → the per-sprint "Suggest Tasks" link should be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
