### PR TITLE
feat: add read-only permission level for task estimated hours

### DIFF
--- a/frontend/src/components/atom/SecurityPermissionRowCompo/SecurityPermissionRowCompo.vue
+++ b/frontend/src/components/atom/SecurityPermissionRowCompo/SecurityPermissionRowCompo.vue
@@ -22,8 +22,22 @@
         <td v-for="(hItem, hIndex) in withoutOwnerRoles.filter((x) => x.key !== 2)" :key="hIndex">
             <div class="d-flex justify-content-around">
                 <template v-for="(permission, pIndex) in permissions">
-                    <div :style="[{'padding-left': pIndex === 0 ? '10px' : ''},{'width':'auto','margin-right': '19px'}]" v-if="item.key !== 'milestone_report' && (advancedPermissionBody.filter((x) => !item.isParent && item.parentId === x._id && x.key === 'sheet_settings').length || item.key === 'task_estimated_hours' || item.key === 'show_tasks') || (item.key === 'per_user_generate_limit' && pIndex === 2) || item.selectionField === true" :key="`${hIndex}_${permission.key}'_${bIndex}_${pIndex}`">
+                    <div class="securityPermission__equalCell" v-if="item.key !== 'milestone_report' && (advancedPermissionBody.filter((x) => !item.isParent && item.parentId === x._id && x.key === 'sheet_settings').length || item.key === 'task_estimated_hours' || item.key === 'show_tasks') || (item.key === 'per_user_generate_limit' && pIndex === 2) || item.selectionField === true" :key="`${hIndex}_${permission.key}'_${bIndex}_${pIndex}`">
                         <template v-if="pIndex === 0 && item.key !== 'per_user_generate_limit'">
+                            <input type="radio" :disabled="!planCondition || item.roles.filter((x) => x.key === hItem.key)[0].disabled" v-if="item.roles.filter((x) => x.key === hItem.key)[0].disabled"/>
+                            <input type="radio" :disabled="!planCondition || item.roles.filter((x) => x.key === hItem.key)[0].disabled" v-else @click="changeRule(permission.key, item, hItem)" :checked="item.roles.filter((x) => x.key === hItem.key).length && item.roles.filter((x) => x.key === hItem.key)[0].permission === permission.key" :name="hItem.name+bIndex+permission.key" :value="permission.key"/>
+                        </template>
+                        <template v-else-if="pIndex === 1 && item.key === 'task_estimated_hours'">
+                            <!-- Read column for Task Estimated Hours. This row previously
+                                 rendered only None (pIndex 0) and the Own/Everyone selector
+                                 (pIndex 2), leaving the Read cell empty so the level could
+                                 never be granted. The value scheme has room for it:
+                                 None = null, Read = false, Own = 1, Everyone = 2. The API
+                                 already treats false as read-only (permissionGuard.js
+                                 isWritable/isReadable) and the task detail shows the field
+                                 whenever the permission !== null, so only this radio was
+                                 missing. Gated on this key so no other selection-field
+                                 row gains a Read option. -->
                             <input type="radio" :disabled="!planCondition || item.roles.filter((x) => x.key === hItem.key)[0].disabled" v-if="item.roles.filter((x) => x.key === hItem.key)[0].disabled"/>
                             <input type="radio" :disabled="!planCondition || item.roles.filter((x) => x.key === hItem.key)[0].disabled" v-else @click="changeRule(permission.key, item, hItem)" :checked="item.roles.filter((x) => x.key === hItem.key).length && item.roles.filter((x) => x.key === hItem.key)[0].permission === permission.key" :name="hItem.name+bIndex+permission.key" :value="permission.key"/>
                         </template>
@@ -76,7 +90,7 @@
                             </template>
                         </template>
                     </div>
