### PR TITLE
fix(dashboard): harden taskMatch filtering + review polish

### DIFF
--- a/.claude/MAINCHAT-SPRINT-DERISK-PLAN.md
+++ b/.claude/MAINCHAT-SPRINT-DERISK-PLAN.md
@@ -2,7 +2,7 @@
 
 **Type:** Design spike (analysis only — no code changes in this document).
 **Ticket:** PRD **P1-1** ("shared-Sprint hot-document risk").
-**Related:** PRD **P0-1** (already merged — removed the *correctness* dependency on the shared Sprint's task count), [`.claude/SOCKET-PERFORMANCE-PLAN.md`](.claude/SOCKET-PERFORMANCE-PLAN.md) (#9 sprint-count caching, #6/#13 pool tuning).
+**Related:** PRD **P0-1** (already merged — removed the *correctness* dependency on the shared Sprint's task count), [`SOCKET-PERFORMANCE-PLAN.md`](SOCKET-PERFORMANCE-PLAN.md) (#9 sprint-count caching, #6/#13 pool tuning).
 
 > **Note on location:** Lives under `.claude/` alongside the repo's other design docs (e.g. `SOCKET-PERFORMANCE-PLAN.md`).
 
@@ -140,7 +140,7 @@ The narrowest fix: chats don't need a sprint task count, burndown, or plan cap, 
 - **Compares A and B (and C) on migration cost, read/write hot-path, blast radius, plan-gate interaction** — §2, §3.
 - **Recommendation with rationale + rough migration outline** — §4, §5.
 - **P0-1 already removed the correctness dependency; scoped as scaling/cleanliness, not urgent** — §1.5, callout in TL;DR, and §4 sequencing.
-- **Delivered as a committed markdown doc alongside `SOCKET-PERFORMANCE-PLAN.md`** — this file (committed at repo root pending relocation to `.claude/`; see the location note at the top).
+- **Delivered as a committed Markdown doc alongside `SOCKET-PERFORMANCE-PLAN.md`** — this file lives under `.claude/` alongside the repo's other design docs.
 
 ---
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false   # don't bake GITHUB_TOKEN into .git/config (build context is `.`)
 
       # `linux/amd64` → `linux-amd64` for use in the per-arch artifact name.
       # matrix.platform is read via env (not string-interpolated into the

--- a/Modules/UserDashboard/helpers/resourceHelpers.js
+++ b/Modules/UserDashboard/helpers/resourceHelpers.js
@@ -164,9 +164,10 @@ async function getLoggedAndTasksInRange(companyId, opts = {}) {
         // into a Mongo match (buildFilterQuery) on task fields ($and/$or) and
         // sends it as taskMatch. Merge it into the task query so the card's
         // Filters section actually narrows results.
-        if (taskMatch && typeof taskMatch === "object" && Object.keys(taskMatch).length) {
-            Object.assign(taskFilter, taskMatch);
-        }
+        // Merge the client's advanced-filter match SAFELY — only its $and/$or clauses, never
+        // a blanket key-copy (which would let a client override deletedStatusKey / inject
+        // Mongo operators). Same hardening as applyTaskMatch.
+        applyTaskMatch(taskFilter, taskMatch);
         const tasks = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.TASKS,
             data: [taskFilter, {
@@ -236,9 +237,9 @@ function applyTaskMatch(taskFilter, taskMatch) {
     if (taskFilter.$or) { andParts.push({ $or: taskFilter.$or }); delete taskFilter.$or; }
     if (Array.isArray(taskMatch.$and)) andParts.push(...taskMatch.$and);
     if (Array.isArray(taskMatch.$or)) andParts.push({ $or: taskMatch.$or });
-    Object.keys(taskMatch).forEach((k) => {
-        if (k !== "$and" && k !== "$or") taskFilter[k] = taskMatch[k];
-    });
+    // SECURITY: only merge the client match's $and/$or scoping clauses. Never blanket-copy
+    // other keys — a client could override base fields (deletedStatusKey / statusType) or
+    // inject Mongo operators ($where / $expr) → filter bypass + NoSQL injection.
     if (andParts.length) taskFilter.$and = (taskFilter.$and || []).concat(andParts);
     return taskFilter;
 }

--- a/frontend/src/components/organisms/DueSoonCard/DueSoonCard.vue
+++ b/frontend/src/components/organisms/DueSoonCard/DueSoonCard.vue
@@ -44,7 +44,9 @@ import * as env from '@/config/env';
 import { buildFilterQuery } from '@/composable/commonFunction';
 import CardSkeleton from '@/components/atom/CardSkeleton/CardSkeleton.vue';
 import TaskDetail from '@/views/TaskDetail/TaskDetail.vue';
+import { useI18n } from 'vue-i18n';
 
+const { t: translate } = useI18n();
 // Member self-card — my open tasks due within the next N days, soonest first.
 // Self-scoped on the backend (caller = req.uid).
 const props = defineProps({
@@ -67,8 +69,8 @@ const priorityRank = (p) => PRIORITY_RANK[String(p || '').toLowerCase()] ?? 2;
 
 const dueLabel = (t) => {
     if (t.daysUntil === null || t.daysUntil === undefined) return '—';
-    if (t.daysUntil === 0) return 'Today';
-    if (t.daysUntil === 1) return 'Tomorrow';
+    if (t.daysUntil === 0) return translate('dashboardCard.Today');
+    if (t.daysUntil === 1) return translate('dashboardCard.Tomorrow');
     return `${t.daysUntil}d`;
 };
 const dueClass = (t) => (t.daysUntil <= 0 ? 'ds-due-now' : t.daysUntil <= 2 ? 'ds-due-soon' : 'ds-due-later');

--- a/frontend/src/components/organisms/NextUpCard/NextUpCard.vue
+++ b/frontend/src/components/organisms/NextUpCard/NextUpCard.vue
@@ -4,7 +4,7 @@
         <template v-else>
             <div v-if="!tasks.length" class="nu-msg">{{ $t('dashboardCard.next_up_empty') }}</div>
             <div v-else class="nu-list">
-                <div v-for="(t, i) in tasks" :key="t.taskId" class="nu-row" @click="openTaskDetail(t)">
+                <div v-for="(t, i) in tasks" :key="t.taskId" class="nu-row" role="button" tabindex="0" @click="openTaskDetail(t)" @keydown.enter="openTaskDetail(t)" @keydown.space.prevent="openTaskDetail(t)">
                     <span class="nu-rank">{{ i + 1 }}</span>
                     <div class="nu-main">
                         <div class="nu-title" :title="(t.taskKey ? t.taskKey + ' ' : '') + t.taskName">
@@ -45,7 +45,9 @@ import * as env from '@/config/env';
 import { buildFilterQuery } from '@/composable/commonFunction';
 import CardSkeleton from '@/components/atom/CardSkeleton/CardSkeleton.vue';
 import TaskDetail from '@/views/TaskDetail/TaskDetail.vue';
+import { useI18n } from 'vue-i18n';
 
+const { t: translate } = useI18n();
 // Member self-card — my open tasks ordered by due date then priority.
 // Self-scoped on the backend (caller = req.uid); no filters/range needed.
 const props = defineProps({
@@ -72,10 +74,10 @@ const dueLabel = (t) => {
     const today = new Date(); today.setHours(0, 0, 0, 0);
     const day = new Date(d); day.setHours(0, 0, 0, 0);
     const diff = Math.round((day - today) / 86400000);
-    if (diff === 0) return 'Today';
-    if (diff === 1) return 'Tomorrow';
-    if (diff === -1) return 'Yesterday';
-    if (diff < 0) return `${Math.abs(diff)}d overdue`;
+    if (diff === 0) return translate('dashboardCard.Today');
+    if (diff === 1) return translate('dashboardCard.Tomorrow');
+    if (diff === -1) return translate('dashboardCard.Yesterday');
+    if (diff < 0) return translate('dashboardCard.overdue_days', { n: Math.abs(diff) });
     return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
 };
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -3285,6 +3285,7 @@ export default {
         Today: "Today",
         Yesterday: "Yesterday",
         Tomorrow: "Tomorrow",
+        overdue_days: "{n}d overdue",
         This_week: "This week",
         Next_week: "Next week",
         Next_seven_days: "Next 7 days",


### PR DESCRIPTION
Addresses the CodeRabbit review on the staging→main promotion PR #356. Fixes land on **staging** so #356 picks them up.

### Fixed (6 of 7 findings)
- **🔒 security (major):** `applyTaskMatch` **and** `getLoggedAndTasksInRange` no longer blanket-copy client `taskMatch` keys — only `$and`/`$or` scoping clauses are merged. Closes a filter-bypass + NoSQL-injection surface (a client could override `deletedStatusKey`/`statusType` or inject `$where`/`$expr`). CodeRabbit flagged one site; **both** are fixed.
- **🔒 ci:** `actions/checkout` → `persist-credentials: false` (no `GITHUB_TOKEN` baked into the Docker build context).
- **🌐 i18n:** DueSoonCard / NextUpCard due labels via `$t` (`Today`/`Tomorrow`/`Yesterday` + new `overdue_days` key).
- **♿ a11y:** NextUp task rows are keyboard-operable (`role="button"`, `tabindex`, Enter/Space).
- **📐 docs:** sprint-derisk plan — fixed the broken relative link + stale location note.

### Deferred (reasoned)
- **MyAchievements reason-chip i18n** — needs ~9 new *interpolated* keys for a minor per-row chip; renders English fine either way. Better as a focused i18n pass, no regression from leaving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)