### PR TITLE
fix(pto): show the requester's name in the admin time-off table

### DIFF
--- a/Modules/Pto/controller.js
+++ b/Modules/Pto/controller.js
@@ -53,7 +53,22 @@ exports.listPto = async (req, res) => {
         const rows = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.PTO_ENTRIES, data: [match, {}, { sort: { startDate: -1 } }],
         }, 'find');
-        return res.json({ status: true, data: rows || [] });
+        // Attach the requester's display name so the admin Team view shows WHO applied —
+        // entries store only userId, and users live in the GLOBAL db. (AHE-3804)
+        const ids = [...new Set((rows || []).map((r) => String(r.userId)).filter((v) => mongoose.Types.ObjectId.isValid(v)))];
+        const users = ids.length ? await MongoDbCrudOpration('global', {
+            type: SCHEMA_TYPE.USERS,
+            data: [{ _id: { $in: ids.map((id) => new mongoose.Types.ObjectId(id)) } }, { Employee_Name: 1, Employee_FName: 1, Employee_LName: 1, Employee_Email: 1 }],
+        }, 'find').catch(() => []) : [];
+        const nameById = {};
+        for (const u of (users || [])) {
+            nameById[String(u._id)] = u.Employee_Name || `${u.Employee_FName || ''} ${u.Employee_LName || ''}`.trim() || u.Employee_Email || '';
+        }
+        const data = (rows || []).map((r) => {
+            const o = typeof r.toObject === 'function' ? r.toObject() : r;
+            return { ...o, userName: nameById[String(o.userId)] || '' };
+        });
+        return res.json({ status: true, data });
     } catch (e) { logger.error(`listPto: ${e.message}`); return res.status(500).json({ status: false, statusText: e.message }); }
 };
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1826,6 +1826,7 @@ export default {
         my_title: "My time off",
         refresh: "Refresh",
         col_dates: "Dates",
+        col_member: "Member",
         col_type: "Type",
         col_hours: "Hours",
         col_status: "Status",

--- a/frontend/src/views/Settings/TimeOff/TimeOff.vue
+++ b/frontend/src/views/Settings/TimeOff/TimeOff.vue
@@ -45,6 +45,7 @@
                 <table class="pto-table">
                     <thead>
                         <tr>
+                            <th v-if="isAdmin">{{ $t('Pto.col_member') }}</th>
                             <th>{{ $t('Pto.col_dates') }}</th>
                             <th>{{ $t('Pto.col_type') }}</th>
                             <th>{{ $t('Pto.col_hours') }}</th>
@@ -54,6 +55,7 @@
                     </thead>
                     <tbody>
                         <tr v-for="e in entries" :key="e._id">
+                            <td v-if="isAdmin" class="pto-nowrap">{{ e.userName || '—' }}</td>
                             <td class="pto-nowrap">{{ fmt(e.startDate) }} → {{ fmt(e.endDate) }}</td>
                             <td>{{ $t('Pto.types.' + (e.type || 'vacation')) }}</td>
                             <td>{{ e.hoursPerDay }}h/day</td>
@@ -66,8 +68,8 @@
                                 <button class="pto-mini del" @click="remove(e)">{{ $t('Pto.delete') }}</button>
                             </td>
                         </tr>
-                        <tr v-if="!entries.length && !loading"><td colspan="5" class="pto-empty">{{ $t('Pto.empty') }}</td></tr>
-                        <tr v-if="loading && !entries.length"><td colspan="5" class="pto-empty">{{ $t('Pto.loading') }}</td></tr>
+                        <tr v-if="!entries.length && !loading"><td :colspan="isAdmin ? 6 : 5" class="pto-empty">{{ $t('Pto.empty') }}</td></tr>
+                        <tr v-if="loading && !entries.length"><td :colspan="isAdmin ? 6 : 5" class="pto-empty">{{ $t('Pto.loading') }}</td></tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Fixes **AHE-3804**.

### Problem
In Settings → Time Off, the admin "Team time off" table listed pending requests (Dates, Type, Hours, Status) with Approve / Reject / Delete — but **no column for who applied**. Admins were approving/rejecting blind.

### Fix
- **Backend** (`Modules/Pto/controller.js` · `listPto`): resolve each entry's `userId` → the member's display name (users live in the global DB) and attach `userName` to the response.
- **Frontend** (`TimeOff.vue`): add a **Member** column (admin/team view only — the member's own "My time off" is always them); empty/loading `colspan` adjusts (6 vs 5).
- **i18n**: `Pto.col_member: "Member"`.

Admin-only, company-scoped; no change to the request / approve logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)