### PR TITLE
feat(tasks): reason prompt on estimate change + TL timesheet flag

### DIFF
--- a/Modules/Tasks/helpers/taskMongo/updateMeta.js
+++ b/Modules/Tasks/helpers/taskMongo/updateMeta.js
@@ -439,7 +439,10 @@ module.exports = {
                             _id: new mongoose.Types.ObjectId(taskData._id)
                         }, {
                             $set: {
-                                ...firebaseObj
+                                ...firebaseObj,
+                                // AHE — flag the task for the TL on a RE-update (an estimate
+                                // already existed). First-time set (previous 0/undefined) never flags.
+                                ...(Number(obj.previousEstimatedTime) > 0 ? { estimateChangedFlag: true } : {})
                             }
                         },
                         {returnDocument: "after"}
@@ -478,9 +481,17 @@ module.exports = {
                             logger.error(`ERROR in notification: ${error.message}`);
                         });
                     }
+                    // AHE — a RE-update requires a reason; append it to the activity-log
+                    // message. Message renders as HTML (v-html), so escape the user text.
+                    const escapeHtml = (s) => String(s == null ? '' : s)
+                        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+                    const reasonText = obj.reason && String(obj.reason).trim()
+                        ? ` <b>Reason:</b> ${escapeHtml(String(obj.reason).trim())}`
+                        : '';
                     let historyObj = {
                         key: "task_total_estimate",
-                        message : `<b>${obj.userName}</b> has updated total estimated time from <b>${previousDisplayText}</b> to <b>${updatedDisplayText}</b>.`,
+                        message : `<b>${obj.userName}</b> has updated total estimated time from <b>${previousDisplayText}</b> to <b>${updatedDisplayText}</b>.${reasonText}`,
                         sprintId: taskData.sprintId
                     };
                     HandleHistory('task',projectData.CompanyId, projectData._id,taskData._id,historyObj, userData).then(async () => {});

--- a/frontend/src/components/atom/TimesheetView/ProjectTimeSheetView/ProjectTimesheetTrComponent.vue
+++ b/frontend/src/components/atom/TimesheetView/ProjectTimeSheetView/ProjectTimesheetTrComponent.vue
@@ -5,6 +5,8 @@
             <div class="d-flex align-items-center">
                 <div class="d-flex align-items-center">
                     <p class="user_hrs_name" :title="trData.projectName">{{ trData.projectName }}</p>
+                    <!-- AHE — red dot: a task in this project had its estimated hours re-updated. -->
+                    <span v-if="trData.hasEstimateChanged" title="A task in this project had its estimated hours changed" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#E5484D;margin-left:6px;flex:none;"></span>
                     <img v-if="trData.status == 'close' || !(trData.deletedStatusKey == 0 || trData.deletedStatusKey == undefined)" :src="logk_icon" alt="loclIcon" class="ml-5px"/>
                 </div>
                 <div>
@@ -99,7 +101,8 @@
                             <div class="d-flex align-items-center">
                                 
                                 <div class="d-flex align-items-center">
-                                    <p class="user_hrs_name" :title="taskObject.TaskName">{{ taskObject.TaskName }}</p>
+                                    <!-- AHE — red task name when this task's estimate was re-updated. -->
+                                    <p class="user_hrs_name" :style="taskObject.estimateChangedFlag ? 'color:#E5484D;font-weight:600;' : ''" :title="taskObject.TaskName">{{ taskObject.TaskName }}</p>
                                 </div>
                                 <div class="blue text-decoration-underline cursor-pointer" @click="taskDetailOpen(taskObject)" >{{taskObject.TaskCode}}  </div>
                                 <div class="inner_div displayRate d-flex">
@@ -231,6 +234,13 @@
     const table_arrow = ref(require("@/assets/images/table_arrow.png"))
     const theModel = ref(props.modelValue);
     const trData = ref(props.projectTrData);
+    // AHE — trData is snapshotted from the prop on mount, but the parent sets
+    // `hasEstimateChanged` asynchronously (after a rollup lookup), so sync that
+    // field onto the snapshot when it arrives — otherwise the red project dot
+    // never appears.
+    watch(() => props.projectTrData && props.projectTrData.hasEstimateChanged, (val) => {
+        if (trData.value) trData.value.hasEstimateChanged = val;
+    }, { immediate: true });
     const fullLoggedData = ref(props.fullLoggedData);
     const fullEstimatedData = ref(props.fullEstimatedData);
     const projectTaskArray = ref([]);
