### PR TITLE
fix(projects): search the whole project, not just your own tasks

### DIFF
--- a/frontend/src/views/Projects/composables/useProjectSearch.js
+++ b/frontend/src/views/Projects/composables/useProjectSearch.js
@@ -20,6 +20,27 @@ export function useProjectSearch(projectData, showArchived) {
 
     const showTasks = computed(() => checkPermission('task.show_tasks', projectData.value.isGlobalPermission, { gettersVal: getters }));
 
+    /**
+     * Whether this search may see everyone's tasks — decided EXACTLY as the task list
+     * decides it (views/Projects/helper.js -> store/ProjectData/actions.js).
+     *
+     * The list only applies the own-tasks-only restriction when the project carries its OWN
+     * permissions; on a project using the global rules it passes `true` and shows
+     * everything. Search applied the restriction unconditionally, so a role whose global
+     * `task.show_tasks` is 1 saw every task in the list and only their own the moment they
+     * typed in the search box. Owner/Admin never hit it — checkPermission short-circuits
+     * roleType 1|2 to `true` — which is why it only ever showed up for other roles.
+     */
+    const showAllTasks = computed(() => (
+        projectData.value.isGlobalPermission === false ? showTasks.value : true
+    ));
+
+    // The same accepted values the store uses: undefined, true and 2 all mean "everyone's".
+    // Anything else — including null, a role the rule does not name — narrows to your own.
+    const seesEveryonesTasks = computed(() => (
+        showAllTasks.value === undefined || showAllTasks.value === true || showAllTasks.value === 2
+    ));
+
     function resetFilters() {
         groupBy.value = 0;
         filterUsers.value = [];
@@ -38,6 +59,15 @@ export function useProjectSearch(projectData, showArchived) {
         if (!taskSearch.value.trim().length && !filterUsers.value.length && !showArchived.value && !Object.keys(filterQuery.value).length) {
             commit('projectData/mutateSearchTask', { data: [], op: 'added' });
             searchTask.value = false;
+            return;
+        }
+
+        // A role the project's own rules do not name gets no tasks at all — getSprintTasks
+        // returns without fetching (helper.js). Search must not be the way around a list
+        // that refuses to load, so it returns nothing here rather than the caller's own.
+        if (showTasks.value === null && projectData.value.isGlobalPermission === false) {
+            commit('projectData/mutateSearchTask', { data: [], op: 'added' });
+            searchTask.value = true;
             return;
         }
 
@@ -82,7 +112,7 @@ export function useProjectSearch(projectData, showArchived) {
             query[0].$match.$and.push({ AssigneeUserId: { $in: filterUsers.value } });
         }
 
-        if (showTasks.value === 1) {
+        if (!seesEveryonesTasks.value) {
             query[0].$match.$and.push({ AssigneeUserId: { $in: [userId.value] } });
         }
 


### PR DESCRIPTION
The task search box inside a project returned only the searching user's own tasks for some roles, while the unfiltered list on the same screen showed everyone's.

Fixes **AHE-3862**.

## Cause

Two places decide *"may this person see everyone's tasks?"*, and they answered differently.

**The list** ([helper.js:777](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/blob/staging/frontend/src/views/Projects/helper.js#L777) → [actions.js:147](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/blob/staging/frontend/src/store/ProjectData/actions.js#L147)):

```js
showAllTasks: projectData.isGlobalPermission === false ? permit : true
// then: restrict unless showAllTasks is undefined | true | 2
```

**The search** ([useProjectSearch.js](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/blob/staging/frontend/src/views/Projects/composables/useProjectSearch.js)):

```js
if (showTasks.value === 1) { $match.AssigneeUserId = { $in: [userId] } }
```

The list applies the own-tasks-only restriction **only when the project carries its own permissions**. On a project using the global rules it passes "show everything" and ignores the permission. Search applied it **unconditionally**.

So on a project using global permissions, a role whose global `task.show_tasks` is `1` got every task in the list and only their own the moment they typed in the search box.

**Why it survived:** `checkPermission` short-circuits `roleType === 1 || 2` to `true`, so an Owner or Admin never reaches the restriction and search behaves correctly. It only misbehaves for other roles — it cannot be reproduced from an admin account.

## Fix

Search now uses the list's rule verbatim rather than a second reading of the same setting — the same `isGlobalPermission` guard, and the same set of values the store accepts as "everyone's" (`undefined`, `true`, `2`), so the two cannot drift on an edge value.

**Also fixes the same pair in the opposite direction.** When a project uses its own permissions and the role is not named in the rule at all, `getSprintTasks` returns without fetching — the user sees an empty project. Search still handed back their own tasks, so it was a way around a list that refuses to load. It now returns nothing, matching.

## Verification

Both rules were transcribed and run side by side over every combination of `isGlobalPermission` × `show_tasks` (`true` / `1` / `2` / `null` / `undefined`):

| isGlobalPermission | show_tasks | list | search before | search now |
|---|---|---|---|---|
| true | **1** | ALL | **OWN** | **ALL** ✅ |
| false | **null** | NOTHING | **ALL** | **NOTHING** ✅ |
| *(other 8 combinations)* | | | already agreed | unchanged |

All ten now agree, and the two that changed are exactly the two described above. This is permission logic whose failure mode is invisible from an admin account, so it is checked rather than eyeballed.

`npm run build` clean; eslint clean.

## Worth testing on a non-admin account

- Search on a **global-permission** project returns other people's matching tasks, and the count is consistent with the unfiltered list
- On a **project-specific** permission project, a role with `show_tasks = 1` still sees only their own — that restriction is intentional and must survive
- Owner/Admin behaviour unchanged
- Assignee filter, archived toggle and the advanced filter still work alongside search

🤖 Generated with [Claude Code](https://claude.com/claude-code)
