### PR TITLE
fix(estimate): require a task description before generating an AI estimate

### DIFF
--- a/Modules/EstimatedTime/controller.js
+++ b/Modules/EstimatedTime/controller.js
@@ -4,7 +4,7 @@ const { SCHEMA_TYPE } = require("../../Config/schemaType");
 const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries");
 const { replaceObjectKey } = require("../Auth/helper");
 const socketEmitter = require("../../event/socketEventEmitter");
-const { estimateAndPersist: estimateTaskTimeWithAI } = require("./aiTaskEstimator");
+const { estimateAndPersist: estimateTaskTimeWithAI, _internal: aiEstimatorInternal } = require("./aiTaskEstimator");
 // BUG fix (found via MCP integration 2026-06-12): updateEstimatedTime called
 // `exports.updateRemainingTime`, which was never defined in this module —
 // every Task Planning save threw "not a function" AFTER persisting the row,
@@ -123,6 +123,19 @@ exports.generateAiEstimate = async (req, res) => {
         const taskDoc = (typeof taskDocRaw.toObject === 'function')
             ? taskDocRaw.toObject()
             : taskDocRaw;
+
+        // A description is required for a meaningful AI estimate. Check the
+        // CANONICAL DB state (the client's task can be stale — descriptions save
+        // async over the socket), using the same extraction the estimator uses.
+        // This gates only the AI trigger; manual estimate/planning is untouched.
+        // Fail OPEN: if the extractor helper is ever unavailable, skip the gate
+        // (never wrongly block a valid estimate) rather than failing closed.
+        const descForEstimate = (aiEstimatorInternal && typeof aiEstimatorInternal.extractDescription === 'function')
+            ? aiEstimatorInternal.extractDescription(taskDoc)
+            : null;
+        if (descForEstimate !== null && !String(descForEstimate).trim()) {
+            return res.status(200).json({ status: false, statusText: 'Please add a task description before generating an AI estimate' });
+        }
 
         // Subtask rollup (richer input): if this is a parent task, attach its
         // subtasks' titles so the model accounts for the work they represent.


### PR DESCRIPTION
### What
The manual **"Generate estimate using AI"** trigger (task-detail sidebar magic-wand) now requires a task description. If the task has none, it shows *"Please add a task description before generating an AI estimate"* instead of running an LLM call on a title-only task.

### Why the check is server-side
The description saves asynchronously (API + socket), so the client's `props.task` is often stale right after editing — a frontend check gave a false "empty" even when a description was present. The AI-estimate endpoint already fetches the task fresh from the DB, so the check runs against the **canonical current state** using the estimator's own `extractDescription`.

### Scope / no side effects
- Gates **only** this manual trigger (`POST /api/v1/estimatedTime/ai/:tid`, called solely by the magic-wand).
- The post-create **auto-estimate** calls `estimateAndPersist` directly (bypasses this endpoint) — unchanged; title-only tasks still get an estimate.
- Manual estimate / task-planning sidebar and all other routes — untouched.
- **Fails open**: if the extractor helper is ever unavailable, the gate is skipped so a valid estimate is never wrongly blocked.

1 file changed (`Modules/EstimatedTime/controller.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)