-                    <div v-else-if="item.key !== 'per_user_generate_limit'" :key="`${hIndex}_${permission.key}'_${bIndex}_${pIndex}`" class="mr-8px w-auto">
+                    <div v-else-if="item.key !== 'per_user_generate_limit'" :key="`${hIndex}_${permission.key}'_${bIndex}_${pIndex}`" class="securityPermission__equalCell">
                         <input type="radio" :disabled="!planCondition || item.roles.filter((x) => x.key === hItem.key)[0].disabled" v-if="item.roles.filter((x) => x.key === hItem.key)[0].disabled"/>
                         <input type="radio" :disabled="!planCondition || item.roles.filter((x) => x.key === hItem.key)[0].disabled" v-else @click="changeRule(permission.key, item, hItem)" :checked="item.roles.filter((x) => x.key === hItem.key).length && item.roles.filter((x) => x.key === hItem.key)[0].permission === permission.key" :name="hItem.name+bIndex+permission.key" :value="permission.key"/>
                     </div>

--- a/frontend/src/components/atom/SecurityPermissionRowCompo/style.css
+++ b/frontend/src/components/atom/SecurityPermissionRowCompo/style.css
@@ -24,6 +24,36 @@
     border-radius: 5px;
 }
 
+/*
+ * One accurate column per permission level (None / Read / Read & Write).
+ *
+ * The column HEADERS are already equal thirds with centred text
+ * (`.permissionname { width: -webkit-fill-available }` in
+ * SecurityandPermissionTable/style.css), so each header centre sits at 1/6,
+ * 1/2 and 5/6 of the cell. The body rows, however, used
+ * justify-content-around, which distributes only the LEFTOVER width — so the
+ * control positions depended on how wide the controls were:
+ *   - plain radio rows carried an asymmetric `mr-8px`, landing ~4px left of
+ *     the header centres;
+ *   - rows with a dropdown (Select / Own / Everyone) have a much wider third
+ *     control, which ate the leftover space and dragged their radios further
+ *     out of line — different rows drifting by different amounts.
+ *
+ * Giving every cell an equal third with centred content makes each control
+ * land exactly on 1/6, 1/2, 5/6 — identical to the headers — so radios and
+ * dropdowns all share one straight column. Applied to BOTH the radio and the
+ * dropdown branches so the whole matrix lines up.
+ * Prefixed to stay clear of the other global rules in this file.
+ */
+.securityPermission__equalCell {
+    flex: 1 1 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    padding: 0;
+}
+
 .hover_securtiy_permisson > td {
     background-color: white;
 }

