### PR TITLE
feat(projects): move view switcher to its own row + lighter header

### DIFF
--- a/frontend/src/components/atom/ViewsList/ViewsList.vue
+++ b/frontend/src/components/atom/ViewsList/ViewsList.vue
@@ -6,11 +6,11 @@
         @click.stop="$emit('click', item)"
     >
         <div :class="{'border-left': firstChild && !active, 'border-right': !active, 'border-none activeViewList': active}" class="d-flex align-items-center font-size-14 view-list position-re"
-        :style="{ height: active ? '48px' : 'auto' }">
+        :style="{ height: active ? '36px' : 'auto' }">
            <span v-if="commentCount" class="count-block comment__count white position-ab">{{commentCount <= 99 ? commentCount : '+99'}}</span> 
-           <img class="position-ab list_make_as_defaultimg" v-if="item.setAsDefault" :src="viewDefaultIcon" />
            <img :src="active ? projectComponentsIcons(item.keyName)?.activeIcon : projectComponentsIcons(item.keyName)?.icon" :alt="item.name" class="mr-10px">
            <span class="gray81">{{$t(`ViewList.${item.name}`)}}</span>
+           <img class="list__default-home" v-if="item.setAsDefault" :src="viewDefaultIcon" />
            <img :src="active ? activePin : pin" v-if="item?.isPin && item.isPin" class="ml-10px active__pin-condition">
            <span class="notification-tick blinking position-sti ml-7px" v-if="item?.isPrivate"></span>
            <div class="view-list__menu" v-if="checkPermission('project.view_list',project.isGlobalPermission) === true">
@@ -209,8 +209,18 @@ defineEmits(['click']);
     height: 20px;
     width: 15px;
 }
-/* ⋯ menu: positioned OVER the tab's right edge (out of flow) so it never
-   reserves space or resizes the tab — it only appears on hover. */
+/* Clear hover affordance on non-active tabs (active tabs already carry
+   .bg-light-gray) so short-named tabs read as an obvious clickable target. */
+.wrapper{
+    border-radius: 8px 8px 0 0;
+}
+.wrapper:hover:not(.bg-light-gray){
+    background: #f4f5f7;
+}
+/* ⋯ menu: out of flow at the tab's right edge (so its dropdown popup is never
+   clipped), shown only on hover. On hover the tab grows its right padding
+   (.wrapper:hover .view-list) to open clear space here, so the ⋯ never covers
+   the view name. */
 .view-list__menu{
     position: absolute;
     right: 2px;
@@ -219,21 +229,29 @@ defineEmits(['click']);
     display: inline-flex;
     align-items: center;
 }
-/* The trigger is a proper rounded button (white chip + soft shadow) so it
-   reads as a control and cleanly masks the sliver of label it overlaps. */
+/* Compact ⋯ trigger: it now lives in empty space (not over the label), so it
+   no longer needs the white "masking chip" — just a light hover highlight. */
 .dots{
-    height: 24px;
-    width: 28px;
-    padding: 4px 6px;
-    border-radius: 6px;
+    height: 20px;
+    width: 20px;
+    padding: 3px;
+    border-radius: 5px;
     box-sizing: border-box;
     object-fit: contain;
     cursor: pointer;
-    background: #fff;
-    box-shadow: 0 1px 4px rgba(16, 24, 40, 0.18);
+    background: transparent;
 }
 .dots:hover{
-    background: #f1f2f4;
+    background: #e9eaee;
+}
+/* "Default view" home marker — in-flow after the name (not an absolute corner
+   badge) so it never overlaps the label. */
+.list__default-home{
+    height: 12px;
+    width: 12px;
+    margin-left: 6px;
+    object-fit: contain;
+    flex: 0 0 auto;
 }
 .count-block.comment__count{
    color: #eabb00 !important;

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -126,7 +126,22 @@
                                     </div>
                                     <img :src="publicFolder" class="vertical-middle" alt="public-folder" v-if="clientWidth > 767 && !projectData.isPrivateSpace"/>
                                 </div>
-                                <div class="list-head-mid h-100" :class="{'desktop-view' : clientWidth > 767}" id="projectview_driver">
+                            </div>
+                            <ProjectActionsBar
+                                :projectData="projectData"
+                                :clientWidth="clientWidth"
+                                :users="users"
+                                :teams="teams"
+                                @openSidebar="open"
+                                @openWatcher="openProjectWatcher = true"
+                                @changeAssignee="(type, $event) => changeAssignee(type, $event)"
+                                @openPermissionSidebar="openPermissionSidebar"
+                                @startEditName="projectName.value = projectData?.ProjectName; editProject = true"
+                                @openColorAvatar="showColorAvatar = true; assignAvatarData({id: projectData._id, name: projectData.ProjectName, icon: projectData?.projectIcon})"
+                                @archiveProject="(val) => { showSidebar = true; archive = val }"
+                            />
+                        </div>
+                        <div class="project-views-row" id="projectview_driver">
                                     <template v-if="clientWidth > 765">
                                         <div class="d-flex align-items-center overflow-x-auto view_list_scroll h-100">
                                             <ViewsList
@@ -227,21 +242,6 @@
                                         </div>
                                     </template>
                                 </div>
-                            </div>
-                            <ProjectActionsBar
-                                :projectData="projectData"
-                                :clientWidth="clientWidth"
-                                :users="users"
-                                :teams="teams"
-                                @openSidebar="open"
-                                @openWatcher="openProjectWatcher = true"
-                                @changeAssignee="(type, $event) => changeAssignee(type, $event)"
-                                @openPermissionSidebar="openPermissionSidebar"
-                                @startEditName="projectName.value = projectData?.ProjectName; editProject = true"
-                                @openColorAvatar="showColorAvatar = true; assignAvatarData({id: projectData._id, name: projectData.ProjectName, icon: projectData?.projectIcon})"
-                                @archiveProject="(val) => { showSidebar = true; archive = val }"
-                            />
-                        </div>
                         <div v-if="showLoader" class="d-flex box-shadow-6 position-fi z-index-10 right-22px bottom-22px bg-white p-10px border-radius-5-px align-items-center">
                             <div class="progress-container d-flex align-items-center position-re">
                                 <div class="progress-circle" :style="circleStyle">
@@ -270,7 +270,7 @@
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
                             ]"
