### PR TITLE
fix(header): hide the integrations item in the workspace menu

### DIFF
--- a/frontend/src/components/organisms/Header/helper.js
+++ b/frontend/src/components/organisms/Header/helper.js
@@ -40,7 +40,8 @@ export function useHelper() {
                 {
                     name: "Integrations",
                     to: {path: `/${companyId.value}/integrations`},
-                    show: true
+                    // Hidden from the Workspace menu for now — route + page are kept; flip to true to restore.
+                    show: false
                 }
             ]
         },


### PR DESCRIPTION
## What
Hides the **Workspace → Integrations** item from the top header menu.

## How
Sets `show: false` on the Integrations submenu entry in `Header/helper.js`. The nav renderer (`NavLinks.vue`) only renders submenu items with `show === true`, so the item simply doesn't appear.

**Hidden, not removed** — the menu entry, the `/integrations` route, and the Integrations page are all kept intact. Flip `show` back to `true` (a comment marks the spot) to restore it.

## Result
Workspace dropdown now shows **Portfolio** and **Capacity Planning** only.

## Test plan
- Header → Workspace dropdown: no "Integrations" item.
- Navigating directly to `/<companyId>/integrations` still works (route/page untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)