### PR TITLE
fix(socket): verify the claimed user id against the authenticated socket

### DIFF
--- a/socket/controller/chatSocket.js
+++ b/socket/controller/chatSocket.js
@@ -1,4 +1,5 @@
 const {
+    isSelf,
     joinRoom,
     leaveRoom,
     upsertRoom,
@@ -41,6 +42,11 @@ const handleTaskChange = (changeData, includeUpdatedFields = false) => {
 
 exports.chatSocketHandler = ({ socket, namespace }) => {
     socket.on('joinChats', (data) => {
+        // The emit side addresses `chat_<projectId>_<participantId>` for each side of a
+        // direct conversation, so this room carries the other party's conversation
+        // documents. The participant id must therefore be the authenticated caller's.
+        if (!data || !isSelf(socket, data.userId)) return;
+
         const roomName = `chat_${data.projectId}_${data.userId}**${data.socketId}`;
         joinRoom(socket, roomName);
         upsertRoom({ roomName, socketId: data.socketId, namespace, socket });

--- a/socket/controller/generalReminderSocket.js
+++ b/socket/controller/generalReminderSocket.js
@@ -5,6 +5,7 @@
 // Scoped to the `generalReminder` module only (SOCKET-PERFORMANCE-PLAN #2), so
 // this handler never wakes for task/comment/company traffic.
 const {
+    isSelf,
     joinRoom,
     upsertRoom,
     findRoomsByPrefix,
@@ -40,6 +41,14 @@ const handleReminderChange = (changeData) => {
 exports.generalReminderSocketHandler = ({ socket, namespace }) => {
     socket.on('joinGeneralReminder', (data) => {
         if (!data || !data.uid) return;
+
+        // The room is keyed by user id and carries the FULL reminder document, so the
+        // id has to be the authenticated caller's — otherwise anyone who knows a
+        // colleague's user id (they are visible on every assignee and mention) could
+        // subscribe to their private reminders. socketinit.js already put the verified
+        // JWT on socket.user; this is the check that was missing, not the identity.
+        if (!isSelf(socket, data.uid)) return;
+
         const roomName = `generalReminder_${data.uid}**${data.socketId}`;
         joinRoom(socket, roomName);
         upsertRoom({

--- a/socket/controller/userNotificationCount.js
+++ b/socket/controller/userNotificationCount.js
@@ -1,4 +1,5 @@
 const {
+    isSelf,
     joinRoom,
     leaveRoom,
     upsertRoom,
@@ -29,6 +30,10 @@ const handleUserNotificationChange = (changeData) => {
 
 exports.userNotificationCountHandler = ({ socket, namespace }) => {
     socket.on('joinUserIdNotification', (data) => {
+        // Keyed by user id and carries that user's counter document — so the id must
+        // be the authenticated caller's, not whatever the client asked for.
+        if (!data || !isSelf(socket, data.uid)) return;
+
         const roomName = `userIdNotification_${data.uid}**${data.socketId}`;
         joinRoom(socket, roomName);
         upsertRoom({

--- a/socket/helper.js
+++ b/socket/helper.js
@@ -24,6 +24,25 @@
 // (duplicate entries on tab refresh / reconnect that previously caused
 // events to fire multiple times for the same room).
 
+/**
+ * Is `claimedUid` actually this socket's authenticated user?
+ *
+ * Several rooms are keyed by user id — `userIdNotification_<uid>`,
+ * `generalReminder_<uid>`, `chat_<pid>_<uid>` — and whatever is pushed to them is
+ * that user's private data. The id arrives from the CLIENT, so without this check
+ * anyone could subscribe to a colleague's room simply by knowing their user id, which
+ * is visible on every assignee, mention and avatar in the app.
+ *
+ * socketinit.js already verifies the JWT and puts the decoded payload on
+ * `socket.user`; the token is signed with `{ uid }` (Config/jwt.js → generateJWTToken).
+ * Fails closed: no authenticated identity means no join.
+ */
+exports.isSelf = (socket, claimedUid) => {
+    const authenticated = socket && socket.user && socket.user.uid;
+    if (!authenticated || !claimedUid) return false;
+    return String(authenticated) === String(claimedUid);
+};
+
 exports.joinRoom = (soket, roomName) => {
     soket.join(roomName);
 };


### PR DESCRIPTION
Addresses CodeRabbit's finding on [#430](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/pull/430) — and the same flaw in two sibling handlers it did not flag.

## The problem

Three socket rooms are keyed by user id and carry that user's private data:

| Room | Carries |
|---|---|
| `generalReminder_<uid>` | full reminder documents |
| `userIdNotification_<uid>` | unread / mention / notification counters |
| `chat_<pid>_<uid>` | direct-conversation documents |

Every join handler took the id **straight from the client payload** and never consulted the authenticated identity — even though `socketinit.js` verifies the JWT and puts it on `socket.user`.

So any signed-in user could subscribe to a colleague's room by emitting a join with their user id. **User ids are not secret** — they appear on every assignee, mention and avatar in the app. The room prefixes carry no company component either, so it wasn't confined to a single tenant.

## The fix

`isSelf(socket, claimedUid)` in `socket/helper.js`, gating all three joins. Fails closed — no authenticated identity means no join.

**Why this can't lock anyone out:** the access token is signed with `{ uid }` (`Config/jwt.js` → `generateJWTToken`), and the client hands that same cookie to the socket handshake. I checked all three call sites before adding the guard — `ReminderPanel.vue`, `store/Users/actions.js` and `store/MainChats/actions.js` each already send the logged-in user's own id.

## Deliberately not covered

The **resource-keyed** rooms — `comments_<pid>_<sid>_<tid>`, `project_sprint_*`, `taskDetail_*`, and `companiesSocket`'s fully client-supplied `roomName`. These leak by conversation/project rather than by user, so the equivalent check is a **membership lookup on the hot path of every subscription** — a design decision, not a one-line guard. `comments_*` is the significant one: it carries message content.

Worth its own change, and I'd rather not bolt a DB round-trip onto every socket join under time pressure.

## Verification

`node --check` clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