--- a/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
+++ b/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
@@ -243,7 +243,7 @@ const totalHours = computed(() => {
 
 function showEtaSidebar() {
     if(!props.permission) {
-        $toast.error(t(`Toast.Access denied`), {position: 'top-right'})
+        $toast.error(t(`Toast.Access_Denied`), {position: 'top-right'})
         return;
     }
     let assigneePermissionCheck = companyUser.value.roleType !== 1 && companyUser.value.roleType !== 2 && props.permission !== 2 ? props.task?.AssigneeUserId?.length && props.task.AssigneeUserId.includes(userId.value) : props.task?.AssigneeUserId?.length;

--- a/frontend/src/components/molecules/EstimatedTimeInput/EstimatedTimeInput.vue
+++ b/frontend/src/components/molecules/EstimatedTimeInput/EstimatedTimeInput.vue
@@ -1,7 +1,8 @@
 <template>
-<div 
-    v-if="!isEditing" 
-    class="time-display" 
+<div
+    v-if="!isEditing"
+    class="time-display"
+    :class="{ 'time-display--readonly': !editable }"
     @click="startEditing"
 >
     {{ displayTime }}
@@ -50,6 +51,14 @@ const props = defineProps({
   task: {
     type: Object,
     required: true
+  },
+  // false => display-only: clicking never opens the inputs. Needed so the
+  // "Read" level of task.task_estimated_hours shows the value without
+  // allowing edits. Defaults to true so the editable behaviour is unchanged
+  // wherever the prop is not passed.
+  editable: {
+    type: Boolean,
+    default: true
   }
 })
 
@@ -91,6 +100,9 @@ const validateMinutes = () => {
 
 // Start editing mode
 const startEditing = async () => {
+  if (!props.editable) {
+    return // read-only permission: never enter edit mode
+  }
   const totalMinutes = props.task.totalEstimatedTime || 0
   editHours.value = Math.floor(totalMinutes / 60)
   editMinutes.value = totalMinutes % 60
@@ -157,6 +169,11 @@ onUnmounted(() => {
 /* .time-display:hover {
   background: #e9ecef;
 } */
+
+/* Read-only: drop the affordance so the value does not look clickable. */
+.time-display--readonly {
+  cursor: default;
+}
 
 .time-inputs {
   display: flex;

--- a/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
+++ b/frontend/src/components/organisms/TaskDetailRightSide/TaskDetailRightSide.vue
@@ -201,6 +201,7 @@
                 <div v-if="Object.keys(task || {}).length && !isMainSpinner" class="d-flex align-items-center estimated-with-ai">
                     <EstimatedTimeInput
                         :task="task"
+                        :editable="canEditEstimatedHours"
                         @update:totalEstimatedTime="(val) => updateTotalEstimatedTime(val)"
                     />
                     <!--
@@ -208,10 +209,13 @@
                       title attribute matches the project's existing tooltip
                       convention (see BulkActionBar.vue / CheckList.vue).
                       Disabled + spinner state while a request is in flight.
-                      Shown whenever the Estimated row is visible — the per-user
-                      edit-permission gate (`=== true`) was removed on request.
+                      Hidden unless the user can actually write the estimate:
+                      the old gate was `=== true`, which wrongly excluded the
+                      Own/Everyone values too and so was dropped; this uses the
+                      correct writable test instead of no test at all.
                     -->
                     <button
+                        v-if="canEditEstimatedHours"
                         type="button"
                         class="ai-estimate-btn"
                         :class="{ 'is-loading': isAiEstimateLoading }"
@@ -413,6 +417,18 @@ const isSpinner = ref(false);
 // In-flight flag for the manual AI-estimate request — drives both the
 // button's spinner state and the click-debounce.
 const isAiEstimateLoading = ref(false);
+
+// task_estimated_hours is a "selection field" permission, so its stored value
+// is null (None) | false (Read) | 1 (Own) | 2 (Everyone) | true (Read & Write).
+// Writable therefore means true/1/2 — mirroring isWritable() in
+// Config/permissionGuard.js. The plain `=== true` test used by the other rows
+// is wrong for this key because it also locks out Own/Everyone, which is why
+// the AI button's gate had previously been dropped altogether. Read (false)
+// must keep the value visible but non-editable.
+const canEditEstimatedHours = computed(() => {
+    const permission = checkPermission('task.task_estimated_hours', project.value?.isGlobalPermission);
+    return permission === true || permission === 1 || permission === 2;
+});
 watch(() => props.task,(val) => {
     taskLeaderData.value = getUser(val?.Task_Leader);
 });
@@ -819,6 +835,12 @@ const estimateReasonText = ref('');
 const estimateReasonError = ref(false);
 
 const updateTotalEstimatedTime = (value) => {
+    // Defence in depth: the input is display-only and the AI button is hidden
+    // without write access, so this should be unreachable — but never persist
+    // an estimate for a read-only (or None) permission.
+    if (!canEditEstimatedHours.value) {
+        return;
+    }
     const previous = Number(props.task.totalEstimatedTime) || 0;
     if (previous > 0 && value !== previous) {
         // Re-update — prompt for a reason before persisting.
@@ -895,6 +917,9 @@ const displayTime = (time) => {
 // the same channel that drives `props.task`.
 const generateAiEstimate = async () => {
     if (isAiEstimateLoading.value) return;
+    // The trigger is hidden without write access; this also blocks the request
+    // itself, since it writes the estimate straight through the API.
+    if (!canEditEstimatedHours.value) return;
     const taskId = props.task && props.task._id;
     if (!taskId) {
         $toast.error('Task is not available', { position: 'top-right' });


### PR DESCRIPTION
Closes AHE-3846.

## Summary

**Task Estimated Hours** in Advanced Permissions could only be set to **None** or **Read & Write** (via the Own/Everyone selector) — there was no way to let a role *see* an estimate without also letting it *change* the estimate. This adds the missing **Read** level and makes it actually enforced.

Reviewing the module turned up four separate problems behind that one requirement.

## No backend change was needed

Read was already supported everywhere except the UI. For this "selection field" key the stored value is:

| Column | Value |
|---|---|
| None | `null` |
| **Read** | `false` |
| Own | `1` |
| Everyone | `2` |
| Read & Write | `true` |

`Config/permissionGuard.js` already documents and implements exactly this — `isWritable = true\|1\|2`, `isReadable = not null/undefined/0` — the task detail already shows the field whenever the permission is not None, and the value persists in an untyped array. So no API, store or schema change.

## 1. The Read radio was never rendered

The selection-field branch of the row only rendered None (`pIndex 0`) and the Own/Everyone selector (`pIndex 2`) — there was **no case for the middle column**, so the Read cell was an empty box and the level was unreachable from the UI.

Adds the missing radio, reusing the same markup, disabled-state and `:checked` logic as every other row. Gated on this key, so no other selection-field row gains a Read option.

## 2. Read wasn't enforced — the field stayed editable

The more serious half. Only **visibility** was gated (`!== null`); nothing checked **write**:

- `EstimatedTimeInput` was rendered with no permission information at all, so clicking the value always opened the editable hours/minutes inputs, for any role.
- The **AI estimate button** was ungated too. The code explained why: an earlier `=== true` gate had been removed — that test was simply wrong, because write access is stored as `1`/`2` for this key, so `=== true` hid the button from everyone who legitimately had access.

Adds one **correct** writable test (`true`/`1`/`2`, mirroring the API) applied to every write path:
1. the value is display-only and loses its clickable cursor;
2. the AI button is hidden without write access — using the correct test, so Own/Everyone users keep it;
3. the save handler refuses to persist;
4. the AI request itself is blocked, since it writes straight through the API rather than via that handler.

## 3. Untranslated denial toast

A read-only user clicking Task Planning saw the literal string **"Toast.Access denied"** — a translation key that doesn't exist, so vue-i18n printed the key. Now points at `Toast.Access_Denied`, already translated in 10 locales.

## 4. Permission matrix alignment

The column headers are equal thirds with centred text (`.permissionname { width: -webkit-fill-available }`), but the body rows used `justify-content-around`, which distributes only the **leftover** width — so control positions depended on control widths:

- plain radio rows sat ~4px left of their headers (asymmetric `mr-8px`);
- rows with a dropdown drifted further, and by **differing amounts**, since the drift scaled with the button's width ("Everyone" > "Own" > "Select").

Every cell now takes an equal third with centred content, so radios and dropdowns share one straight column that lines up with the headers. This replaces three competing spacing rules (`padding-left: 10px`, `margin-right: 19px`, `mr-8px`) with a single source of truth.

## Verification

- `npm run build` — **passes** (`DONE Build complete`, exit 0).
- No backend, store or schema change; 5 frontend files touched.
- `EstimatedTimeInput`'s new `editable` prop defaults to `true`, and the component is used in exactly one place, so nothing else changes.
- The new CSS class is uniquely prefixed and used only by this component — that stylesheet is loaded **non-scoped/global**, so the name matters.

## Test checklist

1. Advanced Permissions → search "est" → set **Task Estimated Hours** to **Read** for Members → Save → reload: still Read.
2. As a Member with Read, open a task: the Estimated value **is visible**.
3. Click it: nothing opens, no editable input, no pointer cursor.
4. The AI (wand) button is **not shown**.
5. Click **Task Planning**: toast reads **"Access Denied"** (not `Toast.Access denied`).
6. Set to **None**: the Estimated / Task Planning / Remaining Hours rows are hidden.
7. Set to **Own**, then **Everyone**: editing works and the AI button is back (regression).
8. As Owner and Admin: full access regardless of the Members setting.
9. Matrix alignment: all three columns form straight lines — check the `Own`/`Everyone`/`Select` rows and the AI per-user-limit row (a text input, the widest control in the table).
10. Regression: other rows (Show Tasks, the Sheet Settings timesheet rows, ordinary radio rows) behave and look correct.

## Known, pre-existing, deliberately not changed

- **Story Points** is intentionally ungated in the web UI ("free for anyone to view + edit"), though the API maps it to this same permission key for API-token requests. Flagging the inconsistency rather than changing it.
- The per-key permission guard only runs for **API-token/MCP** requests; browser (JWT) requests pass through by design. That's how the whole permission system currently works for every action, so server-side gating for browser sessions would be separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
