### PR TITLE
feat(tracker): persistent alert when the tracker auto-stops

### DIFF
--- a/time-tracker-app/main/background.js
+++ b/time-tracker-app/main/background.js
@@ -11,8 +11,15 @@ const trayIconPath = assetPath('traylogo.png')
 // Prod: next export copies public/ into app/. Dev: read straight from renderer/public.
 const notificationHtmlPath = isProd ? path.join(__dirname, 'notification.html') : path.join(__dirname, '..', 'renderer', 'public', 'notification.html')
 const notificationTemplateHtmlPath = isProd ? path.join(__dirname, 'notification-template.html') : path.join(__dirname, '..', 'renderer', 'public', 'notification-template.html')
+// AHE-3835 — the persistent "tracker stopped" alert card (distinct from the
+// routine white notification-template.html toast).
+const notificationAlertHtmlPath = isProd ? path.join(__dirname, 'notification-alert.html') : path.join(__dirname, '..', 'renderer', 'public', 'notification-alert.html')
 let notification = null;
 let screenshotNotificationWindow = null;
+// AHE-3835 — persistent stop-alert state.
+let stoppedAlertWindow = null;   // the single live alert window (one at a time)
+let lastTaskCtx = null;          // { taskId, taskName, comment } — reported by the renderer on start
+let pendingStoppedAlert = null;  // a lock/sleep stop deferred until the user returns
 
 // Store permissions state in a config file
 const permissionsConfigPath = path.join(app.getPath('userData'), 'permissions.json')
@@ -432,24 +439,51 @@ ipcMain.on('stop-listen-event', () => {
   mainWindow.webContents.send('tracking:status', { active: false })
 })
 
-// AHE-3831 — the renderer hit an estimate gate (no estimate set, estimate already
-// met, or a live auto-stop). Surface it via the shared notification card.
+// AHE-3831 / AHE-3835 — the renderer hit an estimate gate. A live auto-stop
+// (estimate reached mid-session) surfaces the NEW persistent "tracker stopped"
+// alert; the other two reasons are START-blocks (not stops), so they keep the
+// routine informational white toast.
 ipcMain.on('estimate:limit', (event, data) => {
   const d = data || {}
+  if (d.reason === 'autostopped') {
+    try {
+      showTrackerStoppedAlert({ reason: 'estimate', taskName: d.taskName || (lastTaskCtx && lastTaskCtx.taskName) || '' })
+    } catch (e) { /* best-effort */ }
+    return
+  }
   const name = d.taskName ? `"${d.taskName}"` : 'This task'
   let title = 'Tracker reached task estimate hours limit'
   let subtitle
   if (d.reason === 'no-estimate') {
     title = 'Add estimated hours to start the tracker'
     subtitle = `${name} has no estimated hours set.`
-  } else if (d.reason === 'autostopped') {
-    subtitle = `${name} reached its estimated hours — tracking stopped.`
   } else {
     subtitle = `${name} has already reached its estimated hours.`
   }
   try {
     showNotification({ title, subtitle })
   } catch (e) { /* notifications are best-effort */ }
+})
+
+// AHE-3835 — the renderer reports the actively-tracked task so the stop alert can
+// name it (lock/sleep) and Resume knows what to restart. Read-only: this never
+// changes tracking behaviour.
+ipcMain.on('tracker:context', (event, data) => {
+  const d = data || {}
+  if (d.taskId) lastTaskCtx = { taskId: String(d.taskId), taskName: d.taskName || '', comment: d.comment || '' }
+})
+
+// AHE-3835 — actions from the stop alert (notification-alert.html).
+ipcMain.on('alert:dismiss', () => { closeStoppedAlert() })
+ipcMain.on('alert:resume', () => {
+  closeStoppedAlert()
+  if (mainWindow && !mainWindow.isDestroyed()) { mainWindow.show(); mainWindow.focus() }
+  if (!lastTaskCtx || !lastTaskCtx.taskId) return
+  // Reuse the proven deep-link start path — its assignee + estimate checks apply,
+  // so an estimate-exceeded task correctly refuses and explains why.
+  const params = new URLSearchParams({ type: 'trackerStart', taskId: lastTaskCtx.taskId })
+  if (lastTaskCtx.comment) params.set('comment', lastTaskCtx.comment)
+  deliverTrackerDeepLink(`myapp://open?${params.toString()}`)
 })
 
 // TIME-05: configurable idle threshold (value in minutes; 0 disables auto-pause).
