### PR TITLE
fix(estimate): require task description before opening estimate sidebar

### DIFF
--- a/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
+++ b/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
@@ -241,9 +241,23 @@ const totalHours = computed(() => {
     .padStart(2, "0")}m`;
 });
 
+function isDescriptionEmpty() {
+    // Description is rich text, so strip tags/entities and check the plain text.
+    const raw = props.task?.description ?? '';
+    const plainText = raw
+        .replace(/<[^>]*>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .trim();
+    return plainText.length === 0;
+}
+
 function showEtaSidebar() {
     if(!props.permission) {
         $toast.error(t(`Toast.Access denied`), {position: 'top-right'})
+        return;
+    }
+    if(isDescriptionEmpty()) {
+        $toast.error(t(`Toast.Description_required_for_estimate`), {position: 'top-right'})
         return;
     }
     let assigneePermissionCheck = companyUser.value.roleType !== 1 && companyUser.value.roleType !== 2 && props.permission !== 2 ? props.task?.AssigneeUserId?.length && props.task.AssigneeUserId.includes(userId.value) : props.task?.AssigneeUserId?.length;

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -2399,6 +2399,7 @@ export default {
         No_assignee_found: "No assignee found",
         No_due_date_found: "No due date found",
         No_self_assignee_found: "No self assignee found",
+        Description_required_for_estimate: "A detailed description is mandatory to generate an accurate estimate time",
         Estimated_time_updated_successfully:
             "Task Planning updated successfully",
         Description_updated_successfully: "Description updated successfully",


### PR DESCRIPTION
## Summary

Fixes **AHE-3793** — "When user clicks on estimate icon check if the task has a description or not".

When a user clicks the estimate (ETA) icon on a task that has **no description**, the app now shows a toast — *"A detailed description is mandatory to generate an accurate estimate time"* — and does **not** open the estimate sidebar. This ensures estimates are only made against a proper task description.

## Changes

- **`frontend/src/components/molecules/EstimateHours/EstimateHours.vue`**
  - Added a guard in `showEtaSidebar()` right after the existing permission check: if the description is empty, show the toast and return before opening the sidebar (runs before the assignee/due-date checks).
  - Added `isDescriptionEmpty()` helper that strips rich-text HTML tags + `&nbsp;` and trims, so a visually-empty description (`<p></p>`, `<p><br></p>`) still counts as missing.
- **`frontend/src/locales/en.js`**
  - New locale key `Toast.Description_required_for_estimate`.

## Scope

Front-end only — no backend/API changes.

## Test

- Task with **empty** description → click estimate icon → toast shown, sidebar stays closed.
- Task with a **real** description → sidebar opens as before (then existing assignee/due-date checks apply).
- Task with only empty rich-text (`<p></p>`) → treated as missing → toast shown.
- Regression: task with description + assignee + due date → opens normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
