### PR TITLE
fix: resolve CodeRabbit PR #328 review findings

### DIFF
--- a/.claude/test-cases/AHE-3789-project-progress-cards.md
+++ b/.claude/test-cases/AHE-3789-project-progress-cards.md
@@ -49,7 +49,7 @@ All additive — no existing card, endpoint, or data path was modified.
 | PPC-08 | Role — member | Non-admin views the activity cards | Reflects only **their** activity (role-scoped). | ⬜ |
 | PPC-09 | Header UI | All cards | Refresh re-fetches; skeleton while loading; period dropdown (Running Projects, Work by Category) sits before the gear; cards resize narrow without the header breaking. | ⬜ |
 | PPC-10 | Regression | Existing cards + add/edit/remove/drag | Work as before; **no console errors**. | ⬜ |
-| PPC-11 | Boot integrity | Restart backend; `GET /api/v1/cardcomponent` | Returns **24** cards; no JSON parse error. | ⬜ |
+| PPC-11 | Boot integrity | Restart backend; `GET /api/v1/cardcomponent` | Returns **31** cards; no JSON parse error. | ⬜ |
 | PPC-12 | Multi-tenant | Second company | Each card shows only the current company's data. | ⬜ |
 | WBC-01 | Work by Category — first add | Add the card | Shows a **"Set up categories"** prompt pointing to the **⚙ settings** (no template yet). | ⬜ |
 | WBC-02 | Settings — template | Card **settings (⚙)** → **Category template** → pick **Development**, tick 2 task types; pick **QA**, tick 1 → **Save** | Table columns appear per non-empty category; each ticked type belongs to exactly **one** category (re-ticking moves it). Template **persists** after reload. | ⬜ |

--- a/Modules/UserDashboard/controller.js
+++ b/Modules/UserDashboard/controller.js
@@ -34,6 +34,27 @@ function resolveVisibleUserIds(payload = {}) {
     return self ? [self] : [];
 }
 
