### PR TITLE
fix(pto): restrict leave types and add reason column to time-off table

### DIFF
--- a/Modules/Pto/helpers/ptoRules.js
+++ b/Modules/Pto/helpers/ptoRules.js
@@ -2,7 +2,7 @@
 // the heart of the feature: approved PTO reduces a user's available capacity.
 // Unit-tested in tests/pto-rules.test.js.
 
-const PTO_TYPES = ['vacation', 'sick', 'holiday', 'personal', 'unpaid'];
+const PTO_TYPES = ['casual', 'privilege', 'sick'];
 const PTO_STATUS = ['pending', 'approved', 'rejected'];
 const DEFAULT_HOURS_PER_DAY = 8;
 const DEFAULT_WEEKEND = [0, 6]; // Sun, Sat
@@ -29,7 +29,7 @@ const validatePtoEntry = (entry = {}) => {
     if (!start) errors.push('a valid startDate is required');
     if (!end) errors.push('a valid endDate is required');
     if (start && end && end < start) errors.push('endDate must be on or after startDate');
-    const type = PTO_TYPES.includes(entry.type) ? entry.type : 'vacation';
+    const type = PTO_TYPES.includes(entry.type) ? entry.type : 'casual';
     let hoursPerDay = Number(entry.hoursPerDay);
     if (!hoursPerDay || hoursPerDay <= 0 || hoursPerDay > 24) hoursPerDay = DEFAULT_HOURS_PER_DAY;
     const status = PTO_STATUS.includes(entry.status) ? entry.status : 'pending';

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1807,7 +1807,7 @@ export default {
     Pto: {
         add_title: "Request time off",
         type: "Type",
-        types: { vacation: "Vacation", sick: "Sick", holiday: "Holiday", personal: "Personal", unpaid: "Unpaid" },
+        types: { casual: "Casual Leave", privilege: "Privilege Leave", sick: "Sick Leave", vacation: "Vacation", holiday: "Holiday", personal: "Personal", unpaid: "Unpaid" },
         start: "Start date",
         end: "End date",
         hours_per_day: "Hours per day",

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1830,6 +1830,7 @@ export default {
         col_type: "Type",
         col_hours: "Hours",
         col_status: "Status",
+        col_reason: "Reason",
         status: { pending: "Pending", approved: "Approved", rejected: "Rejected" },
         approve: "Approve",
         reject: "Reject",

--- a/frontend/src/views/Settings/TimeOff/TimeOff.vue
+++ b/frontend/src/views/Settings/TimeOff/TimeOff.vue
@@ -50,6 +50,7 @@
                             <th>{{ $t('Pto.col_type') }}</th>
                             <th>{{ $t('Pto.col_hours') }}</th>
                             <th>{{ $t('Pto.col_status') }}</th>
+                            <th>{{ $t('Pto.col_reason') }}</th>
                             <th></th>
                         </tr>
                     </thead>
@@ -60,6 +61,7 @@
                             <td>{{ $t('Pto.types.' + (e.type || 'casual')) }}</td>
                             <td>{{ e.hoursPerDay }}h/day</td>
                             <td><span class="pto-badge" :class="e.status">{{ $t('Pto.status.' + e.status) }}</span></td>
+                            <td class="pto-reason" :title="e.reason || ''">{{ e.reason || '—' }}</td>
                             <td class="pto-rowactions">
                                 <template v-if="isAdmin && e.status === 'pending'">
                                     <button class="pto-mini ok" @click="setStatus(e, 'approved')">{{ $t('Pto.approve') }}</button>
@@ -68,8 +70,8 @@
                                 <button class="pto-mini del" @click="remove(e)">{{ $t('Pto.delete') }}</button>
                             </td>
                         </tr>
-                        <tr v-if="!entries.length && !loading"><td :colspan="isAdmin ? 6 : 5" class="pto-empty">{{ $t('Pto.empty') }}</td></tr>
-                        <tr v-if="loading && !entries.length"><td :colspan="isAdmin ? 6 : 5" class="pto-empty">{{ $t('Pto.loading') }}</td></tr>
+                        <tr v-if="!entries.length && !loading"><td :colspan="isAdmin ? 7 : 6" class="pto-empty">{{ $t('Pto.empty') }}</td></tr>
+                        <tr v-if="loading && !entries.length"><td :colspan="isAdmin ? 7 : 6" class="pto-empty">{{ $t('Pto.loading') }}</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -169,6 +171,7 @@ onMounted(load);
 .pto-table th { text-align: left; background: #f7f8fc; color: #3a3f52; font-weight: 700; padding: 9px 12px; border-bottom: 1px solid #e6e7ee; white-space: nowrap; }
 .pto-table td { padding: 9px 12px; border-bottom: 1px solid #f0f1f6; color: #3a3f52; }
 .pto-nowrap { white-space: nowrap; }
+.pto-reason { max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pto-badge { font-size: 11px; font-weight: 700; border-radius: 5px; padding: 2px 8px; text-transform: capitalize; }
 .pto-badge.pending { background: #fff8e6; color: #9a6b00; }
 .pto-badge.approved { background: #e7f6ee; color: #1c7a43; }

--- a/frontend/src/views/Settings/TimeOff/TimeOff.vue
+++ b/frontend/src/views/Settings/TimeOff/TimeOff.vue
@@ -57,7 +57,7 @@
                         <tr v-for="e in entries" :key="e._id">
                             <td v-if="isAdmin" class="pto-nowrap">{{ e.userName || '—' }}</td>
                             <td class="pto-nowrap">{{ fmt(e.startDate) }} → {{ fmt(e.endDate) }}</td>
-                            <td>{{ $t('Pto.types.' + (e.type || 'vacation')) }}</td>
+                            <td>{{ $t('Pto.types.' + (e.type || 'casual')) }}</td>
                             <td>{{ e.hoursPerDay }}h/day</td>
                             <td><span class="pto-badge" :class="e.status">{{ $t('Pto.status.' + e.status) }}</span></td>
                             <td class="pto-rowactions">
@@ -92,13 +92,13 @@ const { t } = useI18n();
 const roleType = computed(() => getters['settings/companyUserDetail'] && getters['settings/companyUserDetail'].roleType);
 const isAdmin = computed(() => roleType.value === 1 || roleType.value === 2);
 
-const types = ['vacation', 'sick', 'holiday', 'personal', 'unpaid'];
+const types = ['casual', 'privilege', 'sick'];
 const busy = ref(false);
 const loading = ref(false);
 const msg = ref(''); const msgType = ref('');
 const entries = ref([]);
 const capacity = ref(null);
-const form = reactive({ type: 'vacation', startDate: '', endDate: '', hoursPerDay: 8, reason: '' });
+const form = reactive({ type: 'casual', startDate: '', endDate: '', hoursPerDay: 8, reason: '' });
 
 const fmt = (d) => { try { return new Date(d).toLocaleDateString(); } catch (e) { return d; } };
 

--- a/tests/pto-rules.test.js
+++ b/tests/pto-rules.test.js
@@ -4,7 +4,7 @@ describe('validatePtoEntry', () => {
     test('accepts a valid entry and normalizes defaults', () => {
         const r = R.validatePtoEntry({ userId: 'u1', startDate: '2026-07-01', endDate: '2026-07-03' });
         expect(r.valid).toBe(true);
-        expect(r.value.type).toBe('vacation');
+        expect(r.value.type).toBe('casual');
         expect(r.value.status).toBe('pending');
         expect(r.value.hoursPerDay).toBe(8);
     });
@@ -15,8 +15,14 @@ describe('validatePtoEntry', () => {
     test('clamps bad hoursPerDay and unknown type/status', () => {
         const r = R.validatePtoEntry({ userId: 'u1', startDate: '2026-07-01', endDate: '2026-07-01', hoursPerDay: 99, type: 'nope', status: 'weird' });
         expect(r.value.hoursPerDay).toBe(8);
-        expect(r.value.type).toBe('vacation');
+        expect(r.value.type).toBe('casual');
         expect(r.value.status).toBe('pending');
+    });
+    test('accepts the configured leave types (casual, privilege, sick)', () => {
+        for (const t of ['casual', 'privilege', 'sick']) {
+            const r = R.validatePtoEntry({ userId: 'u1', startDate: '2026-07-01', endDate: '2026-07-01', type: t });
+            expect(r.value.type).toBe(t);
+        }
     });
 });
 

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -514,7 +514,7 @@ const schema = {
     // reduce a user's available capacity (helpers/ptoRules.computeAvailableCapacity).
     ptoEntries: {
         userId: { type: String, required: true },
-        type: { type: String, default: 'vacation', required: false },
+        type: { type: String, default: 'casual', required: false },
         startDate: { type: Date, required: true },
         endDate: { type: Date, required: true },
         hoursPerDay: { type: Number, default: 8, required: false },


### PR DESCRIPTION
## What
Two small Time Off (SEC-08) changes on the schedule view:

1. **Leave types** — the request dropdown now offers only the 3 types the company uses: **Casual Leave, Privilege Leave, Sick Leave** (was vacation/sick/holiday/personal/unpaid). Aligned across the dropdown, i18n labels, the Mongoose schema default, the validation enum (`ptoRules`) and its unit test. Old labels are kept in the locale so any pre-existing entries still render.
2. **Reason column** — the table now shows each entry's **Reason** (admin Team view + member's own view), with ellipsis + hover-title for long text and `—` when empty. Display-only — `reason` was already stored and returned by `listPto`.

## Test plan
- As a member: Settings → Time Off → Request → dropdown shows only Casual / Privilege / Sick; submit with a reason.
- As owner/admin: Team time-off table shows Member, Type (one of the 3) and the new Reason column.
- `npx jest tests/pto-rules.test.js` → 14/14 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)