### PR TITLE
ci(release): fix release-please never cutting releases (search depth)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,8 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "separate-pull-requests": false,
+  "release-search-depth": 2000,
+  "commit-search-depth": 2000,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Problem
Automated releases have **never** been created by the workflow — v14.9.0–v14.11.0 were tagged **manually** (author `parth0025`), and v14.12.0/v14.13.0 had to be reconciled by hand after they got stuck. Every Release run ends with:

```
✔ No latest release found for path: ., … previous version (X) specified in the manifest
⚠ No latest release pull request found.
⚠ There are untagged, merged release PRs outstanding - aborting
```

## Root cause
release-please finds the previous release by scanning back only `release-search-depth` (default **400**) / `commit-search-depth` (default **500**) commits. This repo's merge-heavy `staging → main` history put the last release tag **outside that window**, so release-please can't establish a baseline, builds no release, and aborts. It’s masked whenever someone manually tags (which resets the boundary to a recent commit).

**Evidence:** the run right after a fresh manual tag found the release in **9 commits** and proceeded normally; the failing runs were considering **760+ commits** with no baseline.

## Fix
Raise both depths to `2000` in `release-please-config.json` (both are documented config fields) so the previous release stays in range.

## Validation
This can only be fully confirmed on the next real release: merge `staging → main`, and the Release workflow should now create the tag + GitHub Release automatically (author `github-actions[bot]`) instead of aborting. If it still aborts, the depth may need to go higher or the history pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release processing to search a deeper history for relevant releases and commits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->