### PR TITLE
feat(settings): distinct nav icons for security and integration menus

### DIFF
--- a/frontend/src/assets/images/svg/auditDoc.svg
+++ b/frontend/src/assets/images/svg/auditDoc.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.3 1.6H8.2L10.9 4.3V12.4H3.3V1.6Z" stroke="#535358" stroke-width="1.8" stroke-linejoin="round"/>
+<path d="M8.2 1.6V4.3H10.9" stroke="#535358" stroke-width="1.6" stroke-linejoin="round"/>
+<path d="M5.2 7.3H8.8M5.2 9.5H8.8M5.2 5.2H6.8" stroke="#535358" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/auditDocActive.svg
+++ b/frontend/src/assets/images/svg/auditDocActive.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.3 1.6H8.2L10.9 4.3V12.4H3.3V1.6Z" stroke="#2F3990" stroke-width="1.8" stroke-linejoin="round"/>
+<path d="M8.2 1.6V4.3H10.9" stroke="#2F3990" stroke-width="1.6" stroke-linejoin="round"/>
+<path d="M5.2 7.3H8.8M5.2 9.5H8.8M5.2 5.2H6.8" stroke="#2F3990" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/integrationPuzzle.svg
+++ b/frontend/src/assets/images/svg/integrationPuzzle.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.2 3.9H5.5C5.5 2.3 6 1.7 7 1.7C8 1.7 8.5 2.3 8.5 3.9H10.8V5.9C12.1 5.9 12.5 6.4 12.5 7.3C12.5 8.2 12.1 8.7 10.8 8.7V11.1H3.2V3.9Z" stroke="#535358" stroke-width="1.8" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/integrationPuzzleActive.svg
+++ b/frontend/src/assets/images/svg/integrationPuzzleActive.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.2 3.9H5.5C5.5 2.3 6 1.7 7 1.7C8 1.7 8.5 2.3 8.5 3.9H10.8V5.9C12.1 5.9 12.5 6.4 12.5 7.3C12.5 8.2 12.1 8.7 10.8 8.7V11.1H3.2V3.9Z" stroke="#2F3990" stroke-width="1.8" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/scimUsers.svg
+++ b/frontend/src/assets/images/svg/scimUsers.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4.9" cy="4.7" r="2.1" stroke="#535358" stroke-width="1.6"/>
+<path d="M1.6 11.6C1.6 9 3 7.6 4.9 7.6C6.8 7.6 8.2 9 8.2 11.6" stroke="#535358" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M9 2.9C10.2 2.9 11.1 3.8 11.1 5C11.1 6 10.5 6.8 9.6 7" stroke="#535358" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M10 7.7C11.5 7.9 12.4 9.2 12.4 11.1" stroke="#535358" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/scimUsersActive.svg
+++ b/frontend/src/assets/images/svg/scimUsersActive.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4.9" cy="4.7" r="2.1" stroke="#2F3990" stroke-width="1.6"/>
+<path d="M1.6 11.6C1.6 9 3 7.6 4.9 7.6C6.8 7.6 8.2 9 8.2 11.6" stroke="#2F3990" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M9 2.9C10.2 2.9 11.1 3.8 11.1 5C11.1 6 10.5 6.8 9.6 7" stroke="#2F3990" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M10 7.7C11.5 7.9 12.4 9.2 12.4 11.1" stroke="#2F3990" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/ssoKey.svg
+++ b/frontend/src/assets/images/svg/ssoKey.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4.9" cy="4.9" r="2.6" stroke="#535358" stroke-width="1.8"/>
+<path d="M6.85 6.85L12 12" stroke="#535358" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M9.6 9.6L10.8 8.4M10.6 10.6L11.8 9.4" stroke="#535358" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/ssoKeyActive.svg
+++ b/frontend/src/assets/images/svg/ssoKeyActive.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4.9" cy="4.9" r="2.6" stroke="#2F3990" stroke-width="1.8"/>
+<path d="M6.85 6.85L12 12" stroke="#2F3990" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M9.6 9.6L10.8 8.4M10.6 10.6L11.8 9.4" stroke="#2F3990" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/twoFactorLock.svg
+++ b/frontend/src/assets/images/svg/twoFactorLock.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2.8" y="6.1" width="8.4" height="6.2" rx="1.5" stroke="#535358" stroke-width="1.8"/>
+<path d="M4.8 6.1V4.6C4.8 3.4 5.79 2.4 7 2.4C8.21 2.4 9.2 3.4 9.2 4.6V6.1" stroke="#535358" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="7" cy="8.8" r="1.05" fill="#535358"/>
+<path d="M7 9.6V10.7" stroke="#535358" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/svg/twoFactorLockActive.svg
+++ b/frontend/src/assets/images/svg/twoFactorLockActive.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2.8" y="6.1" width="8.4" height="6.2" rx="1.5" stroke="#2F3990" stroke-width="1.8"/>
+<path d="M4.8 6.1V4.6C4.8 3.4 5.79 2.4 7 2.4C8.21 2.4 9.2 3.4 9.2 4.6V6.1" stroke="#2F3990" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="7" cy="8.8" r="1.05" fill="#2F3990"/>
+<path d="M7 9.6V10.7" stroke="#2F3990" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/components/templates/Settings/Settings.vue
+++ b/frontend/src/components/templates/Settings/Settings.vue
@@ -180,21 +180,21 @@
         },{
             label: "SSO",
             to: {name: "SsoSettings"},
-            icon: require("@/assets/images/svg/workspaceSecurity.svg"),
+            icon: require("@/assets/images/svg/ssoKey.svg"),
             permissions:['settings.settings_security_permissions'],
-            activeIcon: require("@/assets/images/svg/workspaceSecurityActive.svg")
+            activeIcon: require("@/assets/images/svg/ssoKeyActive.svg")
         },{
             label: "SCIM",
             to: {name: "ScimSettings"},
-            icon: require("@/assets/images/svg/workspaceSecurity.svg"),
+            icon: require("@/assets/images/svg/scimUsers.svg"),
             permissions:['settings.settings_security_permissions'],
-            activeIcon: require("@/assets/images/svg/workspaceSecurityActive.svg")
+            activeIcon: require("@/assets/images/svg/scimUsersActive.svg")
         },{
             label: "Audit Log",
             to: {name: "AuditLog"},
-            icon: require("@/assets/images/svg/workspaceSecurity.svg"),
+            icon: require("@/assets/images/svg/auditDoc.svg"),
             permissions:['settings.settings_security_permissions'],
-            activeIcon: require("@/assets/images/svg/workspaceSecurityActive.svg")
+            activeIcon: require("@/assets/images/svg/auditDocActive.svg")
         },{
             label: "Time Off",
             to: {name: "TimeOff"},
@@ -223,15 +223,15 @@
         },{
             label: "Two-Factor Authentication",
             to: {name: "twoFactorAuth"},
-            icon: require("@/assets/images/svg/WorkspaceSettingsInactive.svg"),
+            icon: require("@/assets/images/svg/twoFactorLock.svg"),
             isVisible:true,
-            activeIcon: require("@/assets/images/svg/WorkspaceSettings.svg")
+            activeIcon: require("@/assets/images/svg/twoFactorLockActive.svg")
         },{
             label: "Integrations",
             to: {name: "Integrations"},
-            icon: require("@/assets/images/svg/WorkspaceSettingsInactive.svg"),
+            icon: require("@/assets/images/svg/integrationPuzzle.svg"),
             isVisible:true,
-            activeIcon: require("@/assets/images/svg/WorkspaceSettings.svg")
+            activeIcon: require("@/assets/images/svg/integrationPuzzleActive.svg")
         },{
             label: "Company",
             to: {name: "Company"},


### PR DESCRIPTION
## Summary

The settings-section nav items **SSO, SCIM, Audit Log, Two-Factor Authentication, and Integrations** all rendered the **same** shield/gear icon, making the menu hard to scan. This gives each its own purpose-built icon.

| Menu | Was | Now |
|------|-----|-----|
| SSO | shield | **key** |
| SCIM | shield | **people** |
| Audit Log | shield | **document** |
| Two-Factor Authentication | gear | **padlock** |
| Integrations | gear | **puzzle piece** |

Each ships as an inactive (gray `#535358`) + active (blue `#2F3990`) pair, matching the existing nav-icon format, viewBox, and stroke weight so they read as clearly as the built-in icons.

## Changes

- 10 new SVGs in `frontend/src/assets/images/svg/` (5 icons × 2 states)
- Icon/activeIcon wiring for the 5 items in `components/templates/Settings/Settings.vue`
- **Additive only** — no logic or behavior change.

## Test plan

- [x] `npm run build` passes
- [ ] Settings → each of the five items shows its own distinct icon; the selected item shows the blue active variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
