### PR TITLE
fix(projects): align empty-state CTA buttons into a consistent pair

### DIFF
--- a/frontend/src/views/Projects/components/ProjectEmptyState.vue
+++ b/frontend/src/views/Projects/components/ProjectEmptyState.vue
@@ -3,9 +3,9 @@
         <img :src="noProjectsIcon" alt="noProjectsIcon">
         <template v-if="!showArchivedProjects">
             <h2>{{ $t('ProjectSlider.you_dont') }}</h2>
-            <div v-if="canCreate && !isFilterHasData">
-                <button class="outline-primary ml-1 font-size-16 p0x-13px" @click="$emit('createProject')">+ {{ $t('ProjectSlider.new_project') }}</button>
-                <button v-if="currentCompany?.planFeature?.aiPermission" class="btn btn-primary ml-1 font-size-16 p0x-13px" @click="$emit('createAiProject')">{{ aiButtonLabel }}</button>
+            <div v-if="canCreate && !isFilterHasData" class="d-flex justify-content-center align-items-center mt-2">
+                <button class="outline-primary font-size-16 p0x-13px" @click="$emit('createProject')">+ {{ $t('ProjectSlider.new_project') }}</button>
+                <button v-if="currentCompany?.planFeature?.aiPermission" class="outline-primary ml-1 font-size-16 p0x-13px" @click="$emit('createAiProject')">{{ aiButtonLabel }}</button>
             </div>
         </template>
         <template v-else>


### PR DESCRIPTION
Fixes the misaligned, stacked CTA buttons on the Projects empty state. Wraps the two buttons in a centered flex row and uses the same outline-primary style for both (matching the sidebar), so they render as a consistent equal-height pair. Template-only change in ProjectEmptyState.vue; frontend build green.