@@ -629,14 +663,91 @@ function showNotification({ title, subtitle = '', image = null, timeout = 10000 
   });
 }
 
+// AHE-3835 — the PERSISTENT "tracker stopped" alert. Unlike showNotification()
+// (routine white toast that auto-dismisses), this is a distinct amber card that
+// stays until the user clicks Resume or Dismiss — so a user who had stepped away
+// when the tracker stopped still sees it on return. One instance at a time.
+function closeStoppedAlert() {
+  if (stoppedAlertWindow && !stoppedAlertWindow.isDestroyed()) stoppedAlertWindow.close()
+  stoppedAlertWindow = null
+}
+
+function showTrackerStoppedAlert({ reason, taskName = '', stoppedAt = Date.now() } = {}) {
+  closeStoppedAlert() // never let alerts stack in the corner
+
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize
+  const windowWidth = 372
+  const initialHeight = 190
+
+  const win = new BrowserWindow({
+    width: windowWidth,
+    height: initialHeight,
+    x: width - windowWidth,
+    y: height - initialHeight,
+    frame: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    resizable: false,
+    transparent: true,
+    show: false,
+    webPreferences: { nodeIntegration: true, contextIsolation: false },
+  })
+  stoppedAlertWindow = win
+
+  let shown = false
+  const showOnce = () => {
+    if (shown || win.isDestroyed()) return
+    shown = true
+    win.showInactive() // never steal focus from the user's current input
+  }
+
+  // Fit the window to the card's real height (reason / task length varies).
+  // Scoped to THIS window so it can never resize a later alert.
+  const sizeHandler = (event, data) => {
+    if (win.isDestroyed() || event.sender !== win.webContents) return
+    const h = Math.max(120, Math.min(Math.round((data && data.height) || initialHeight), height - 20))
+    win.setBounds({ x: width - windowWidth, y: height - h, width: windowWidth, height: h })
+    showOnce()
+  }
+  ipcMain.on('alert:size', sizeHandler)
+
+  win.loadFile(notificationAlertHtmlPath)
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.send('alert:render', { reason, taskName, stoppedAt })
+    setTimeout(showOnce, 400) // fallback if no size report arrives
+  })
+
+  win.once('closed', () => {
+    ipcMain.removeListener('alert:size', sizeHandler)
+    if (stoppedAlertWindow === win) stoppedAlertWindow = null
+  })
+}
+
+// Show a stop that happened while the screen was locked / asleep — but only once
+// the user RETURNS (unlock / resume), never into a locked or black screen.
+function surfacePendingStoppedAlert() {
+  if (!pendingStoppedAlert) return
+  const p = pendingStoppedAlert
+  pendingStoppedAlert = null
+  try {
+    showTrackerStoppedAlert({ reason: p.reason, taskName: (lastTaskCtx && lastTaskCtx.taskName) || '', stoppedAt: p.stoppedAt })
+  } catch (e) { /* best-effort */ }
+}
+
 powerMonitor.on('suspend', () => {
-  mainWindow.webContents.send('stop-tracker', true);
+  // A running session is about to be stopped by sleep — remember it and show the
+  // alert on resume (showing it now, into a sleeping screen, would be pointless).
+  if (isTracking) pendingStoppedAlert = { reason: 'suspended', stoppedAt: Date.now() }
+  if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send('stop-tracker', true);
 });
 // HANDLE LOCK SCREEN
 powerMonitor.on('lock-screen', () => {
-  mainWindow.webContents.send('stop-tracker', true);
-  // win.webContents.send('lock-screen', true);
+  if (isTracking) pendingStoppedAlert = { reason: 'locked', stoppedAt: Date.now() }
+  if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send('stop-tracker', true);
 });
