### PR TITLE
fix(views): remove duplicate legacy gantt and timeline views

### DIFF
--- a/frontend/src/components/molecules/ProjectsListingSetting/ProjectsListingSetting.vue
+++ b/frontend/src/components/molecules/ProjectsListingSetting/ProjectsListingSetting.vue
@@ -226,8 +226,12 @@ const userData = {
 const requireComp = computed(() => {
     let arr = getters['settings/projectTabComponents'];
     const removeArr = ["gantt", "timeline","embed"];
+    // Also drop the dead legacy 'Gantt'/'Timeline' keyNames (replaced by 'GanttView'/'TimelineView').
+    // getView() has no case for them (they render NotFound) and they duplicate the working views in
+    // this Required-Views picker — the value-based removeArr above doesn't catch them by keyName.
+    const removeKeyNames = ["Gantt", "Timeline"];
     arr= arr?.filter((item) => {
-        if(!removeArr.includes(item.value)) {
+        if(!removeArr.includes(item.value) && !removeKeyNames.includes(item.keyName)) {
             return item;
         }
     });

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -154,19 +154,9 @@ export const projectComponentsIcons = (key) => {
             keyName: "Workload"
         },
         {
-            icon: require("@/assets/images/svg/component-inactive-icons/comp_gantt_inactive.svg"),
-            activeIcon: require("@/assets/images/svg/component-active-icons/comp_gantt_active.svg"),
-            keyName: "Gantt"
-        },
-        {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_table_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_table_active.svg"),
             keyName: "TableView"
-        },
-        {
-            icon: require("@/assets/images/svg/component-inactive-icons/comp_timeline_inactive.svg"),
-            activeIcon: require("@/assets/images/svg/component-active-icons/comp_timeline_active.svg"),
-            keyName: "Timeline"
         },
         {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_embed_inactive.svg"),

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -846,6 +846,10 @@ const getChange = () => {
     const Tabs2 = projectData.value.ProjectRequiredComponent?.filter((item) => item._id.length > 6);
     const ids = projectData.value.ProjectRequiredComponent?.map((item) => item._id);
     viewsListArray.value = [...(userTabs.filter((element) => element.id.length > 6 && (!ids.includes(element.id)))), ...Tabs2].sort((a, b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))));
+    // Drop the dead legacy 'Gantt'/'Timeline' keyNames (replaced by 'GanttView'/'TimelineView').
+    // getView() has no case for them so they render NotFound; older projects may still carry the
+    // stale entry. The "+ View" catalog already hides them, so mirror that filter in the tab bar.
+    viewsListArray.value = viewsListArray.value.filter((item) => item.keyName !== 'Timeline' && item.keyName !== 'Gantt');
     embedViews.value = ([...projectData.value.ProjectRequiredComponent.filter((item) => item._id.length == 6), ...(userTabs.filter((element) => element.id.length == 6))].sort((a, b) => (a.name.toLowerCase() < b.name.toLowerCase()) ? -1 : ((b.name.toLowerCase() < a.name.toLowerCase()) ? 1 : 0))).sort((a, b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))));
     if (projectDetailPermission.value === null) {
         viewsListArray.value = viewsListArray.value.filter((item) => item.keyName !== 'ProjectDetail');

--- a/utils/data.js
+++ b/utils/data.js
@@ -1823,26 +1823,10 @@ exports.importProjectTabComponents = (companyName) => {
             viewStatus: false
         },
         {
-            name: "Gantt",
-            sortIndex: 8,
-            keyName: "Gantt",
-            value: "gantt",
-            setAsDefault: false,
-            viewStatus: false
-        },
-        {
             name: "Table",
             sortIndex: 9,
             keyName: "TableView",
             value: "TableView",
-            setAsDefault: false,
-            viewStatus: false
-        },
-        {
-            name: "Timeline",
-            sortIndex: 10,
-            keyName: "Timeline",
-            value: "timeline",
             setAsDefault: false,
             viewStatus: false
         },


### PR DESCRIPTION
## Problem
Projects showed **two identical "Timeline"** tabs (and a latent duplicate "Gantt") — a legacy view keyName (`Timeline`/`Gantt`) alongside the working rebuilt view (`TimelineView`/`GanttView`). The legacy keyNames have **no case in `getView()`**, so clicking one rendered the **Not Found** page. They also showed as duplicate icons in the project-settings **Required Views** picker.

## Fix — all layers
| File | Layer |
|---|---|
| `utils/data.js` | **Seed** — drop legacy `Gantt`/`Timeline` from `importProjectTabComponents` (new companies never get them) |
| `commonFunction.js` | **Icon catalog** — drop the legacy entries from `projectComponentsIcons` |
| `Projects.vue` | **Tab bar** — filter dead `Timeline`/`Gantt` keyNames from `viewsListArray` (existing projects) |
| `ProjectsListingSetting.vue` | **Required Views picker** — filter them from `requireComp` (existing companies) |

The working `TimelineView` / `GanttView` are untouched. Source changes stop it going forward; the two display filters clean up existing data that already has the legacy keyNames stored.

## Test plan
- Open a project that had the duplicate → **one** Timeline tab (and one Gantt), rendering the real view (no *Not Found*).
- Settings → Projects → **Required Views** → no duplicate timeline/gantt icons.
- New company → seeded views contain only `TimelineView`/`GanttView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)