### PR TITLE
feat(projects): compact project sidebar header and "+ New" menu

### DIFF
--- a/frontend/src/components/molecules/ProjectListComponent/ProjectListComponent.vue
+++ b/frontend/src/components/molecules/ProjectListComponent/ProjectListComponent.vue
@@ -38,7 +38,7 @@
             </div>
             <div @click="$emit('update:showArchivedProjects', false)">{{$t('ProjectSlider.hide_archive')}}</div>
         </div>
-        <div class="bg-white position-sti d-flex align-items-center justify-content-between p-10px assignee__drop-wrapper" v-if="!showArchivedProjects">
+        <div class="bg-white position-sti d-flex align-items-center justify-content-between assignee__drop-wrapper" style="height: 36px; padding: 0 10px;" v-if="!showArchivedProjects">
             <div class="d-flex align-items-center">
                 <img id="projestleftlistfilter_driver" :src="filterFavorites ? starImage : blankStar" alt="starImage" class="cursor-pointer fillstar__image" @click="emit('update:filterFavorites', !filterFavorites)" v-show="!search && ProjectfilterObject?.query && !Object.keys(ProjectfilterObject?.query).length && !Object.keys(ProjectfilterObject?.sortByField).length && !Object.keys(ProjectfilterObject?.sortByOrder).length"/>
             </div>
@@ -53,8 +53,19 @@
                         </DropDownOption>
                     </template>
                 </DropDown>
-                <button v-if="!showArchivedProjects && checkPermission('project.project_list',projectData.isGlobalPermission) === true && checkPermission('project.project_create',projectData.isGlobalPermission) === true" class="outline-primary ml-1 font-size-16 p0x-13px" @click="tourTest('isProjectTour'), $emit('createProject')" id="createproject_driver">+ {{$t('ProjectSlider.new_project')}}</button>
-                <button v-if="!showArchivedProjects && currentCompany?.planFeature?.aiPermission && checkPermission('project.project_list',projectData.isGlobalPermission) === true && checkPermission('project.project_create',projectData.isGlobalPermission) === true" class="outline-primary ml-1 font-size-16 p0x-13px aipg-trigger" @click="$emit('createAiProject')" id="createAiProject_driver" :title="$t ? $t('Projects.create_with_ai') : 'Create project with AI'">✨ Create with AI</button>
+                <DropDown v-if="!showArchivedProjects && checkPermission('project.project_list',projectData.isGlobalPermission) === true && checkPermission('project.project_create',projectData.isGlobalPermission) === true" class="project__new-dropdown">
+                    <template #button>
+                        <button ref="new_project_menu" class="ml-1 project__new-btn" id="createproject_driver" :title="$t('ProjectSlider.new_project')">+ New <span class="project__new-caret">▾</span></button>
+                    </template>
+                    <template #options>
+                        <DropDownOption @click="$refs.new_project_menu.click(), tourTest('isProjectTour'), $emit('createProject')">
+                            <span>Blank project</span>
+                        </DropDownOption>
+                        <DropDownOption v-if="currentCompany?.planFeature?.aiPermission" class="aipg-trigger" id="createAiProject_driver" @click="$refs.new_project_menu.click(), $emit('createAiProject')">
+                            <span>Create with AI</span>
+                        </DropDownOption>
+                    </template>
+                </DropDown>
             </div>
         </div>
         </div>

--- a/frontend/src/views/Projects/ProjectsListing/style.css
+++ b/frontend/src/views/Projects/ProjectsListing/style.css
@@ -13,7 +13,7 @@
 }
 
 .searchBox {
-  height: 48px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -22,6 +22,37 @@
   top: 0px;
   z-index: 1;
   /* box-shadow: 0px 2px 10px #bbb9b9; */
+}
+/* Lighter divider under the project-sidebar search header only. Scoped with the
+   compound selector so the shared global .border-bottom-serach (also used by the
+   dashboard/calendar headers) is left untouched. */
+.searchBox.border-bottom-serach {
+  border-bottom: 1px solid #e5e7eb;
+}
+/* Compact single "+ New project" dropdown button (Option A) — replaces the two
+   larger "New project" / "Create with AI" buttons to save space. */
+.project__new-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 12px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  color: #fff;
+  background: linear-gradient(90deg, #4B5DEE 0%, #F241CD 100%);
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.project__new-btn:hover {
+  filter: brightness(0.97);
+}
+.project__new-btn .project__new-caret {
+  font-size: 12px;
+  opacity: 0.9;
 }
 .project-list-title {
   font-size: 16px;


### PR DESCRIPTION
## What
Tightens and cleans up the left project-sidebar top area (search header + the star/gear/New row).

## Changes
**Search header** (`.searchBox`)
- Height `48px → 44px`.
- Lighter 1px divider `#e5e7eb`, scoped via `.searchBox.border-bottom-serach` so the shared global `.border-bottom-serach` utility (dashboard/calendar headers) is left unchanged.

**"+ New" menu** (Option A — consolidation)
- Replaced the two separate `New project` / `Create with AI` buttons with a single compact gradient **`+ New ▾`** dropdown → **Blank project** / **Create with AI**.
- Styled like the "Write with AI" button (blue→pink gradient, white text, 8px radius).
- Permission gating preserved: whole button gated by `project.project_create`; the *Create with AI* item additionally gated by `aiPermission`. No permission → button hidden (just star + gear). Tour ids (`createproject_driver`, `createAiProject_driver`) kept.

**Toolbar row**
- Fixed `height: 36px` (no vertical padding) so the row height is **identical whether or not the user has create permission** (previously padding-driven → mismatch when the button was hidden).

## Files
- `frontend/src/components/molecules/ProjectListComponent/ProjectListComponent.vue`
- `frontend/src/views/Projects/ProjectsListing/style.css`

## Note
The `+ New`, `Blank project`, and `Create with AI` labels are literal English (the old AI button was hard-coded the same way). Can be moved to i18n keys if translations are needed.

## Test
- With create permission: `+ New ▾` gradient button; menu opens `Blank project` / `Create with AI`, both run the existing create flows.
- Without create permission: only star + gear; row stays the same 36px height.
- Search header is slimmer with a lighter divider; dashboard/calendar borders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)