### PR TITLE
fix(logtime): tracked-time activity log showed DATE_undefined

### DIFF
--- a/Modules/LogTime/controllerV2/tracker.js
+++ b/Modules/LogTime/controllerV2/tracker.js
@@ -353,7 +353,11 @@ exports.endTimeTracker = (req, res) => {
             }
             MongoDbCrudOpration(req.body.companyId, obj, "findOneAndUpdate")
                 .then((resUp) => {
-                    const dt = response.CreatedAt;
+                    // Activity-log date = the day of the logged session. `response.CreatedAt`
+                    // is not a field on the timesheet (Mongoose stores lowercase `createdAt`),
+                    // so it was undefined → "DATE_undefined". Use the session start in epoch ms,
+                    // matching the adjacent TIMESTAMP_ placeholders and the manual-log path.
+                    const dt = response.LogStartTime * 1000;
                     function convertTimestampToTime(timestamp) {
                         const dateTime = DateTime.fromSeconds(timestamp);
                         const formattedTime = dateTime.toFormat('hh:mm a');


### PR DESCRIPTION
## Bug

The **tracked-timer** "logged hours" entry in the **Activity Log** showed **`DATE_undefined`** instead of the date (seen on AHE-3787's activity log).

## Cause

Activity-log messages embed a `DATE_<epoch-ms>` placeholder that `frontend/src/components/molecules/ActivityLogContent/ActivityContent.vue` formats via `moment(parseInt(...)).format(dateFormat)`. Its regex is `/DATE_\d+/` — **digits only**.

In `Modules/LogTime/controllerV2/tracker.js` the tracked-time message built that placeholder from `response.CreatedAt`, which **isn't a field** on the timesheet document (Mongoose stores lowercase `createdAt`) → `undefined` → `DATE_undefined`, which doesn't match `/DATE_\d+/`, so it's printed raw.

The **manual** log path (`Modules/LogTime/controllerV2/manualLogtime.js`) already uses `new Date(req.body.logTimeDate).getTime()`, so only the **timer/tracker** path was affected.

## Fix

```js
// tracker.js
const dt = response.LogStartTime * 1000;   // was: response.CreatedAt
```

`LogStartTime` is in seconds (the adjacent `TIMESTAMP_` placeholders already do `× 1000`), so this yields epoch-ms → matches `/DATE_\d+/` → formats to the session's date.

## Verification

Couldn't exercise the timer locally (the tracker app points at the production URL), so verified by tracing the full path: construction (`tracker.js`) → renderer regex `/DATE_\d+/` → `moment(parseInt(ms))`. A numeric ms value matches and formats correctly; the old `undefined` did not.

## Scope

- Backend only; renderer unchanged.
- **Forward fix** — entries created from now on are correct. Already-stored `DATE_undefined` records are unchanged; a separate one-off migration could repair them from the `from` timestamp embedded in the same message (not included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
