### PR TITLE
feat(dashboard): restrict Active Projects / Projects by Type / Running Projects cards to Owner/Admin

### DIFF
--- a/frontend/src/plugins/dashboard/views/HomePage.vue
+++ b/frontend/src/plugins/dashboard/views/HomePage.vue
@@ -317,15 +317,26 @@
             isDataFetching.value = false;
         },2000)
     });
+    // Management-only dashboard cards (company-wide data) — visible only to
+    // Owner/Admin (roleType 1/2). Hidden from the "Add card" catalog AND from
+    // an already-saved layout for anyone below that.
+    const MANAGEMENT_ONLY_CARDS = ['MilestoneReportCard', 'ActiveProjectsCard', 'ProjectsByTypeCard', 'RunningProjectsCard'];
+    const isManagementUser = () => [1, 2].includes(companyUserDetail.value?.roleType);
+
     const getUserDashboard = async() => {
         try {
             const response = await apiRequest("get", `${env.DASHBOARD}/${userId.value}`);
             if (response?.data?.length > 0) {
-                const cards = response.data[0].cards || [];
+                let cards = response.data[0].cards || [];
                 currentLayout.value = response.data[0];
+                // Drop management-only cards from a non-management user's saved
+                // layout so any previously-added instance stops rendering.
+                if (!isManagementUser()) {
+                    cards = cards.filter((e) => !MANAGEMENT_ONLY_CARDS.includes(e.componentId));
+                }
                 if(cards) {
                     layout.value = cards.map((e) => ({...e.config.position,...(getCardsComponentsSize(e.componentId) ?? {}), i:e.uid,componentId:e.componentId, cardData: e.config.cardData, filterData: e.config.filterData}));
-                } 
+                }
             }
         } catch (error) {
             console.error(error)
@@ -351,10 +362,9 @@
             if (response?.data?.length > 0) {
                 let cardsArray = checkPermission('sheet_settings.workload_timesheet') !== null ? response?.data : response?.data?.filter((e)=> !["TimeEstimatedWorkloadComp","TimeTrackComp","TimeEstimatedComp"].includes(e.key))
                 // Management-only cards — hide from the "Add card" catalog for
-                // anyone below Owner/Admin (roleType 1/2). The card's data
-                // endpoint is server-gated too.
-                if ([1, 2].includes(companyUserDetail.value?.roleType) === false) {
-                    cardsArray = cardsArray?.filter((e) => !["MilestoneReportCard"].includes(e.key));
+                // anyone below Owner/Admin (roleType 1/2).
+                if (!isManagementUser()) {
+                    cardsArray = cardsArray?.filter((e) => !MANAGEMENT_ONLY_CARDS.includes(e.key));
                 }
                 cardComponent.value = JSON.parse(JSON.stringify(cardsArray));
                 filterCardComponent.value = structureCards(cardsArray);


### PR DESCRIPTION
## What
Restricts three **Project Progress** dashboard cards — **Active Projects**, **Projects by Type**, **Running Projects** — to Owner/Admin (roleType 1 & 2) only, matching the existing Milestone Report card. Closes AHE-3808.

## Why
These cards surface company-wide project information (active counts, type breakdown, running projects) that should be limited to management.

## Changes (frontend — `HomePage.vue`)
- Added a single shared list `MANAGEMENT_ONLY_CARDS` = `MilestoneReportCard, ActiveProjectsCard, ProjectsByTypeCard, RunningProjectsCard`.
- **Add Card catalog** filters these keys out for any non-Owner/Admin role (extends the existing milestone filter).
- **Saved layout**: on dashboard load, these cards are also dropped for non-management, so any already-placed instance stops rendering.
- Owner/Admin behaviour unchanged.

## Test plan
1. Owner/Admin → all three cards appear in Add Card + render normally.
2. Member / Team Lead (roleType ≥ 3) → the three cards are absent from Add Card.
3. Non-management user who already had one placed → it no longer renders after reload.
4. Owner/Admin dashboards unchanged.

## Note
Frontend visibility only. Optional follow-up (defense-in-depth): role-gate the three cards' data endpoints on the server, like the Milestone card's backend guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)