### PR TITLE
fix(ai-assist): count sub-tasks in the sprint task count

### DIFF
--- a/Modules/AIProjectGenerator/orchestrator.js
+++ b/Modules/AIProjectGenerator/orchestrator.js
@@ -795,13 +795,16 @@ async function createTasksForSprint({ companyId, projectDoc, sprintDoc, tasks, s
         data: [docs],
     }, 'insertMany');
 
-    // Sprint task count tracks TOP-LEVEL tasks only — sub-tasks are nested
-    // under their parent, not listed directly in the sprint.
+    // Sprint task count = EVERY task, parent AND sub-task, each counting 1 —
+    // matching manual creation (Tasks/.../create.js does `$inc { tasks: 1 }` for
+    // every task, parent or sub) and the archive math (removing a parent decrements
+    // by subTasks+1). Counting only parents here undercounted AI-created sprints
+    // and misled the user, so use the full doc count (parents + sub-tasks).
     await MongoDbCrudOpration(companyId, {
         type: SCHEMA_TYPE.SPRINTS,
         data: [
             { _id: sprintDoc._id },
-            { $inc: { tasks: parentDocs.length } },
+            { $inc: { tasks: docs.length } },
         ],
     }, 'updateOne').catch(() => {});
 


### PR DESCRIPTION
## Problem
AI-Assist ("Plan with AI") sprint generation showed a task count that missed sub-tasks — e.g. a sprint with 8 parent tasks + 8 sub-tasks displayed "8 Tasks". This misleads the end user.

## Root cause
`orchestrator.js` `createTasksForSprint` incremented the sprint's `tasks` count by `parentDocs.length` (parents only). But the rest of the app counts **every** task: manual creation (`Tasks/.../create.js`) does `$inc { tasks: 1 }` for each task — parent OR sub-task — and the archive math decrements a parent by `subTasks + 1`. So AI-created sprints diverged from manual ones.

## Fix
Increment by `docs.length` (parents + sub-tasks — every inserted doc), matching manual creation. Both write to the same SPRINTS-doc `tasks` field, so they're now fully consistent. Comment corrected.

## Note
Applies to new AI-Assist generations. Sprints created before this keep their old stored count (re-generate or a one-off recount to correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)