### PR TITLE
fix(auto-close): don't swallow activity-check errors

### DIFF
--- a/Modules/projectClose/helper.js
+++ b/Modules/projectClose/helper.js
@@ -112,6 +112,12 @@ function computeCutoff(inactiveMonths) {
  * Has this project seen ANY activity since `cutoff`? Activity = a logged time
  * entry OR a created/updated task. Either signal short-circuits to `true`.
  * TimeSheet.LogStartTime is epoch SECONDS; tasks.updatedAt is a Date.
+ *
+ * IMPORTANT: a query failure is NOT swallowed here — it propagates to the
+ * caller (runAutoCloseForCompany), whose `.catch(() => true)` fail-safe then
+ * treats the project as active and skips closing it. If we caught the error
+ * here and returned `false`, a transient DB hiccup would read as "no activity"
+ * and wrongly auto-close an active project.
  */
 async function projectHasActivitySince(companyId, projectId, cutoff) {
     const cutoffSec = Math.floor(cutoff.getTime() / 1000);
@@ -119,13 +125,13 @@ async function projectHasActivitySince(companyId, projectId, cutoff) {
     const loggedTime = await MongoDbCrudOpration(companyId, {
         type: SCHEMA_TYPE.TIMESHEET,
         data: [{ ProjectId: String(projectId), LogStartTime: { $gte: cutoffSec } }, { _id: 1 }],
-    }, 'findOne').catch(() => null);
+    }, 'findOne');
     if (loggedTime) return true;
 
     const touchedTask = await MongoDbCrudOpration(companyId, {
         type: SCHEMA_TYPE.TASKS,
         data: [{ ProjectID: new mongoose.Types.ObjectId(projectId), updatedAt: { $gte: cutoff }, deletedStatusKey: { $in: [0, undefined] } }, { _id: 1 }],
-    }, 'findOne').catch(() => null);
+    }, 'findOne');
     if (touchedTask) return true;
 
     return false;


### PR DESCRIPTION
Addresses the CodeRabbit review finding on the auto-close feature (promotion PR #348).

`projectHasActivitySince()` caught both lookup queries with `.catch(() => null)` and returned `false` on error. So `runAutoCloseForCompany()` read a transient DB failure as "no activity" and could close an **active** project — its `.catch(() => true)` fail-safe was effectively dead code because the errors never bubbled up.

**Fix:** let the query errors propagate so the caller's `.catch(() => true)` fail-safe keeps the project open on a detection failure.

- Only caller (`runAutoCloseForCompany`) already has the `.catch(() => true)` guard; the function is not called elsewhere.
- Docstring updated to document the intentional error-propagation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)