@@ -296,6 +306,7 @@
                                 id: uniqueTaskIds[i],
                                 TaskName: singleTaskData.TaskName,
                                 TaskCode: singleTaskData.TaskKey,
+                                estimateChangedFlag: singleTaskData.estimateChangedFlag,
                                 taskLoggedHours: tmpfullLoggedData.filter((x) => x.taskId == uniqueTaskIds[i]).reduce((a,b) => a + b.logMinutes, 0),
                                 manuallyLoggedHours: tmpfullLoggedData.filter((x) => x.taskId == uniqueTaskIds[i] && (x.logType === 0 || !x.logType)).reduce((a,b) => a + b.logMinutes, 0),
                                 trackdLoggedHours: tmpfullLoggedData.filter((x) => x.taskId == uniqueTaskIds[i] && x.logType === 1).reduce((a,b) => a + b.logMinutes, 0),

--- a/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
+++ b/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
@@ -225,6 +225,30 @@
                     </button>
                 </div>
             </div>
+            <!-- AHE — reason required when RE-updating an already-set estimate; the
+                 reason is written to the task Activity Log by the backend. -->
+            <Modal
+                :modelValue="showEstimateReasonModal"
+                :closeOnBackdrop="false"
+                :acceptButtonText="$t('Home.Confirm')"
+                :cancelButtonText="$t('Projects.cancel')"
+                @accept="submitEstimateReason"
+                @close="cancelEstimateReason"
+            >
+                <template #header>
+                    <h3 class="m-0 font-size-16 font-weight-600 black">Reason for changing estimated hours</h3>
+                </template>
+                <template #body>
+                    <textarea
+                        v-model.trim="estimateReasonText"
+                        class="w-100 border-radius-6-px font-size-14"
+                        style="min-height:90px; resize:vertical; border:1px solid #DFE1E6; outline:none; padding:8px;"
+                        placeholder="Why are you changing the estimated hours?"
+                        @input="estimateReasonError = false"
+                    ></textarea>
+                    <span v-if="estimateReasonError" class="red font-size-12">Please enter a reason.</span>
+                </template>
+            </Modal>
             <div class="d-flex task-detail-right-side-label" v-if="checkApps('TimeEstimates') && checkPermission('task.task_estimated_hours',project?.isGlobalPermission) !== null">
                 <h4>{{$t('UserTimesheet.task_planning')}}</h4>
                 <Skelaton v-if="isMainSpinner" style="height: 24px;" class="w-100px border-radius-7-px"/>
@@ -787,7 +811,27 @@ const updateStartDate = (event) => {
         $toast.error(t('Toast.Start_date_not_updated'),{position: 'top-right'});
     }
 }
