### PR TITLE
fix(epics): compute epic progress from tasks instead of a stale counter (AHE-3853)

### DIFF
--- a/Modules/Epics/controller.js
+++ b/Modules/Epics/controller.js
@@ -6,8 +6,70 @@ const socketEmitter = require('../../event/socketEventEmitter');
 const { validateEpicInput, validateAssignInput, countDeltas, isObjectIdString, EPIC_STATUSES, EPIC_PRIORITIES, parseEpicDates } = require('./helpers/epicRules');
 
 // Epics: a grouping layer above tasks with progress roll-up. Tasks carry an
-// optional epicId; epics keep denormalised taskCount/completedCount which
-// the assign flow maintains and /recount can rebuild from scratch.
+// optional epicId.
+//
+// Progress is COMPUTED FROM THE TASKS on every read — see countsForProject.
+// The stored taskCount/completedCount fields are a cache only; nothing renders
+// them directly any more.
+//
+// Why (AHE-3853): those stored fields were maintained by $inc in the assign flow
+// alone, using the task's status at the moment it joined the epic. Nothing told
+// an epic that one of its tasks had since been completed, deleted, restored, or
+// bulk-moved — so `completedCount` froze at whatever it was on assignment and
+// every epic sat at 0%. Keeping counters correct by hooking every writer is what
+// failed: `statusType` is written from six places across mongo_helper.js,
+// mergeDuplicate.js, structural.js and bulk.js, and any path that forgets the
+// hook corrupts the number silently and permanently. One aggregation at read
+// time cannot drift, and epics-per-project is small enough that the cost is
+// irrelevant.
+
+/**
+ * Live task/completed counts for every epic in a project, as
+ * { [epicId]: { taskCount, completedCount } }.
+ *
+ * One aggregation for the whole project rather than a query per epic. Excludes
+ * soft-deleted tasks, which is what makes a deleted task stop inflating its
+ * epic. "Completed" is statusType === 'close', the same definition /recount and
+ * the assign flow use.
+ *
+ * Never throws: progress is decoration, so a failure here must not take the
+ * epic list down with it — the caller falls back to the stored values.
+ */
+const countsForProject = async (companyId, projectId) => {
+    try {
+        const rows = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.TASKS,
+            data: [[
+                {
+                    $match: {
+                        ProjectID: new mongoose.Types.ObjectId(projectId),
+                        epicId: { $exists: true, $ne: null },
+                        deletedStatusKey: { $ne: 1 },
+                    },
+                },
+                {
+                    $group: {
+                        _id: '$epicId',
+                        taskCount: { $sum: 1 },
+                        completedCount: { $sum: { $cond: [{ $eq: ['$statusType', 'close'] }, 1, 0] } },
+                    },
+                },
+            ]],
+        }, 'aggregate');
+        const map = {};
+        (rows || []).forEach((row) => {
+            if (!row || !row._id) return;
+            map[String(row._id)] = {
+                taskCount: Number(row.taskCount) || 0,
+                completedCount: Number(row.completedCount) || 0,
+            };
+        });
+        return map;
+    } catch (error) {
+        logger.error(`ERROR in epic count aggregation: ${error.message}`);
+        return null;
+    }
+};
 
 /* POST /api/v2/epics  body: { name, description?, color?, projectId, userData } */
 exports.createEpic = async (req, res) => {
@@ -63,7 +125,22 @@ exports.listEpics = async (req, res) => {
                 { sort: { createdAt: 1 } },
             ],
         }, 'find');
-        return res.send({ status: true, statusText: 'Epics fetched.', data: epics || [] });
+
+        // Overlay live counts. If the aggregation failed we fall through to the
+        // stored values rather than reporting zeros — stale is better than wrong.
+        const counts = await countsForProject(companyId, projectId);
+        const data = (epics || []).map((epic) => {
+            const plain = epic && epic.toObject ? epic.toObject() : { ...epic };
+            const live = counts && counts[String(plain._id)];
+            if (counts) {
+                // An epic with no matching tasks is absent from the aggregation,
+                // which legitimately means zero — don't leave a stale count there.
+                plain.taskCount = live ? live.taskCount : 0;
+                plain.completedCount = live ? live.completedCount : 0;
+            }
+            return plain;
+        });
+        return res.send({ status: true, statusText: 'Epics fetched.', data });
     } catch (error) {
         logger.error(`ERROR in list epics: ${error.message}`);
         return res.send({ status: false, statusText: error.message });


### PR DESCRIPTION
## The bug

Epic progress never moved. Every epic sat at **0%** no matter how many of its tasks were finished.

## Cause

`completedCount` was maintained by `$inc` in the assign flow alone, using the task's status **at the moment it joined the epic** — [controller.js:190](../blob/fix/epic-progress-live-counts/Modules/Epics/controller.js#L190):

```js
isCompleted: task.statusType === 'close',
```

After that the number is frozen. The Tasks module has **zero** references to `SCHEMA_TYPE.EPICS`, so completing a task never tells its epic.

The same missing hook meant:

| action | effect |
|---|---|
| task in an epic completed | `completedCount` stale ← **reported** |
| task deleted | `taskCount` stays inflated |
| task restored | `taskCount` too low |
| bulk status change / move | drifts for every task touched |

`POST /api/v2/epics/:id/recount` could have repaired all of it — but it has **never had a single caller**.

## Fix

**Not** by hooking the status writers. `statusType` is written from six places across `mongo_helper.js`, `mergeDuplicate.js`, `structural.js` and `bulk.js`; any path that forgets the hook corrupts the number silently and permanently, which is exactly how this bug arose.

Instead `listEpics` **computes both numbers from the tasks** — one aggregation per project, grouped by `epicId`, excluding soft-deleted tasks. It cannot drift, needs no hooks, and fixes all four rows above at once.

- Stored `taskCount`/`completedCount` remain as a cache; nothing renders them
- `countsForProject` never throws — progress is decoration, so a failed aggregation falls back to the stored values rather than reporting zeros or taking the epic list down
- An epic absent from the aggregation legitimately has no tasks, so it reads `0/0` rather than keeping a stale number

## Verified against real data

Two epics whose tasks were completed after assignment:

```
Billing      live 2/4   ← stored cache still said 0/4
Development  live 2/2   ← stored cache still said 0/2
```

That is the bug reproduced and corrected. Checked task by task: 2 of 4 `Billing` tasks are `statusType: 'close'`, both `Development` tasks are, and the two empty epics correctly read `0/0`.

On data where nothing had been completed, computed equals stored exactly — so this changes nothing except where the old number was actually wrong.

## Note for review — some counts will go DOWN

The AI project generator sets `taskCount` from the plan at epic creation, whether or not the tasks ended up carrying the `epicId` ([orchestrator.js:1284](../blob/fix/epic-progress-live-counts/Modules/AIProjectGenerator/orchestrator.js#L1284)). One epic in another workspace stored `0/5` with **no linked tasks at all**, and now correctly reads `0/0`.

That is a fabricated number being replaced by the real one, not a regression — worth knowing before someone asks why an epic "lost" tasks.

## Scope

Backend only, one file. No route, schema or frontend change; `EpicsPanel` already renders whatever `listEpics` returns.

Deliberately **not** in this PR, from the wider review of Epics:

- can't click an epic to see its tasks
- no epic filter or group-by (design agreed, implementation deferred)
- no epic badge on task rows
- owner is displayed but has no picker
- an empty epic reads "0%" where "No tasks yet" would be clearer

Those are feature gaps rather than this defect, and are being tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)