### PR TITLE
feat(tracker): custom idle notification via a shared notification template

### DIFF
--- a/time-tracker-app/main/background.js
+++ b/time-tracker-app/main/background.js
@@ -10,6 +10,7 @@ const iconPath = assetPath('logo.png')
 const trayIconPath = assetPath('traylogo.png')
 // Prod: next export copies public/ into app/. Dev: read straight from renderer/public.
 const notificationHtmlPath = isProd ? path.join(__dirname, 'notification.html') : path.join(__dirname, '..', 'renderer', 'public', 'notification.html')
+const notificationTemplateHtmlPath = isProd ? path.join(__dirname, 'notification-template.html') : path.join(__dirname, '..', 'renderer', 'public', 'notification-template.html')
 let notification = null;
 let screenshotNotificationWindow = null;
 
@@ -259,6 +260,11 @@ function verifyScreenCapturePermission() {
 
 ;(async () => {
   await app.whenReady()
+
+  // Windows shows the AppUserModelID as the notification header ("attribution").
+  // Set a friendly one so toasts read "AlianHub Time Tracker" instead of the
+  // default "electron.app.alianhubtimetracker".
+  if (process.platform === 'win32') app.setAppUserModelId('AlianHub Time Tracker')
   
   // Load saved permissions state
   loadPermissionsState()
@@ -392,7 +398,7 @@ const startActivitySampling = () => {
       // is just a heads-up that no input was detected for the threshold.
       mainWindow.webContents.send('idle:detected', { idleSeconds, thresholdSeconds: idleThresholdSec })
       try {
-        new Notification({ title: 'Alianhub Time Tracker', body: `No activity detected for ${Math.round(idleThresholdSec / 60)} min.` }).show()
+        showNotification({ title: 'No activity detected', subtitle: `You've been idle for ${Math.round(idleThresholdSec / 60)} min.` })
       } catch (e) { /* notifications are best-effort */ }
     }
     if (mouseMoved) {
@@ -525,6 +531,57 @@ function sendNotification(dataUrl) {
     });
   });
 
+}
+
+// Common in-app notification — one shared layout (notification-template.html)
+// whose content is passed in, so any future notification can reuse it:
+//   showNotification({ title, subtitle, image, timeout })
+// Pass `image` (a data URL / path) to show a media preview; omit it for a
+// compact text-only card. The screenshot notification keeps its own file and
+// flow (sendNotification) and is intentionally left untouched.
+function showNotification({ title, subtitle = '', image = null, timeout = 10000 }) {
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+  const windowWidth = 372;
+  // Taller when there's a media/preview image; compact for text-only.
+  const windowHeight = image ? 282 : 92;
+
+  const win = new BrowserWindow({
+    width: windowWidth,
+    height: windowHeight,
+    x: width - windowWidth,
+    y: height - windowHeight,
+    frame: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    resizable: false,
+    transparent: true,
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadFile(notificationTemplateHtmlPath);
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.send('logo-path', iconPath);
+    win.webContents.send('notification:render', { title, subtitle, image, timeout });
+    win.showInactive(); // don't steal focus from the user's current input
+
+    const closeHandler = () => {
+      if (!win.isDestroyed()) win.close();
+    };
+    ipcMain.once('notification:close', closeHandler);
+
+    const autoCloseTimer = setTimeout(() => {
+      if (!win.isDestroyed()) win.close();
+    }, timeout);
+
+    win.once('closed', () => {
+      clearTimeout(autoCloseTimer);
+      ipcMain.removeListener('notification:close', closeHandler);
+    });
+  });
 }
 
 powerMonitor.on('suspend', () => {

--- a/time-tracker-app/package.json
+++ b/time-tracker-app/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "alianhubtimetracker",
   "description": "My application description",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "author": "Alian Software",
   "homepage": "https://aliansoftware.com",
   "main": "app/background.js",

--- a/time-tracker-app/renderer/public/notification-template.html
+++ b/time-tracker-app/renderer/public/notification-template.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Notification</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body { overflow: hidden; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+      background: transparent;
+      padding: 12px 16px 16px;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    @keyframes toastIn {
+      from { opacity: 0; transform: translateY(12px) scale(0.9); }
+      to   { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes toastOut {
+      from { opacity: 1; transform: translateY(0) scale(1); }
+      to   { opacity: 0; transform: translateY(12px) scale(0.9); }
+    }
+
+    .toast {
+      position: relative;
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.85) 0%, rgba(255, 255, 255, 0.8) 100%);
+      -webkit-backdrop-filter: blur(24px) saturate(180%);
+      backdrop-filter: blur(24px) saturate(180%);
+      border: 1px solid rgba(255, 255, 255, 0.6);
+      border-radius: 14px;
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.6);
+      overflow: hidden;
+      transform-origin: bottom right;
+      animation: toastIn 0.26s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    .toast.closing { animation: toastOut 0.2s ease-in forwards; }
+    .toast::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(120% 80% at 0% 0%, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0) 55%);
+      pointer-events: none;
+    }
+
+    /* Text-only card is snug; when a media image is present the head tightens
+       up so the preview sits right below it (matches the screenshot layout). */
+    .toast-head { display: flex; align-items: center; gap: 10px; padding: 14px 12px; position: relative; z-index: 1; }
+    body.has-image .toast-head { padding: 12px 12px 10px; }
+
+    .logo { width: 30px; height: 30px; border-radius: 50%; object-fit: cover; flex-shrink: 0; }
+
+    .head-text { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+    .title { font-size: 14px; font-weight: 700; color: #171b26; line-height: 1.2; letter-spacing: 0.2px; }
+    .subtitle { font-size: 12px; color: #444b5c; margin-top: 2px; }
+
+    .close {
+      width: 22px; height: 22px;
+      display: flex; align-items: center; justify-content: center;
+      border-radius: 6px;
+      cursor: pointer;
+      color: #4b5162;
+      flex-shrink: 0;
+      transition: background 0.15s, color 0.15s;
+    }
+    .close:hover { background: rgba(0, 0, 0, 0.08); color: #171b26; }
+
+    .media-wrap { padding: 0 12px 14px; position: relative; z-index: 1; }
+    .media {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      height: auto;
+      object-fit: cover;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.7);
+      display: block;
+      background: rgba(255, 255, 255, 0.25);
+    }
+
+    .countdown-track {
+      position: absolute;
+      bottom: 0; left: 0;
+      width: 100%;
+      height: 5px;
+      background: rgba(47, 57, 144, 0.15);
+      z-index: 1;
+    }
+    .countdown {
+      height: 100%;
+      width: 100%;
+      background: linear-gradient(90deg, #2F3990, #5561d6);
+      border-radius: 0 3px 3px 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="toast">
+    <div class="toast-head">
+      <img src="./logo.png" class="logo" alt="Logo" id="logo">
+      <div class="head-text">
+        <span class="title" id="title">Notification</span>
+        <span class="subtitle" id="subtitle"></span>
+      </div>
+      <div class="close" id="close_icon" title="Dismiss">
+        <svg width="14" height="14" viewBox="0 0 490 490" fill="currentColor">
+          <polygon points="456.851,0 245,212.564 33.149,0 0.708,32.337 212.669,245.004 0.708,457.678 33.149,490 245,277.443 456.851,490 489.292,457.678 277.331,245.004 489.292,32.337 "/>
+        </svg>
+      </div>
+    </div>
+    <div class="media-wrap" id="media-wrap" style="display:none;">
+      <img id="media" class="media" src="" alt="">
+    </div>
+    <div class="countdown-track">
+      <div class="countdown" id="progress-bar-fill"></div>
+    </div>
+  </div>
+
+  <script>
+    const { ipcRenderer } = require('electron');
+    const toast = document.querySelector('.toast');
+    const OUT_MS = 200;
+    let closing = false;
+    let started = false;
+
+    ipcRenderer.on('logo-path', (event, path) => {
+      document.getElementById('logo').src = path;
+    });
+
+    // Single entry point: the shared layout renders whatever the caller sends.
+    // { title, subtitle, image?, timeout? } — pass an image to show the media
+    // preview, omit it for a compact text-only card.
+    ipcRenderer.on('notification:render', (event, data) => {
+      data = data || {};
+      if (data.title != null) document.getElementById('title').textContent = data.title;
+      if (data.subtitle != null) document.getElementById('subtitle').textContent = data.subtitle;
+
+      const wrap = document.getElementById('media-wrap');
+      if (data.image) {
+        document.getElementById('media').src = data.image;
+        wrap.style.display = '';
+        document.body.classList.add('has-image');
+      } else {
+        wrap.style.display = 'none';
+        document.body.classList.remove('has-image');
+      }
+
+      startCountdown(typeof data.timeout === 'number' ? data.timeout : 10000);
+    });
+
+    function closeWithAnim() {
+      if (closing) return;
+      closing = true;
+      toast.classList.add('closing');
+      setTimeout(() => ipcRenderer.send('notification:close'), OUT_MS);
+    }
+    document.getElementById('close_icon').addEventListener('click', closeWithAnim);
+
+    // Auto-dismiss + depleting countdown bar, synced to the caller's timeout.
+    function startCountdown(timeout) {
+      if (started) return;
+      started = true;
+      setTimeout(closeWithAnim, Math.max(timeout - OUT_MS, 0));
+      const fill = document.getElementById('progress-bar-fill');
+      const start = Date.now();
+      (function tick() {
+        const remaining = Math.max(1 - (Date.now() - start) / timeout, 0);
+        fill.style.width = (remaining * 100) + '%';
+        if (remaining > 0) requestAnimationFrame(tick);
+      })();
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What
Replaces the native OS "no activity" toast in the time-tracker app with a **custom in-app card** styled like the existing screenshot notification, and factors that card into a **reusable template** future notifications can share.

## Changes
- **New `renderer/public/notification-template.html`** — a shared glass-card layout driven entirely by IPC content:
  ```js
  win.webContents.send('notification:render', { title, subtitle, image, timeout })
  ```
  Pass an `image` for a media-preview card, omit it for a compact text-only card; `timeout` drives the auto-dismiss + countdown. Dismiss via `notification:close`.
- **`background.js`** — generic `showNotification({ title, subtitle, image?, timeout? })` helper that opens the template window; the idle / no-activity case now calls it. Also sets a friendly `AppUserModelId` for the app's taskbar/notification identity.
- **Screenshot notification untouched** — still its own `notification.html` + `sendNotification` flow.
- **Version bump** to `5.1.2`.

## Not included
- `renderer/.env` (API URL) is gitignored — not part of this PR.
- The Windows code-signing config in `package.json` is unchanged (it was only removed locally for unsigned test builds).

## Test
Built + installed the `5.1.2` production package locally: idle notification renders from the shared template (logo + "No activity detected" + "You've been idle for X min." + countdown), and the screenshot notification still works from its own file. Reusing `showNotification(...)` renders any future notification in the same layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)