### PR TITLE
fix: release-please auto-tagging and duplicate docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,11 +30,6 @@ on:
   release:
     types: [published]
 
-  # Build + publish image on every commit to main (after a PR merges)
-  push:
-    branches:
-      - main
-
   # Manual trigger from the Actions UI
   workflow_dispatch:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,6 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "package-name": "alianhub",
       "changelog-path": "CHANGELOG.md"
     }
   },


### PR DESCRIPTION
## What

Two release-pipeline fixes bundled into one PR:

1. **release-please auto-tagging** — remove the deviant `package-name: "alianhub"` from `release-please-config.json`.
2. **Docker triggers** — drop the `push: main` build from `docker.yml`, keeping `release: published` + `workflow_dispatch`.

## Why — release-please has never auto-tagged this repo

Every release **v14.1.0 → v14.6.0 was cut manually** (`parth0025`), never by `github-actions[bot]`. After the `chore: release main` PR merges, the Release workflow finishes "success" but the `createReleases()` step logs:

```
⚠ PR component: undefined does not match configured component: alianhub
⚠ Expected 1 releases, only found 0
```

…so it never creates the tag / GitHub Release, and the merged PR stays labeled `autorelease: pending` — which then makes the *next* release abort with "There are untagged, merged release PRs outstanding".

**Root cause:** the config declared `package-name: "alianhub"`, but `package.json`'s name is `alian-hub-v3`. That phantom component is never matched when release-please parses the merged release PR back to a package. Removing the explicit `package-name` lets release-please derive the component from `package.json` — the canonical single-root-package setup that tags correctly. Tags stay componentless (`vX.Y.Z`) because `include-component-in-tag: false`.

## Docker trigger trim

`docker.yml` fired on **both** `push: main` and `release: published`, so one release cycle spawned 2–3 overlapping builds (the staging→main promotion push, the release-PR merge push, and the release event) — and the earlier build was self-cancelled by the next push (the `cancelled` runs). Dropping `push: main` leaves exactly one image set per release.

- **Dropped:** `edge` and `main-<sha>` images (only built on main commits).
- **Unaffected:** `vX.Y.Z` / `{major}.{minor}` / `{major}` / `latest` release images.

## Validation & risk

- **Docker change** — safe and immediate: fewer triggers, identical release images.
- **release-please change** — targets the exact defect in the run log and is the canonical config form. It can only be **fully validated on the next real release (v14.7.0)**, because the failure happens in the post-merge tagging step (not reproducible in a dry-run). Worst case is no worse than today (manual cut), and the manual-cut procedure stays documented as the fallback. It cannot break PR *creation* — that runs off the manifest + commits, not `package-name`.

## Test plan

- [ ] CI green (branch-name, commitlint, PR-title, deploy/validate)
- [ ] Next `staging → main` promotion + `chore: release main` merge: `github-actions[bot]` auto-creates the tag + GitHub Release with **no** manual cut
- [ ] Exactly one Docker build runs per release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
