### PR TITLE
fix: address CodeRabbit review nits (mongoose require + shared ASSIGNEE_FIELD)

### DIFF
--- a/Modules/TimeSheet/helpers/reminderSettings.js
+++ b/Modules/TimeSheet/helpers/reminderSettings.js
@@ -17,7 +17,7 @@
  *   }
  */
 
-const { default: mongoose } = require('mongoose');
+const mongoose = require('mongoose');
 const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
 const { SCHEMA_TYPE } = require('../../../Config/schemaType');
 

--- a/frontend/src/components/organisms/FreeResourcesCard/FreeResourcesCard.vue
+++ b/frontend/src/components/organisms/FreeResourcesCard/FreeResourcesCard.vue
@@ -42,7 +42,7 @@ import { apiRequest } from '@/services';
 import * as env from '@/config/env';
 import { teamIdToUserId, buildFilterQuery } from '@/composable/commonFunction';
 import { resolveIsoRange, formatMinutes } from '@/composable/useResourceWorkload';
-import { resolveAssigneeFilter, passesAssigneeFilter, isFree } from '@/composable/freeResourceRules';
+import { ASSIGNEE_FIELD, resolveAssigneeFilter, passesAssigneeFilter, isFree } from '@/composable/freeResourceRules';
 import CardSkeleton from '@/components/atom/CardSkeleton/CardSkeleton.vue';
 
 // Resource Utilization card #7 — "Free or in-training resources".
@@ -73,7 +73,7 @@ const filterRows = () => (Array.isArray(props.filterData) ? props.filterData : O
 
 // Assignee is a PERSON filter here, not a task filter: as a task filter it
 // would zero co-assignees' workload and mark busy people free.
-const isAssigneeRow = (r) => r.name.value === 'AssigneeUserId';
+const isAssigneeRow = (r) => r.name.value === ASSIGNEE_FIELD;
 const assigneeUserFilter = computed(() =>
     resolveAssigneeFilter(filterRows(), (ids) => teamIdToUserId(ids, getters['settings/teams'] || [])));
 


### PR DESCRIPTION
Two behaviour-neutral cleanups flagged by CodeRabbit on #338. No functional change, no other modules touched.

- **reminderSettings.js** — plain equire('mongoose') instead of destructuring .default (matches repo convention; ObjectId usage verified working on mongoose 8.17.2).
- **FreeResourcesCard.vue** — import + use the exported ASSIGNEE_FIELD constant instead of re-hardcoding 'AssigneeUserId', keeping it in sync with reeResourceRules.js (constant value is identical, so behaviour is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)