### PR TITLE
fix(settings): hide sso, scim and audit log from the settings sidebar

### DIFF
--- a/frontend/src/components/templates/Settings/Settings.vue
+++ b/frontend/src/components/templates/Settings/Settings.vue
@@ -177,25 +177,29 @@
             icon: require("@/assets/images/svg/workspaceSecurity.svg"),
             permissions:['settings.settings_security_permissions'],
             activeIcon: require("@/assets/images/svg/workspaceSecurityActive.svg")
-        },{
-            label: "SSO",
-            to: {name: "SsoSettings"},
-            icon: require("@/assets/images/svg/ssoKey.svg"),
-            permissions:['settings.settings_security_permissions'],
-            activeIcon: require("@/assets/images/svg/ssoKeyActive.svg")
-        },{
-            label: "SCIM",
-            to: {name: "ScimSettings"},
-            icon: require("@/assets/images/svg/scimUsers.svg"),
-            permissions:['settings.settings_security_permissions'],
-            activeIcon: require("@/assets/images/svg/scimUsersActive.svg")
-        },{
-            label: "Audit Log",
-            to: {name: "AuditLog"},
-            icon: require("@/assets/images/svg/auditDoc.svg"),
-            permissions:['settings.settings_security_permissions'],
-            activeIcon: require("@/assets/images/svg/auditDocActive.svg")
-        },{
+        },
+        // SSO, SCIM and Audit Log menu items are hidden for now — their pages and
+        // routes are kept intact; uncomment the three blocks below to restore them.
+        // {
+        //     label: "SSO",
+        //     to: {name: "SsoSettings"},
+        //     icon: require("@/assets/images/svg/ssoKey.svg"),
+        //     permissions:['settings.settings_security_permissions'],
+        //     activeIcon: require("@/assets/images/svg/ssoKeyActive.svg")
+        // },{
+        //     label: "SCIM",
+        //     to: {name: "ScimSettings"},
+        //     icon: require("@/assets/images/svg/scimUsers.svg"),
+        //     permissions:['settings.settings_security_permissions'],
+        //     activeIcon: require("@/assets/images/svg/scimUsersActive.svg")
+        // },{
+        //     label: "Audit Log",
+        //     to: {name: "AuditLog"},
+        //     icon: require("@/assets/images/svg/auditDoc.svg"),
+        //     permissions:['settings.settings_security_permissions'],
+        //     activeIcon: require("@/assets/images/svg/auditDocActive.svg")
+        // },
+        {
             label: "Time Off",
             to: {name: "TimeOff"},
             icon: require("@/assets/images/svg/WorkspaceSettingsInactive.svg"),


### PR DESCRIPTION
## What
Hides the **SSO**, **SCIM**, and **Audit Log** items from the Settings sidebar menu.

## How
Comments out the three menu entries in `Settings.vue`. The sidebar renders from that array, so commented entries no longer appear.

**Hidden, not removed** — the routes (`SsoSettings`, `ScimSettings`, `AuditLog`) and their pages are untouched. Uncomment the three blocks (a restore note is left in place) to bring them back.

## Result
Settings sidebar now goes **Security & Permissions → Time Off** directly.

## Test plan
- Settings sidebar: no SSO / SCIM / Audit Log items.
- Direct navigation to those routes still works (pages untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)