### PR TITLE
fix(chat): harden main-chat authorization and fix reliability/perf bugs

### DIFF
--- a/Modules/Comments/controller.js
+++ b/Modules/Comments/controller.js
@@ -8,6 +8,7 @@ const socketEmitter = require('../../event/socketEventEmitter');
 const { escapeRegex } = require("../../utils/escapeRegex");
 const { parseMentionIds } = require("./helpers/parseMentions");
 const { handleNotificationtFun } = require("../notification/prepare-notification-data/controllerV2");
+const { getRoleType, isPrivileged } = require("../../Config/permissionGuard");
 
 /* @mention delivery: record the mention (feeds the in-app "mentions" tab, which
  * queries the mentions collection by mentionIds) and fire the notification
@@ -69,6 +70,9 @@ exports.save = async (req, res) => {
     try {
         const { data } = req.body
         const convertData = replaceObjectKey(data, ["objId"]);
+        // SEC (AHE-3834) — the author is the authenticated caller, never a client-supplied
+        // userId. Legit callers already send their own id, so this is transparent.
+        if (req.uid) convertData.userId = req.uid;
         // @mentions: extract the [Name](userId) tokens the editor inserts so the
         // comment records who was mentioned (drives the mention notification).
         const mentionIds = parseMentionIds(convertData.message);
@@ -123,6 +127,29 @@ exports.update = async (req, res) => {
                 status: false,
                 message: `'id' parameter is required.`
             });
+        }
+
+        // SEC (AHE-3834) — a comment may only be edited/soft-deleted by its author
+        // (or an Owner/Admin). Non-owners may ONLY toggle `pinnedMessage` — the sole
+        // field the UI lets any member change. Matches every legit caller (edit/delete
+        // are own-only in the UI, pin is member-wide) and blocks editing/deleting/
+        // re-authoring someone else's message.
+        const existingComment = await MongoDbCrudOpration(
+            req.headers['companyid'],
+            { type: SCHEMA_TYPE.COMMENTS, data: [{ _id: new mongoose.Types.ObjectId(id) }] },
+            'findOne'
+        );
+        if (!existingComment) {
+            return res.status(404).json({ status: false, message: 'Comment not found.' });
+        }
+        const isOwner = String(existingComment.userId) === String(req.uid);
+        const changedKeys = Object.keys(data || {});
+        const pinOnly = changedKeys.length > 0 && changedKeys.every((k) => k === 'pinnedMessage');
+        if (!isOwner && !pinOnly) {
+            const roleType = await getRoleType(req.headers['companyid'], req.uid);
+            if (!isPrivileged(roleType)) {
+                return res.status(403).json({ status: false, message: 'Not allowed to modify this comment.' });
+            }
         }
 
         const params = {

--- a/Modules/MainChats/controller.js
+++ b/Modules/MainChats/controller.js
@@ -82,10 +82,19 @@ exports.updateMainChat = (companyId, chatObj) => {
 exports.setChats = async (req, res) => {
     try {
         const { findQuery } = req.body;
-        let query =  replaceObjectKey(findQuery,['objId'])
+        const parsed = replaceObjectKey(findQuery, ['objId']);
+        const clientFilter = (Array.isArray(parsed) && parsed[0] && typeof parsed[0] === 'object') ? parsed[0] : {};
+        // SEC (AHE-3834) — never run the client's query verbatim. Only ever return the
+        // CALLER's own main-chat conversations in the requested project: force
+        // mainChat + AssigneeUserId=req.uid, and keep only ProjectID + the updatedAt
+        // (tab-sync) filter from the request. Matches every legit caller; blocks
+        // reading others' DMs or dumping all tasks in the company.
+        const safeFilter = { mainChat: true, AssigneeUserId: req.uid };
+        if (clientFilter.ProjectID) safeFilter.ProjectID = clientFilter.ProjectID;
+        if (clientFilter.updatedAt) safeFilter.updatedAt = clientFilter.updatedAt;
         const setChatsObj = {
             type: SCHEMA_TYPE.TASKS,
-            data: query
+            data: [safeFilter]
         };
         // BUG-019 / #73 fix: `setChat = await ...` without a declaration
         // keyword created an implicit global. In non-strict mode that's a

--- a/Modules/notification-count/controller.js
+++ b/Modules/notification-count/controller.js
@@ -181,7 +181,17 @@ exports.updateUnReadCommentsCountFun = (req) => {
             if (!(req.body && req.body.companyId)) {
                 reject({
                     status: false,
-                    statusText: "companyId is required"  
+                    statusText: "companyId is required"
+                });
+                return;
+            }
+
+            // SEC (AHE-3834) — the tenant is the authenticated company (header), not a
+            // client-chosen body value. Blocks mutating another company's unread counts.
+            if (req.headers && req.headers['companyid'] && String(req.body.companyId) !== String(req.headers['companyid'])) {
+                reject({
+                    status: false,
+                    statusText: "companyId mismatch"
                 });
                 return;
             }

--- a/frontend/src/components/atom/ChatListItem/ChatListItem.vue
+++ b/frontend/src/components/atom/ChatListItem/ChatListItem.vue
@@ -79,16 +79,9 @@
 import { computed, inject, onMounted, ref, watch } from "vue";
 import { useCustomComposable, useGetterFunctions } from "@/composable";
 import { useStore } from "vuex";
-import { library, dom } from "@fortawesome/fontawesome-svg-core";
-import { far } from "@fortawesome/free-regular-svg-icons";
-import { fab } from "@fortawesome/free-brands-svg-icons"
-import { fas } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-library.add(far);
-library.add(fab)
-library.add(fas);
-dom.watch();
-const icons = [...new Set([...Object.keys(far).map(key => far[key]),...Object.keys(fab).map(key => fab[key]),...Object.keys(fas).map(key => fas[key])])]
+// AHE-3834 — one-time shared FA registration (was per-row in <script setup>).
+import { ensureFaIcons, findFaIcon } from "@/utils/faIcons";
 
 // COMPONENTS
 import UserProfile from "@/components/atom/UserProfile/UserProfile.vue"
@@ -138,6 +131,11 @@ function getImage(arr = []) {
     receiver.value = getUser(receiverId);
 }
 
+// Register the FA icon packs once, at setup time — matching the timing of the
+// previous per-instance `library.add(...)` so channel icons resolve on first
+// render. Memoized, so every row after the first is a no-op.
+ensureFaIcons();
+
 onMounted(() => {
     if(props.type === 'user') {
         getImage(props?.item?.AssigneeUserId || [])
@@ -151,8 +149,7 @@ watch(() => props.item, () => {
 })
 
 function renderIcon(icon) {
-    const tmpIcon =  icons.find((x) => x.iconName === icon.iconName && x.prefix === icon.prefix);
-    return tmpIcon;
+    return findFaIcon(icon.iconName, icon.prefix);
 }
 </script>
 

--- a/frontend/src/components/atom/CommentInput/CommentInput.vue
+++ b/frontend/src/components/atom/CommentInput/CommentInput.vue
@@ -310,10 +310,14 @@ function checkShowMentions(selectionStart, keyCode) {
 }
 
 function handlePaste(e) {
-    const item = e.clipboardData.items[0];
+    // AHE-3834 — guard: an empty/absent clipboard payload threw on `item.kind`.
+    // Also collect ALL pasted files instead of only the first item.
+    const items = Array.from(e?.clipboardData?.items || []);
+    if(!items.length) return;
 
-    if(item.kind === "file") {
-        emit('pasteFile', [item.getAsFile()]);
+    const files = items.filter((item) => item.kind === "file").map((item) => item.getAsFile()).filter(Boolean);
+    if(files.length) {
+        emit('pasteFile', files);
     }
 }
 </script>

--- a/frontend/src/components/organisms/Comment/Comment.vue
+++ b/frontend/src/components/organisms/Comment/Comment.vue
@@ -42,13 +42,13 @@
                                 <template v-if="message.type === 'image'">
                                     <div class="d-flex flex-column" @click.prevent="previewImageFun()">
                                         <ImageIcon
-                                            v-if="message.mediaURL.includes('http')"
+                                            v-if="message.mediaURL?.includes('http')"
                                             :src="message.mediaURL"
                                             :alt="message.mediaOriginalName"
-                                            :extension="message.mediaOriginalName.split('.').pop()"
+                                            :extension="message.mediaOriginalName?.split('.').pop()"
                                             class="comment-media comment__image" />
                                         <WasabiImageComp v-else
-                                            :data="{url: message.mediaURL,title: message.mediaOriginalName, filename: message.mediaOriginalNamem, extension: message.mediaOriginalName.split('.').pop()}"
+                                            :data="{url: message.mediaURL,title: message.mediaOriginalName, filename: message.mediaOriginalNamem, extension: message.mediaOriginalName?.split('.').pop()}"
                                             @downloadUrl="handleDownloadUrl" class="comment-media comment__image" />
                                     </div>
                                 </template>
@@ -71,10 +71,10 @@
 
                                 <template v-else-if="message.type !== 'text' && message.type !== 'link'">
                                     <div class="d-flex flex-column" @click.prevent="previewImageFun()">
-                                        <ImageIcon v-if="message.mediaURL.includes('http')" :src="message.mediaURL" :extension="message.mediaName.split('.').pop()" :alt="message.mediaName" class="comment-media"/>
+                                        <ImageIcon v-if="message.mediaURL?.includes('http')" :src="message.mediaURL" :extension="message.mediaName?.split('.').pop()" :alt="message.mediaName" class="comment-media"/>
                                         <WasabiImageComp
                                             v-else
-                                            :data="{url: message.mediaURL, title: message.mediaOriginalName, filename: message.mediaOriginalNamem, extension: message.mediaOriginalName.split('.').pop()}"
+                                            :data="{url: message.mediaURL, title: message.mediaOriginalName, filename: message.mediaOriginalNamem, extension: message.mediaOriginalName?.split('.').pop()}"
                                             class="comment-media comment__image"
                                             @downloadUrl="(eve) => {downloadurl(eve)}"
                                         />
@@ -298,7 +298,7 @@ function previewImageFun() {
     let previewData = {
         title: props.message.mediaOriginalName,
         filename: props.message.mediaOriginalName,
-        extension: props.message.mediaOriginalName.split(".").pop(),
+        extension: props.message.mediaOriginalName?.split(".").pop(),
         type: props.message.type,   
         url: downloadValue.value ? downloadValue.value : props.message.mediaURL,
         downloadUrl: downloadValue.value ? downloadValue.value : props.message.mediaURL,
@@ -310,6 +310,11 @@ function previewImageFun() {
 async function processUrl(message) {
     if (message.type !== "video" || message.type !== "audio" || message.type !== "image") {
         let properUrl = message.downloadURL || message.mediaURL;
+
+        // AHE-3834 — text/link messages carry no media URL. Without this guard
+        // `properUrl.includes` threw (undefined) or, when mediaURL was an empty
+        // string, fired a pointless storage request for every text message.
+        if (!properUrl) return;
 
         if (!properUrl.includes("http")) {
 

--- a/frontend/src/components/organisms/FilterChat/FilterChat.vue
+++ b/frontend/src/components/organisms/FilterChat/FilterChat.vue
@@ -132,7 +132,10 @@ function hightlight(msg, wrapStart = `<b class="mentioned">`, wrapEnd = `</b>`) 
         })
     }
     if(searchText.value){
-        const regex = new RegExp(`(${searchText.value})`, 'gi');
+        // AHE-3834 — escape regex metacharacters. A search containing `(`, `[`, `*`
+        // etc. previously threw inside RegExp and silently killed the highlight.
+        const escaped = searchText.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regex = new RegExp(`(${escaped})`, 'gi');
         return msg.replace(regex, '<mark>$1</mark>');
     }else{
         return msg;

--- a/frontend/src/store/MainChats/actions.js
+++ b/frontend/src/store/MainChats/actions.js
@@ -27,21 +27,38 @@ export const setChats = ({ commit, rootState }, payload) => {
                     .catch((error) => {
                         reject(error);
                     })
+            } else {
+                // AHE-3834 — the fetch is skipped when the list is already cached
+                // (`from` set). Previously nothing resolved here, so any awaiting
+                // caller hung forever (e.g. the chat loading skeleton).
+                resolve(rootState.mainChat?.chats?.data?.length || []);
             }
-            rootState.settings?.socketInstance?.emit('joinChats', { projectId: payload.projectId, socketId: rootState.settings.socketInstance.id, userId: payload.userId });
+            const socketInstance = rootState.settings?.socketInstance;
+            if (socketInstance) {
+                socketInstance.emit('joinChats', { projectId: payload.projectId, socketId: socketInstance.id, userId: payload.userId });
 
-            rootState.settings?.socketInstance?.on('chatTaskInsert', (data) => {
-                commit('mutateChats', [{ snap: {}, op: "added", data: { ...data.fullDocument } }]);
-            })
-            rootState.settings?.socketInstance?.on('chatTaskUpdate', (data) => {
-                commit('mutateChats', [{ snap: {}, op: "modified", data: { ...data.fullDocument } }]);
-            })
-            rootState.settings?.socketInstance?.on('chatTaskDelete', (data) => {
-                commit('mutateChats', [{ snap: {}, op: "modified", data: { ...data } }]);
-            })
-            rootState.settings?.socketInstance?.on('chatTaskReplace', (data) => {
-                commit('mutateChats', [{ snap: {}, op: "removed", data: { ...data.fullDocument } }]);
-            })
+                // AHE-3834 — always `.off()` before `.on()`. Without this, every
+                // re-dispatch (project switch, reconnect, storeWatch) stacked another
+                // handler on the same socket, so one incoming chat event fired the
+                // mutation N times.
+                socketInstance.off('chatTaskInsert');
+                socketInstance.off('chatTaskUpdate');
+                socketInstance.off('chatTaskDelete');
+                socketInstance.off('chatTaskReplace');
+
+                socketInstance.on('chatTaskInsert', (data) => {
+                    commit('mutateChats', [{ snap: {}, op: "added", data: { ...data.fullDocument } }]);
+                })
+                socketInstance.on('chatTaskUpdate', (data) => {
+                    commit('mutateChats', [{ snap: {}, op: "modified", data: { ...data.fullDocument } }]);
+                })
+                socketInstance.on('chatTaskDelete', (data) => {
+                    commit('mutateChats', [{ snap: {}, op: "modified", data: { ...data } }]);
+                })
+                socketInstance.on('chatTaskReplace', (data) => {
+                    commit('mutateChats', [{ snap: {}, op: "removed", data: { ...data.fullDocument } }]);
+                })
+            }
         } catch (e) {
             reject(e);
         }

--- a/frontend/src/store/MainChats/mutations.js
+++ b/frontend/src/store/MainChats/mutations.js
@@ -59,7 +59,9 @@ export const mutateChatSprints = (state,payload) => {
                 state.mainChatSprints[pId].push(data);
             }
         }else{
-            state.mainChatSprints = {[pId]:[data]}
+            // AHE-3834 — merge into the map; do NOT reassign it (that wiped every
+            // other project's cached channels, so only 1 project was ever cached).
+            state.mainChatSprints[pId] = [data];
         }
     }else if(op === "modified"){
         const sprintIndex = state.mainChatSprints[pId] && state.mainChatSprints[pId].length > 0 && state.mainChatSprints[pId]?.findIndex((x) => x._id === data._id);
@@ -87,7 +89,8 @@ export const mutateChatFolders = (state,payload) => {
                 state.mainChatFolders[pId].push(data);
             }
         }else{
-            state.mainChatFolders = {[pId]:[data]}
+            // AHE-3834 — merge into the map; do NOT reassign it (same cache-wipe bug).
+            state.mainChatFolders[pId] = [data];
         }
     }else if(op === "modified"){
         const sprintIndex = state.mainChatFolders[pId] && state.mainChatFolders[pId].length > 0 && state.mainChatFolders[pId]?.findIndex((x) => x._id === data._id);

--- a/frontend/src/store/Users/index.js
+++ b/frontend/src/store/Users/index.js
@@ -3,7 +3,7 @@ import * as mutations from './mutations';
 
 const state = {
     users: [],
-    myCounts: [],
+    myCounts: {},
 }
 
 const getters = {

--- a/frontend/src/store/Users/mutations.js
+++ b/frontend/src/store/Users/mutations.js
@@ -18,5 +18,17 @@ export const mutateUsers = (state, payload) => {
     }
 }
 export const mutateCounts = (state, payload) => {
+    // AHE-3834 — the unread counts are delta-based and can transiently drift
+    // negative on decrement races; never surface a negative badge. Clamp only the
+    // count fields (composite keys ending in `_comments`), leaving other doc
+    // fields untouched.
+    const data = payload && payload.data;
+    if (data && typeof data === 'object') {
+        for (const key of Object.keys(data)) {
+            if (key.endsWith('_comments') && typeof data[key] === 'number' && data[key] < 0) {
+                data[key] = 0;
+            }
+        }
+    }
     state.myCounts = payload;
 }

--- a/frontend/src/utils/faIcons.js
+++ b/frontend/src/utils/faIcons.js
@@ -1,0 +1,32 @@
+// AHE-3834 — Font Awesome registration for chat channel icons.
+//
+// Previously ChatListItem.vue ran `library.add(far, fab, fas)`, `dom.watch()`,
+// and built a ~2000-entry icon array inside `<script setup>` — i.e. ONCE PER
+// CONVERSATION ROW. This centralizes it to a single lazy, memoized registration
+// shared by every row (and any other chat consumer).
+
+import { library, dom } from "@fortawesome/fontawesome-svg-core";
+import { far } from "@fortawesome/free-regular-svg-icons";
+import { fab } from "@fortawesome/free-brands-svg-icons";
+import { fas } from "@fortawesome/free-solid-svg-icons";
+
+let iconList = null;
+
+// Register the icon packs + build the lookup list exactly once. Cheap no-op on
+// every call after the first.
+export function ensureFaIcons() {
+    if (iconList) return iconList;
+    library.add(far, fab, fas);
+    dom.watch();
+    iconList = [...new Set([
+        ...Object.values(far),
+        ...Object.values(fab),
+        ...Object.values(fas),
+    ])];
+    return iconList;
+}
+
+// Resolve a stored { iconName, prefix } to its Font Awesome icon definition.
+export function findFaIcon(iconName, prefix) {
+    return ensureFaIcons().find((x) => x.iconName === iconName && x.prefix === prefix);
+}

--- a/frontend/src/views/Chat/Chat.vue
+++ b/frontend/src/views/Chat/Chat.vue
@@ -195,6 +195,11 @@ import { useStore } from "vuex";
 import { useToast } from "vue-toast-notification";
 import FileAndLinks from '@/components/molecules/FileAndLinks/FileAndLinks.vue'
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+// AHE-3834 — this view renders a channel FontAwesomeIcon in its header but never
+// registered the icon packs; it silently relied on ChatListItem's side effect
+// (so the header icon broke when no chat row had rendered yet). Register here too
+// — the call is memoized, so it costs nothing after the first.
+import { ensureFaIcons } from "@/utils/faIcons";
 import UpgradePlan from '@/components/atom/UpgradYourPlanComponent/UpgradYourPlanComponent.vue';
 
 // COMPONENTS
@@ -245,6 +250,9 @@ defineComponent({
         Comments
     }
 })
+
+// Register the FA icon packs used by the channel icon in this view's header.
+ensureFaIcons();
 
 const chatSidebar = ref(false);
 const searchType = ref("");
@@ -352,6 +360,8 @@ onUnmounted(() => {
         snapRef.value();
     }
     commit("mainChat/setChatPayload",{});
+    // AHE-3834 — guard: on a dropped/never-established socket this threw on unmount.
+    if(!socket.value || !socket.value.id) return;
     socket.value.emit('getRoomList', socket.value.id, (rooms) => {
         let chatRooms = rooms.filter((x)=> x.includes('chat_'));
         if (chatRooms.length) {

--- a/frontend/src/views/Chat/helper.js
+++ b/frontend/src/views/Chat/helper.js
@@ -32,22 +32,26 @@ export function useMainChat() {
                 if(!projectId) {
                     throw "NO project";
                 }
-                if(getters["mainChat/chats"]?.data?.length) {
-                    resolve(getters["mainChat/chats"]?.length)
-                } else {
-                    dispatch("mainChat/setChats", {
-                        projectId: projectId,
-                        companyId: companyId.value,
-                        userId: userId.value,
-                        sprintId
-                    })
-                    .then((chats) => {
-                        resolve(chats);
-                    })
-                    .catch((error) => {
-                        reject(error)
-                    })
-                }
+                const cached = getters["mainChat/chats"]?.data?.length;
+                // AHE-3834 — the socket room join + chatTask* listeners live inside
+                // setChats. Previously a cached chat list short-circuited the dispatch
+                // entirely, so leaving Chat (onUnmounted leaves the rooms) and coming
+                // back left the conversation list with NO live updates until a reload.
+                // Now we always dispatch; `from: 'storeWatch'` re-arms the socket
+                // without re-fetching the cached list.
+                dispatch("mainChat/setChats", {
+                    projectId: projectId,
+                    companyId: companyId.value,
+                    userId: userId.value,
+                    sprintId,
+                    ...(cached ? { from: 'storeWatch' } : {})
+                })
+                .then((chats) => {
+                    resolve(cached ? cached : chats);
+                })
+                .catch((error) => {
+                    reject(error)
+                })
             } catch (error) {
                 reject(error);
             }


### PR DESCRIPTION
## Summary

Authorization hardening + reliability/perf fixes for the **Main Chat** module (AHE-3834). All changes are server-authoritative or defensive; the shared `Comments.vue` / `Comment.vue` / `CommentInput.vue` (used by the **Task Comments** and **Project Comments** tabs too) were verified non-breaking for all three consumers, and the frontend builds clean.

## Security (never trust the request body)

- **`comments.save`** — the author is forced to `req.uid` (was a client-supplied `userId`).
- **`comments.update`** — edit/soft-delete gated to the comment's author or an Owner/Admin (via `getRoleType`/`isPrivileged`); non-owners may only toggle `pinnedMessage` (matches the UI). Blocks editing/deleting/re-authoring others' messages.
- **`main-chats.setChats`** — no longer runs the client `findQuery` verbatim (which could dump all company tasks). Builds a caller-scoped filter `{ mainChat:true, AssigneeUserId:req.uid, +ProjectID, +updatedAt }` — identical results for legit callers, blocks reading others' DMs.
- **`notification-count`** — rejects unread-count updates whose `body.companyId` ≠ the authenticated `companyid` header.

## Reliability / correctness

- **Duplicate socket handlers** — `.off()` before `.on()` on the `chatTask*` events (bound only in `store/MainChats/actions.js`); every project switch/reconnect used to stack another handler, firing each event N times.
- **Live updates after re-entry** — the socket room + listeners now re-arm on returning to Chat (a cached list short-circuited the dispatch, so the conversation list went stale until reload). Uses `from:'storeWatch'` so the cached list is not re-fetched — no duplicate rows.
- **Hanging skeleton** — `setChats` now resolves its promise on the cached path.
- **Store cache-wipe** — adding a project's sprints/folders no longer replaces the whole map (dropping other projects').
- **`Comment.vue`** — media handling guards text/link messages (no `mediaURL`) and optional-chains media metadata; stops a throw + a wasted storage request per text message. (Media/image comments unchanged → Task/Project comments unaffected.)
- **`CommentInput` paste** — guards an empty clipboard; attaches all pasted files, not just the first.
- **`FilterChat` search** — escapes regex metacharacters (a `(`/`[`/`*` in the query threw and killed the highlight).
- **Unread counts** — `myCounts` initialized `{}` (was `[]`); negative `*_comments` counts clamped to 0.

## Performance

- **`ChatListItem`** — Font Awesome is registered **once** via a shared `utils/faIcons.js` util instead of `library.add(far,fab,fas)` + `dom.watch()` + a ~2000-entry array **per conversation row**. Also fixes a latent bug: `Chat.vue`'s header icon relied on that per-row side effect and broke when no row had rendered.

## Testing

Frontend builds clean (verified). Backend changes need the API restarted. Manual paths to check: send/edit/delete/pin a chat message, list conversations, unread badges, **and the Task Comments tab** (send/edit/delete/paste) to confirm parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
