### PR TITLE
feat(tasks): self-assign new tasks by default in the inline create row

### DIFF
--- a/frontend/src/components/atom/CreateTask/CreateTask.vue
+++ b/frontend/src/components/atom/CreateTask/CreateTask.vue
@@ -133,9 +133,12 @@ const props = defineProps({
         type: Object,
         default: null
     },
+    // Pre-fill the creator as assignee when the inline task row opens. Defaults
+    // to true so a new task is self-assigned instead of starting unassigned;
+    // pass false to opt a call site out.
     addDefaultAssignee: {
         type: Boolean,
-        default: false
+        default: true
     },
     startDate: {
         type: Date

--- a/frontend/src/components/organisms/SprinstList/SprintsList.vue
+++ b/frontend/src/components/organisms/SprinstList/SprintsList.vue
@@ -168,7 +168,6 @@
                     @cancel="createTask = false"
                     @submit="taskSubmit"
                     :groupBy="groupType"
-                    :addDefaultAssignee="project?._id === '6571e7195470e64b1203295c'"
                     :groupType="groupType"
                 />
                 <div v-if="taskListAi && taskListAi.length">

--- a/frontend/src/views/Projects/TableView/TableView.vue
+++ b/frontend/src/views/Projects/TableView/TableView.vue
@@ -21,7 +21,6 @@
                 :sprint="sprints[0]"
                 @cancel="createTask = false"
                 :assigneeOptions="project.AssigneeUserId"
-                :addDefaultAssignee="project?._id === '6571e7195470e64b1203295c'"
                 :groupBy="grouped"
             />
         </div>


### PR DESCRIPTION
## What

Opening the inline **"New Task"** row left the assignee empty, so every task started unassigned and had to be assigned manually. It now pre-fills the creator as assignee.

## Why it wasn't just a flag

The `addDefaultAssignee` mechanism already existed on `CreateTask`, but two call sites gated it behind a **hardcoded project id**:

```js
:addDefaultAssignee="project?._id === '6571e7195470e64b1203295c'"
```

So self-assign only ever applied to that one project.

## Changes (3 lines)

- `CreateTask.vue` — `addDefaultAssignee` now defaults to `true`.
- `SprintsList.vue` and `TableView.vue` — removed the hardcoded project checks.

Removing those two was **required, not cleanup**: an explicit `false` would have overridden the new default and left those views unassigned anyway.

## Scope

Because this is now the component default, it also applies to the other two call sites — `ItemList.vue` and `SubTasks.vue` (subtask creation) — which previously never passed the prop. That seemed right for consistency.

The assignee remains editable before saving, and any call site can opt out with `:addDefaultAssignee="false"`.

## Verification

Frontend compiles clean (only the repo's pre-existing warnings), and the behaviour was confirmed in the list view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
