### PR TITLE
feat(installer): dynamic first-run setup, no default user

### DIFF
--- a/Modules/CheckInstallStep/createCompany.js
+++ b/Modules/CheckInstallStep/createCompany.js
@@ -6,7 +6,6 @@ const logger = require('../../Config/loggerConfig.js');
 const { default: mongoose } = require("mongoose");
 const { emitListener } = require("./eventController.js");
 const createUserRef = require("../Auth/controller/createUser.js");
-const sendMailRef = require("../Auth/controller/sendVerificationMail.js")
 const { dbCollections } = require("../../Config/collections.js");
 // const { installSteps, envVar } = require("./controller.js");
 const mainCtr = require("./controller.js");
@@ -400,19 +399,40 @@ exports.createUserAndCompany = (req,res) => {
                         isProductOwner: true
                     }
                     createUserRef.addUserMongodbV2(userObj).then((respo)=>{
-                        sendMailRef.sendVerificationEmailPromise(respo.statusText._id,respo.statusText.Employee_Email).catch((error)=>{
-                            logger.error(error.statusText);
-                        })
-                        emitListener(req.body?.eventId, {step: 1});
-                        exports.createCompanyFromAPIFunction(respo.statusText._id,req.body).then(()=>{
-                            mainCtr.installSteps[7].status = "done";
-                            serviceFun.writeFile(installStepsFilePath, JSON.stringify({installSteps: mainCtr.installSteps, envVar: mainCtr.envVar}, null, 4), () => {
-                                res.status(200).json({message: "user and company create successfully"})
-                            });
+                        const ownerId = respo.statusText._id;
+                        // The first owner is created by the trusted installer (the
+                        // operator running setup), so mark the account email-verified
+                        // immediately — same as the OAuth signup paths. Without this,
+                        // login is hard-blocked by the "Email is not verified" gate
+                        // (Auth/controller/authHelpers.js#generateTokenV2Fun) and, since
+                        // SMTP is usually skipped during install, no verification email
+                        // is ever sent — locking the operator out of the account they
+                        // just created. Scoped to the installer flow only; the public
+                        // /api/v2/createUser signup still requires verification.
+                        const verifyOwnerObj = {
+                            type: dbCollections.USERS,
+                            data: [
+                                { _id: ownerId },
+                                { $set: { isEmailVerified: true, verificationToken: "" } },
+                            ],
+                        };
+                        MongoDbCrudOpration('global', verifyOwnerObj, 'findOneAndUpdate').then(()=>{
+                            emitListener(req.body?.eventId, {step: 1});
+                            exports.createCompanyFromAPIFunction(ownerId,req.body).then(()=>{
+                                mainCtr.installSteps[7].status = "done";
+                                serviceFun.writeFile(installStepsFilePath, JSON.stringify({installSteps: mainCtr.installSteps, envVar: mainCtr.envVar}, null, 4), () => {
+                                    res.status(200).json({message: "user and company create successfully"})
+                                });
+                            }).catch((error)=>{
+                                mainCtr.installSteps[7].status = "error";
+                                serviceFun.writeFile(installStepsFilePath, JSON.stringify({installSteps: mainCtr.installSteps, envVar: mainCtr.envVar}, null, 4), () => {
+                                    res.status(400).json({message: error});
+                                });
+                            })
                         }).catch((error)=>{
                             mainCtr.installSteps[7].status = "error";
                             serviceFun.writeFile(installStepsFilePath, JSON.stringify({installSteps: mainCtr.installSteps, envVar: mainCtr.envVar}, null, 4), () => {
-                                res.status(400).json({message: error});
+                                res.status(400).json({message: error?.message || error});
                             });
                         })
                     }).catch((error)=>{

--- a/README.md
+++ b/README.md
@@ -81,30 +81,39 @@ cd AlianHub-Project-Management-System
 npm run setup
 ```
 
-That's it. **No technical knowledge required.** `npm run setup` will:
+That's it. `npm run setup` will:
 
 1. Install all dependencies (root, frontend, wizard) in parallel
 2. Generate a `.env` file with secure random secrets
 3. Build the installation wizard UI
-4. Start the backend and frontend dev server
-5. **Auto-complete the installation wizard** — connects to MongoDB, sets up storage, skips optional services (Firebase / AI / SMTP), initializes the database, and creates an admin account
-6. Open `http://localhost:8080` in your browser
+4. Start the server (the same entry production uses)
+5. Open `http://localhost:4000` in your browser
+
+On a fresh system the server serves the **installation wizard**. Complete it
+yourself — connect MongoDB, choose storage, skip or configure optional services
+(Firebase / AI / SMTP), and create **your own** company and admin account.
+Nothing is created automatically.
 
 When it's done, you'll see this in your terminal:
 
 ```
-──────────────────────────────────────────────────────────
-  ✓  AlianHub is ready!
-──────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────
+  ✓  Server running — finish installation in your browser
+────────────────────────────────────────────────────────────
 
-  URL:       http://localhost:8080
-  Email:     admin@admin.local
-  Password:  admin123
-
-  API:       http://localhost:4000
-  Stop:      Ctrl+C in this terminal
-──────────────────────────────────────────────────────────
+  URL:   http://localhost:4000
+  The wizard guides you to connect MongoDB, choose storage, and create
+  your own company and admin account.
+  When it finishes, the app rebuilds and the server stops (same as
+  production). Run `npm start` again, then sign in.
+  Stop:  Ctrl+C
+────────────────────────────────────────────────────────────
 ```
+
+The wizard's final step rebuilds the frontend and the server exits — the same
+flow production relies on, where a process manager (e.g. pm2) restarts the app.
+Locally there's no process manager, so just run **`npm start`** again, open
+`http://localhost:4000`, and **log in with the account you created**.
 
 **Prerequisite:** MongoDB running locally on `mongodb://localhost:27017`. If you don't have it: `docker run -d -p 27017:27017 mongo:7` or download from [mongodb.com](https://www.mongodb.com/try/download/community).
 
@@ -112,21 +121,12 @@ When it's done, you'll see this in your terminal:
 
 | Command | What it does |
 |---------|--------------|
-| `npm run setup` | Full setup — install, configure, start, auto-complete wizard, open browser |
-| `npm run dev` | Fast restart — skips install, just starts the services |
+| `npm run setup` | Install deps, prepare `.env`, build the wizard UI, and start the server |
+| `npm run dev` | Same as setup but skips dependency install |
 | `npm run setup:reset` | Wipe `node_modules` and reinstall everything |
-| `npm run setup -- --manual` | Skip auto-setup — open the interactive wizard instead |
 | `npm run setup -- --no-open` | Start without auto-opening a browser |
 
-### Custom admin credentials
-
-```bash
-SETUP_ADMIN_EMAIL=you@example.com SETUP_ADMIN_PASSWORD=secret npm run setup
-```
-
-Other env-var overrides: `SETUP_ADMIN_FIRST`, `SETUP_ADMIN_LAST`, `SETUP_COMPANY`, `SETUP_PHONE`, `SETUP_COUNTRY`, `SETUP_CITY`, `SETUP_STATE`.
-
-> **Manual setup still works.** Everything above is an additive convenience layer. All existing scripts (`npm start`, `npm run nodemon`, `npm run basic-install`, etc.) and the original interactive wizard are unchanged. If `npm run setup` ever fails it falls back automatically to the wizard UI so you can finish manually.
+> All existing scripts (`npm start`, `npm run nodemon`, `npm run basic-install`) are unchanged. For active development with hot-reload, run the backend (`npm run nodemon`) and the frontend dev server (`cd frontend && npm run serve`) separately once the system is installed.
 
 ---
 

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
 /**
- * AlianHub Developer Setup
+ * AlianHub Setup
  *
- * One command, zero technical knowledge required:
- *   npm run setup              → installs deps, configures, starts, auto-completes wizard, opens browser
- *   npm run dev                → fast restart (skip install)
+ * Mirrors the production first-run flow locally — no dummy account, no auto-fill:
+ *   npm run setup              → installs deps, prepares .env, starts the server
+ *   npm run dev                → start without reinstalling deps (--skip-install)
  *   npm run setup -- --force   → wipe node_modules and reinstall
  *   npm run setup -- --no-open → don't auto-open a browser
- *   npm run setup -- --manual  → skip auto-setup; open the interactive wizard UI instead
  *
- * Custom admin credentials (optional):
- *   SETUP_ADMIN_EMAIL=you@you.com SETUP_ADMIN_PASSWORD=mypw npm run setup
+ * On a fresh system the server serves the installation wizard. You complete it
+ * yourself — connecting MongoDB, choosing storage, and creating your OWN company
+ * and admin account. Exactly like production: nothing is created automatically.
+ *
+ * The wizard's final step rebuilds the frontend and the process exits — the same
+ * behaviour production relies on (pm2 then restarts the app). Locally there is no
+ * process manager, so just run `npm start` again afterwards and sign in.
  *
  * All existing scripts (npm start, npm run nodemon, npm run basic-install) are untouched.
  */
@@ -18,7 +22,6 @@
 
 const { spawn, exec } = require('child_process');
 const http = require('http');
-const net = require('net');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -37,21 +40,6 @@ const argv         = process.argv.slice(2);
 const SKIP_INSTALL = argv.includes('--skip-install');
 const FORCE        = argv.includes('--force');
 const NO_OPEN      = argv.includes('--no-open');
-const MANUAL       = argv.includes('--manual'); // skip auto-setup, open wizard manually
-
-// ─── Defaults ────────────────────────────────────────────────────────────────
-const DEFAULT_ADMIN = {
-  firstName:     process.env.SETUP_ADMIN_FIRST    || 'Admin',
-  lastName:      process.env.SETUP_ADMIN_LAST     || 'User',
-  email:         process.env.SETUP_ADMIN_EMAIL    || 'admin@admin.local',
-  password:      process.env.SETUP_ADMIN_PASSWORD || 'admin123',
-  companyName:   process.env.SETUP_COMPANY        || 'My Company',
-  phoneNumber:   process.env.SETUP_PHONE          || '0000000000',
-  country:       process.env.SETUP_COUNTRY        || 'United States',
-  city:          process.env.SETUP_CITY           || 'San Francisco',
-  state:         process.env.SETUP_STATE          || 'California',
-  countryCodeObj: { name: 'United States', dialCode: '+1', isoCode: 'US' },
-};
 
 // ─── ANSI helpers ─────────────────────────────────────────────────────────────
 const R      = '\x1b[0m';
@@ -64,7 +52,6 @@ const RED    = '\x1b[31m';
 
 const tag   = (label, color) => `${color}${BOLD}[${label}]${R}`;
 const tick  = msg => console.log(`${GREEN}✓${R}  ${msg}`);
-const dash  = msg => console.log(`${DIM}-  ${msg}${R}`);
 const warn  = msg => console.log(`${YELLOW}⚠${R}  ${msg}`);
 const fatal = msg => { console.error(`${RED}✗${R}  ${msg}`); process.exit(1); };
 const step  = msg => console.log(`\n${BOLD}▶ ${msg}${R}`);
@@ -77,7 +64,6 @@ function cleanupChildren() {
 }
 process.on('SIGINT',  () => { process.stdout.write('\n'); cleanupChildren(); process.exit(0); });
 process.on('SIGTERM', () => { cleanupChildren(); process.exit(0); });
-// Don't orphan backend/frontend children if the orchestrator itself crashes.
 process.on('uncaughtException', err => {
   console.error(`${RED}✗${R}  Setup script crashed: ${err && err.stack || err}`);
   cleanupChildren();
@@ -148,9 +134,9 @@ function isDistValid(dir) {
 async function buildWizard() {
   if (SKIP_INSTALL) return;
   if (!fs.existsSync(INSTALL_DIR)) return;
-  // Only skip if a real built dist exists somewhere. The wizard UI is served
-  // from installation/dist; if frontend/dist is already built we skip too
-  // (full setup already completed; user can go straight to the app).
+  // Skip only if a real built dist already exists. The wizard UI is served from
+  // installation/dist; if the main app (frontend/dist) is already built the
+  // system is set up and the wizard isn't needed.
   if (isDistValid(INSTALL_DIST) || isDistValid(FRONTEND_DIST)) return;
 
   step('Building installation wizard UI (one-time, ~1 min)');
@@ -163,7 +149,7 @@ async function buildWizard() {
       d.toString().split('\n').forEach(l => l.trim() && process.stderr.write(`${DIM}${tag('wizard', YELLOW)} ${l}\n${R}`))
     );
     child.on('close', code => {
-      if (code !== 0) warn('Wizard UI build failed — wizard may not be visible if auto-setup falls back.');
+      if (code !== 0) warn('Wizard UI build failed — the wizard may not display until it is built.');
       else tick('Installation wizard UI built');
       resolve();
     });
@@ -171,11 +157,14 @@ async function buildWizard() {
 }
 
 // ─── Stage 3 : Bootstrap .env ────────────────────────────────────────────────
+// Ensures a valid .env exists so the server can boot (random secrets, a local
+// MongoDB default, server-side storage). This is environment scaffolding only —
+// the operator still connects MongoDB, chooses storage, and creates their
+// account in the wizard, exactly as in production.
 function bootstrapEnv() {
   step('Environment');
   if (fs.existsSync(ENV_PATH)) {
     tick('.env already exists — skipping bootstrap');
-    // Defensive: ensure critical keys are present (APIURL/WEBURL/PORT) — patch in-place if missing
     patchMissingEnvKeys();
     return;
   }
@@ -192,11 +181,11 @@ function bootstrapEnv() {
 
   fs.writeFileSync(ENV_PATH, src, 'utf8');
   tick('.env created (secrets auto-generated; STORAGE_TYPE=server for local dev)');
-  info('Wasabi / Firebase / AI / SMTP can be configured later via the admin UI.');
+  info('Wasabi / Firebase / AI / SMTP can be configured in the wizard or later via the admin UI.');
 }
 
 // Defensive: an existing .env created by an older bootstrap (or hand-edited)
-// might be missing keys the backend reads at module-load time. We append any
+// might be missing keys the backend reads at module-load time. Append any
 // missing critical keys so the backend doesn't crash on startup.
 function patchMissingEnvKeys() {
   const required = {
@@ -221,7 +210,7 @@ function patchMissingEnvKeys() {
   info(`.env was missing ${missing.length} required key(s) — added defaults: ${missing.map(s => s.split('=')[0]).join(', ')}`);
 }
 
-// ─── Stage 4 : Spawn backend + frontend ──────────────────────────────────────
+// ─── Stage 4 : Start the server (same entry production uses) ──────────────────
 function spawnService(cmd, args, cwd, label, color) {
   const child = spawn(cmd, args, { cwd, shell: true });
   const prefix = `${tag(label, color)} `;
@@ -231,19 +220,24 @@ function spawnService(cmd, args, cwd, label, color) {
   child.stderr.on('data', d =>
     d.toString().split('\n').forEach(l => l.trim() && process.stderr.write(`${prefix}${l}\n`))
   );
-  child.on('close', code => {
-    if (code != null && code !== 0) {
-      console.log(`${prefix}process exited (code ${code})`);
-    }
-  });
   children.push(child);
   return child;
 }
 
-function startServices() {
-  step('Starting backend and frontend');
-  spawnService('npm', ['run', 'nodemon'], ROOT,        'API', GREEN);
-  spawnService('npm', ['run', 'serve'],  FRONTEND_DIR, 'WEB', CYAN);
+function startServer(apiPort) {
+  step('Starting the server');
+  const child = spawnService('npm', ['start'], ROOT, 'SERVER', GREEN);
+  child.on('close', code => {
+    // The installation wizard's final step rebuilds the frontend and calls
+    // process.exit() — the same flow production uses, where pm2 then restarts
+    // the app. We deliberately do NOT auto-respawn: a recursive restart wrapper
+    // previously exhausted the process table and took staging down (see
+    // server.js). Just tell the operator how to bring the app back up.
+    console.log(`\n${YELLOW}${BOLD}Server stopped${R}${DIM} (exit ${code}).${R}`);
+    console.log(`${DIM}  If you just finished the installation wizard, this is expected — the app was rebuilt.${R}`);
+    console.log(`${DIM}  Start it again:  ${R}${CYAN}npm start${R}${DIM}   then open ${R}${CYAN}http://localhost:${apiPort}${R}${DIM} and sign in.${R}\n`);
+  });
+  return child;
 }
 
 // ─── Stage 5 : Wait helpers ───────────────────────────────────────────────────
@@ -263,21 +257,17 @@ function poll(url, intervalMs = 1500, timeoutMs = 120_000) {
   });
 }
 
-// ─── Stage 6 : HTTP helpers for headless wizard ──────────────────────────────
-function fetchJson(url, { method = 'GET', body = null } = {}, { timeoutMs = 30_000 } = {}) {
+// ─── Stage 6 : Install-state probe ───────────────────────────────────────────
+function fetchJson(url, { timeoutMs = 10_000 } = {}) {
   return new Promise((resolve, reject) => {
     const u = new URL(url);
-    const payload = body ? JSON.stringify(body) : null;
     const req = http.request({
       hostname: u.hostname,
       port:     u.port,
       path:     u.pathname + u.search,
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(payload ? { 'Content-Length': Buffer.byteLength(payload) } : {}),
-      },
-      timeout: timeoutMs,
+      method:   'GET',
+      headers:  { 'Content-Type': 'application/json' },
+      timeout:  timeoutMs,
     }, res => {
       let raw = '';
       res.on('data', chunk => raw += chunk);
@@ -288,46 +278,13 @@ function fetchJson(url, { method = 'GET', body = null } = {}, { timeoutMs = 30_0
       });
     });
     req.on('error', reject);
-    req.on('timeout', () => req.destroy(new Error(`Timeout: ${method} ${url}`)));
-    if (payload) req.write(payload);
+    req.on('timeout', () => req.destroy(new Error(`Timeout: GET ${url}`)));
     req.end();
   });
 }
 
-// ─── Stage 6b : MongoDB probe (with retry) ───────────────────────────────────
-function probeMongoOnce(host, port) {
-  return new Promise(resolve => {
-    const s = new net.Socket();
-    s.setTimeout(2000);
-    s.once('connect', () => { s.destroy(); resolve(true); });
-    s.once('error',   () => resolve(false));
-    s.once('timeout', () => { s.destroy(); resolve(false); });
-    s.connect(port, host);
-  });
-}
-async function probeMongo(url) {
-  // Only probe plain mongodb:// URLs; mongodb+srv:// requires DNS SRV lookup.
-  const m = url && url.match(/^mongodb:\/\/(?:[^@\/]+@)?([^:\/?]+)(?::(\d+))?/);
-  if (!m) return true; // SRV or unrecognised → don't block; let wizard try
-  const host = m[1];
-  const port = parseInt(m[2] || '27017', 10);
-  // Retry up to 3 times with a 2s delay — handles a still-starting `docker run`
-  // container or a Windows service that takes a moment to come up.
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    if (await probeMongoOnce(host, port)) return true;
-    if (attempt < 3) await new Promise(r => setTimeout(r, 2000));
-  }
-  return false;
-}
-
-function readEnvValue(key) {
-  if (!fs.existsSync(ENV_PATH)) return null;
-  const content = fs.readFileSync(ENV_PATH, 'utf8');
-  const m = content.match(new RegExp(`^${key}=["']?([^"'\\n]+)["']?`, 'm'));
-  return m ? m[1] : null;
-}
-
-// ─── Stage 7 : Headless wizard auto-completion ───────────────────────────────
+// Best-effort: has installation finished already? Used only to tailor the
+// console banner (wizard vs. ready-to-sign-in). Any failure → treat as not done.
 async function isInstallationComplete(apiPort) {
   try {
     const { body } = await fetchJson(`http://localhost:${apiPort}/api/v1/installstep/get`);
@@ -340,95 +297,7 @@ async function isInstallationComplete(apiPort) {
   }
 }
 
-async function wizardStep(apiPort, body, timeoutMs = 60_000) {
-  const { statusCode, body: resp } = await fetchJson(
-    `http://localhost:${apiPort}/api/v1/checkinstallstep`,
-    { method: 'POST', body },
-    { timeoutMs },
-  );
-  if (statusCode >= 400 || resp?.status === false) {
-    const err = resp?.error || resp?.message || `HTTP ${statusCode}`;
-    throw new Error(typeof err === 'string' ? err : JSON.stringify(err));
-  }
-  return resp;
-}
-
-async function autoCompleteWizard(apiPort) {
-  if (MANUAL) {
-    info('--manual flag set — skipping auto-setup. The wizard UI will open instead.');
-    return { mode: 'manual' };
-  }
-
-  // Already done?
-  if (await isInstallationComplete(apiPort)) {
-    return { mode: 'already-done' };
-  }
-
-  // Probe MongoDB
-  const mongoUrl = readEnvValue('MONGODB_URL') || 'mongodb://localhost:27017';
-  const mongoOk = await probeMongo(mongoUrl);
-  if (!mongoOk) {
-    warn(`MongoDB doesn't appear to be running at ${mongoUrl}.`);
-    info('Install & start MongoDB locally, then re-run `npm run setup`. Quick options:');
-    info('  • Docker:   docker run -d -p 27017:27017 --name mongo mongo:7');
-    info('  • Windows:  https://www.mongodb.com/try/download/community');
-    info('Opening the wizard UI so you can enter a different MongoDB URL manually…');
-    return { mode: 'no-mongo' };
-  }
-
-  step('Auto-configuring AlianHub (no input required)');
-
-  try {
-    await wizardStep(apiPort, { step: 1 });
-    tick('Step 1/8  Token verified');
-
-    await wizardStep(apiPort, { step: 2, mongodbUrl: mongoUrl });
-    tick(`Step 2/8  MongoDB connected (${mongoUrl})`);
-
-    await wizardStep(apiPort, { step: 3, chooseStorage: 'default' });
-    tick('Step 3/8  Storage set to local server');
-
-    await wizardStep(apiPort, { step: 4, isDoItLater: true });
-    dash('Step 4/8  Firebase skipped (configure later if you need push notifications)');
-
-    await wizardStep(apiPort, { step: 5, isDoItLater: true });
-    dash('Step 5/8  AI skipped (configure later in Settings)');
-
-    await wizardStep(apiPort, { step: 6, isDoItLater: true });
-    dash('Step 6/8  SMTP skipped (configure later in Settings)');
-
-    info('Saving configuration and initializing database (10-15s)…');
-    await wizardStep(apiPort, { step: 7 }, 90_000);
-    tick('Step 7/8  Configuration saved + database initialized');
-
-    info('Creating your admin account and company (10s)…');
-    const { statusCode, body } = await fetchJson(
-      `http://localhost:${apiPort}/api/v1/installstep/createUserAndCompany`,
-      { method: 'POST', body: DEFAULT_ADMIN },
-      { timeoutMs: 90_000 },
-    );
-    if (statusCode === 420) {
-      tick('Step 8/8  Admin account already exists');
-      return { mode: 'partial-already-done' };
-    }
-    if (statusCode >= 400) {
-      // The controller's error paths use both `message` and `error` depending on
-      // which branch fails — check both, and stringify objects for visibility.
-      const raw = body?.message || body?.error || `HTTP ${statusCode}`;
-      throw new Error(typeof raw === 'string' ? raw : JSON.stringify(raw));
-    }
-    tick(`Step 8/8  Admin account created (${DEFAULT_ADMIN.email})`);
-
-    return { mode: 'completed', credentials: { email: DEFAULT_ADMIN.email, password: DEFAULT_ADMIN.password } };
-  } catch (e) {
-    const msg = (e && e.message) || String(e);
-    warn(`Auto-setup hit a snag: ${msg}`);
-    info('Falling back to the interactive wizard so you can complete the missing step.');
-    return { mode: 'failed', error: msg };
-  }
-}
-
-// ─── Stage 8 : Open browser ───────────────────────────────────────────────────
+// ─── Stage 7 : Open browser ───────────────────────────────────────────────────
 function openBrowser(url) {
   if (NO_OPEN) {
     info(`Browser launch skipped (--no-open). Visit: ${CYAN}${url}${R}`);
@@ -443,27 +312,13 @@ function openBrowser(url) {
   });
 }
 
-// ─── Stage 9 : Print credentials banner ───────────────────────────────────────
-// Flexible — gracefully handles long custom emails / passwords without breaking
-// alignment, because there's no fixed-width box to maintain.
-function printReadyBanner(apiPort, creds) {
-  const bar = '─'.repeat(58);
-  console.log(`\n${GREEN}${bar}${R}`);
-  console.log(`  ${GREEN}${BOLD}✓  AlianHub is ready!${R}`);
-  console.log(`${GREEN}${bar}${R}\n`);
-  console.log(`  URL:       ${CYAN}${BOLD}http://localhost:8080${R}`);
-  if (creds) {
-    console.log(`  Email:     ${BOLD}${creds.email}${R}`);
-    console.log(`  Password:  ${BOLD}${creds.password}${R}`);
-  }
-  console.log('');
-  console.log(`  API:       ${DIM}http://localhost:${apiPort}${R}`);
-  console.log(`  Stop:      ${DIM}Ctrl+C in this terminal${R}`);
-  console.log(`  Logs:      ${DIM}[API] and [WEB] streaming above${R}`);
-  console.log(`${GREEN}${bar}${R}\n`);
-}
-
 // ─── Utility : read PORT from .env ────────────────────────────────────────────
+function readEnvValue(key) {
+  if (!fs.existsSync(ENV_PATH)) return null;
+  const content = fs.readFileSync(ENV_PATH, 'utf8');
+  const m = content.match(new RegExp(`^${key}=["']?([^"'\\n]+)["']?`, 'm'));
+  return m ? m[1] : null;
+}
 function readApiPort() {
   const v = readEnvValue('PORT');
   return v ? parseInt(v, 10) : 4000;
@@ -471,8 +326,8 @@ function readApiPort() {
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 async function main() {
-  console.log(`\n${BOLD}${CYAN}◆ AlianHub Developer Setup${R}`);
-  console.log(`${DIM}  One command — installs, configures, starts, and opens the app.${R}\n`);
+  console.log(`\n${BOLD}${CYAN}◆ AlianHub Setup${R}`);
+  console.log(`${DIM}  Installs, prepares the environment, and starts the server.${R}\n`);
 
   checkNode();
 
@@ -481,58 +336,38 @@ async function main() {
   bootstrapEnv();
 
   const apiPort = readApiPort();
-  startServices();
+  startServer(apiPort);
 
-  // Wait for backend first so we can talk to the wizard API while the frontend builds.
-  step('Waiting for backend');
+  step('Waiting for the server');
   try {
-    await poll(`http://localhost:${apiPort}/health`, 1500, 90_000);
-    tick(`Backend ready → http://localhost:${apiPort}`);
+    await poll(`http://localhost:${apiPort}/health`, 1500, 120_000);
+    tick(`Server ready → http://localhost:${apiPort}`);
   } catch (e) {
-    fatal(`Backend never came up: ${e.message}. Scroll up for [API] errors.`);
+    fatal(`Server never came up: ${e.message}. Scroll up for [SERVER] errors.`);
   }
 
-  // Auto-complete the wizard while the Vue dev server is still compiling.
-  const autoResult = await autoCompleteWizard(apiPort);
+  const url = `http://localhost:${apiPort}`;
+  const installed = await isInstallationComplete(apiPort);
+  openBrowser(url);
 
-  // Wait for the frontend dev server (Vue first compile ~30–60s).
-  step('Waiting for frontend (first compile takes ~30-60s)');
-  try {
-    await poll('http://localhost:8080', 2000, 180_000);
-    tick('Frontend ready → http://localhost:8080');
-  } catch (e) {
-    warn(`Frontend dev server not responding yet. You can still visit http://localhost:8080 once it finishes compiling.`);
+  const bar = '─'.repeat(60);
+  console.log(`\n${GREEN}${bar}${R}`);
+  if (installed) {
+    console.log(`  ${GREEN}${BOLD}✓  AlianHub is ready${R}`);
+    console.log(`${GREEN}${bar}${R}\n`);
+    console.log(`  URL:   ${CYAN}${BOLD}${url}${R}`);
+    console.log(`  ${DIM}Log in with the account you created during installation.${R}`);
+  } else {
+    console.log(`  ${GREEN}${BOLD}✓  Server running — finish installation in your browser${R}`);
+    console.log(`${GREEN}${bar}${R}\n`);
+    console.log(`  URL:   ${CYAN}${BOLD}${url}${R}`);
+    console.log(`  ${DIM}The wizard guides you to connect MongoDB, choose storage, and create${R}`);
+    console.log(`  ${DIM}your own company and admin account.${R}`);
+    console.log(`  ${DIM}When it finishes, the app rebuilds and the server stops (same as${R}`);
+    console.log(`  ${DIM}production). Run ${R}${CYAN}npm start${R}${DIM} again, then sign in.${R}`);
   }
-
-  // Decide where to send the user based on the auto-setup outcome.
-  switch (autoResult.mode) {
-    case 'completed':
-      openBrowser('http://localhost:8080');
-      printReadyBanner(apiPort, autoResult.credentials);
-      break;
-
-    case 'already-done':
-    case 'partial-already-done':
-      step('Setup already complete — opening login page');
-      openBrowser('http://localhost:8080');
-      printReadyBanner(apiPort, null);
-      info('Log in with the credentials you created previously.');
-      break;
-
-    case 'no-mongo':
-    case 'failed':
-    case 'manual':
-    default: {
-      const wizardUrl = fs.existsSync(INSTALL_DIST) ? `http://localhost:${apiPort}` : 'http://localhost:8080';
-      step('Opening installation wizard');
-      openBrowser(wizardUrl);
-      console.log(`\n${YELLOW}${BOLD}Manual setup needed.${R}`);
-      console.log(`${DIM}  Wizard:  ${wizardUrl}${R}`);
-      console.log(`${DIM}  App:     http://localhost:8080 (after wizard completes)${R}`);
-      console.log(`${DIM}  Stop:    Ctrl+C${R}\n`);
-      break;
-    }
-  }
+  console.log(`  ${DIM}Stop:  Ctrl+C${R}`);
+  console.log(`${GREEN}${bar}${R}\n`);
 }
 
 main().catch(e => fatal(e.message || String(e)));


### PR DESCRIPTION
## What & why

A fresh clone running `npm run setup` previously auto-created a hardcoded `admin@admin.local` and silently completed the wizard. This makes setup **fully dynamic** instead: the operator runs the installation wizard themselves and creates their **own** company and admin — local behaves the same as production.

It also fixes a real lockout: any owner created by the installer was stored `isEmailVerified:false`, and login is hard-blocked by the "Email is not verified" gate — with SMTP skipped during setup, no verification email is ever sent, so the operator could never log in.

## Changes

| File | Change |
|------|--------|
| `scripts/dev.js` | Setup now mirrors production: install deps → prepare `.env` → build wizard UI → start the server (`npm start`). Removed the dummy admin, headless auto-complete, `--manual`/`SETUP_ADMIN_*`, and the `:8080` dev server. No dev-only code paths. |
| `Modules/CheckInstallStep/createCompany.js` | The installer-created owner is marked `isEmailVerified:true` at creation (matching the OAuth signup paths). Scoped to the installer flow only — the public `/api/v2/createUser` signup still requires verification. |
| `README.md` | Quick Start rewritten to match the new flow. |

`index.js` and `controller.js` are intentionally untouched — the existing static-file order already serves the wizard on a fresh system and the app once installed.

## Flow (local = production)

1. Fresh clone → `npm run setup` → browser opens `http://localhost:4000` showing the **wizard**.
2. Operator completes the wizard with their own MongoDB / storage / company / admin.
3. Final step rebuilds the frontend and the server exits (same as production, where pm2 restarts it). Locally: run `npm start` again.
4. Open `http://localhost:4000` → **sign in** with the account just created.

## Tested
- Fresh extract + replaced files → `npm run setup` → wizard shown at `:4000` → completed all steps → server stopped → `npm start` → login screen → signed in with own credentials. ✅

## Notes / not breaking
- Public self-signup and invited-user verification behavior unchanged.
- Once installed, normal starts (`npm start`, or `npm run nodemon` + `cd frontend && npm run serve`) go straight to the login flow — the wizard does not reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)