### PR TITLE
fix(kanban): clean up card checkbox and drop task type from board cards

### DIFF
--- a/frontend/src/views/Projects/Kanban/BoardViewDisplayCardComponent.vue
+++ b/frontend/src/views/Projects/Kanban/BoardViewDisplayCardComponent.vue
@@ -21,14 +21,10 @@
             <div>
                 <div class="d-flex justify-content-between">
                     <div class="d-flex align-items-center mw-82">
-                        <ProjectTaskType
-                            :id="element._id+'type'"
-                            :modelValue="taskType"
-                            :options="projectTaskType"
-                            :disabled="showArchiveVar && checkPermission('task.task_list', projectData.isGlobalPermission) !== true || checkPermission('task.task_type', projectData.isGlobalPermission) !== true || showArchiveVar !== false"
-                            @select="changeTaskType($event)"
-                            :imgClasses="`m-0`"
-                        />
+                        <!-- Task type removed from the Kanban card. This spacer keeps the
+                             top-left slot for the absolute multi-select checkbox so the
+                             title never sits underneath it. -->
+                        <span class="kanban-card-checkbox-space" aria-hidden="true"></span>
                         <div class="list-group-kanban-item__taskName text-ellipsis font-weight-500 font-size-14 ml-5px black" :title="element.TaskName">
                             <img v-if="element.deletedStatusKey === 2" :src="inventoryIcon" alt="inventory" class="ml-5px" />
                             <img v-if="element.deletedStatusKey === 1" :src="deleteIcon" alt="delete" class="ml-5px" />
@@ -245,7 +241,6 @@
     import ConvertToSubTaskSidebar from '@/components/molecules/ConvertToSubTaskSidebar/ConvertToSubTaskSidebar.vue';
     import ConvertToList from '@/components/molecules/ConvertToList/ConvertToList.vue';
     import DueDateCompo from '@/components/molecules/DueDateCompo/DueDateCompo.vue';
-    import ProjectTaskType from "@/components/atom/TaskTypeSelection/TaskTypeSelection.vue"
     import { useI18n } from "vue-i18n";
     const { t } = useI18n();
     const router = useRouter()
@@ -310,12 +305,6 @@
     const openSubTaskSideabr = ref(false)
     const dueDate = computed(() => element.value.DueDate)
 
-    const projectTaskType = computed(() => {
-        return projectData.value.taskTypeCounts;
-    })
-    const taskType = computed(() => {
-        return projectData.value.taskTypeCounts.find((x) => x.key === element.value.TaskTypeKey)
-    })
     const myCounts = computed(() => {
         let total = 0;
         if(getters["users/myCounts"]?.data?.[`task_${projectData.value._id}_${props.data.sprintId}_${props.data._id}_comments`]) {
@@ -515,11 +504,6 @@
         } catch (error) {
             console.error("ERROR in updateDueDate: ", error);
         }
-    }
-    function changeTaskType(status) {
-        const statusIndex = projectData.value.taskTypeCounts.findIndex((x) => x.key === props.data.TaskTypeKey);
-        if(statusIndex === -1) return;
-        updateTaskByGroup(element.value, status, 4);
     }
     function updateTask(value = null) {
         const deletedStatusKey = value !== null ? value : archive.value ? 2 : 1;

--- a/frontend/src/views/Projects/Kanban/new-style.css
+++ b/frontend/src/views/Projects/Kanban/new-style.css
@@ -12,25 +12,32 @@
 .kanban-card-wrapper { position: relative; }
 .kanban-card-multi-select {
     position: absolute;
-    top: 6px;
-    left: 6px;
+    top: 8px;
+    left: 8px;
     z-index: 5;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 20px;
     height: 20px;
-    background: #fff;
-    border: 1px solid #e0e0e0;
+    /* no background/border here — the native checkbox draws its own box; a
+       wrapper box just doubled up with it. */
     border-radius: 4px;
     cursor: pointer;
 }
 .kanban-card-multi-select input[type="checkbox"] {
-    width: 12px;
-    height: 12px;
+    width: 14px;
+    height: 14px;
     cursor: pointer;
     accent-color: #8591F9;
     margin: 0;
+}
+/* Leading spacer where the task-type icon used to be: reserves the top-left
+   corner for the absolute multi-select checkbox so the card title stays clear. */
+.kanban-card-checkbox-space {
+    display: inline-block;
+    flex: 0 0 auto;
+    width: 20px;
 }
 
 .kanban-board .kanban-column {


### PR DESCRIPTION
## What
Cleans up the Board (Kanban) task-card top-left area.

## Changes
**Multi-select checkbox** (`.kanban-card-multi-select`)
- Removed the label wrapper's `border` and `background` so it no longer **double-borders** with the native checkbox (only the checkbox's own single border shows now).
- Checkbox size `12px → 14px`.
- Position nudged to `top: 8px; left: 8px`.

**Task type removed from the card**
- Removed the `<ProjectTaskType>` icon (it sat directly under the checkbox).
- Added a small leading spacer (`.kanban-card-checkbox-space`, 20px) so the checkbox keeps its top-left corner and the card **title stays clear** (a plain delete would slide the title under the checkbox).
- Dropped the now-unused `ProjectTaskType` import, the `projectTaskType`/`taskType` computeds, and the `changeTaskType` handler (keeps lint/build clean).

## Note
The task type is no longer shown or editable on the board card; it remains on the task and editable from Task Detail / other views.

## Files
- `frontend/src/views/Projects/Kanban/BoardViewDisplayCardComponent.vue`
- `frontend/src/views/Projects/Kanban/new-style.css`

## Test
Board view — each card shows a single-bordered 14px checkbox at top-left (checked = brand fill + tick), no type icon behind it, and the title sits clear with no overlap. Multi-select still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)