### PR TITLE
fix: skip husky setup when devDependencies are omitted

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,14 @@
+// Husky bootstrap — runs from the package.json "prepare" script.
+// Production/CI installs omit devDependencies, so husky isn't present there;
+// requiring it directly made `npm install` fail on the deploy server
+// (sh: husky: not found, exit 127). Skip silently in that case — git hooks
+// are a dev-machine concern only.
+if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
+    process.exit(0);
+}
+try {
+    const { default: husky } = await import('husky');
+    console.log(husky());
+} catch {
+    // husky not installed (devDependencies omitted) — nothing to set up.
+}

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "dev": "node scripts/dev.js --skip-install",
     "setup:reset": "node scripts/dev.js --force",
     "lint:commits": "commitlint --from ${BASE_BRANCH:-origin/staging} --to HEAD --verbose",
-    "prepare": "husky"
+    "prepare": "node .husky/install.mjs"
   },
   "author": "Alian Software <https://alianhub.com>",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

The staging deploy failed after merging #329 — not because of the dashboard changes, but because of the husky hook setup from the earlier tooling PR:

```
> alian-hub-v3@14.7.0 prepare
> husky
sh: 1: husky: not found
npm error code 127
```

`"prepare": "husky"` runs on **every** `npm install`, but the deploy server installs without devDependencies, so the husky binary doesn't exist there.

## Fix

Official husky v9 pattern: `prepare` now runs `.husky/install.mjs`, which

- exits silently when `NODE_ENV=production` or `CI=true`
- exits silently when husky can't be imported (devDependencies omitted)
- bootstraps the git hooks normally on dev machines

Verified locally in both modes (hooks installed with husky present; clean exit with `NODE_ENV=production`). `.gitattributes` already forces LF on `.husky/*`, so the new script is covered.

## Note (separate, non-blocking)

The same deploy log shows `EBADENGINE`: the server now runs **Node 22** while `package.json` engines pins `node: 20.x`. It's only a warning, but worth deciding whether to bump the engines range or pin the server back to Node 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)