### PR TITLE
fix(task): remove permission gate on story points field

### DIFF
--- a/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
+++ b/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
@@ -112,12 +112,13 @@
                     :permission="checkPermission('task.task_priority',project?.isGlobalPermission) === true"
                 />
             </div>
-            <div class="d-flex task-detail-right-side-label" v-if="checkPermission('task.task_estimated_hours',project?.isGlobalPermission) !== null">
+            <!-- Story Points: permission gate removed — free for anyone to view + edit. -->
+            <div class="d-flex task-detail-right-side-label">
                 <h4>Story Points</h4>
                 <StoryPoints
                     :pointsVal="task.points"
                     :estimationScale="project?.estimationScale || 'fibonacci'"
-                    :permission="checkPermission('task.task_estimated_hours',project?.isGlobalPermission) === true"
+                    :permission="true"
                     @select="updatePoints($event)"
                     class="taskdetail-label task-detail-right-wrapper ml-0"
                 />


### PR DESCRIPTION
## What
Removes the permission gating on the **Story Points** field in the task detail panel — it's now visible and editable by **any user**, regardless of role.

## Why
Story Points was gated by `task.task_estimated_hours === true` (full edit), while the sibling **Estimated** and **Task Planning** fields — which share the same permission — were deliberately relaxed. So a member with a non-full estimate permission could edit Estimated but **not** Story Points. This makes it consistent and freely usable.

## Change — `TaskDetailRightSide.vue`
- Removed the row-level `v-if` permission check → always visible.
- `:permission="true"` on `<StoryPoints>` → always editable.

## Test plan
- As a member (or any non-admin role): open a task → Story Points is visible and the picker opens + saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)