### PR TITLE
fix(projects): only grow view tabs on hover when the user has the view menu

### DIFF
--- a/frontend/src/components/atom/ViewsList/ViewsList.vue
+++ b/frontend/src/components/atom/ViewsList/ViewsList.vue
@@ -1,7 +1,7 @@
 <template>
     <div
     v-if="item._id && item._id.length>6"
-        :class="{'bg-light-gray': active}"
+        :class="{'bg-light-gray': active, 'has-view-menu': hasViewMenu}"
         class="d-flex align-items-center text-nowrap border-top-radius-10-px cursor-pointer wrapper h-100"
         @click.stop="$emit('click', item)"
     >
@@ -13,7 +13,7 @@
            <img class="list__default-home" v-if="item.setAsDefault" :src="viewDefaultIcon" />
            <img :src="active ? activePin : pin" v-if="item?.isPin && item.isPin" class="ml-10px active__pin-condition">
            <span class="notification-tick blinking position-sti ml-7px" v-if="item?.isPrivate"></span>
-           <div class="view-list__menu" v-if="checkPermission('project.view_list',project.isGlobalPermission) === true">
+           <div class="view-list__menu" v-if="hasViewMenu">
            <DropDown :id="item._id" @isVisible="isDropDownVisible" :zIndex="6">
                 <template #button>
                     <img :src="dots" class="dots ml-5px" :ref="item._id">
@@ -89,6 +89,10 @@ const companyOwner = computed(() => getters["settings/companyOwnerDetail"])
 const project = inject("selectedProject")
 const {checkPermission} = useCustomComposable();
 const {getters,commit} = useStore()
+// The per-view triple-dot menu only renders when the user has this permission.
+// The hover width-increase exists to make room for that menu, so gate it on the
+// same permission -- a user without the menu should not get a pointless gap.
+const hasViewMenu = computed(() => checkPermission('project.view_list', project.value?.isGlobalPermission) === true);
 const toast = useToast()
 const user = getUser(userId.value);
 const userData = {

--- a/frontend/src/views/Projects/style.css
+++ b/frontend/src/views/Projects/style.css
@@ -149,8 +149,10 @@
   transition: padding-right 0.15s ease;
 }
 /* Grow the hovered tab so the ⋯ menu opens into fresh space at the right,
-   never overlapping the view name (works for any name length / tab count). */
-.wrapper:hover .view-list {
+   never overlapping the view name (works for any name length / tab count).
+   Gated on .has-view-menu: only tabs whose user can open the ⋯ menu expand,
+   otherwise the widening would just add dead space. */
+.wrapper.has-view-menu:hover .view-list {
   padding-right: 34px;
 }
 .list-head-midmobile {


### PR DESCRIPTION
## What
Follow-up to #390. The per-view hover width-increase now only applies when the current user actually has the per-view triple-dot menu.

## Why
The `...` menu on each view tab renders only with the `project.view_list` permission. The hover width-increase exists to open space for that menu, but it was applying for **every** user - so a user without the menu got a pointless empty gap when hovering a tab.

## Fix
- New `hasViewMenu` computed (`checkPermission('project.view_list', ...)`), reused for the menu's `v-if`.
- The tab gets a `has-view-menu` class only when the permission is present.
- Hover-expand is scoped to `.wrapper.has-view-menu:hover .view-list`, so tabs only widen for users who have the menu.

## Files
- `frontend/src/components/atom/ViewsList/ViewsList.vue`
- `frontend/src/views/Projects/style.css`

## Test
- As a role **without** `project.view_list`: hover a view tab -> only the light hover tint, no width increase, no gap; no `...` menu.
- As owner/admin (**with** the permission): hover still widens the tab and shows the `...` menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)