### PR TITLE
fix(ai-assist): list sprints inside folders in the Plan with AI picker

### DIFF
--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -525,15 +525,46 @@ const currentVideoUrl = ref(0);
 const openAiSidebar = ref(false);
 const showDriverSidebar = ref(false);
 const showAiTaskCreator = ref(false);
-// Sprints for the "Plan with AI" tasks-only picker: [{ id, name }] from the
-// project's sprint map (non-deleted). Active default = the sprint being viewed
-// (route param), else the first.
+// Sprints for the "Plan with AI" tasks-only picker: [{ id, name }].
+//
+// A project keeps its sprints in two places — `sprintsObj` holds the ones at the
+// root, and each folder in `sprintsfolders` has its own `sprintsObj`. Reading
+// only the first meant every sprint inside a folder was missing from the picker,
+// so a project that organises its sprints into folders offered almost nothing to
+// choose from.
+//
+// Folder sprints are labelled "Folder / Sprint": two folders can easily hold a
+// sprint of the same name, and without the prefix they'd be indistinguishable.
+//
+// Active default = the sprint being viewed (route param), else the first.
 const aiSprints = computed(() => {
-    const obj = projectData.value && projectData.value.sprintsObj;
-    if (!obj) return [];
-    return Object.values(obj)
-        .filter((s) => s && s.id && (s.deletedStatusKey === 0 || s.deletedStatusKey === undefined))
-        .map((s) => ({ id: String(s.id), name: s.name || 'Sprint' }));
+    const project = projectData.value;
+    if (!project) return [];
+
+    const isLive = (x) => x && (x.deletedStatusKey === 0 || x.deletedStatusKey === undefined);
+    const out = [];
+    const seen = new Set();
+    const push = (sprint, prefix) => {
+        if (!isLive(sprint) || !sprint.id) return;
+        const id = String(sprint.id);
+        if (seen.has(id)) return;   // never offer the same sprint twice
+        seen.add(id);
+        const name = sprint.name || 'Sprint';
+        out.push({ id, name: prefix ? `${prefix} / ${name}` : name });
+    };
+
+    // Root-level sprints first, so the common case stays at the top.
+    Object.values(project.sprintsObj || {}).forEach((s) => push(s, ''));
+
+    // Then each folder's sprints. Folders are keyed by id, and a deleted folder's
+    // sprints are not offered.
+    Object.values(project.sprintsfolders || {}).forEach((folder) => {
+        if (!isLive(folder)) return;
+        const folderName = folder.name || 'Folder';
+        Object.values(folder.sprintsObj || {}).forEach((s) => push(s, folderName));
+    });
+
+    return out;
 });
 const aiActiveSprintId = computed(() => {
     const rid = route.params && route.params.sprintId;

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -302,7 +302,7 @@
                                 @manageFilterUsers="manageFilterUsers"
                                 @changeAssignee="(type, $event) => changeAssignee(type, $event)"
                                 @openAi="openAiSidebar = true"
-                                @openAiAssist="showAiTaskCreator = true"
+                                @openAiAssist="openAiTaskCreator()"
                                 @update:showArchived="(v) => showArchived = v"
                                 @openCalendar="calendartoggle = true; rangeObjectFRun(calendarDate ? new Date(calenderSelectDate) : new Date())"
                                 @handleStartEndDate="handleStartEndDate"
@@ -536,8 +536,21 @@ const showAiTaskCreator = ref(false);
 // Folder sprints are labelled "Folder / Sprint": two folders can easily hold a
 // sprint of the same name, and without the prefix they'd be indistinguishable.
 //
-// Active default = the sprint being viewed (route param), else the first.
-const aiSprints = computed(() => {
+// Built into a REF when the modal opens — deliberately not a computed.
+//
+// As a computed consumed by the template it joined this view's render effect, and
+// walking `sprintsfolders` registered a reactive dependency on every folder and
+// every sprint nested inside one. Clicking a sprint mutates that state
+// (expansion / selection), which then invalidated the render effect and cascaded
+// into the project-list watchers further down: the list re-filtered and the
+// selection fell back to the first project. The original version read only root
+// `sprintsObj`, so it never observed folder state and the problem did not exist.
+//
+// A ref filled on open owns no reactive dependencies, so nothing here can feed
+// back into rendering.
+const aiSprints = ref([]);
+
+const buildAiSprints = () => {
     const project = projectData.value;
     if (!project) return [];
 
@@ -565,7 +578,21 @@ const aiSprints = computed(() => {
     });
 
     return out;
-});
+};
+
+/**
+ * Fill the list, then open. Order matters: AiTaskCreator's own open-watcher calls
+ * reset(), which seeds its selection from `props.sprints[0]` — so the list has to
+ * be there before the flag flips, rather than racing two watchers on the same
+ * tick. Building it here also means the project's sprint maps are read at exactly
+ * one moment, never during rendering.
+ */
+const openAiTaskCreator = () => {
+    aiSprints.value = buildAiSprints();
+    showAiTaskCreator.value = true;
+};
+
+// Active default = the sprint being viewed (route param), else the first.
 const aiActiveSprintId = computed(() => {
     const rid = route.params && route.params.sprintId;
     if (rid && aiSprints.value.some((s) => s.id === String(rid))) return String(rid);


### PR DESCRIPTION
## The bug

**Plan with AI → Tasks only → "Add tasks to sprint" only offered root-level sprints.** A project that organises its sprints into folders had almost nothing to choose from — the reported case showed 2 options against 17 folders of sprints.

It also meant **"Tasks only" was disabled outright** for any project whose sprints all live in folders, since that button keys off the list being non-empty.

## Cause

A project keeps sprints in two places: `sprintsObj` at the root, and a *separate* `sprintsObj` inside each entry of `sprintsfolders`. `aiSprints` read only the first.

`BurndownModal` and `ConvertToList` already walk both, so this was the outlier rather than a new convention. `ConvertToSubTaskSidebar` uses its own folder tree and isn't affected.

**No backend change needed** — `loadSprintForTasks` looks a sprint up by `_id` with no folder constraint, so a folder-nested sprint already worked once it could be selected.

## Fix

Folder sprints are labelled `Folder / Sprint`, because two folders can easily hold a sprint of the same name and they'd be indistinguishable in a flat select. Root sprints stay first so the common case is at the top:

```
AHE - Workflow
Road Map
AHE - v14.5.0 / Sprint 1
AHE - v14.5.0 / Sprint 2
AHE - v14.6.0 / Sprint 1
```

## Second commit: a regression I introduced, and why it's worth reading

The first commit did the folder walk inside the existing **computed**. That broke sprint navigation: clicking any sprint reloaded the project list and reset the selection to the first project.

`aiSprints` is consumed by the template, so it belonged to this view's render effect. Walking `sprintsfolders` registered a reactive dependency on every folder and every sprint nested inside one — and clicking a sprint mutates exactly that state (expansion / selection). That invalidated the render effect and cascaded into the project-list watchers in the same file: `assignProjects` re-filtered the list, then the `[projects, route]` watcher failed to find the current project in the rebuilt list and fell back to `projects[0]`.

The original code read only root `sprintsObj`, so it never observed folder state and none of this fired. **Adding folder support to a computed was the mistake, not the folder walk itself.**

`aiSprints` is now a plain `ref`, filled by `buildAiSprints()` from the click handler that opens the modal. The sprint maps are read at exactly one moment and never during rendering, so folder mutation cannot reach the render effect.

Filled at the click rather than in a watcher on the open flag, because `AiTaskCreator`'s own open-watcher calls `reset()`, which seeds its selection from `props.sprints[0]` — the list has to exist before the flag flips instead of two watchers racing on the same tick.

Both commits are kept rather than squashed, so the regression and its cause are on the record.

### Note for reviewers

Those two project-list watchers are worth a look in their own right. They were dormant here, but:

- `route` is a dependency of a **deep** watcher that re-filters the entire project list, so any navigation rebuilds it ([Projects.vue:919](../blob/fix/ai-sprint-picker-folders/frontend/src/views/Projects/Projects.vue#L919))
- when the current project isn't found in the rebuilt list, the selection **silently falls back to `projects[0]`** rather than being left alone ([Projects.vue:984](../blob/fix/ai-sprint-picker-folders/frontend/src/views/Projects/Projects.vue#L984))

Not touched here — that's core navigation and deserves its own change.

## Testing

Logic verified against root+folders, deleted sprints, deleted folders, the same sprint present in both maps (listed once), and every pre-existing shape — root-only, no sprints, null project, missing name, sprint without an id — all unchanged. Confirmed the template no longer references `sprintsfolders` anywhere. eslint clean; `npm run build` passes.

Not yet confirmed by manual QA in the app — worth exercising sprint clicks (root and in-folder, across projects) plus generating tasks into a folder sprint, since that path was previously unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)