### PR TITLE
fix: drop the dimmed backdrop from the reminders popover

### DIFF
--- a/frontend/src/components/molecules/GeneralReminder/panel.css
+++ b/frontend/src/components/molecules/GeneralReminder/panel.css
@@ -1,10 +1,15 @@
 /* Reminders list panel. Scoped to this component — no global selectors. */
 
+/* Transparent, matching Notepad and Clips: this is a header POPOVER, not a modal.
+   It only exists to catch the outside click that closes the panel, so dimming the
+   page behind it made a lightweight panel feel like it had taken over the app —
+   and made Reminders behave unlike its two siblings in the same header row.
+   z-index matches theirs too, so the three stack consistently. */
 .grp__overlay {
     position: fixed;
     inset: 0;
-    z-index: 19;
-    background: rgba(23, 24, 36, 0.28);
+    z-index: 1000;
+    background: transparent;
 }
 
 .grp__panel {


### PR DESCRIPTION
## What

The Reminders panel painted `rgba(23, 24, 36, 0.28)` over the page behind it, so
opening a small list read as a modal taking over the app.

Reminders sits in the same header row as **Clips** and **Notepad**, and all three
are the same kind of control: a panel anchored under an icon, dismissed by
clicking outside. Its two siblings use a fully transparent overlay whose only job
is to catch that outside click — Reminders was the odd one out.

## Change

One file, `frontend/src/components/molecules/GeneralReminder/panel.css`:

| | before | after |
|---|---|---|
| `background` | `rgba(23, 24, 36, 0.28)` | `transparent` |
| `z-index` | `19` | `1000` |

`z-index` is raised to match `.cl__overlay` (Clips) and `.np__overlay` (Notepad)
so the three header popovers stack consistently.

## Why the stacking is safe

Both things that render above the panel are children of `.grp__overlay`, so
raising the parent doesn't change their order relative to it:

- `ReminderModal` (`.gr__overlay`, `z-index: 20`) is a sibling of `.grp__panel`
  inside the overlay
- `.grp__menu` (the row action menu) is `position: fixed; z-index: 25`, also
  inside the overlay

The reminder components use no `Teleport` and no shared dropdown that renders to
`body`, so nothing outside the overlay needed to sit above it.

## Testing

- Open Reminders from the header clock → panel appears with no page dimming,
  matching Clips and Notepad
- Click outside → closes (the transparent overlay still catches it)
- `+ Add` → create modal opens above the panel; date picker, assignee and file
  attach all reachable
- Row `⋯` menu → opens above the panel, snooze/edit/delete work
- Open Clips and Notepad → unchanged

Frontend build verified: `npm run build` completes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)