### PR TITLE
feat(projects): representational "app not enabled" teaser blocks + unlock checklist

### DIFF
--- a/frontend/src/components/molecules/AppTeaserBlock/AppTeaserBlock.vue
+++ b/frontend/src/components/molecules/AppTeaserBlock/AppTeaserBlock.vue
@@ -1,0 +1,76 @@
+<template>
+    <!-- Inline variant: a compact "locked" chip for inline controls (tags, AI buttons). -->
+    <div v-if="variant === 'inline'" class="app-teaser-chip cursor-pointer" role="button" tabindex="0"
+        :title="resolvedDescription" @click="goToSettings" @keyup.enter="goToSettings">
+        <span class="app-teaser-chip__lock" aria-hidden="true">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="4" y="11" width="16" height="9" rx="2"></rect>
+                <path d="M8 11V8a4 4 0 0 1 8 0v3"></path>
+            </svg>
+        </span>
+        <span class="app-teaser-chip__label">{{ resolvedTitle }}</span>
+        <span class="app-teaser-chip__cta">Enable</span>
+    </div>
+
+    <!-- Block variant (default): compact dashed "available, not enabled" banner.
+         Auto-height, single row (wraps in narrow columns). A quiet accent CTA —
+         not the green button — so it reads as a free toggle, not a paid upgrade. -->
+    <div v-else class="app-teaser-banner cursor-pointer" role="button" tabindex="0" @click="goToSettings" @keyup.enter="goToSettings">
+        <span class="app-teaser-banner__ic" aria-hidden="true">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="4" y="11" width="16" height="9" rx="2"></rect>
+                <path d="M8 11V8a4 4 0 0 1 8 0v3"></path>
+            </svg>
+        </span>
+        <span class="app-teaser-banner__text">
+            <span class="app-teaser-banner__title">{{ resolvedTitle }}</span>
+            <span class="app-teaser-banner__desc">{{ resolvedDescription }}</span>
+        </span>
+        <span class="app-teaser-banner__cta">
+            {{ buttonText }}
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"></path></svg>
+        </span>
+    </div>
+</template>
+
+<script setup>
+import { computed, inject } from 'vue';
+import { useRouter } from 'vue-router';
+
+const props = defineProps({
+    // Key of the app this block represents, e.g. "CustomFields".
+    appKey: { type: String, default: '' },
+    // 'block' — full dimmed-preview panel; 'inline' — compact locked chip.
+    variant: { type: String, default: 'block' },
+    // Optional overrides — otherwise resolved from APP_META by appKey.
+    title: { type: String, default: '' },
+    description: { type: String, default: '' },
+    buttonText: { type: String, default: 'Enable in settings' },
+    // Heading is composed as: "{headPrefix} <highlight>{title}</highlight> {headSuffix}".
+    headPrefix: { type: String, default: 'Enable' },
+    headSuffix: { type: String, default: 'in this project' }
+});
+
+const router = useRouter();
+const companyId = inject('$companyId', null);
+
+// Copy for each representable app. Kept here so call sites only pass `appKey`.
+const APP_META = {
+    CustomFields: { title: 'Custom fields', description: 'Add your own fields to capture what matters on tasks.' },
+    TimeTracking: { title: 'Time tracking', description: 'Log time against tasks and see where hours go.' },
+    Milestones: { title: 'Milestones', description: 'Group work toward dated goals and track progress.' },
+    AI: { title: 'AI', description: 'Draft tasks, summaries, and plans with AI.' },
+    tags: { title: 'Tags', description: 'Label and filter tasks across the project.' }
+};
+
+const meta = computed(() => APP_META[props.appKey] || {});
+const resolvedTitle = computed(() => props.title || meta.value.title || props.appKey);
+const resolvedDescription = computed(() => props.description || meta.value.description || '');
+
+function goToSettings() {
+    const cid = companyId?.value || companyId;
+    router.push({ name: 'Settings-Projects', params: { cid } }).catch(() => {});
+}
+</script>
+
+<style src="./style.css"></style>

