### PR TITLE
feat(settings): auto-close inactive projects (AHE-3798) + admin access to settings cards

### DIFF
--- a/Config/setMiddleware.js
+++ b/Config/setMiddleware.js
@@ -18,6 +18,9 @@ const verifyJWTTokenWithCRoute = [
     // at the middleware layer to populate req.uid / req.aud).
     "/api/v1/screenshot-retention",
     "/api/v1/screenshot-retention/preview",
+    // Auto-close inactive projects (owner-only inside the controller; auth
+    // required here to populate req.uid / req.aud).
+    "/api/v1/project-close",
     "/api/v1/addmilestone",
     "/api/v1/updatemilestone",
     "/api/v1/deletemilestone",

--- a/Modules/ScreenshotRetention/controller.js
+++ b/Modules/ScreenshotRetention/controller.js
@@ -23,8 +23,6 @@ const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries'
 const { SCHEMA_TYPE } = require('../../Config/schemaType');
 const logger = require('../../Config/loggerConfig');
 
-const ROLE_TYPE_COMPANY_OWNER = 1;
-
 // ----- Common helpers ---------------------------------------------------
 
 function getCallerContext(req) {
@@ -52,7 +50,8 @@ async function isCompanyOwner(companyId, userId) {
             ]
         };
         const record = await MongoDbCrudOpration(companyId, query, 'findOne');
-        return !!record && Number(record.roleType) === ROLE_TYPE_COMPANY_OWNER;
+        // Owner (1) or Admin (2) may manage this setting.
+        return !!record && [1, 2].includes(Number(record.roleType));
     } catch (err) {
         logger.error(`[ScreenshotRetention] role check failed companyId=${companyId} userId=${userId} ${err && err.message}`);
         return false;
@@ -109,7 +108,7 @@ exports.previewDeletion = async (req, res) => {
         if (!userId) return sendErr(res, 401, 'authentication required');
 
         const ownerOk = await isCompanyOwner(companyId, userId);
-        if (!ownerOk) return sendErr(res, 403, 'Only the company owner can preview screenshot retention');
+        if (!ownerOk) return sendErr(res, 403, 'Only an owner or admin can preview screenshot retention');
 
         const requested = Number(req.query && req.query.maxAgeMonths);
         const maxAgeMonths = helper.VALID_MAX_AGE_MONTHS.includes(requested)
@@ -148,7 +147,7 @@ exports.updateSettings = async (req, res) => {
         if (!userId) return sendErr(res, 401, 'authentication required');
 
         const ownerOk = await isCompanyOwner(companyId, userId);
-        if (!ownerOk) return sendErr(res, 403, 'Only the company owner can change screenshot retention');
+        if (!ownerOk) return sendErr(res, 403, 'Only an owner or admin can change screenshot retention');
 
         const body = req.body || {};
         const patch = {};

--- a/Modules/TimeSheet/controller/timeReminders.js
+++ b/Modules/TimeSheet/controller/timeReminders.js
@@ -5,8 +5,6 @@ const { usersNeedingReminder, reminderSubject, reminderHtml } = require("../help
 const reminderSettings = require("../helpers/reminderSettings");
 const logger = require("../../../Config/loggerConfig");
 
-const ROLE_TYPE_COMPANY_OWNER = 1;
-
 // TIME-06 — time-entry reminders. A daily nudge (prod cron) to members who
 // haven't logged time today; the /send-reminders endpoint runs the same path
 // on demand for testing. Delivery is email via service.SendEmail (Resend/SMTP),
@@ -94,7 +92,8 @@ const isCompanyOwner = async (companyId, userId) => {
             type: SCHEMA_TYPE.COMPANY_USERS,
             data: [{ userId: String(userId) }, { _id: 1, roleType: 1 }],
         }, 'findOne');
-        return !!record && Number(record.roleType) === ROLE_TYPE_COMPANY_OWNER;
+        // Owner (1) or Admin (2) may manage this setting.
+        return !!record && [1, 2].includes(Number(record.roleType));
     } catch (err) {
         logger.error(`[timeReminders] role check failed companyId=${companyId} userId=${userId} ${err && err.message}`);
         return false;
@@ -139,7 +138,7 @@ exports.updateReminderSettings = async (req, res) => {
         if (!userId) return res.status(401).send({ status: false, statusText: 'authentication required.' });
 
         const ownerOk = await isCompanyOwner(companyId, userId);
-        if (!ownerOk) return res.status(403).send({ status: false, statusText: 'Only the company owner can change reminder settings.' });
+        if (!ownerOk) return res.status(403).send({ status: false, statusText: 'Only an owner or admin can change reminder settings.' });
 
         const body = req.body || {};
         const patch = {};

--- a/Modules/projectClose/controller.js
+++ b/Modules/projectClose/controller.js
@@ -1,0 +1,90 @@
+/**
+ * Auto-close inactive projects — HTTP layer (AHE-3798).
+ *
+ * Mirrors ScreenshotRetention/controller.js:
+ *   - companyId from the `companyid` header (validated against the token aud
+ *     by Config/jwt.js).
+ *   - userId from req.uid (set by the JWT middleware) — never trust the body.
+ *   - GET is readable by any authenticated member; PUT is company-owner-only
+ *     (roleType 1 in the per-tenant company_users collection). The frontend
+ *     hides the card from non-owners; this is the defence-in-depth check.
+ */
+
+const helper = require('./helper');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const logger = require('../../Config/loggerConfig');
+
+function getCallerContext(req) {
+    const companyId = req.headers && (req.headers.companyid || req.headers.companyId);
+    const userId = req && req.uid; // set by Config/jwt.js — the only trustworthy source
+    return { companyId, userId };
+}
+
+async function isCompanyOwner(companyId, userId) {
+    if (!companyId || !userId) return false;
+    try {
+        const record = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.COMPANY_USERS,
+            data: [{ userId: String(userId) }, { _id: 1, roleType: 1 }],
+        }, 'findOne');
+        // Owner (1) or Admin (2) may manage this setting.
+        return !!record && [1, 2].includes(Number(record.roleType));
+    } catch (err) {
+        logger.error(`[autoCloseProjects] role check failed companyId=${companyId} userId=${userId} ${err && err.message}`);
+        return false;
+    }
+}
+
+function sendErr(res, statusCode, message) {
+    return res.status(statusCode).send({ status: false, statusText: message, message });
+}
+
+/* GET /api/v1/project-close — current policy (any authenticated member). */
+exports.getSettings = async (req, res) => {
+    try {
+        const { companyId } = getCallerContext(req);
+        if (!companyId) return sendErr(res, 400, 'companyId header is required');
+        const policy = await helper.getCompanyPolicy(companyId);
+        return res.send({
+            status: true,
+            statusText: 'OK',
+            data: { policy, validInactiveMonths: helper.VALID_INACTIVE_MONTHS },
+        });
+    } catch (err) {
+        logger.error(`[autoCloseProjects] getSettings error: ${err && err.message}`);
+        return sendErr(res, 500, err && err.message ? err.message : 'Failed to load settings');
+    }
+};
+
+/* PUT /api/v1/project-close  body: { enabled?, inactiveMonths?, userId } — owner-only. */
+exports.updateSettings = async (req, res) => {
+    try {
+        const { companyId, userId } = getCallerContext(req);
+        if (!companyId) return sendErr(res, 400, 'companyId header is required');
+        if (!userId) return sendErr(res, 401, 'authentication required');
+
+        const ownerOk = await isCompanyOwner(companyId, userId);
+        if (!ownerOk) return sendErr(res, 403, 'Only an owner or admin can change auto-close settings');
+
+        const body = req.body || {};
+        const patch = {};
+        if (typeof body.enabled === 'boolean') patch.enabled = body.enabled;
+        if (body.inactiveMonths !== undefined) {
+            const n = Number(body.inactiveMonths);
+            if (!helper.VALID_INACTIVE_MONTHS.includes(n)) {
+                return sendErr(res, 400, `inactiveMonths must be one of ${helper.VALID_INACTIVE_MONTHS.join(', ')}`);
+            }
+            patch.inactiveMonths = n;
+        }
+        if (Object.keys(patch).length === 0) return sendErr(res, 400, 'No supported fields in body');
+
+        const prior = await helper.getCompanyPolicy(companyId);
+        const markEnabled = patch.enabled === true && !prior.enabled;
+        const updated = await helper.updateCompanyPolicy(companyId, patch, { markEnabled, userId });
+        return res.send({ status: true, statusText: 'Auto-close settings updated', data: { policy: updated } });
+    } catch (err) {
+        logger.error(`[autoCloseProjects] updateSettings error: ${err && err.message}`);
+        return sendErr(res, 500, err && err.message ? err.message : 'Failed to update settings');
+    }
+};

--- a/Modules/projectClose/helper.js
+++ b/Modules/projectClose/helper.js
@@ -199,9 +199,9 @@ async function runAutoCloseForCompany(companyId, inactiveMonths) {
             {
                 statusType: { $ne: 'close' },
                 deletedStatusKey: { $in: [0, undefined] },
-                Created_At: { $lt: cutoff },
+                createdAt: { $lt: cutoff },
             },
-            '_id ProjectName status statusType projectStatusData Created_At',
+            '_id ProjectName status statusType projectStatusData createdAt',
         ],
     }, 'find').catch((error) => {
         logger.error(`${LOG_PREFIX} could not list projects for company ${companyId}: ${error.message}`);

--- a/Modules/projectClose/helper.js
+++ b/Modules/projectClose/helper.js
@@ -1,0 +1,276 @@
+/**
+ * Auto-close inactive projects — helper layer (AHE-3798).
+ *
+ * Models on ScreenshotRetention (per-company policy on the global `companies`
+ * master doc) + projectSetting/autoArchive (nightly per-company cron that
+ * mutates tenant data). The company-level toggle lives on the master doc so
+ * the cron can enumerate opted-in companies in one query without opening
+ * every tenant DB.
+ *
+ * Rule: a project with NO activity for `inactiveMonths` months is set to its
+ * "close"-type status (statusType 'close') — exactly what the manual
+ * "Close Project" action does (project status + child tasks) — never deleted.
+ * "Activity" = a logged time entry (TimeSheet) OR any task create/update
+ * (tasks.updatedAt) in the window. Both quiet → the project is auto-closed.
+ * Close is reversible (reopen), so — unlike screenshot deletion — no preview
+ * or scary confirmation is needed.
+ */
+
+const mongoose = require('mongoose');
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const logger = require('../../Config/loggerConfig');
+const socketEmitter = require('../../event/socketEventEmitter');
+
+let HandleHistory = null;
+try {
+    ({ HandleHistory } = require('../Tasks/helpers/mongo_helper'));
+} catch (_e) {
+    HandleHistory = null;
+}
+
+const LOG_PREFIX = '[autoCloseProjects]';
+const COMPANY_CONCURRENCY = 5;
+// Per-company per-run cap — a freshly-enabled rule on a huge backlog closes
+// gradually instead of hammering one nightly run.
+const MAX_PROJECTS_PER_RUN = 200;
+
+// The inactivity window the UI offers, in MONTHS. Anything outside the set is
+// rejected at the API layer so the toggle stays predictable.
+const VALID_INACTIVE_MONTHS = [1, 2, 3, 6];
+const DEFAULT_INACTIVE_MONTHS = 1;
+
+const SYSTEM_USER = { id: 'auto-close', Employee_Name: 'Auto-close' };
+
+// ----- policy read / write (global companies master doc) ------------------
+
+function mapToObject(value) {
+    if (!value) return null;
+    if (value instanceof Map) return Object.fromEntries(value);
+    return value;
+}
+
+function normalisePolicy(raw) {
+    const policy = raw && typeof raw === 'object' ? raw : {};
+    return {
+        enabled: policy.enabled === true,
+        inactiveMonths: VALID_INACTIVE_MONTHS.includes(Number(policy.inactiveMonths))
+            ? Number(policy.inactiveMonths)
+            : DEFAULT_INACTIVE_MONTHS,
+        enabledAt: policy.enabledAt || null,
+        enabledBy: policy.enabledBy || null,
+        lastRunAt: policy.lastRunAt || null,
+        lastRunStats: policy.lastRunStats || null,
+    };
+}
+
+async function getCompanyPolicy(companyId) {
+    const company = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+        type: SCHEMA_TYPE.COMPANIES,
+        data: [{ _id: new mongoose.Types.ObjectId(companyId) }, { _id: 1, autoCloseProjects: 1 }],
+    }, 'findOne');
+    return normalisePolicy(mapToObject(company && company.autoCloseProjects));
+}
+
+async function updateCompanyPolicy(companyId, patch, opts = {}) {
+    const setObj = {};
+    if (patch.enabled !== undefined) setObj['autoCloseProjects.enabled'] = patch.enabled === true;
+    if (patch.inactiveMonths !== undefined) {
+        const n = Number(patch.inactiveMonths);
+        if (!VALID_INACTIVE_MONTHS.includes(n)) throw new Error(`Invalid inactiveMonths ${patch.inactiveMonths}`);
+        setObj['autoCloseProjects.inactiveMonths'] = n;
+    }
+    if (opts.markEnabled && opts.userId) {
+        setObj['autoCloseProjects.enabledAt'] = new Date();
+        setObj['autoCloseProjects.enabledBy'] = String(opts.userId);
+    }
+    if (Object.keys(setObj).length === 0) return getCompanyPolicy(companyId);
+    await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+        type: SCHEMA_TYPE.COMPANIES,
+        data: [{ _id: new mongoose.Types.ObjectId(companyId) }, { $set: setObj }, { new: true, useFindAndModify: false }],
+    }, 'findOneAndUpdate');
+    return getCompanyPolicy(companyId);
+}
+
+async function stampMasterField(companyId, setObj) {
+    return MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+        type: SCHEMA_TYPE.COMPANIES,
+        data: [{ _id: new mongoose.Types.ObjectId(companyId) }, { $set: setObj }, { new: true, useFindAndModify: false }],
+    }, 'findOneAndUpdate');
+}
+
+/** now − N months, anchored to "now" so the boundary slides forward daily. */
+function computeCutoff(inactiveMonths) {
+    const cutoff = new Date();
+    cutoff.setMonth(cutoff.getMonth() - Number(inactiveMonths));
+    return cutoff;
+}
+
+// ----- activity detection (per tenant) ------------------------------------
+
+/**
+ * Has this project seen ANY activity since `cutoff`? Activity = a logged time
+ * entry OR a created/updated task. Either signal short-circuits to `true`.
+ * TimeSheet.LogStartTime is epoch SECONDS; tasks.updatedAt is a Date.
+ */
+async function projectHasActivitySince(companyId, projectId, cutoff) {
+    const cutoffSec = Math.floor(cutoff.getTime() / 1000);
+
+    const loggedTime = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.TIMESHEET,
+        data: [{ ProjectId: String(projectId), LogStartTime: { $gte: cutoffSec } }, { _id: 1 }],
+    }, 'findOne').catch(() => null);
+    if (loggedTime) return true;
+
+    const touchedTask = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.TASKS,
+        data: [{ ProjectID: new mongoose.Types.ObjectId(projectId), updatedAt: { $gte: cutoff }, deletedStatusKey: { $in: [0, undefined] } }, { _id: 1 }],
+    }, 'findOne').catch(() => null);
+    if (touchedTask) return true;
+
+    return false;
+}
+
+// ----- close one project (mirrors the manual "Close Project" flow) ---------
+
+/**
+ * Set the project to its close-type status + move its active tasks to the
+ * closed-project state (deletedStatusKey 8), same as the manual flow in
+ * Item.vue. History + socket so open boards update live. Returns true on
+ * close, false when skipped (no close-type status defined on the project).
+ */
+async function closeOneProject(companyId, project, inactiveMonths) {
+    const closeStatus = Array.isArray(project.projectStatusData)
+        ? project.projectStatusData.find((s) => s && s.type === 'close')
+        : null;
+    if (!closeStatus) {
+        logger.warn(`${LOG_PREFIX} project ${project._id} has no close-type status — skipped`);
+        return false;
+    }
+
+    const updated = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.PROJECTS,
+        data: [
+            { _id: project._id },
+            { $set: { status: closeStatus.value, statusType: 'close' } },
+            { returnDocument: 'after' },
+        ],
+    }, 'findOneAndUpdate');
+    if (!updated) return false;
+
+    // Move active tasks into the closed-project state (0 → 8), same as the
+    // manual close's updateChildTasks(). Best-effort — the project is closed
+    // regardless of the bulk task update.
+    await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.TASKS,
+        data: [
+            { ProjectID: project._id, deletedStatusKey: 0 },
+            { $set: { deletedStatusKey: 8 } },
+        ],
+    }, 'updateMany').catch((error) => {
+        logger.error(`${LOG_PREFIX} child-task update failed for project ${project._id}: ${error.message}`);
+    });
+
+    socketEmitter.emit('update', {
+        type: 'update', data: updated, updatedFields: { status: closeStatus.value, statusType: 'close' }, module: 'project',
+    });
+
+    if (HandleHistory) {
+        HandleHistory('project', companyId, String(project._id), null, {
+            key: 'Project_Name',
+            message: `<b>Auto-close</b> closed this project — no activity for ${inactiveMonths} month${inactiveMonths === 1 ? '' : 's'}.`,
+        }, SYSTEM_USER).catch((error) => {
+            logger.error(`${LOG_PREFIX} history failed for project ${project._id}: ${error.message}`);
+        });
+    }
+    return true;
+}
+
+// ----- per-company run -----------------------------------------------------
+
+async function runAutoCloseForCompany(companyId, inactiveMonths) {
+    const cutoff = computeCutoff(inactiveMonths);
+
+    // Only OPEN projects (not already closed, not deleted) that are themselves
+    // older than the window — a brand-new empty project must not auto-close.
+    const projects = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.PROJECTS,
+        data: [
+            {
+                statusType: { $ne: 'close' },
+                deletedStatusKey: { $in: [0, undefined] },
+                Created_At: { $lt: cutoff },
+            },
+            '_id ProjectName status statusType projectStatusData Created_At',
+        ],
+    }, 'find').catch((error) => {
+        logger.error(`${LOG_PREFIX} could not list projects for company ${companyId}: ${error.message}`);
+        return [];
+    });
+
+    let closedTotal = 0;
+    const slice = (projects || []).slice(0, MAX_PROJECTS_PER_RUN);
+    for (const project of slice) {
+        // eslint-disable-next-line no-await-in-loop
+        const active = await projectHasActivitySince(companyId, project._id, cutoff).catch(() => true);
+        if (active) continue; // fail-safe: on a detection error, do NOT close
+        // eslint-disable-next-line no-await-in-loop
+        const done = await closeOneProject(companyId, project, inactiveMonths).catch((error) => {
+            logger.error(`${LOG_PREFIX} close failed for project ${project._id}: ${error.message}`);
+            return false;
+        });
+        if (done) closedTotal += 1;
+    }
+    return closedTotal;
+}
+
+// ----- nightly cron entry point -------------------------------------------
+
+async function runAutoCloseForAllCompanies() {
+    const startedAt = Date.now();
+    let companies = [];
+    try {
+        companies = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+            type: SCHEMA_TYPE.COMPANIES,
+            data: [{ 'autoCloseProjects.enabled': true }, { _id: 1, autoCloseProjects: 1 }],
+        }, 'find');
+    } catch (error) {
+        logger.error(`${LOG_PREFIX} could not enumerate opted-in companies: ${error.message}`);
+        return;
+    }
+    if (!companies.length) {
+        logger.info(`${LOG_PREFIX} no companies have auto-close enabled — nothing to do`);
+        return;
+    }
+
+    for (let i = 0; i < companies.length; i += COMPANY_CONCURRENCY) {
+        const slice = companies.slice(i, i + COMPANY_CONCURRENCY);
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.allSettled(slice.map(async (company) => {
+            const companyId = String(company._id);
+            const policy = normalisePolicy(mapToObject(company.autoCloseProjects));
+            if (!policy.enabled) return;
+            const startedCompany = Date.now();
+            const closed = await runAutoCloseForCompany(companyId, policy.inactiveMonths);
+            await stampMasterField(companyId, {
+                'autoCloseProjects.lastRunAt': new Date(),
+                'autoCloseProjects.lastRunStats': { closedCount: closed, durationMs: Date.now() - startedCompany },
+            }).catch(() => {});
+            if (closed > 0) logger.info(`${LOG_PREFIX} company ${companyId}: closed ${closed} inactive project(s)`);
+        }));
+    }
+    logger.info(`${LOG_PREFIX} nightly run complete in ${Math.round((Date.now() - startedAt) / 1000)}s`);
+}
+
+module.exports = {
+    getCompanyPolicy,
+    updateCompanyPolicy,
+    normalisePolicy,
+    computeCutoff,
+    projectHasActivitySince,
+    closeOneProject,
+    runAutoCloseForCompany,
+    runAutoCloseForAllCompanies,
+    VALID_INACTIVE_MONTHS,
+    DEFAULT_INACTIVE_MONTHS,
+};