+// Surface the deferred stop alert when the user comes back.
+powerMonitor.on('unlock-screen', () => { surfacePendingStoppedAlert() });
+powerMonitor.on('resume', () => { surfacePendingStoppedAlert() });
 
 // Add this handler to check permissions status
 ipcMain.handle('check-permissions', async () => {

--- a/time-tracker-app/package.json
+++ b/time-tracker-app/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "alianhubtimetracker",
   "description": "My application description",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "author": "Alian Software",
   "homepage": "https://aliansoftware.com",
   "main": "app/background.js",

--- a/time-tracker-app/renderer/components/Layout/Layout.jsx
+++ b/time-tracker-app/renderer/components/Layout/Layout.jsx
@@ -122,6 +122,19 @@ const Layout = ({ children }) => {
     }
   },[])
 
+  // AHE-3835 — report the actively-tracked task to main so the "tracking stopped"
+  // alert can name it (lock/sleep) and offer one-click resume. Read-only; does
+  // not affect tracking behaviour.
+  useEffect(() => {
+    if (timeLog.trackerStart && timeLog.taskId) {
+      window.ipc.send('tracker:context', {
+        taskId: timeLog.taskId,
+        taskName: timeLog.taskName || '',
+        comment: timeLog.comment || '',
+      });
+    }
+  }, [timeLog.trackerStart, timeLog.taskId]);
+
   const replayQueue = async () => {
     const queue = await getQueue();
     for (const req of queue) {

--- a/time-tracker-app/renderer/public/notification-alert.html
+++ b/time-tracker-app/renderer/public/notification-alert.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Tracker Stopped</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { overflow: hidden; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+      background: transparent;
+      /* room for the shadow to fade without clipping (matches notification-template.html) */
+      padding: 12px 16px 16px;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    @keyframes popIn {
+      from { opacity: 0; transform: translateY(12px) scale(0.96); }
+      to   { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    @keyframes popOut {
+      from { opacity: 1; transform: translateY(0) scale(1); }
+      to   { opacity: 0; transform: translateY(12px) scale(0.96); }
+    }
+
+    /* ---- distinct "stopped" identity: amber, NOT the routine white toast ---- */
+    .alert {
+      position: relative;
+      background: #ffffff;
+      border-radius: 14px;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      box-shadow: 0 12px 34px rgba(0, 0, 0, 0.45), 0 2px 6px rgba(0, 0, 0, 0.30);
+      transform-origin: bottom right;
+      animation: popIn 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    .alert.closing { animation: popOut 0.2s ease-in forwards; }
+
+    .alert-head {
+      display: flex; align-items: center; gap: 11px;
+      padding: 12px 12px 12px 14px;
+      background: linear-gradient(135deg, #F59E0B 0%, #D97706 100%);
+      position: relative;
+    }
+    .alert-head::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 1px; background: rgba(0,0,0,.08); }
+
+    .a-icon {
+      width: 34px; height: 34px; border-radius: 50%;
+      background: rgba(255,255,255,.22); border: 1px solid rgba(255,255,255,.35);
+      display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+    }
+    .a-icon svg { width: 16px; height: 16px; fill: #fff; }
+
+    .a-head-text { flex: 1; min-width: 0; }
+    .a-title { color: #fff; font-size: 14.5px; font-weight: 800; letter-spacing: .2px; line-height: 1.15; }
+    .a-kicker { color: rgba(255,255,255,.85); font-size: 11px; font-weight: 600; margin-top: 1px; }
+
+    .a-close {
+      width: 24px; height: 24px; border-radius: 7px;
+      display: flex; align-items: center; justify-content: center;
+      cursor: pointer; color: #fff; opacity: .9; flex-shrink: 0;
+      transition: background .15s, opacity .15s;
+    }
+    .a-close:hover { background: rgba(255,255,255,.22); opacity: 1; }
+    .a-close svg { width: 12px; height: 12px; fill: currentColor; }
+
+    .alert-body { padding: 13px 14px 14px; }
+    .a-reason { font-size: 13.5px; line-height: 1.45; color: #2b3040; }
+    .a-reason b { color: #171B26; font-weight: 700; }
+
+    .a-meta { display: flex; align-items: center; gap: 7px; margin-top: 9px; color: #5b6270; font-size: 12px; font-weight: 600; }
+    .a-dot { width: 7px; height: 7px; border-radius: 50%; background: #F59E0B; box-shadow: 0 0 0 3px #FEF3C7; flex-shrink: 0; }
+
+    .a-actions { display: flex; gap: 9px; margin-top: 14px; }
+    .btn {
+      height: 34px; border-radius: 9px; font-size: 13px; font-weight: 700; cursor: pointer;
+      border: 1px solid transparent; display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+      transition: transform .06s, background .15s, box-shadow .15s;
+    }
+    .btn:active { transform: translateY(1px); }
+    .btn-resume {
+      flex: 1; color: #fff;
+      background: linear-gradient(135deg, #F59E0B, #D97706);
+      box-shadow: 0 3px 10px rgba(217,119,6,.35);
+    }
+    .btn-resume:hover { box-shadow: 0 5px 14px rgba(217,119,6,.45); }
+    .btn-resume svg { width: 13px; height: 13px; fill: #fff; }
+    .btn-dismiss { padding: 0 16px; color: #4b5162; background: #f4f5f7; border-color: #e6e8ec; }
+    .btn-dismiss:hover { background: #e9ebef; }
+  </style>
+</head>
+<body>
+  <div class="alert" id="alert">
+    <div class="alert-head">
+      <div class="a-icon">
+        <!-- stop glyph -->
+        <svg viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="2.5"/></svg>
+      </div>
+      <div class="a-head-text">
+        <div class="a-title">Time tracking stopped</div>
+        <div class="a-kicker">AlianHub Time Tracker</div>
+      </div>
+      <div class="a-close" id="close_icon" title="Dismiss">
+        <svg viewBox="0 0 490 490"><polygon points="456.851,0 245,212.564 33.149,0 0.708,32.337 212.669,245.004 0.708,457.678 33.149,490 245,277.443 456.851,490 489.292,457.678 277.331,245.004 489.292,32.337 "/></svg>
+      </div>
+    </div>
+    <div class="alert-body">
+      <div class="a-reason" id="reason">Tracking has stopped.</div>
+      <div class="a-meta"><span class="a-dot"></span><span id="ago">Stopped just now</span></div>
+      <div class="a-actions">
+        <button class="btn btn-resume" id="resume_btn">
+          <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+          Resume tracking
+        </button>
+        <button class="btn btn-dismiss" id="dismiss_btn">Dismiss</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const { ipcRenderer } = require('electron');
+    const alertEl = document.getElementById('alert');
+    const OUT_MS = 200;
+    let closing = false;
+    let stoppedAt = null;
+
+    // Fit the window to the card's real laid-out height (task names/reasons vary
+    // in length), keeping the bottom edge anchored above the taskbar.
+    function reportSize() {
+      const cs = getComputedStyle(document.body);
+      const padV = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0);
+      const h = Math.ceil(alertEl.getBoundingClientRect().height + padV);
+      ipcRenderer.send('alert:size', { height: h });
+    }
+
+    function escapeHtml(s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    // Build the human reason line from the stop reason + (optional) task name.
+    function reasonText(reason, taskName) {
+      const t = taskName ? ' on <b>“' + escapeHtml(taskName) + '”</b>' : '';
+      switch (reason) {
+        case 'estimate':
+          return 'Reached the estimated hours' + (taskName ? ' on <b>“' + escapeHtml(taskName) + '”</b>' : '') + ' — tracking has stopped.';
+        case 'locked':
+          return 'Your screen was locked, so tracking' + t + ' was stopped.';
+        case 'suspended':
+          return 'Your computer went to sleep, so tracking' + t + ' was stopped.';
+        default:
+          return 'Time tracking' + t + ' has stopped.';
+      }
+    }
+
+    // Live "Stopped X ago" so a returning user instantly knows how long it's been off.
+    function fmtAgo() {
+      if (!stoppedAt) return 'Stopped just now';
+      const s = Math.max(0, Math.floor((Date.now() - stoppedAt) / 1000));
+      if (s < 5) return 'Stopped just now';
+      if (s < 60) return 'Stopped ' + s + ' second' + (s > 1 ? 's' : '') + ' ago';
+      const m = Math.floor(s / 60);
+      if (m < 60) return 'Stopped ' + m + ' minute' + (m > 1 ? 's' : '') + ' ago';
+      const h = Math.floor(m / 60);
+      return 'Stopped ' + h + ' hour' + (h > 1 ? 's' : '') + ' ago';
+    }
+    function tickAgo() {
+      const el = document.getElementById('ago');
+      if (el) el.textContent = fmtAgo();
+    }
+    setInterval(tickAgo, 1000);
+
+    // Single entry point — main sends { reason, taskName, stoppedAt }.
+    ipcRenderer.on('alert:render', (event, data) => {
+      data = data || {};
+      stoppedAt = typeof data.stoppedAt === 'number' ? data.stoppedAt : Date.now();
+      document.getElementById('reason').innerHTML = reasonText(data.reason, data.taskName);
+      tickAgo();
+      // Wait for layout to settle, then fit the window. (No auto-dismiss — this
+      // card is PERSISTENT: it stays until the user acts.)
+      requestAnimationFrame(() => requestAnimationFrame(reportSize));
+    });
+
+    function closeWithAnim(channel) {
+      if (closing) return;
+      closing = true;
+      alertEl.classList.add('closing');
+      setTimeout(() => ipcRenderer.send(channel), OUT_MS);
+    }
+
+    document.getElementById('close_icon').addEventListener('click', () => closeWithAnim('alert:dismiss'));
+    document.getElementById('dismiss_btn').addEventListener('click', () => closeWithAnim('alert:dismiss'));
+    document.getElementById('resume_btn').addEventListener('click', () => closeWithAnim('alert:resume'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Enhances the notification shown when the desktop time tracker **auto-stops** (AHE-3835). The auto-stop used the common white toast (`notification-template.html`) — which looks like every routine toast and auto-dismisses in ~10s — so a user who had stepped away when the tracker stopped came back unaware. This adds a **dedicated, persistent "Tracker Stopped" alert**, wired through every auto-stop trigger. The existing white template is **untouched** and still serves its other uses.

## What changed

**New `notification-alert.html`** — a distinct **amber** card (not the routine white toast): stop glyph, the **reason**, a live **"stopped X ago"** timestamp, and **Resume** / **Dismiss** actions. **No countdown — it does not auto-dismiss**, so a returning user always sees it. Bottom-right, `showInactive` (never steals focus).

**`main/background.js`**
- `showTrackerStoppedAlert()` — persistent alert window (one at a time, self-fits to content); `alert:resume` / `alert:dismiss` handlers.
- Estimate **auto-stop** now routes to the new alert; the two estimate **start-blocks** (`no-estimate` / `reached`) keep the old white toast (the user is present for those).
- **`lock-screen` / `suspend`** record the stop (only when actually tracking) and **re-surface the alert on `unlock-screen` / `resume`** — not into a locked/asleep screen. Both were previously silent.
- `tracker:context` stores the active task so the alert can name it and **Resume** restarts it via the existing, tested deep-link start path (its assignee + estimate guards apply — an estimate-exceeded task correctly refuses).

**`renderer/components/Layout/Layout.jsx`** — one read-only `useEffect` reporting the active task to main. No change to tracking behaviour.

**`package.json`** — tracker `5.1.3 → 5.1.4`.

## Covered triggers

| Reason | Before | After |
|---|---|---|
| Estimate reached mid-session | white 10s toast | persistent amber alert |
| Screen locked | *silent* | amber alert on unlock |
| System sleep | *silent* | amber alert on wake |

## Non-breaking

The shared white `showNotification` / `notification-template.html` is unchanged and still fires for the idle "No activity" heads-up, the estimate start-blocks, and the screenshot flow. Only the auto-stop path changed.

## Testing

Built **v5.1.4** (unsigned, local). Manual checklist: estimate auto-stop (small estimate), lock→unlock, sleep→wake, Resume, Dismiss; confirm no alert when not tracking, and the white toast still shows for idle / start-blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