--- a/frontend/src/components/molecules/AppTeaserBlock/AppTeaserBlock.vue
+++ b/frontend/src/components/molecules/AppTeaserBlock/AppTeaserBlock.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Inline variant: a compact "locked" chip for inline controls (tags, AI buttons). -->
     <div v-if="variant === 'inline'" class="app-teaser-chip cursor-pointer" role="button" tabindex="0"
-        :title="resolvedDescription" @click="goToSettings" @keyup.enter="goToSettings">
+        :title="`${resolvedDescription} — enable under ${location}`" @click="goToSettings" @keyup.enter="goToSettings">
         <span class="app-teaser-chip__lock" aria-hidden="true">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="4" y="11" width="16" height="9" rx="2"></rect>
@@ -25,6 +25,13 @@
         <span class="app-teaser-banner__text">
             <span class="app-teaser-banner__title">{{ resolvedTitle }}</span>
             <span class="app-teaser-banner__desc">{{ resolvedDescription }}</span>
+            <span class="app-teaser-banner__hint">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="12" cy="12" r="3"></circle>
+                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 3.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H8a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V8a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                </svg>
+                {{ location }}
+            </span>
         </span>
         <span class="app-teaser-banner__cta">
             {{ buttonText }}
@@ -48,7 +55,9 @@ const props = defineProps({
     buttonText: { type: String, default: 'Enable in settings' },
     // Heading is composed as: "{headPrefix} <highlight>{title}</highlight> {headSuffix}".
     headPrefix: { type: String, default: 'Enable' },
-    headSuffix: { type: String, default: 'in this project' }
+    headSuffix: { type: String, default: 'in this project' },
+    // Breadcrumb telling the user exactly where to switch the app on.
+    location: { type: String, default: 'Settings → Projects → Apps' }
 });
 
 const router = useRouter();

--- a/frontend/src/components/molecules/AppTeaserBlock/style.css
+++ b/frontend/src/components/molecules/AppTeaserBlock/style.css
@@ -1,0 +1,89 @@
+/* Block variant: compact dashed "available, not enabled" banner — auto height,
+   wraps in narrow columns (e.g. the task/project Details sidebar). */
+.app-teaser-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    width: 100%;
+    margin: 16px 0;
+    padding: 10px 12px;
+    border: 1px dashed #C9CDE0;
+    border-radius: 10px;
+    background: transparent;
+    transition: border-color 0.12s ease, background 0.12s ease;
+}
+.app-teaser-banner:hover {
+    border-color: #4B5DEE;
+    background: #F7F8FF;
+}
+.app-teaser-banner__ic {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex: none;
+    border-radius: 8px;
+    background: #EEF0FF;
+    color: #2B37A8;
+}
+.app-teaser-banner__text {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 120px;
+}
+.app-teaser-banner__title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #191A2B;
+}
+.app-teaser-banner__desc {
+    font-size: 12px;
+    line-height: 1.4;
+    color: #6B6B70;
+}
+.app-teaser-banner__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    margin-left: auto;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: #4B5DEE;
+    white-space: nowrap;
+}
+
+/* Inline "locked" chip variant */
+.app-teaser-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 30px;
+    padding: 0 10px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #565979;
+    background: #F4F4FA;
+    border: 1px solid #E1E1EF;
+    border-radius: 8px;
+    white-space: nowrap;
+}
+.app-teaser-chip:hover {
+    border-color: #B9C0F5;
+    background: #EEF0FF;
+}
+.app-teaser-chip__lock {
+    display: inline-flex;
+    align-items: center;
+    color: #8A8CA6;
+}
+.app-teaser-chip__label {
+    color: #191A2B;
+}
+.app-teaser-chip__cta {
+    color: #4B5DEE;
+    font-weight: 600;
+}
+

--- a/frontend/src/components/molecules/AppTeaserBlock/style.css
+++ b/frontend/src/components/molecules/AppTeaserBlock/style.css
@@ -44,6 +44,17 @@
     line-height: 1.4;
     color: #6B6B70;
 }