+// AHE — re-updating an already-set estimate requires a reason (logged to the
+// task Activity Log). The first-ever set (previous 0) saves directly.
+const showEstimateReasonModal = ref(false);
+const pendingEstimateValue = ref(null);
+const estimateReasonText = ref('');
+const estimateReasonError = ref(false);
+
 const updateTotalEstimatedTime = (value) => {
+    const previous = Number(props.task.totalEstimatedTime) || 0;
+    if (previous > 0 && value !== previous) {
+        // Re-update — prompt for a reason before persisting.
+        pendingEstimateValue.value = value;
+        estimateReasonText.value = '';
+        estimateReasonError.value = false;
+        showEstimateReasonModal.value = true;
+        return;
+    }
+    persistEstimate(value);
+}
+
+const persistEstimate = (value, reason = '') => {
     const userData = getUserData();
 
     const firebaseObj = {
@@ -795,7 +839,8 @@ const updateTotalEstimatedTime = (value) => {
     }
     let obj = {
         'previousEstimatedTime': props.task.totalEstimatedTime,
-        'userName' : userData.Employee_Name
+        'userName' : userData.Employee_Name,
+        ...(reason ? { reason } : {})
     }
     const projectData = {
         _id: project.value._id,
@@ -812,6 +857,26 @@ const updateTotalEstimatedTime = (value) => {
     .catch((err) => {
         console.error(err);
     })
+}
+
+const submitEstimateReason = () => {
+    if (!estimateReasonText.value || !estimateReasonText.value.trim()) {
+        estimateReasonError.value = true;
+        return;
+    }
+    persistEstimate(pendingEstimateValue.value, estimateReasonText.value.trim());
+    showEstimateReasonModal.value = false;
+    pendingEstimateValue.value = null;
+    estimateReasonText.value = '';
+    estimateReasonError.value = false;
+}
+
+const cancelEstimateReason = () => {
+    // Abort the change — nothing persists, so the input reverts to the task's value.
+    showEstimateReasonModal.value = false;
+    pendingEstimateValue.value = null;
+    estimateReasonText.value = '';
+    estimateReasonError.value = false;
 }
 
 const displayTime = (time) => {

--- a/frontend/src/views/Timesheet/ProjectTimesheet/ProjectTimesheet.vue
+++ b/frontend/src/views/Timesheet/ProjectTimesheet/ProjectTimesheet.vue
@@ -599,6 +599,18 @@
                                         }
                                     }
                                 }
+                                // AHE — flag projects that contain any task whose estimate was
+                                // re-updated, so the row shows a red dot for the TL. One grouped
+                                // lookup; best-effort (never blocks the timesheet render).
+                                try {
+                                    apiRequest('post', `${env.TASK}/find`, { findQuery: [
+                                        { $match: { estimateChangedFlag: true, deletedStatusKey: { $ne: 1 } } },
+                                        { $group: { _id: "$ProjectID" } }
+                                    ] }).then((flagRes) => {
+                                        const flaggedIds = new Set((flagRes?.data || []).map((r) => String(r._id)));
+                                        finalProjectData.value = finalProjectData.value.map((p) => ({ ...p, hasEstimateChanged: flaggedIds.has(String(p.id)) }));
+                                    }).catch((e) => console.error('estimate-flag rollup failed', e));
+                                } catch (e) { console.error(e); }
                                 isManinSpinner.value = false;
                             } else {
                                 isManinSpinner.value = false;

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -196,6 +196,14 @@ const schema = {
             type: Number,
             required: false
         },
+        // AHE — set true when a task's estimate is RE-updated (changed after it was
+        // first set). Surfaced in the Project Timesheet so a TL sees which tasks had
+        // their estimate changed. Permanent for now; a manual clear will be added later.
+        estimateChangedFlag: {
+            type: Boolean,
+            default: false,
+            required: false
+        },
         points: {
             type: Number,
             default: null,


### PR DESCRIPTION
## Summary

Re-updating a task's **estimated hours** now requires a **reason**, the reason is logged to the task **Activity Log**, and the **Project Timesheet** flags changed estimates for the TL.

## Behavior

- **First-time set** (0 → X): saves directly, no prompt.
- **Changing an existing estimate** (X → Y): a **reason modal** opens; the new value saves only after a reason is submitted (cancel/empty aborts — the input reverts).
- The reason shows in the task **Activity Log**: *"…updated total estimated time from X to Y. **Reason:** …"*.
- **Project Timesheet:** the changed task's name renders **red**, and the project row shows a **red dot** when any of its tasks is flagged.

## Implementation

- `utils/mongo-handler/schema.js` — new `estimateChangedFlag` (Boolean) on the task schema.
- `Modules/Tasks/helpers/taskMongo/updateMeta.js` — appends the (HTML-escaped) reason to the existing `task_total_estimate` history message and sets `estimateChangedFlag` on a re-update (`previousEstimatedTime > 0`). **Reuses the existing history mechanism — no new/hardcoded activity-log field.**
- `frontend/.../TaskDetailRightSide.vue` — reason modal (reuses the `Modal` atom) gating the save on re-update.
- `frontend/.../ProjectTimesheetTrComponent.vue` — red task name + project red dot (+ syncs the async project flag onto the snapshotted row).
- `frontend/.../ProjectTimesheet.vue` — one grouped `/task/find` rollup marks which projects have flagged tasks (project rows render before tasks are lazily fetched, so the dot needs its own signal).

## Notes / decisions

- **Permanent flag for now** (CEO decision); a **manual clear** trigger is a planned follow-up — the field + rollup are shaped for it.
- Triggers on **any re-update** regardless of role (roles are dynamic per company; only Owner/Admin are fixed).
- **AI-recalc button excluded** — an AI estimate has no user reason and doesn't raise the flag.
- Reason modal's header/placeholder are hardcoded English (Cancel/Confirm reuse existing i18n keys); adding locale keys is a small follow-up.

## Testing

Verified locally: first-set saves silently; a re-update prompts and logs the reason to the Activity Log; the Project Timesheet shows the red task name + the project red dot. (Backend schema/handler changes require the API restarted to load.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
