### PR TITLE
fix(deploy): survive husky prepare so the release Docker build passes

### DIFF
--- a/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
+++ b/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
@@ -241,23 +241,9 @@ const totalHours = computed(() => {
     .padStart(2, "0")}m`;
 });
 
-function isDescriptionEmpty() {
-    // Description is rich text, so strip tags/entities and check the plain text.
-    const raw = props.task?.description ?? '';
-    const plainText = raw
-        .replace(/<[^>]*>/g, '')
-        .replace(/&nbsp;/g, ' ')
-        .trim();
-    return plainText.length === 0;
-}
-
 function showEtaSidebar() {
     if(!props.permission) {
         $toast.error(t(`Toast.Access denied`), {position: 'top-right'})
-        return;
-    }
-    if(isDescriptionEmpty()) {
-        $toast.error(t(`Toast.Description_required_for_estimate`), {position: 'top-right'})
         return;
     }
     let assigneePermissionCheck = companyUser.value.roleType !== 1 && companyUser.value.roleType !== 2 && props.permission !== 2 ? props.task?.AssigneeUserId?.length && props.task.AssigneeUserId.includes(userId.value) : props.task?.AssigneeUserId?.length;

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -2399,7 +2399,6 @@ export default {
         No_assignee_found: "No assignee found",
         No_due_date_found: "No due date found",
         No_self_assignee_found: "No self assignee found",
-        Description_required_for_estimate: "A detailed description is mandatory to generate an accurate estimate time",
         Estimated_time_updated_successfully:
             "Task Planning updated successfully",
         Description_updated_successfully: "Description updated successfully",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "dev": "node scripts/dev.js --skip-install",
     "setup:reset": "node scripts/dev.js --force",
     "lint:commits": "commitlint --from ${BASE_BRANCH:-origin/staging} --to HEAD --verbose",
-    "prepare": "node .husky/install.mjs"
+    "prepare": "node .husky/install.mjs || true"
   },
   "author": "Alian Software <https://alianhub.com>",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Two fixes, both headed for the next 14.9.0 re-release:

### 1. Deploy — husky `prepare` breaks the release Docker build
The `backend-deps` stage does `COPY package.json package-lock.json* ./` then `RUN npm ci --omit=dev`, which runs `prepare` → `node .husky/install.mjs` **before `.husky/` is copied** → `Cannot find module /app/.husky/install.mjs` → `npm ci` exits 1 → the `docker.yml` release-image build fails → no image published → prod stays on the old version even though the release/tag were cut. Fixed by making prepare tolerant: `node .husky/install.mjs || true` (dev still installs hooks; Docker/CI skips cleanly). This is what stranded v14.9.0.

### 2. Estimate — drop the mandatory-description guard (revert #337)
The estimate / task-planning sidebar no longer blocks on an empty task description (removed `isDescriptionEmpty()` + its toast + the i18n string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)