+.app-teaser-banner__hint {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: 4px;
+    font-size: 11px;
+    color: #9092AC;
+}
+.app-teaser-banner__hint svg {
+    flex: none;
+}
 .app-teaser-banner__cta {
     display: inline-flex;
     align-items: center;

--- a/frontend/src/components/molecules/CheckList/CheckList.vue
+++ b/frontend/src/components/molecules/CheckList/CheckList.vue
@@ -3,18 +3,8 @@
     Assignee: Parth Detroja [30-05-2023]
 -->
 <template>
-    <div :class="[{'position-re':!props.planCondition}]" class="pt-20px">
-        <div v-if="!props.planCondition">
-            <UpgradePlan 
-                :isImage="false"
-                :buttonText="$t('Upgrades.upgrade_your_plan')"
-                :lastTitle="$t('Checklist.to_unlock_checklist')"
-                :secondTitle="$t('Upgrades.unlimited')"
-                :firstTitle="$t('Upgrades.upgrade_to')"
-                :message="$t('Upgrades.the_feature_not_available')"
-            />
-        </div>
-        <div class="checklist-main mobile__bg--withPadding" :class="[{'bg-colorlightgray pointer-event-none opacity-5 blur-3-px':!props.planCondition}]">
+    <div class="pt-20px">
+        <div class="checklist-main mobile__bg--withPadding">
             <div class="d-flex align-items-center">
                 <h4 :class="{'font-size-16 font-weight-600' : clientWidth <=767 , 'font-size-14 font-weight-700' : clientWidth > 767 }" class="black">{{$t('Checklist.checklist')}}</h4>
                 <div class="d-flex align-items-center ml-auto" @click="generateChecklistWithAi()" v-if="checkApps('AI',project) && checkPermission('task.task_checklist',project?.isGlobalPermission) === true">
@@ -155,7 +145,6 @@ import AiCheckList from './AiCheckList.vue';
 import { useAiApiFunction } from "@/composable/aiHelper";
 import Skelaton from "@/components/atom/Skelaton/AiSkelaton.vue";
 import Skelatons from '@/components/atom/Skelaton/Skelaton.vue';
-import UpgradePlan from '@/components/atom/UpgradYourPlanComponent/UpgradYourPlanComponent.vue';
 import { useI18n } from "vue-i18n";
 const { t } = useI18n();
 import taskClass from "@/utils/TaskOperations";

--- a/frontend/src/components/molecules/TabListItem/TabListItem.vue
+++ b/frontend/src/components/molecules/TabListItem/TabListItem.vue
@@ -1,6 +1,6 @@
 <template>
     <li
-        v-if="tabKey === 'time-log' ? checkApps('TimeTracking') : true"
+        v-if="tabKey === 'time-log' ? (checkApps('TimeTracking') || getAppState('TimeTracking') === 'disabled') : true"
         role="presentation"
         :class="{ active: isActive }"
         class="cursor-pointer"
@@ -35,7 +35,7 @@
 <script setup>
 import { defineProps, defineEmits } from 'vue';
 import { useCustomComposable } from '@/composable';
-const { checkApps } = useCustomComposable();
+const { checkApps, getAppState } = useCustomComposable();
 
 defineEmits(["changeTab"]);
 defineProps({

--- a/frontend/src/components/molecules/TaskDetailTab/TaskDetailTab.vue
+++ b/frontend/src/components/molecules/TaskDetailTab/TaskDetailTab.vue
@@ -16,6 +16,11 @@
                     <CreateTagPopup :task="task" @send:tagChipArray="(val)=>tagChipArray = val"  @send:ids="(val)=>ids = val" :project="projectData" :isTaskList="false" />
                 </template>
             </div>
+            <!-- Tags app available on the plan but not switched on for this project: representational teaser. -->
+            <AppTeaserBlock
+                v-else-if="getAppState('tags', projectData) === 'disabled'"
+                appKey="tags" class="mb-1"
+            />
             <Description
                 v-if="checkPermission('task.task_description',projectData?.isGlobalPermission) !== null && checkApps('AI',projectData) !== undefined && checkPermission('task.task_description',projectData?.isGlobalPermission) !== undefined && Object.keys(projectData).length > 0"
                 :isShowAi="checkApps('AI',projectData) && checkPermission('task.task_description',projectData?.isGlobalPermission) == true"
@@ -44,8 +49,9 @@
                 :task="task"
                 class="mt-1"
             />
-            <div class="position-re">
-                <div v-if="checkPermission('task.task_custom_field',projectData?.isGlobalPermission) !== null && checkApps('CustomFields')">
+            <div class="position-re" v-if="checkPermission('task.task_custom_field',projectData?.isGlobalPermission) !== null">
+                <!-- App enabled for this project: existing behavior (feature, or blurred feature + upgrade overlay when the plan doesn't include it). -->
+                <div v-if="checkApps('CustomFields')">
                     <div :class="[{'pointer-event-none opacity-5 blur-3-px':!currentCompany?.planFeature?.customFields}]">
                         <CustomFieldRenderViewComponent
                             @blurUpdate="submitHandler"
@@ -67,6 +73,11 @@
                         />
                     </div>
                 </div>
+                <!-- App available on the plan but not switched on for this project: representational teaser. -->
+                <AppTeaserBlock
+                    v-else-if="getAppState('CustomFields', projectData) === 'disabled'"
+                    appKey="CustomFields"
+                />
             </div>
             <CheckListComponent 
                 v-if="checkPermission('task.task_checklist',projectData?.isGlobalPermission) !== null"
@@ -131,6 +142,7 @@ import axios from 'axios';
 import { useCustomComposable, useGetterFunctions } from '@/composable';
 import taskClass from '@/utils/TaskOperations';
 import UpgradePlan from '@/components/atom/UpgradYourPlanComponent/UpgradYourPlanComponent.vue';
+import AppTeaserBlock from '@/components/molecules/AppTeaserBlock/AppTeaserBlock.vue';
 import {storageQueryBuilder,generateFileName} from '@/utils/storageQueryBuild.js';
 import { useClipRecorder } from '@/composables/useClipRecorder';
 import { useI18n } from 'vue-i18n';
@@ -140,7 +152,7 @@ const $toast = useToast();
 const {t} = useI18n();
 const { getters,commit } = useStore();
 const { getUser } = useGetterFunctions();
-const { checkPermission, makeUniqueId, checkBucketStorage,checkApps } = useCustomComposable();
+const { checkPermission, makeUniqueId, checkBucketStorage,checkApps,getAppState } = useCustomComposable();
 const { openRecorder } = useClipRecorder();
 
 // props

--- a/frontend/src/components/organisms/ProjectDetailRightSide/ProjectDetailRightSide.vue
+++ b/frontend/src/components/organisms/ProjectDetailRightSide/ProjectDetailRightSide.vue
@@ -131,8 +131,9 @@
                 </template>
             </div>
         </div>
-        <div class="position-re">
-            <div v-if="checkPermission('project.project_custom_field',projectData?.isGlobalPermission) !== null && checkApps('CustomFields')">
+        <div class="position-re" v-if="checkPermission('project.project_custom_field',projectData?.isGlobalPermission) !== null">
+            <!-- App enabled for this project: existing behavior (feature, or blurred feature + upgrade overlay when the plan doesn't include it). -->
+            <div v-if="checkApps('CustomFields')">
                 <div v-if="projectData" :class="[{'pointer-event-none opacity-5 blur-3-px':!currentCompany?.planFeature?.customFields}]">
                     <CustomFieldProjectDetailView
                         @blurUpdate="submitHandler"
@@ -154,6 +155,11 @@
                     />
                 </div>
             </div>
+            <!-- App available on the plan but not switched on for this project: representational teaser. -->
+            <AppTeaserBlock
+                v-else-if="getAppState('CustomFields', projectData) === 'disabled'"
+                appKey="CustomFields"
+            />
         </div>
         <ConfirmModal :modelValue="showConfirmModal" :acceptButtonText="$t('Home.Confirm')"
                     :cancelButtonText="$t('Projects.cancel')" maxlength="150" :header="false" :showCloseIcon="false" @close="showConfirmModal = false">
@@ -200,9 +206,10 @@ import { projectAssignee, projectAssigneeRemove, projectCurrency, projectDueDate
 import { useConvertDate, useCustomComposable, useGetterFunctions } from '@/composable';
 import StartEndDate from '@/components/molecules/FixMilestoneDate/FixMilestoneDate.vue';
 import UpgradePlan from '@/components/atom/UpgradYourPlanComponent/UpgradYourPlanComponent.vue';
+import AppTeaserBlock from '@/components/molecules/AppTeaserBlock/AppTeaserBlock.vue';
 import UserProfile from '@/components/atom/UserProfile/UserProfile.vue';
 
-const { checkPermission,checkApps } = useCustomComposable();
+const { checkPermission,checkApps,getAppState } = useCustomComposable();
 const {convertDateFormat} = useConvertDate();
 
 const { t } = useI18n();

--- a/frontend/src/composable/index.js
+++ b/frontend/src/composable/index.js
@@ -116,6 +116,41 @@ export function useCustomComposable() {
             return null;
         }
     }
+
+    // Tri-state variant of checkApps for the representational "app not enabled"
+    // blocks. Returns:
+    //   'enabled'  — app is switched on for this project and entitled by the plan
+    //   'disabled' — entitled by the plan but not switched on for this project
+    //   'upgrade'  — not entitled by the company's subscription plan
+    // Plan gating mirrors checkApps; only the flags we have confirmed are gated,
+    // any other app is treated as always-entitled so it never shows a false
+    // upgrade state.
+    function getAppState(app = null, projectData) {
+        if(app === null) return 'disabled';
+
+        const currentCompany = computed(() => Store.getters["settings/selectedCompany"]);
+        const planFeature = currentCompany.value?.planFeature || {};
+        const planKeyByApp = {
+            Priority: 'projectProjectApp',
+            tags: 'tagProjectApp',
+            CustomFields: 'customFields',
+            AI: 'aiPermission'
+        };
+        const planKey = planKeyByApp[app];
+        if(planKey && !planFeature[planKey]) return 'upgrade';
+
+        const project = inject("selectedProject") || {};
+        const checkProject = project?.value && Object.keys(project.value || {}).length > 0 ? project.value : projectData;
+
+        let appIndex = -1;
+        if(checkProject?.apps) {
+            appIndex = checkProject.apps.findIndex((x) => x.key === app);
+            if(appIndex === -1) {
+                appIndex = checkProject.apps.findIndex((x) => x === app);
+            }
+        }
+        return appIndex !== -1 ? 'enabled' : 'disabled';
+    }
  // eslint-disable-next-line
   /* eslint-disable */
     function showCounts({project, key = "project", sprints = [], showArchived = false}){
@@ -446,6 +481,7 @@ export function useCustomComposable() {
         makeUniqueId,
         checkPermission,
         checkApps,
+        getAppState,
         showCounts,
         changeText,
         checkLink,

--- a/frontend/src/views/Projects/ProjectDetail/ProjectDetail.vue
+++ b/frontend/src/views/Projects/ProjectDetail/ProjectDetail.vue
@@ -70,6 +70,10 @@
                     @updateTotalDifference="updateTotalDifference"
                 />
             </div>
+            <!-- Milestones app available on the plan but not switched on for this project: representational teaser. -->
+            <div class="milestone__fixhourly-wrapper" v-else-if="getAppState('Milestones', projectData) === 'disabled' && checkPermission('project.project_milestone',projectData.isGlobalPermission) !== null">
+                <AppTeaserBlock appKey="Milestones" />
+            </div>
             <ProjectDetailRightSide v-if="activeTab === 'ProjectDetail' && clientWidth <= 767 && activeTab !== 'Calendar'" :projectData="projectData" @rightSideBarEmit="rightSideBarEmit" @description="handleDescription" />
         </template>
     </div>
@@ -85,6 +89,7 @@
     import HourlyMilestone from '@/components/organisms/HourlyMilestone/HourlyMilestone.vue';
     import CheckListComponent from '@/components/molecules/CheckList/CheckList.vue'
     import UpgradePlan from '@/components/atom/UpgradYourPlanComponent/UpgradYourPlanComponent.vue';
+    import AppTeaserBlock from '@/components/molecules/AppTeaserBlock/AppTeaserBlock.vue';
     import * as env from '@/config/env';
     import { apiRequest, apiRequestWithoutCompnay } from '../../../services'
     import Swal from 'sweetalert2';
@@ -107,7 +112,7 @@
         isvisible:{type:Boolean,default:() => true}
     });
     const projectData = inject('selectedProject');
-    const { checkPermission, makeUniqueId, checkApps, checkBucketStorage, sanitizeInput } = useCustomComposable();
+    const { checkPermission, makeUniqueId, checkApps, getAppState, checkBucketStorage, sanitizeInput } = useCustomComposable();
     const { getters,commit } = useStore();
     const checkList = computed(() => projectData.value.checklistArray)
     const currentCompany = computed(() => getters["settings/selectedCompany"])

--- a/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
+++ b/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
@@ -63,6 +63,16 @@
                         <img src="@/assets/images/svg/ai_image_white.svg" class="mr-10-px"/>
                         <span>{{ $t('AI.write_with_ai') }}</span>
                     </button>
+                    <!-- Tags app available on the plan but not switched on for this project: inline locked chip. -->
+                    <AppTeaserBlock
+                        v-if="getAppState('tags', projectData) === 'disabled' && checkPermission('task.task_tag',projectData?.isGlobalPermission) !== null"
+                        appKey="tags" variant="inline" class="mr-1"
+                    />
+                    <!-- AI app available on the plan but not switched on for this project: inline locked chip. -->
+                    <AppTeaserBlock
+                        v-if="getAppState('AI', projectData) === 'disabled' && checkPermission('task.task_create',projectData?.isGlobalPermission) === true"
+                        appKey="AI" variant="inline" class="mr-1"
+                    />
                     <DropDown id="group_by" class="mr-1 group_by">
                         <template #button>
                             <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="group_by_status" @click="currentActive='group'">
@@ -282,8 +292,9 @@ const showEstimationScale = ref(false);
 const showRecent = ref(false);
 const showExport = ref(false);
 import { useCustomComposable } from '@/composable';
+import AppTeaserBlock from '@/components/molecules/AppTeaserBlock/AppTeaserBlock.vue';
 
-const { checkPermission, checkApps } = useCustomComposable();
+const { checkPermission, checkApps, getAppState } = useCustomComposable();
 
 defineProps({
     activeTab: { type: String, required: true },

--- a/frontend/src/views/TimeLog/TimeLog.vue
+++ b/frontend/src/views/TimeLog/TimeLog.vue
@@ -98,8 +98,15 @@
         </div>
         <AddTimeLog v-if="activeTimeLog === true" :closeTimeLogSidebar="closeTimeLogSidebar" :isAddLog="isAddLog" :task="task" :modelValue="timeLogData" @addTime="(eve) => addTime(eve,selectedFilter)" />
     </div>
-    <!-- Time Tracking app available on the plan but not switched on for this project: representational teaser. -->
-    <AppTeaserBlock v-else-if="getAppState('TimeTracking') === 'disabled'" appKey="TimeTracking" class="m-3" />
+    <!-- Time Tracking app available on the plan but not switched on for this project: representational teaser.
+         Centered + width-constrained so it reads as a tidy empty-state card in the wide Time Log tab
+         (the full-width block variant is meant for narrow sidebar columns), matching the access-denied
+         state below. -->
+    <div v-else-if="getAppState('TimeTracking') === 'disabled'" class="d-flex align-items-center justify-content-center w-100 h-100 p-3">
+        <div class="w-100" style="max-width: 480px;">
+            <AppTeaserBlock appKey="TimeTracking" />
+        </div>
+    </div>
     <div v-else class="d-flex align-items-center justify-content-center w-100 h-100">
         <img :src="accessDeniedImage" alt="accessDenied">
     </div>

--- a/frontend/src/views/TimeLog/TimeLog.vue
+++ b/frontend/src/views/TimeLog/TimeLog.vue
@@ -98,6 +98,8 @@
         </div>
         <AddTimeLog v-if="activeTimeLog === true" :closeTimeLogSidebar="closeTimeLogSidebar" :isAddLog="isAddLog" :task="task" :modelValue="timeLogData" @addTime="(eve) => addTime(eve,selectedFilter)" />
     </div>
+    <!-- Time Tracking app available on the plan but not switched on for this project: representational teaser. -->
+    <AppTeaserBlock v-else-if="getAppState('TimeTracking') === 'disabled'" appKey="TimeTracking" class="m-3" />
     <div v-else class="d-flex align-items-center justify-content-center w-100 h-100">
         <img :src="accessDeniedImage" alt="accessDenied">
     </div>
@@ -109,6 +111,7 @@
 
     import { useStore } from 'vuex';
     import { useGetterFunctions, useCustomComposable } from "@/composable";
+    import AppTeaserBlock from '@/components/molecules/AppTeaserBlock/AppTeaserBlock.vue';
 
     import RangePickerComp from '@/components/molecules/RangePickerComp/RangePickerComp.vue';
     import UserProfile from "@/components/atom/UserProfile/UserProfile.vue";
@@ -124,7 +127,7 @@
     const userId =  inject('$userId');
     const {getUser} = useGetterFunctions();
     const { getters } = useStore();
-    const {makeUniqueId,checkApps} = useCustomComposable();
+    const {makeUniqueId,checkApps,getAppState} = useCustomComposable();
     const defaultUserIcon = inject("$defaultUserAvatar");
     const accessDeniedImage = require("@/assets/images/access_denied_img.png");
 


### PR DESCRIPTION
## Why

AlianHub projects can toggle optional **apps** — Custom Fields, Milestones, Time Tracking, Tags, AI, and so on. When an app is switched off, its area rendered **nothing**, so users never discovered the feature existed. This PR adds a lightweight, consistent **teaser** wherever a disabled feature would appear: it tells the user the feature is available and points them to project settings to turn it on.

## What changed

### New
- **`AppTeaserBlock`** (`frontend/src/components/molecules/AppTeaserBlock/`) — reusable, with two variants:
  - **block** — a compact, auto-height dashed banner: lock icon, feature name, a one-line value pitch, and a quiet `Enable in settings →` link. Deliberately **not** the green upgrade button, so "enable" (a free toggle) is visually distinct from "upgrade" (paid).
  - **inline** — a small "locked" chip for toolbar / inline controls.
- **`getAppState(key, projectData)`** in `composable/index.js` — a tri-state helper returning `enabled | disabled | upgrade`, reusing the existing `checkApps` plan-entitlement map so the three states stay cleanly separated (real feature / teaser / existing `UpgradYourPlanComponent`).

### Wired surfaces
| App | Surface | Style |
|---|---|---|
| Custom Fields | Project details, Task detail | block |
| Milestones | Project details | block |
| Time Tracking | Time Log tab | block |
| Tags | Task detail | block |
| Tags, AI | Project toolbar | inline chip |

- **Time Log tab** now stays visible when Time Tracking is off (`TabListItem.vue`) so its teaser is reachable (it was hidden before).
- **Checklist gate removed** (`CheckList.vue`) — dropped the "Upgrade to Unlimited To Unlock Checklist" overlay and the blur/disable gating. The checklist is now always usable, matching this being an open-source repo with no paid plans.

## Files
- **add:** `components/molecules/AppTeaserBlock/{AppTeaserBlock.vue, style.css}`
- **edit:** `composable/index.js`, `components/molecules/CheckList/CheckList.vue`, `components/molecules/TabListItem/TabListItem.vue`, `components/molecules/TaskDetailTab/TaskDetailTab.vue`, `components/organisms/ProjectDetailRightSide/ProjectDetailRightSide.vue`, `views/Projects/ProjectDetail/ProjectDetail.vue`, `views/Projects/components/ProjectFiltersToolbar.vue`, `views/TimeLog/TimeLog.vue`

No backend changes.

## Follow-ups (not in this PR)
- The teaser's **Enable** button routes to Settings › Projects, which does not yet have a per-app enable toggle — wiring that control completes the enable loop.
- Tags / AI have other scattered inline spots (subtask rows, kanban cards, checklist "generate with AI") that currently just hide; the inline chip can be extended there.

## Verification
`cd frontend && npm run serve` compiles cleanly (only the repo's pre-existing warnings). Manually verified: disabling an app shows the teaser; the button routes to project settings; enabled apps render unchanged; plan-locked features still show the existing upgrade block; the checklist renders and is fully interactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