+// SECURITY: resolve the caller's real role for this company from the DB, never
+// from the request body. These routes are JWT-protected (req.uid is the
+// verified user; the companyid header is checked against the token audience),
+// but roleType isn't in the token — so look it up in company_users. Fails
+// closed to the most-restricted role (3) when absent, so a forged
+// callerRoleType in the body can never widen the visibility scope.
+async function resolveCallerRoleType(companyId, uid) {
+    if (!uid) return 3;
+    try {
+        const row = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.COMPANY_USERS,
+            data: [{ userId: String(uid), isDelete: { $ne: true } }, { roleType: 1 }],
+        }, "findOne");
+        const rt = Number(row && row.roleType);
+        return Number.isFinite(rt) && rt > 0 ? rt : 3;
+    } catch (e) {
+        logger.error(`resolveCallerRoleType error (company=${companyId}, uid=${uid}): ${e.message || e}`);
+        return 3;
+    }
+}
+
 /**
  * This endpoint is used to get user user dashboard template
  * @param {*} req 
@@ -219,6 +240,12 @@ exports.getEmployeeWorkloadReport = async (req, res) => {
         }
 
         const payload = req.body || {};
+        // SECURITY (CodeRabbit): derive caller identity + role from the
+        // authenticated session, never the request body. req.uid is the verified
+        // JWT user; the role is resolved server-side. A forged
+        // callerUserId/callerRoleType in the body can no longer widen scope.
+        payload.callerUserId = String(req.uid || "");
+        payload.callerRoleType = await resolveCallerRoleType(companyId, req.uid);
         // All thresholds come from the caller's card config — no
         // fallback constants here. If they're missing we just skip
         // the badge calculation and return 'normal' for everyone.
@@ -802,6 +829,12 @@ exports.getTeamTaskTypeBreakdown = async (req, res) => {
             return res.status(400).json({ status: false, message: "companyId header required" });
         }
         const payload = req.body || {};
+        // SECURITY (CodeRabbit): derive caller identity + role from the
+        // authenticated session, never the request body. req.uid is the verified
+        // JWT user; the role is resolved server-side. A forged
+        // callerUserId/callerRoleType in the body can no longer widen scope.
+        payload.callerUserId = String(req.uid || "");
+        payload.callerRoleType = await resolveCallerRoleType(companyId, req.uid);
         const dimension = ["type", "effort_nature", "work_category", "billable"].includes(payload.dimension)
             ? payload.dimension : "type";
         const { fromSec, toSec, dateFrom, dateTo } = getDayOrRangeBounds(payload);
@@ -942,6 +975,12 @@ exports.getTeamLoggedVsEta = async (req, res) => {
             return res.status(400).json({ status: false, message: "companyId header required" });
         }
         const payload = req.body || {};
+        // SECURITY (CodeRabbit): derive caller identity + role from the
+        // authenticated session, never the request body. req.uid is the verified
+        // JWT user; the role is resolved server-side. A forged
+        // callerUserId/callerRoleType in the body can no longer widen scope.
+        payload.callerUserId = String(req.uid || "");
+        payload.callerRoleType = await resolveCallerRoleType(companyId, req.uid);
         const { fromSec, toSec } = getDayOrRangeBounds(payload);
         const visibleUserIds = resolveVisibleUserIds(payload);
         if (Array.isArray(visibleUserIds) && !visibleUserIds.length) {
@@ -1074,6 +1113,12 @@ exports.getProjectProgressMetric = async (req, res) => {
         }
 
         const payload = req.body || {};
+        // SECURITY (CodeRabbit): derive caller identity + role from the
+        // authenticated session, never the request body. req.uid is the verified
+        // JWT user; the role is resolved server-side. A forged
+        // callerUserId/callerRoleType in the body can no longer widen scope.
+        payload.callerUserId = String(req.uid || "");
+        payload.callerRoleType = await resolveCallerRoleType(companyId, req.uid);
         const metric = String(payload.metric || "");
         const dateFrom = payload.dateFrom ? new Date(payload.dateFrom) : null;
         const dateTo = payload.dateTo ? new Date(payload.dateTo) : null;
@@ -1448,6 +1493,12 @@ exports.getOnLeaveBoard = async (req, res) => {
         }
 
         const payload = req.body || {};
+        // SECURITY (CodeRabbit): derive caller identity + role from the
+        // authenticated session, never the request body. req.uid is the verified
+        // JWT user; the role is resolved server-side. A forged
+        // callerUserId/callerRoleType in the body can no longer widen scope.
+        payload.callerUserId = String(req.uid || "");
+        payload.callerRoleType = await resolveCallerRoleType(companyId, req.uid);
         const projectIds = (Array.isArray(payload.projectIds) ? payload.projectIds : [])
             .filter((id) => mongoose.Types.ObjectId.isValid(String(id)))
             .map((id) => new mongoose.Types.ObjectId(String(id)));

--- a/Modules/service.js
+++ b/Modules/service.js
@@ -2,6 +2,11 @@ const nodemailer = require("nodemailer");
 const config =  require('../Config/config.js');
 const logger = require("../Config/loggerConfig.js");
 
+// TLS certificate validation is ON by default. Only disable it (e.g. a
+// self-signed SMTP cert in a controlled environment) via an explicit env
+// opt-in — never silently, since disabling it exposes SMTP traffic to MITM.
+const allowSelfSigned = String(process.env.NODEMAILER_ALLOW_SELF_SIGNED || "").toLowerCase() === "true";
+
 
 /**
  * Send mail via email
@@ -23,7 +28,7 @@ exports.SendEmail = async (subject, html, toMail, isHtml, cb) => {
                 pass: config.NODEMAILER_EMAIL_PASSWORD, // generated ethereal password
             },
             tls: {
-                rejectUnauthorized: false
+                rejectUnauthorized: !allowSelfSigned
             }
         });
 
@@ -36,7 +41,7 @@ exports.SendEmail = async (subject, html, toMail, isHtml, cb) => {
             if (err) {
                 cb({
                     status:false,
-                    error: err,
+                    error: err.message ? err.message : err,
                 })
             } else {
                 cb({
@@ -74,7 +79,7 @@ exports.SendNotificationEmail = async (subject, html, toMail, isHtml, cb) => {
                 pass: config.NODEMAILER_EMAIL_PASSWORD, // generated ethereal password
             },
             tls: {
-                rejectUnauthorized: false
+                rejectUnauthorized: !allowSelfSigned
             }
         });
 
@@ -87,7 +92,7 @@ exports.SendNotificationEmail = async (subject, html, toMail, isHtml, cb) => {
             if (err) {
                 cb({
                     status:false,
-                    error: err,
+                    error: err.message ? err.message : err,
                 })
             } else {
                 cb({
@@ -97,7 +102,7 @@ exports.SendNotificationEmail = async (subject, html, toMail, isHtml, cb) => {
             }
         });
     } catch(error) {
-        logger.error(`Send Verify Email Catch Error: ${error.messge}`);
+        logger.error(`Send Verify Email Catch Error: ${error.message}`);
         cb({
             status: false,
             error: error.message
@@ -124,7 +129,7 @@ exports.sendAttachMail = (subject, html, toMail,attachMents, cb) => {
             pass: config.NODEMAILER_EMAIL_PASSWORD, // generated ethereal password
         },
         tls: {
-            rejectUnauthorized: false
+            rejectUnauthorized: !allowSelfSigned
         }
     });
     transporter.sendMail({

--- a/frontend/src/components/organisms/FreeResourcesCard/FreeResourcesCard.vue
+++ b/frontend/src/components/organisms/FreeResourcesCard/FreeResourcesCard.vue
@@ -63,13 +63,16 @@ const props = defineProps({
 
 const userId = inject('$userId');
 const { getters } = useStore();
-const teamsArr = getters['settings/teams'] || [];
 
 const employees = ref([]);
 const loading = ref(false);
 
 // Planned threshold: free when planned hours fall UNDER this (default 3h).
-const thresholdHours = computed(() => Number(props.cardData?.freeThresholdHours) || 3);
+const thresholdHours = computed(() => {
+    // Explicit 0 is a valid threshold — only fall back to 3 when it's unset.
+    const v = props.cardData?.freeThresholdHours;
+    return v === undefined || v === null || v === '' ? 3 : Number(v);
+});
 const thresholdMin = computed(() => thresholdHours.value * 60);
 // Logged threshold: free when logged hours are AT OR BELOW this (default 0h,
 // i.e. nothing logged). Number(...)||0 keeps 0 as a valid configured value.
@@ -101,7 +104,8 @@ const load = async () => {
     loading.value = true;
     try {
         const { dateFrom, dateTo } = resolveIsoRange(1); // today
-        const employeeIds = teamIdToUserId(props.cardData?.AssigneeUserId || [], teamsArr);
+        // Read teams fresh — the store may populate after this card mounts.
+        const employeeIds = teamIdToUserId(props.cardData?.AssigneeUserId || [], getters['settings/teams'] || []);
         const payload = {
             employeeIds: Array.isArray(employeeIds) ? employeeIds : [],
             projectIds: props.cardData?.projectId || [],

--- a/frontend/src/components/organisms/TeamCategoryBreakdownCard/TeamCategoryBreakdownCard.vue
+++ b/frontend/src/components/organisms/TeamCategoryBreakdownCard/TeamCategoryBreakdownCard.vue
@@ -71,7 +71,6 @@ const props = defineProps({
 
 const userId = inject('$userId');
 const { getters } = useStore();
-const teamsArr = getters['settings/teams'] || [];
 
 const teams = ref([]);
 const loading = ref(false);
@@ -95,7 +94,8 @@ const load = async () => {
     loading.value = true;
     try {
         const { dateFrom, dateTo } = resolveCardRange(timerange.value, globalRange && globalRange.value);
-        const employeeIds = teamIdToUserId(props.cardData?.AssigneeUserId || [], teamsArr);
+        // Read teams fresh — the store may populate after this card mounts.
+        const employeeIds = teamIdToUserId(props.cardData?.AssigneeUserId || [], getters['settings/teams'] || []);
         const payload = {
             dimension: dimension.value,
             employeeIds: Array.isArray(employeeIds) ? employeeIds : [],


### PR DESCRIPTION
## Summary

Fixes the actionable findings CodeRabbit raised on the promotion PR #328. Merge this into `staging` first, then re-sync #328 so the promotion carries the fixes — the security items should land before staging→main.

## Fixed

- 🔴 **Critical (Security) — forgeable role/user.** The dashboard endpoints scoped data visibility from client-supplied `callerRoleType`/`callerUserId`, so a non-admin could POST `callerRoleType: 1` and read every user's workload/time data. Now the caller is derived from the authenticated session (`req.uid`) and the role is resolved server-side from `company_users` (fail-closed to the most-restricted role). Applied to `employee-workload`, `team-tasktype-breakdown`, `team-logged-vs-eta`, `project-metrics`, and `on-leave`.
- 🟠 **Stale Vuex getter (reactivity)** — `FreeResourcesCard` + `TeamCategoryBreakdownCard` now read `settings/teams` fresh inside `load()` instead of capturing it once at setup.
- 🟡 **`FreeResourcesCard`** — an explicit `freeThresholdHours: 0` is now honored (was falsy-coerced to the default 3).
- 🔒 **Mail transport (Security)** — `service.js` now validates TLS certificates by default across all three mail paths; self-signed requires an explicit `NODEMAILER_ALLOW_SELF_SIGNED=true` opt-in (was a hardcoded `rejectUnauthorized:false` → MITM exposure). Also returns `err.message` (not the raw `Error`, which serialized to `{}`) and fixes an `error.messge` typo.
- 📝 Corrected the boot-integrity expected card count in the AHE-3789 test case (24 → **31**, the actual count).

## Deferred (needs a decision — not a blocker)

- **Week-range consistency** (`ProjectResourceCard` vs `ProjectPulseCard`) — Sunday-based vs Monday-based windows for the same filter. Unifying requires deciding the canonical week start and touches the broadly-used `getTimeRange` / `resolveIsoRange` helpers, so it warrants cross-card testing rather than a rushed change inside a release promotion.
- **`LiveWorkCard` cardData/filters** — CodeRabbit noted this was already addressed by later commits on #328.

## Verification

- `node --check` on `controller.js` + `service.js`; eslint clean on the touched Vue components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