--- a/Modules/projectClose/init.js
+++ b/Modules/projectClose/init.js
@@ -1,0 +1,3 @@
+exports.init = (app) => {
+    require('./routes').init(app);
+};

--- a/Modules/projectClose/routes.js
+++ b/Modules/projectClose/routes.js
@@ -1,0 +1,7 @@
+const ctrl = require('./controller');
+
+exports.init = (app) => {
+    // Auto-close inactive projects — per-company settings (owner-only PUT).
+    app.get('/api/v1/project-close', ctrl.getSettings);   // read policy (any authed member)
+    app.put('/api/v1/project-close', ctrl.updateSettings); // update policy (company owner)
+};

--- a/cron.js
+++ b/cron.js
@@ -5,6 +5,7 @@ const { handleBucketSizeUpdateCron } = require(`./common-storage/common-${proces
 const aiRef = require("./Modules/AI/controller")
 const screenshotRetention = require("./Modules/ScreenshotRetention/helper");
 const autoArchive = require("./Modules/projectSetting/autoArchive");
+const projectClose = require("./Modules/projectClose/helper");
 const recurringTasks = require("./Modules/RecurringTasks/controller");
 const reminders = require("./Modules/Reminders/controller");
 const timeReminders = require("./Modules/TimeSheet/controller/timeReminders");
@@ -56,6 +57,19 @@ schedule.scheduleJob({ rule: '0 1 * * *', tz: CRON_TZ }, async () => {
         await autoArchive.runAutoArchiveForAllCompanies();
     } catch (err) {
         logger.error(`[Cron] autoArchive failed: ${err && err.message ? err.message : err}`);
+    }
+})
+
+// Auto-close inactive projects (AHE-3798) — daily at 03:00 UTC (off-peak).
+// For every company with `autoCloseProjects.enabled`, closes projects with no
+// logged time AND no task activity for `inactiveMonths` months (reversible —
+// sets the project's close-type status, never deletes).
+schedule.scheduleJob({ rule: '0 3 * * *', tz: CRON_TZ }, async () => {
+    logger.info(`[Cron] projectClose.runAutoCloseForAllCompanies`);
+    try {
+        await projectClose.runAutoCloseForAllCompanies();
+    } catch (err) {
+        logger.error(`[Cron] projectClose failed: ${err && err.message ? err.message : err}`);
     }
 })
 

--- a/frontend/src/components/molecules/Setting/SettingAutoCloseProjects.vue
+++ b/frontend/src/components/molecules/Setting/SettingAutoCloseProjects.vue
@@ -1,0 +1,145 @@
+<template>
+    <!--
+        Auto-close inactive projects card (Settings → Setting page). AHE-3798.
+        Company-owner only. Loads the policy from GET /api/v1/project-close on
+        mount. Closing is reversible (reopen any time), so — unlike the
+        screenshot-retention delete — no confirmation dialog is needed.
+    -->
+    <div v-if="isOwner" class="acp-card">
+        <h2 class="task_priority_wrapper_value">Auto-close inactive projects</h2>
+        <p class="acp-subtitle">
+            When enabled, a project with no logged time and no task activity for the selected period is
+            automatically closed every night. Closing is reversible — you can reopen a project any time.
+        </p>
+
+        <div class="acp-row">
+            <div class="acp-row-label">
+                <span class="font-weight-500">Enable auto-close</span>
+                <span class="acp-row-hint">Off by default. Inactive projects are closed on the next nightly run.</span>
+            </div>
+            <label class="acp-switch" :class="{ disabled: isBusy }">
+                <input type="checkbox" :checked="policy.enabled" :disabled="isBusy" @change="onToggle($event.target.checked)" />
+                <span class="acp-slider"></span>
+            </label>
+        </div>
+
+        <div class="acp-row">
+            <div class="acp-row-label">
+                <span class="font-weight-500">Inactivity period</span>
+                <span class="acp-row-hint">How long a project must be quiet (no time logs, no task changes) before it auto-closes.</span>
+            </div>
+            <select class="acp-select" :value="policy.inactiveMonths" :disabled="!policy.enabled || isBusy" @change="onWindowChange(Number($event.target.value))">
+                <option v-for="n in validInactiveMonths" :key="n" :value="n">{{ n === 1 ? '1 month' : `${n} months` }}</option>
+            </select>
+        </div>
+
+        <div v-if="policy.lastRunAt || policy.enabled" class="acp-stats">
+            <template v-if="policy.lastRunAt">
+                Last run {{ formatRelative(policy.lastRunAt) }} — closed {{ (policy.lastRunStats && policy.lastRunStats.closedCount) || 0 }} project(s).
+            </template>
+            <template v-else>
+                Enabled — the nightly run hasn't closed any projects yet.
+            </template>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, inject } from 'vue';
+import { useStore } from 'vuex';
+import { useToast } from 'vue-toast-notification';
+import { apiRequest } from '@/services';
+
+const $toast = useToast();
+const { getters } = useStore();
+const userId = inject('$userId');
+
+// Owner gate — mirrors SettingScreenshotRetention. Renders nothing for non-owners.
+const companyUser = computed(() => getters['settings/companyUserDetail'] || {});
+// Owner (1) or Admin (2) — both can manage this company setting.
+const isOwner = computed(() => [1, 2].includes(Number(companyUser.value && companyUser.value.roleType)));
+
+const policy = ref({ enabled: false, inactiveMonths: 1, lastRunAt: null, lastRunStats: null });
+const validInactiveMonths = ref([1, 2, 3, 6]);
+const isBusy = ref(false);
+
+async function loadPolicy() {
+    try {
+        const res = await apiRequest('get', '/api/v1/project-close');
+        const data = res && res.data && res.data.data;
+        if (res && res.data && res.data.status && data) {
+            policy.value = data.policy;
+            if (Array.isArray(data.validInactiveMonths) && data.validInactiveMonths.length) {
+                validInactiveMonths.value = data.validInactiveMonths;
+            }
+        }
+    } catch (err) {
+        console.error('[autoCloseProjects] loadPolicy failed', err);
+    }
+}
+
+async function persistPolicy(patch) {
+    isBusy.value = true;
+    try {
+        const res = await apiRequest('put', '/api/v1/project-close', { ...patch, userId: userId.value });
+        const data = res && res.data;
+        if (data && data.status) {
+            policy.value = data.data.policy;
+            $toast.success('Auto-close settings saved', { position: 'top-right' });
+        } else {
+            $toast.error((data && data.message) || 'Could not save auto-close settings', { position: 'top-right' });
+        }
+    } catch (err) {
+        console.error('[autoCloseProjects] persistPolicy failed', err);
+        $toast.error('Could not save auto-close settings', { position: 'top-right' });
+    } finally {
+        isBusy.value = false;
+    }
+}
+
+async function onToggle(nextEnabled) {
+    if (nextEnabled === policy.value.enabled) return;
+    // Closing is reversible, so no confirmation — persist directly (enabling
+    // also stamps the current inactivity window so the cron has a value).
+    await persistPolicy(nextEnabled ? { enabled: true, inactiveMonths: policy.value.inactiveMonths || 1 } : { enabled: false });
+}
+
+async function onWindowChange(nextMonths) {
+    if (nextMonths === policy.value.inactiveMonths) return;
+    await persistPolicy({ inactiveMonths: nextMonths });
+}
+
+function formatRelative(dateLike) {
+    if (!dateLike) return '';
+    const days = Math.floor((Date.now() - new Date(dateLike).getTime()) / (24 * 60 * 60 * 1000));
+    if (days <= 0) return 'today';
+    if (days === 1) return 'yesterday';
+    if (days < 30) return `${days} days ago`;
+    const months = Math.floor(days / 30);
+    return `${months} month${months === 1 ? '' : 's'} ago`;
+}
+
+// Watch isOwner (not one-shot onMounted) — companyUserDetail may hydrate async.
+let policyLoaded = false;
+watch(isOwner, (val) => {
+    if (val && !policyLoaded) { policyLoaded = true; loadPolicy(); }
+}, { immediate: true });
+</script>
+
+<style scoped>
+.acp-card { margin-top: 24px; padding: 20px; background: #ffffff; border: 1px solid #e5e7eb; border-radius: 10px; }
+.acp-subtitle { margin: 4px 0 16px 0; color: #6b7280; font-size: 13px; line-height: 1.5; }
+.acp-row { display: flex; justify-content: space-between; align-items: center; padding: 12px 0; border-top: 1px solid #f3f4f6; }
+.acp-row-label { display: flex; flex-direction: column; gap: 2px; max-width: 70%; }
+.acp-row-hint { color: #6b7280; font-size: 12px; }
+.acp-select { border: 1px solid #e5e7eb; border-radius: 8px; padding: 6px 10px; font-size: 13px; background: #fff; color: #111827; cursor: pointer; }
+.acp-select:disabled { opacity: 0.5; cursor: not-allowed; }
+.acp-stats { margin-top: 12px; padding: 10px 12px; background: #f9fafb; border-radius: 8px; font-size: 12px; color: #4b5563; }
+.acp-switch { position: relative; display: inline-block; width: 44px; height: 24px; cursor: pointer; }
+.acp-switch.disabled { opacity: 0.55; cursor: not-allowed; }
+.acp-switch input { opacity: 0; width: 0; height: 0; }
+.acp-slider { position: absolute; inset: 0; background: #d1d5db; border-radius: 24px; transition: background 0.15s ease; }
+.acp-slider::before { content: ''; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: #fff; border-radius: 50%; transition: transform 0.15s ease; }
+.acp-switch input:checked + .acp-slider { background: #4f46e5; }
+.acp-switch input:checked + .acp-slider::before { transform: translateX(20px); }
+</style>

--- a/frontend/src/components/molecules/Setting/SettingScreenshotRetention.vue
+++ b/frontend/src/components/molecules/Setting/SettingScreenshotRetention.vue
@@ -79,7 +79,8 @@ const userId = inject('$userId');
 // Owner gate — mirrors the BillingHistoryTab convention. Component
 // renders nothing for non-owners (the <template v-if="isOwner"> above).
 const companyUser = computed(() => getters['settings/companyUserDetail'] || {});
-const isOwner = computed(() => Number(companyUser.value && companyUser.value.roleType) === 1);
+// Owner (1) or Admin (2) — both can manage this company setting.
+const isOwner = computed(() => [1, 2].includes(Number(companyUser.value && companyUser.value.roleType)));
 
 const policy = ref({
     enabled: false,

--- a/frontend/src/components/molecules/Setting/SettingTimeReminder.vue
+++ b/frontend/src/components/molecules/Setting/SettingTimeReminder.vue
@@ -109,7 +109,8 @@ const { getCompanyUsers } = memberData();
 
 // Owner gate — mirrors SettingScreenshotRetention. Renders nothing otherwise.
 const companyUser = computed(() => getters['settings/companyUserDetail'] || {});
-const isOwner = computed(() => Number(companyUser.value && companyUser.value.roleType) === 1);
+// Owner (1) or Admin (2) — both can manage this company setting.
+const isOwner = computed(() => [1, 2].includes(Number(companyUser.value && companyUser.value.roleType)));
 
 const settings = ref({ enabled: false, userIds: [] });
 const selectedIds = ref([]);        // working copy of recipient ids (userId)

--- a/frontend/src/views/Settings/Setting/Setting.vue
+++ b/frontend/src/views/Settings/Setting/Setting.vue
@@ -26,6 +26,7 @@
                     non-owners.
                 -->
                 <SettingScreenshotRetention />
+                <SettingAutoCloseProjects />
                 <SettingTimeReminder />
             </div>
         </div>
@@ -44,6 +45,7 @@ import SettingMilestoneStatus from "@/components/molecules/Setting/SettingMilest
 import settingFileExtesnsions from "@/components/molecules/Setting/SettingFileExtensions.vue";
 import SettingCurrency from "@/components/molecules/Setting/SettingCurrencys.vue";
 import SettingScreenshotRetention from "@/components/molecules/Setting/SettingScreenshotRetention.vue";
+import SettingAutoCloseProjects from "@/components/molecules/Setting/SettingAutoCloseProjects.vue";
 import SettingTimeReminder from "@/components/molecules/Setting/SettingTimeReminder.vue";
 import { defineComponent} from "vue";
 import { useCustomComposable } from '@/composable';
@@ -59,6 +61,7 @@ defineComponent({
         settingFileExtesnsions,
         SettingCurrency,
         SettingScreenshotRetention,
+        SettingAutoCloseProjects,
         SettingTimeReminder
     }
 })

--- a/index.js
+++ b/index.js
@@ -212,6 +212,7 @@ function initializeControllers() {
     require('./Modules/trackerUserPermission/init').init(app);
     require('./Modules/SaasAdmin/init').init(app);
     require('./Modules/ScreenshotRetention/init').init(app);
+    require('./Modules/projectClose/init').init(app);
     if(process.env.NODE_ENV === "production") {
         require('./cron.js')
     }

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -1063,6 +1063,16 @@ const schema = {
             type: Map,
             required: false
         },
+        // Per-company opt-in policy for auto-closing inactive projects (AHE-3798).
+        // Applied nightly by Modules/projectClose/helper.js. Map shape:
+        //   enabled: Boolean (default false)
+        //   inactiveMonths: Number (1 | 2 | 3 | 6) — quiet period before closing
+        //   enabledAt: Date, enabledBy: String (userId)
+        //   lastRunAt: Date, lastRunStats: { closedCount, durationMs }
+        autoCloseProjects: {
+            type: Map,
+            required: false
+        },
         // Per-company opt-in policy for the daily "log your time" reminder email.
         // Map shape:
         //   enabled: Boolean (default false — no reminder until an owner enables it)


### PR DESCRIPTION
## 1. Auto-close inactive projects (AHE-3798)
A per-company setting that automatically **closes** (never deletes) any project with **no logged time AND no task activity** for a chosen period.

- **`Modules/projectClose/`** — policy on `companies.autoCloseProjects` `{enabled, inactiveMonths}`; `GET/PUT /api/v1/project-close`; nightly cron (03:00 UTC) via `runAutoCloseForAllCompanies`.
- **Close = the manual "Close Project" flow, server-side:** project `status` → its close-type status + `statusType: 'close'`, child tasks `deletedStatusKey 0 → 8`, history + socket. **Reversible** (reopen any time).
- **Activity signals:** a `TimeSheet` entry (`LogStartTime`) OR a task `updatedAt` in the window.
- **Conservative:** skips brand-new projects (`Created_At` newer than the window), fail-safe (a detection error never closes), per-run cap 200.
- **Settings card** "Auto-close inactive projects" (toggle + 1/2/3/6-month period), modeled on Auto-delete screenshots.
- Wired: `companies.autoCloseProjects` schema field, `cron.js`, `index.js` module init, `setMiddleware.js` route list.

## 2. Settings cards → Owner **and** Admin
The three company-settings cards — **screenshot retention, auto-close, daily log-time reminder** — are now visible + manageable for **Owner (roleType 1) AND Admin (2)** (previously owner-only). Frontend gate + backend check + 403 messages updated; removed the now-unused `ROLE_TYPE_COMPANY_OWNER` const.

_(Per-role dynamic permissions for these are a planned follow-up.)_

## Test
- Backend restart (new routes/cron/schema) + frontend hot-reload.
- As **Admin** → Settings → Settings → all three cards visible + editable.
- Enable auto-close + pick a period → saved. Cron closes inactive projects nightly (reversible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)