### PR TITLE
fix: prevent comment count overlapping the project view tab label

### DIFF
--- a/frontend/src/components/atom/ViewsList/ViewsList.vue
+++ b/frontend/src/components/atom/ViewsList/ViewsList.vue
@@ -7,9 +7,9 @@
     >
         <div :class="{'border-left': firstChild && !active, 'border-right': !active, 'border-none activeViewList': active}" class="d-flex align-items-center font-size-14 view-list position-re"
         :style="{ height: active ? '36px' : 'auto' }">
-           <span v-if="commentCount" class="count-block comment__count white position-ab">{{commentCount <= 99 ? commentCount : '+99'}}</span> 
            <img :src="active ? projectComponentsIcons(item.keyName)?.activeIcon : projectComponentsIcons(item.keyName)?.icon" :alt="item.name" class="mr-10px">
            <span class="gray81">{{$t(`ViewList.${item.name}`)}}</span>
+           <span v-if="commentCount" class="count-block comment__count white">{{commentCount <= 99 ? commentCount : '+99'}}</span>
            <img class="list__default-home" v-if="item.setAsDefault" :src="viewDefaultIcon" />
            <img :src="active ? activePin : pin" v-if="item?.isPin && item.isPin" class="ml-10px active__pin-condition">
            <span class="notification-tick blinking position-sti ml-7px" v-if="item?.isPrivate"></span>
@@ -257,12 +257,14 @@ defineEmits(['click']);
     object-fit: contain;
     flex: 0 0 auto;
 }
+/* In-flow pill after the view name (not an absolute corner badge) so the
+   comment count never overlaps the label — in any state, at any tab width. */
 .count-block.comment__count{
    color: #eabb00 !important;
    background-color: transparent;
    border: 1px solid #eabb00 !important;
-   top: -9px;
-   right: 4px;
+   margin-left: 6px;
+   flex: 0 0 auto;
 }
 
 .active__pin-condition{

--- a/frontend/src/views/Projects/style.css
+++ b/frontend/src/views/Projects/style.css
@@ -162,9 +162,6 @@
   color: #2f3990;
   font-weight: 500;
 }
-.activeViewList .count-block {
-  top: 5px !important;
-}
 .list_make_as_defaultimg {
   right: 2px;
   top: -6px;


### PR DESCRIPTION
## Summary

Fixes the unread-comment count badge overlapping the label on the project **Comments** view tab (AHE-3828).

## Root cause

The count badge was absolutely positioned at `right: 4px`. The v14.16.0 view-row compaction reduced the tab's idle right padding to `12px`, so the ~14px-wide badge reached back over the last characters of the left-aligned label. It only cleared on hover (when the tab grows its right padding to 34px to make room for the `⋯` menu).

## Fix

Take the badge out of absolute positioning and let it flow **inline, right after the view name**. An in-flow pill widens the tab to fit itself, so it can never overlap the label — in any state (idle / hover / active), for any name length or number of views. Count value and visibility (`commentCount`) are unchanged.

## Changes

- `frontend/src/components/atom/ViewsList/ViewsList.vue` — moved the count `<span>` to after the name and removed the `position-ab` (absolute) class; badge style now uses `margin-left: 6px` + `flex: 0 0 auto` instead of `top`/`right` offsets.
- `frontend/src/views/Projects/style.css` — removed the now-dead `.activeViewList .count-block { top: 5px }` override (a no-op once the badge is in-flow).

## Test cases

- [ ] Comments tab with an unread count (e.g. `1`) → count sits beside the label with a gap, no overlap.
- [ ] Hover the tab so the `⋯` menu appears → count still clears the menu.
- [ ] Longer view name + count → no overlap; tab widens to fit.
- [ ] Active vs inactive Comments tab → count aligned and readable in both.
- [ ] Count > 99 → shows `+99` beside the name without overlap.

Task: AHE-3828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