-                            :style="{height: clientWidth > 767 ? 'calc(100% - 48px)' : 'calc(100% - 62px)'}"
+                            :style="{height: clientWidth > 767 ? 'calc(100% - 80px)' : 'calc(100% - 62px)'}"
                         >
                             <ProjectFiltersToolbar
                                 :activeTab="activeTab"

--- a/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
+++ b/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
@@ -8,7 +8,7 @@
                         type="text"
                         :placeHolder="$t('PlaceHolder.search')"
                         class="form-control"
-                        :style="{width: (clientWidth > 1025 ? '260px' : '90%')}"
+                        :style="{width: (clientWidth > 767 ? '260px' : '90%')}"
                         :value="taskSearch"
                         @input="$emit('update:taskSearch', $event.target.value)"
                     >
@@ -389,6 +389,18 @@ const groupIcon = require('@/assets/images/peopleGray.png');
 @media (min-width: 768px) {
     .task-filter-assignee > :deep(.mr-1) {
         margin-right: 8px;
+    }
+    /* Responsive fix: keep the search box at its own width so it never
+       stretches to fill the row when the toolbar wraps (previously the 90%
+       width ballooned across a full wrapped line). And give the wrapper a
+       row-gap so, when the search + action groups wrap onto two lines, the
+       rows have clean vertical spacing instead of touching. */
+    .task-filtersearchassignee-wrapper {
+        row-gap: 10px;
+    }
+    .task-filtersearch,
+    .task-fitler-search {
+        flex: 0 0 auto;
     }
 }
 </style>

--- a/frontend/src/views/Projects/style.css
+++ b/frontend/src/views/Projects/style.css
@@ -12,12 +12,30 @@
 }
 .list-view-header {
   padding: 0px 19px;
-  border-bottom: 1px solid #CFCFCF;
+  border-bottom: 1px solid #e8eaed;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 48px;
+  height: 44px;
   background-color: #fff;
+}
+/* ── Project view-tabs strip lives on its OWN full-width row (ClickUp-style),
+   between the project header and the filter toolbar — so short tab names like
+   "List" get a roomy, unambiguous clickable area instead of being squeezed in
+   the header next to the title + actions. Hidden on mobile (the header keeps
+   its own "all views" dropdown there). */
+.project-views-row {
+  display: flex;
+  align-items: center;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 12px;
+  background-color: #fff;
+  border-bottom: 1px solid #e8eaed;
+  box-sizing: border-box;
+}
+@media (max-width: 767px) {
+  .project-views-row { display: none; }
 }
 .list-head-left {
   display: flex;
@@ -45,28 +63,29 @@
    cap the width, so they're always clearly visible. !important overrides the
    old base rule that capped this bar to ~15%. */
 .list-head-right { flex-shrink: 0; max-width: none !important; }
-/* Tab strip: fill remaining width, scroll horizontally, gap between tabs. */
+/* Tab strip: sized to its tabs (no width cap) so "+ View" sits right after the
+   last tab, ClickUp-style, across the full-width row. It only scrolls when the
+   tabs genuinely overflow the row — in the common case everything fits and no
+   scrollbar shows at all. */
 .view_list_scroll {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
-  max-width: 800px;
   /* Horizontal scroll only (the tall active tab must not trigger a vertical
-     scrollbar), and offset the 6px scrollbar with matching top padding so the
-     tab labels stay vertically centered in the row while it's showing. */
+     scrollbar). No top padding: with no scrollbar in the common case the tabs
+     sit vertically centered on their own. */
   overflow-y: hidden;
-  padding-top: 6px;
   box-sizing: border-box;
-  scrollbar-width: thin;            /* Firefox */
-  scrollbar-color: #b4b8c0 #eef0f2; /* Firefox: thumb / track */
+  scrollbar-width: thin;                 /* Firefox */
+  scrollbar-color: #c7ccd4 transparent;  /* Firefox: thumb / track */
 }
 .view-list-wrapper { flex-shrink: 0; }
 .project__requirementcomponent-wrapper { flex-shrink: 0; }
 /* Clearly-visible 6px horizontal scrollbar (the strip no longer uses the
    2px `style-scroll` utility). */
