### PR TITLE
feat(tracker): gate tracking on task estimated hours

### DIFF
--- a/time-tracker-app/main/background.js
+++ b/time-tracker-app/main/background.js
@@ -432,6 +432,26 @@ ipcMain.on('stop-listen-event', () => {
   mainWindow.webContents.send('tracking:status', { active: false })
 })
 
+// AHE-3831 — the renderer hit an estimate gate (no estimate set, estimate already
+// met, or a live auto-stop). Surface it via the shared notification card.
+ipcMain.on('estimate:limit', (event, data) => {
+  const d = data || {}
+  const name = d.taskName ? `"${d.taskName}"` : 'This task'
+  let title = 'Tracker reached task estimate hours limit'
+  let subtitle
+  if (d.reason === 'no-estimate') {
+    title = 'Add estimated hours to start the tracker'
+    subtitle = `${name} has no estimated hours set.`
+  } else if (d.reason === 'autostopped') {
+    subtitle = `${name} reached its estimated hours — tracking stopped.`
+  } else {
+    subtitle = `${name} has already reached its estimated hours.`
+  }
+  try {
+    showNotification({ title, subtitle })
+  } catch (e) { /* notifications are best-effort */ }
+})
+
 // TIME-05: configurable idle threshold (value in minutes; 0 disables auto-pause).
 ipcMain.on('idle:set-threshold', (event, value) => {
   const minutes = Number(value)
@@ -542,14 +562,18 @@ function sendNotification(dataUrl) {
 function showNotification({ title, subtitle = '', image = null, timeout = 10000 }) {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
   const windowWidth = 372;
-  // Taller when there's a media/preview image; compact for text-only.
-  const windowHeight = image ? 282 : 92;
+  // Best-guess starting height; the renderer measures its real laid-out content
+  // and we resize to fit (see 'notification:size' below), so content of ANY
+  // length — a 1–3 line title, with or without a media preview — is shown in
+  // full and never clipped. The card stays anchored bottom-right and grows
+  // upward, so its bottom is always above the taskbar.
+  const initialHeight = image ? 282 : 120;
 
   const win = new BrowserWindow({
     width: windowWidth,
-    height: windowHeight,
+    height: initialHeight,
     x: width - windowWidth,
-    y: height - windowHeight,
+    y: height - initialHeight,
     frame: false,
     alwaysOnTop: true,
     skipTaskbar: true,
@@ -562,11 +586,31 @@ function showNotification({ title, subtitle = '', image = null, timeout = 10000 
     }
   });
 
+  // Show only once — either after the first size report, or via the fallback.
+  let shown = false;
+  const showOnce = () => {
+    if (shown || win.isDestroyed()) return;
+    shown = true;
+    win.showInactive(); // don't steal focus from the user's current input
+  };
+
+  // Fit the window to the content the renderer actually rendered, keeping the
+  // bottom edge above the taskbar. Scoped to THIS window (event.sender check) so
+  // concurrent notifications never resize each other.
+  const sizeHandler = (event, data) => {
+    if (win.isDestroyed() || event.sender !== win.webContents) return;
+    const h = Math.max(60, Math.min(Math.round((data && data.height) || initialHeight), height - 20));
+    win.setBounds({ x: width - windowWidth, y: height - h, width: windowWidth, height: h });
+    showOnce();
+  };
+  ipcMain.on('notification:size', sizeHandler);
+
   win.loadFile(notificationTemplateHtmlPath);
   win.webContents.on('did-finish-load', () => {
     win.webContents.send('logo-path', iconPath);
     win.webContents.send('notification:render', { title, subtitle, image, timeout });
-    win.showInactive(); // don't steal focus from the user's current input
+    // Fallback: show at the initial height if no size report arrives shortly.
+    setTimeout(showOnce, 400);
 
     const closeHandler = () => {
       if (!win.isDestroyed()) win.close();
@@ -580,6 +624,7 @@ function showNotification({ title, subtitle = '', image = null, timeout = 10000 
     win.once('closed', () => {
       clearTimeout(autoCloseTimer);
       ipcMain.removeListener('notification:close', closeHandler);
+      ipcMain.removeListener('notification:size', sizeHandler);
     });
   });
 }

--- a/time-tracker-app/package.json
+++ b/time-tracker-app/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "alianhubtimetracker",
   "description": "My application description",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "author": "Alian Software",
   "homepage": "https://aliansoftware.com",
   "main": "app/background.js",

--- a/time-tracker-app/renderer/components/TrackerTask.jsx
+++ b/time-tracker-app/renderer/components/TrackerTask.jsx
@@ -5,6 +5,7 @@ import { setComment, setTrackerStartTime } from '../store/timelog';
 import { DateTime } from 'luxon';
 import { apiRequest } from '../utils/services';
 import { DEFAULT_TASK_IMAGE } from '../utils/imageDefaults';
+import { fetchEstimateStatus } from '../utils/estimateLimit';
 import WasabiImage from './WasabiImage/WasabiImage';
 
 export default function TrackerTask({
@@ -29,6 +30,14 @@ export default function TrackerTask({
     }
     setIsSpinner(true);
     try {
+      const taskId = selectedTaskData?.fullData?.TicketID || selectedTaskData?.fullData?._id;
+      // AHE-3831 — a task needs an estimate with time left to be tracked.
+      const est = await fetchEstimateStatus(currentCopany?._id, taskId);
+      if (est.ok && est.blockStart) {
+        setTaskModalError(est.blockMessage);
+        setIsSpinner(false);
+        return;
+      }
       window.ipc.send("start-listen-event");
       let obj = {
         userId: user?._id || "",
@@ -53,7 +62,8 @@ export default function TrackerTask({
           projectName: selectedTaskData?.projectName,
           folderName: selectedTaskData?.folderName || '',
           sprintName: selectedTaskData?.sprintName,
-          taskTypeImage: taskTypeImage
+          taskTypeImage: taskTypeImage,
+          remainingMinutes: est.hasEstimate ? est.remainingMinutes : null
         }));
         setIsSpinner(false);
         onClose();

--- a/time-tracker-app/renderer/hooks/useDeepLinkStart.js
+++ b/time-tracker-app/renderer/hooks/useDeepLinkStart.js
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { apiRequest } from '../utils/services';
 import { setComment, setTrackerStartTime } from '../store/timelog';
 import { DEFAULT_TASK_IMAGE } from '../utils/imageDefaults';
+import { estimateStatusFromTask } from '../utils/estimateLimit';
 
 // Start a tracker session from a deep link (myapp://…?taskId=&comment=).
 // Fetches just what start needs (task + project/folder/sprint names), guards to
@@ -60,6 +61,16 @@ export function useDeepLinkStart(setLoading = () => {}) {
       const description = (comment && comment.trim()) || taskName;
       const taskTypeImage = getTaskTypeImage(projectName, task.TaskType);
 
+      // AHE-3831 — a task needs an estimate with time left to be tracked
+      // (no estimate, or estimate already met, both block the start).
+      const est = estimateStatusFromTask(task);
+      if (est.blockStart) {
+        setLoading(false);
+        try { window.ipc.send('estimate:limit', { reason: est.blockReason, taskName }); } catch (e) { /* best-effort */ }
+        console.warn(`Deep-link start blocked: ${est.blockReason}`);
+        return false;
+      }
+
       window.ipc.send('start-listen-event');
       const startRes = await apiRequest('post', `/api/v3/timeTracker/start`, {
         userId: user?._id || '',
@@ -72,7 +83,7 @@ export function useDeepLinkStart(setLoading = () => {}) {
       });
       if (startRes?.data?.status) {
         dispatch(setTrackerStartTime(startRes.data.statusText));
-        dispatch(setComment({ comment: description, sprintId, taskId, projectId, taskName, projectName, folderName, sprintName, taskTypeImage }));
+        dispatch(setComment({ comment: description, sprintId, taskId, projectId, taskName, projectName, folderName, sprintName, taskTypeImage, remainingMinutes: est.hasEstimate ? est.remainingMinutes : null }));
         setLoading(false);
         router.push('/trackerRunning');
         return true;

--- a/time-tracker-app/renderer/pages/home.jsx
+++ b/time-tracker-app/renderer/pages/home.jsx
@@ -18,6 +18,7 @@ import { formatMinutes } from '../hooks/useTodayLogged'
 import { DEFAULT_TASK_IMAGE } from '../utils/imageDefaults'
 import { openTaskInWeb } from '../utils/taskWebLink'
 import { useDeepLinkStart } from '../hooks/useDeepLinkStart'
+import { fetchEstimateStatus } from '../utils/estimateLimit'
 
 export default function HomePage() {
   const router = useRouter();
@@ -297,10 +298,17 @@ export default function HomePage() {
     startTrackerWithData(selectedData);
   };
 
-  const startTrackerWithData = (selectedData) => {
+  const startTrackerWithData = async (selectedData) => {
     if (!selectedData) return;
     setIsSpinner(true);
     try {
+      // AHE-3831 — a task needs an estimate with time left to be tracked.
+      const est = await fetchEstimateStatus(currentCopany?._id, selectedData?.selectedTask?.value || "");
+      if (est.ok && est.blockStart) {
+        setIsSpinner(false);
+        try { window.ipc.send('estimate:limit', { reason: est.blockReason, taskName: (selectedData?.selectedTask?.label || '').split(' | ')[1] || '' }); } catch (e) { /* best-effort */ }
+        return;
+      }
       window.ipc.send("start-listen-event");
       let obj = {
         userId: user?._id || "",
@@ -346,7 +354,8 @@ export default function HomePage() {
             projectName: selectedData?.selectedProject?.ProjectName,
             folderName: folderName,
             sprintName: sprintName,
-            taskTypeImage: taskTypeImage
+            taskTypeImage: taskTypeImage,
+            remainingMinutes: est.hasEstimate ? est.remainingMinutes : null
           }));
           setIsSpinner(false);
           router.push('/trackerRunning')

--- a/time-tracker-app/renderer/pages/trackerRunning.jsx
+++ b/time-tracker-app/renderer/pages/trackerRunning.jsx
@@ -4,6 +4,7 @@ import Router from 'next/router';
 import { setCaptures, setActivityTick, setTrackerStopTime, removeExtraClicks, setComment, setTrackerStartTime, removeAllTimeLog } from '../store/timelog';
 import { TrackerController } from '../controller/tracker/tracker';
 import { apiRequest } from '../utils/services';
+import { fetchEstimateStatus } from '../utils/estimateLimit';
 import store from '../store/store';
 import moment from 'moment';
 import { DateTime } from 'luxon';
@@ -53,6 +54,16 @@ function TimeTrackerView() {
       dispatch(setTrackerStopTime());
       dispatch(removeAllTimeLog());
 
+      // AHE-3831 — the stop finalized the prior session, so re-check the estimate
+      // before restarting; if it's now met, stay stopped.
+      const companyId = store.getState()?.company?.currentCompany?._id || "";
+      const est = await fetchEstimateStatus(companyId, ctx.taskId);
+      if (est.ok && est.blockStart) {
+        try { window.ipc.send('estimate:limit', { reason: est.blockReason, taskName: ctx.taskName }); } catch (e) { /* best-effort */ }
+        Router.push('/home');
+        return;
+      }
+
       // ...then start a fresh one on the same task with the new comment.
       window.ipc.send("start-listen-event");
       const startObj = {
@@ -67,6 +78,7 @@ function TimeTrackerView() {
       const res = await apiRequest('post', `/api/v3/timeTracker/start`, startObj);
 
       if (res?.data?.status) {
+        autoStoppedRef.current = false;
         dispatch(setTrackerStartTime(res.data.statusText));
         dispatch(setComment({
           comment: newComment,
@@ -78,6 +90,7 @@ function TimeTrackerView() {
           folderName: ctx.folderName,
           sprintName: ctx.sprintName,
           taskTypeImage: ctx.taskTypeImage,
+          remainingMinutes: est.hasEstimate ? est.remainingMinutes : null,
         }));
         setIsEditing(false);
         // Sync the ref to the just-updated store, else startScreenshotCapture sees
@@ -103,6 +116,8 @@ function TimeTrackerView() {
   const timeLogRef = React.useRef(timeLog);
   const keyboardClicksRef = React.useRef(keyboardClicks);
   const screenshotTimeoutRef = useRef(null);
+  // AHE-3831 — guards the estimate auto-stop so it fires exactly once per session.
+  const autoStoppedRef = useRef(false);
 
   // Update refs when values change
   useEffect(() => {
@@ -257,6 +272,32 @@ function TimeTrackerView() {
     } else {
       setTimeAgo("");
     }
+    checkEstimateLimit(currentTimeLog);
+  };
+
+  // AHE-3831 — auto-stop when this session's elapsed time reaches the minutes
+  // that were left against the task estimate when it started. `remainingMinutes`
+  // is null when the task has no estimate, so it never caps those.
+  const checkEstimateLimit = async (currentTimeLog) => {
+    if (autoStoppedRef.current) return;
+    if (!currentTimeLog?.trackerStart || !currentTimeLog?.startTime) return;
+    if (typeof currentTimeLog.remainingMinutes !== 'number') return;
+
+    const elapsedMinutes = (Date.now() - new Date(currentTimeLog.startTime).getTime()) / 60000;
+    if (elapsedMinutes < currentTimeLog.remainingMinutes) return;
+
+    // Set the guard synchronously so the next 1s tick can't double-stop.
+    autoStoppedRef.current = true;
+    const taskName = currentTimeLog.taskName;
+    try {
+      await TrackerController.TrackerStop();
+    } catch (e) {
+      console.error('Estimate auto-stop failed', e);
+    }
+    dispatch(setTrackerStopTime());
+    dispatch(removeAllTimeLog());
+    try { window.ipc.send('estimate:limit', { reason: 'autostopped', taskName }); } catch (e) { /* best-effort */ }
+    Router.push('/home');
   };
 
   const setActivityEvent = (e) => {

--- a/time-tracker-app/renderer/public/notification-template.html
+++ b/time-tracker-app/renderer/public/notification-template.html
@@ -129,6 +129,21 @@
       document.getElementById('logo').src = path;
     });
 
+    // Measure the actual laid-out card and ask main to fit the window to it, so
+    // content of ANY length is shown in full and never clipped. Height = the
+    // card + the body's vertical padding (which reserves room for the shadow).
+    function reportSize() {
+      const card = document.querySelector('.toast');
+      if (!card) return;
+      const cs = getComputedStyle(document.body);
+      const padV = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0);
+      const h = Math.ceil(card.getBoundingClientRect().height + padV);
+      ipcRenderer.send('notification:size', { height: h });
+    }
+    // Re-measure once a media preview finishes loading (its box may resize).
+    const mediaEl = document.getElementById('media');
+    if (mediaEl) mediaEl.addEventListener('load', reportSize);
+
     // Single entry point: the shared layout renders whatever the caller sends.
     // { title, subtitle, image?, timeout? } — pass an image to show the media
     // preview, omit it for a compact text-only card.
@@ -148,6 +163,8 @@
       }
 
       startCountdown(typeof data.timeout === 'number' ? data.timeout : 10000);
+      // Wait for layout to settle after the text/image change, then fit the window.
+      requestAnimationFrame(() => requestAnimationFrame(reportSize));
     });
 
     function closeWithAnim() {

--- a/time-tracker-app/renderer/store/timelog.js
+++ b/time-tracker-app/renderer/store/timelog.js
@@ -18,7 +18,10 @@ const timeLog = createSlice({
     taskName: "",
     projectName: "",
     folderName: "",
-    sprintName: ""
+    sprintName: "",
+    // AHE-3831 — minutes of tracking left before this task hits its estimate,
+    // captured at session start. `null` = no cap (task has no estimate).
+    remainingMinutes: null
   },
   reducers: {
     setComment: (state, action) => {
@@ -31,6 +34,7 @@ const timeLog = createSlice({
       state.folderName = action.payload.folderName;
       state.sprintName = action.payload.sprintName;
       state.taskTypeImage = action.payload.taskTypeImage
+      state.remainingMinutes = action.payload.remainingMinutes ?? null
     },
     setTrackerStartTime: (state, action) => {
       
@@ -92,6 +96,7 @@ const timeLog = createSlice({
       state.projectName = "";
       state.folderName = "";
       state.sprintName = "";
+      state.remainingMinutes = null;
     }
 
   },

--- a/time-tracker-app/renderer/utils/estimateLimit.js
+++ b/time-tracker-app/renderer/utils/estimateLimit.js
@@ -1,0 +1,56 @@
+import { apiRequest } from './services';
+
+// AHE-3831 — tracking is gated on a task's estimated hours:
+//   • no estimate set          → cannot start (must add an estimate first)
+//   • estimate set, time left   → starts, and auto-stops at the estimate
+//   • estimate already met/over → cannot start
+// The estimate is `task.totalEstimatedTime` (minutes); the server keeps
+// `task.remainingHours = estimate − all-users-logged` fresh. BOTH fields are
+// `undefined` on a fresh task until an estimate is added — `Number(undefined) || 0`
+// treats that as 0 (no estimate), which is exactly the "cannot start" case.
+
+export const ESTIMATE_LIMIT_MESSAGE = 'Tracker reached task estimate hours limit';
+export const NO_ESTIMATE_MESSAGE = 'Add estimated hours to start the tracker';
+
+// Derive tracking status from a task document. Values in minutes.
+export function estimateStatusFromTask(task) {
+  const estimate = Number(task && task.totalEstimatedTime) || 0;
+  const remainingRaw = Number(task && task.remainingHours);
+  const remaining = Number.isFinite(remainingRaw) ? remainingRaw : estimate;
+  const hasEstimate = estimate > 0;
+  const reached = hasEstimate && remaining <= 0;
+  const blockReason = !hasEstimate ? 'no-estimate' : (reached ? 'reached' : null);
+  return {
+    hasEstimate,
+    estimateMinutes: estimate,
+    remainingMinutes: Math.max(remaining, 0),
+    reached,
+    // Start is blocked when there is no estimate at all, or the estimate is met.
+    blockStart: blockReason !== null,
+    blockReason,
+    blockMessage:
+      blockReason === 'no-estimate' ? NO_ESTIMATE_MESSAGE :
+      blockReason === 'reached' ? ESTIMATE_LIMIT_MESSAGE : null,
+  };
+}
+
+// Fetch a task's status from the server (fresh remainingHours).
+// `ok` reports whether the task was actually read. Callers must ENFORCE the
+// block only when `ok` is true, so a transient fetch failure never blocks
+// legitimate tracking (fail open).
+export async function fetchEstimateStatus(companyId, taskId) {
+  try {
+    if (!companyId || !taskId) return { ...estimateStatusFromTask(null), ok: false };
+    const res = await apiRequest('post', `/api/v1/task/find`, {
+      findQuery: [
+        { $match: { objId: { _id: taskId, CompanyId: companyId } } },
+      ],
+    });
+    const task = res && res.data && res.data[0];
+    if (!task) return { ...estimateStatusFromTask(null), ok: false };
+    return { ...estimateStatusFromTask(task), ok: true };
+  } catch (e) {
+    console.error('fetchEstimateStatus error', e);
+    return { ...estimateStatusFromTask(null), ok: false };
+  }
+}


### PR DESCRIPTION
## Summary

Gates the desktop time tracker on a task's **estimated hours** (AHE-3831): the tracker won't start without an estimate, auto-stops when the session reaches the estimate, and won't start once the estimate is already met.

## Behavior

| Task estimate | Start? | Message |
|---|---|---|
| **None** (0 / undefined) | ❌ blocked | *"Add estimated hours to start the tracker"* |
| **Set, time left** | ✅ starts → auto-stops at the estimate | (auto-stop notification when reached) |
| **Set, met/exceeded** | ❌ blocked | *"Tracker reached task estimate hours limit"* |

## Implementation

Entirely in `time-tracker-app` — **no backend or web changes**. Reuses the server-computed `task.remainingHours` (all-users basis, same value shown in the task sidebar) fetched via `/api/v1/task/find`.

- **New** `renderer/utils/estimateLimit.js` — `estimateStatusFromTask` / `fetchEstimateStatus` → `{ hasEstimate, remainingMinutes, reached, blockStart, blockReason, blockMessage, ok }`. Handles the `undefined` estimate fields on a fresh task, and **fails open** on a fetch error so a transient failure never blocks legitimate tracking.
- **Block start** at all four entry points: home dropdown, task modal, deep-link start (also covers the web "Start Tracker", which deep-links into the app), and the comment-edit restart.
- **Auto-stop** in `trackerRunning.jsx`: the existing 1-second interval compares elapsed vs the remaining-at-start baseline and stops via the existing `TrackerController.TrackerStop()`, guarded so it fires once.
- **Notifications** reuse the shared `notification-template.html` card via `showNotification()`, which now **measures its rendered content and resizes the window to fit** (anchored bottom-right, growing upward) — fixes clipping of multi-line content and benefits every future notification.
- Tracker app version → **5.1.3**.

## Testing

Built and installed 5.1.3 locally (production APIURL) and verified all three cases across the start paths, the auto-stop notification, and the resized card. The screenshot notification (`notification.html`) is untouched.

Task: AHE-3831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