-.view_list_scroll::-webkit-scrollbar { height: 6px; }
-.view_list_scroll::-webkit-scrollbar-track { background: #eef0f2; border-radius: 6px; }
-.view_list_scroll::-webkit-scrollbar-thumb { background: #b4b8c0; border-radius: 6px; }
-.view_list_scroll::-webkit-scrollbar-thumb:hover { background: #969ba6; }
+.view_list_scroll::-webkit-scrollbar { height: 4px; }
+.view_list_scroll::-webkit-scrollbar-track { background: transparent; }
+.view_list_scroll::-webkit-scrollbar-thumb { background: #c7ccd4; border-radius: 4px; }
+.view_list_scroll::-webkit-scrollbar-thumb:hover { background: #a9afb9; }
 /* Per-tab "⋯" menu shows on hover only; it's positioned over the tab's right
    edge in ViewsList (out of flow) so it never reserves space or resizes. */
 .list-head-right {
@@ -92,8 +111,8 @@
   display: block;
 }
 .list-view-header-title{
-  font-size: 18px;
-  line-height: 26.4px;
+  font-size: 16px;
+  line-height: 22px;
 }
 .key-wapper {
   margin-left: 12px;
@@ -120,11 +139,19 @@
   width: 0px;
 }
 .view-list {
-  /* Symmetric padding gives each name breathing room and centers the
-     border-right divider between two tabs (no flex `gap`, which would only
-     pad one side of the divider). */
-  padding: 0 18px 0 18px;
-  justify-content: center;
+  /* Left-aligned, compact tabs. The hover ⋯ menu is out of flow at the right
+     edge and shows only on hover; to give it room WITHOUT ever covering the
+     name, the tab GROWS its right padding on hover (see .wrapper:hover rule
+     below). So the view name stays fully visible in every case — idle or
+     hovered, few views or many. */
+  padding: 0 12px;
+  justify-content: flex-start;
+  transition: padding-right 0.15s ease;
+}
+/* Grow the hovered tab so the ⋯ menu opens into fresh space at the right,
+   never overlapping the view name (works for any name length / tab count). */
+.wrapper:hover .view-list {
+  padding-right: 34px;
 }
 .list-head-midmobile {
   display: none;
@@ -262,7 +289,7 @@
 @media (max-width: 1820px) {
   .list-head-left {max-width: 50%;}
   .list-head-mid {max-width: 50%;}
-  .view-list {padding: 0 20px 0 20px;}
+  .view-list {padding: 0 12px;}
   .view-list-wrapper {margin-left: 5px;}
   .list-head-leftrightwrappper {width: 80%;}
   .list-head-right {width: 20%;}


### PR DESCRIPTION
## What
Restructures the project view switcher into its own full-width row (ClickUp-style) and gives the project header a slimmer, lighter look. UI-only; no change to view switching, pin/default/delete, "+ View", or embed views.

## Why
The view tabs were squeezed into the 48px header next to the project title and action icons. Short tabs like "List" had a cramped click area, and the hover 3-dot menu / default-view badge overlapped the label.

## Changes
- **Dedicated tab row** (`.project-views-row`, 36px) between the header and the filter toolbar. The strip sizes to its tabs; "+ View" sits right after the last tab; a thin, subtle scrollbar appears only when tabs overflow the full-width row.
- **No more overlap:** tabs are left-aligned; on hover the tab grows its right padding so the 3-dot menu opens into clear space (never over the name), for any name length or view count. The "default view" home marker is now an in-flow icon after the name instead of an absolute corner badge.
- **Lighter header:** height 48 -> 44px, title 18 -> 16px, softer 1px dividers (#e8eaed) on both the header and the tab row.
- Body height recalculated (44px header + 36px row).
- Tab row hidden on mobile (the header keeps its existing "all views" dropdown).

## Files
- `frontend/src/views/Projects/Projects.vue` - moved the switcher out of the header into the new row; body height.
- `frontend/src/views/Projects/style.css` - `.project-views-row`, tab + hover styling, header + title + dividers.
- `frontend/src/components/atom/ViewsList/ViewsList.vue` - tab hover, compact 3-dot trigger, in-flow default-home marker, active-tab height.

## Test
- Desktop: tabs in their own row; hover any tab (esp. short ones) widens it and the 3-dot menu clears the name; default-view marker inline; row fits without a scrollbar.
- 3-dot menu (pin / set default / delete), "+ View", and embed views all work.
- Mobile (<768px): tab row hidden; header dropdown switches views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)