### PR TITLE
feat(webhooks): scope integrations to their owner, and page the logs

### DIFF
--- a/Config/setMiddleware.js
+++ b/Config/setMiddleware.js
@@ -238,6 +238,12 @@ const verifyJWTTokenWithCRoute = [
     // is the entire point of them.
     '/api/v2/public-shares',
     '/api/v2/intake',
+    // Outgoing webhooks (Modules/Webhooks). A webhook belongs to the member who created
+    // it, and every route is scoped to req.uid — which only this middleware sets. These
+    // were in neither list, so the owner was taken from the request body instead: with
+    // the list now filtered by owner, that would have been a way to read someone else's
+    // integrations rather than merely to mislabel one.
+    '/api/v2/webhooks',
 ];
 const verifyJWTToken = [
     "/api/v2/company/delete",

--- a/Modules/Webhooks/controller.js
+++ b/Modules/Webhooks/controller.js
@@ -7,6 +7,38 @@ const { invalidateCompanyCache } = require('./dispatcher');
 
 // Outgoing-webhook management. The HMAC secret is generated server-side and
 // returned ONCE on create; list/update responses always mask it.
+//
+// A webhook belongs to the person who made it, not to the company: it carries their
+// Slack or Discord URL, and one member's integrations are not another's business. Every
+// route below is scoped to the caller — hiding rows from the list alone would leave them
+// editable, deletable and readable by id.
+
+/**
+ * Who is asking, from the JWT — never from the request body.
+ *
+ * createWebhook used to take the owner from `userData` off the body, which meant the
+ * recorded owner was whatever the caller typed. With the list now filtered by owner, that
+ * would have been a way to read someone else's integrations rather than merely to
+ * mislabel one.
+ */
+const callerId = (req) => String((req && req.uid) || '');
+
+/**
+ * Match only what this caller owns.
+ *
+ * Rows with no owner stay visible to everyone. They are webhooks that predate ownership
+ * being recorded, and hiding them would leave an ACTIVE integration nobody can see, edit
+ * or delete while it keeps posting company data to whatever URL it holds. Visible and
+ * removable beats invisible and running.
+ */
+const ownedBy = (uid) => ({
+    $or: [
+        { createdBy: uid },
+        { createdBy: '' },
+        { createdBy: null },
+        { createdBy: { $exists: false } },
+    ],
+});
 
 const maskHook = (hook) => ({
     _id: hook._id,
@@ -26,13 +58,17 @@ exports.listEvents = (req, res) => {
     return res.send({ status: true, statusText: 'Webhook events.', data: EVENT_TYPES });
 };
 
-/* POST /api/v2/webhooks  body: { name, url, events, userData } */
+/* POST /api/v2/webhooks  body: { name, url, events, format } */
 exports.createWebhook = async (req, res) => {
     try {
         const companyId = req.headers['companyid'] || '';
-        const { name, url, events, format, userData } = req.body || {};
+        const { name, url, events, format } = req.body || {};
+        const uid = callerId(req);
         if (!companyId) {
             return res.send({ status: false, statusText: 'companyId is required.' });
+        }
+        if (!uid) {
+            return res.send({ status: false, statusText: 'An authenticated user is required.' });
         }
         const check = validateWebhookInput({ name, url, events, format });
         if (!check.valid) {
@@ -49,7 +85,7 @@ exports.createWebhook = async (req, res) => {
                 secret,
                 active: true,
                 format: format || 'json',
-                createdBy: userData && (userData.id || userData._id) ? String(userData.id || userData._id) : '',
+                createdBy: uid,
             },
         }, 'save');
 
@@ -71,7 +107,7 @@ exports.listWebhooks = async (req, res) => {
         }
         const hooks = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.WEBHOOKS,
-            data: [{}],
+            data: [ownedBy(callerId(req))],
         }, 'find');
         return res.send({ status: true, statusText: 'Webhooks fetched.', data: (hooks || []).map(maskHook) });
     } catch (error) {
@@ -110,9 +146,16 @@ exports.updateWebhook = async (req, res) => {
             return res.send({ status: false, statusText: 'Nothing to update.' });
         }
 
+        // Ownership is part of the MATCH, not a check after the fact: someone else's
+        // webhook is simply not found, which is also the answer that tells a prober
+        // nothing about whether the id exists.
         const updated = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.WEBHOOKS,
-            data: [{ _id: new mongoose.Types.ObjectId(id) }, { $set: update }, { returnDocument: 'after' }],
+            data: [
+                { _id: new mongoose.Types.ObjectId(id), ...ownedBy(callerId(req)) },
+                { $set: update },
+                { returnDocument: 'after' },
+            ],
         }, 'findOneAndUpdate');
         if (!updated) {
             return res.send({ status: false, statusText: 'Webhook not found.' });
@@ -134,6 +177,15 @@ exports.deleteWebhook = async (req, res) => {
             return res.send({ status: false, statusText: 'companyId and a valid webhook id are required.' });
         }
         const webhookId = new mongoose.Types.ObjectId(id);
+        // Confirm it is the caller's BEFORE deleting anything — a plain deleteOne on the id
+        // would let one member remove another's integration, and the logs with it.
+        const owned = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.WEBHOOKS,
+            data: [{ _id: webhookId, ...ownedBy(callerId(req)) }],
+        }, 'findOne');
+        if (!owned) {
+            return res.send({ status: false, statusText: 'Webhook not found.' });
+        }
         await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.WEBHOOKS,
             data: [{ _id: webhookId }],
@@ -150,7 +202,13 @@ exports.deleteWebhook = async (req, res) => {
     }
 };
 
-/* GET /api/v2/webhooks/:id/logs — newest 50 deliveries. */
+/**
+ * GET /api/v2/webhooks/:id/logs?skip=&limit= — newest deliveries, a page at a time.
+ *
+ * A busy webhook accumulates a row per delivery and this used to return 50 in one go for
+ * a panel that shows a handful. Paged at 10 by default, capped at 50 so a caller cannot
+ * ask for the whole table back.
+ */
 exports.listWebhookLogs = async (req, res) => {
     try {
         const companyId = req.headers['companyid'] || '';
@@ -158,11 +216,33 @@ exports.listWebhookLogs = async (req, res) => {
         if (!companyId || !isObjectIdString(id)) {
             return res.send({ status: false, statusText: 'companyId and a valid webhook id are required.' });
         }
-        const logs = await MongoDbCrudOpration(companyId, {
+        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10, 1), 50);
+        const skip = Math.max(parseInt(req.query.skip, 10) || 0, 0);
+        // Delivery logs carry the destination's responses, so they are as private as the
+        // webhook itself — check ownership before reading them.
+        const webhookId = new mongoose.Types.ObjectId(id);
+        const owned = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.WEBHOOKS,
+            data: [{ _id: webhookId, ...ownedBy(callerId(req)) }],
+        }, 'findOne');
+        if (!owned) {
+            return res.send({ status: false, statusText: 'Webhook not found.' });
+        }
+        // One row past the page is read but never returned: that is what makes hasMore
+        // exact. Asking for exactly the page cannot tell "there are more" from "that was
+        // the last one", which leaves a Load more button that does nothing when clicked.
+        const rows = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.WEBHOOK_LOGS,
-            data: [{ webhookId: new mongoose.Types.ObjectId(id) }, null, { sort: { createdAt: -1 }, limit: 50 }],
+            data: [{ webhookId }, null, { sort: { createdAt: -1 }, skip, limit: limit + 1 }],
         }, 'find');
-        return res.send({ status: true, statusText: 'Delivery log fetched.', data: logs || [] });
+        const page = (rows || []).slice(0, limit);
+        return res.send({
+            status: true,
+            statusText: 'Delivery log fetched.',
+            data: page,
+            hasMore: (rows || []).length > limit,
+            nextSkip: skip + page.length,
+        });
     } catch (error) {
         logger.error(`ERROR in list webhook logs: ${error.message}`);
         return res.send({ status: false, statusText: error.message });

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -2192,6 +2192,8 @@ export default {
         edit: "Edit",
         delete: "Delete",
         no_logs: "No deliveries recorded yet.",
+        load_more: "Load more",
+        loading: "Loading…",
         event: "Event",
         status: "Status",
         duration: "Duration",

--- a/frontend/src/views/Settings/Integrations/Integrations.vue
+++ b/frontend/src/views/Settings/Integrations/Integrations.vue
@@ -123,6 +123,13 @@
                                                 </tr>
                                             </tbody>
                                         </table>
+                                        <button
+                                            v-if="logsHasMore"
+                                            type="button"
+                                            class="intg-logs-more"
+                                            :disabled="logsBusy"
+                                            @click="loadMoreLogs"
+                                        >{{ logsBusy ? $t('Integrations.loading') : $t('Integrations.load_more') }}</button>
                                     </div>
                                 </div>
                             </div>
@@ -239,7 +246,7 @@ export default { name: 'IntegrationsSettings' };
 <script setup>
 import * as env from '@/config/env';
 import { useToast } from 'vue-toast-notification';
-import { ref, computed, inject, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import SpinnerComp from '@/components/atom/SpinnerComp/SpinnerComp.vue';
 import { apiRequest } from '../../../services';
 import { useI18n } from 'vue-i18n';
@@ -253,7 +260,6 @@ import {
 
 const { t } = useI18n();
 const $toast = useToast();
-const userId = inject('$userId');
 
 const isSpinner = ref(false);
 const webhooks = ref([]);
@@ -262,6 +268,9 @@ const newSecret = ref('');
 const editingId = ref('');
 const logsFor = ref('');
 const logs = ref([]);
+const logsHasMore = ref(false);
+const logsNextSkip = ref(0);
+const logsBusy = ref(false);
 
 const formatOptions = [
     { value: 'slack', label: 'Slack' },
@@ -343,7 +352,9 @@ const submitForm = async () => {
         if (editingId.value) {
             res = await apiRequest('put', `${env.WEBHOOKS}/${editingId.value}`, body);
         } else {
-            res = await apiRequest('post', env.WEBHOOKS, { ...body, userData: { id: userId.value } });
+            // No userData: the server takes the owner from the session token now, since a
+            // caller-supplied id would decide whose integrations it can later read.
+            res = await apiRequest('post', env.WEBHOOKS, body);
         }
         if (!ok(res)) {
             $toast.error((res && res.data && res.data.statusText) || t('Toast.something_went_wrong'), { position: 'top-right' });
@@ -401,18 +412,45 @@ const removeWebhook = async (hook) => {
     }
 };
 
-const viewLogs = async (hook) => {
-    if (logsFor.value === hook._id) { logsFor.value = ''; return; }
+// Delivery logs are paged: a webhook firing on every task event builds thousands of rows,
+// and the panel shows a handful. LOGS_PAGE must match nothing on the server — it caps the
+// request there — this is only what we ask for.
+const LOGS_PAGE = 10;
+
+const loadLogs = async (hookId, append = false) => {
     try {
-        isSpinner.value = true;
-        const res = await apiRequest('get', `${env.WEBHOOKS}/${hook._id}/logs`);
-        logs.value = ok(res) ? (res.data.data || []) : [];
-        logsFor.value = hook._id;
+        if (append) logsBusy.value = true; else isSpinner.value = true;
+        const skip = append ? logsNextSkip.value : 0;
+        const res = await apiRequest('get', `${env.WEBHOOKS}/${hookId}/logs?skip=${skip}&limit=${LOGS_PAGE}`);
+        if (!ok(res)) return;
+        const page = res.data.data || [];
+        logs.value = append ? [...logs.value, ...page] : page;
+        // Trust the server's own count rather than inferring from page length: a full page
+        // is not evidence of more, and a short one is not proof there is nothing left.
+        logsHasMore.value = res.data.hasMore === true;
+        logsNextSkip.value = typeof res.data.nextSkip === 'number' ? res.data.nextSkip : logs.value.length;
     } catch (e) {
         $toast.error(t('Toast.something_went_wrong'), { position: 'top-right' });
     } finally {
         isSpinner.value = false;
+        logsBusy.value = false;
     }
+};
+
+const viewLogs = async (hook) => {
+    if (logsFor.value === hook._id) { logsFor.value = ''; return; }
+    // Opening a different webhook starts a fresh list — carrying the previous one's rows
+    // or its paging offset would show one hook's deliveries under another's name.
+    logs.value = [];
+    logsHasMore.value = false;
+    logsNextSkip.value = 0;
+    await loadLogs(hook._id, false);
+    logsFor.value = hook._id;
+};
+
+const loadMoreLogs = () => {
+    if (logsBusy.value || !logsHasMore.value || !logsFor.value) return;
+    loadLogs(logsFor.value, true);
 };
 
 const copySecret = async () => {
@@ -607,6 +645,21 @@ onMounted(() => {
 .intg-logs-table { width: 100%; border-collapse: collapse; font-size: 12px; }
 .intg-logs-table th { text-align: left; color: #8A909C; font-weight: 600; padding: 4px 8px; }
 .intg-logs-table td { padding: 4px 8px; color: #1F212A; border-top: 1px solid #F2F4F8; }
+.intg-logs-more {
+    display: block;
+    width: 100%;
+    margin-top: 8px;
+    padding: 7px 0;
+    border: 1px solid #E3E6EF;
+    border-radius: 6px;
+    background: #FAFBFD;
+    color: #2F3990;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+.intg-logs-more:hover:not(:disabled) { background: #F2F4FB; }
+.intg-logs-more:disabled { opacity: 0.6; cursor: default; }
 .intg-ok { color: #1B7F3B; }
 .intg-fail { color: #E5484D; }
 


### PR DESCRIPTION
Two changes to the same files, one commit.

## 1. Integrations belong to whoever created them

An integration carries the member's own Slack or Discord URL — but every member of the company saw, edited and deleted every other member's.

**Scoped on every route, not just the list.** Filtering the list alone would have been cosmetic: the rows stayed reachable by id, so another member could still edit one, delete it, or read its delivery logs. `update` and `delete` fold ownership into the **match**, so someone else's webhook is simply *"not found"* — which also tells a prober nothing about whether the id exists. `delete` and `logs` verify before acting.

### Identity had to be fixed first

`/api/v2/webhooks` was in **neither** JWT list — the same hole `/api/v2/pages` and `/api/v2/public-shares` had — and the owner came from `userData` on the request body.

Left alone, "user-specific" would have meant *"specific to whichever user id the caller typed"*. With the list now filtered by owner, that turns a mislabelling bug into a way to **read another member's integrations**. Routes are now JWT-guarded, the owner comes from `req.uid`, and the frontend no longer sends it.

### One judgement call worth review

**Webhooks with no recorded owner stay visible to everyone.** They predate ownership being recorded, and hiding them would leave an *active* integration that nobody can see, edit or delete while it keeps posting company data to whatever URL it holds. Visible and removable beats invisible and running.

The frontend has always stamped the creator, so there probably aren't any — if that's confirmed against the data, this should tighten to strict owner-only.

**Delivery is untouched:** a webhook still fires on company events regardless of who owns it. Only visibility and management changed.

## 2. Delivery logs are paged

The panel pulled **50 rows on every open**, for a webhook that writes a row per task event — the Discord hook in the screenshot that prompted this had a full screen of them.

Now `?skip=&limit=`, **10 by default**, capped at 50 so a caller can't ask for the whole table back.

The query reads **one row past the page** and doesn't return it. That's what makes `hasMore` exact: asking for exactly the page can't distinguish "there are more" from "that was the last one", which leaves a Load more button that does nothing when clicked.

The client appends pages and trusts the server's `hasMore` rather than inferring from page length. Opening a *different* webhook resets the rows and the offset first, or one hook's deliveries would appear under another's name.

## Testing

`npm run build` clean; eslint clean; backend syntax-checked.

- Ownership: every route asserted owner-scoped, `delete`/`logs` asserted to check *before* acting, and the dispatcher asserted unchanged so delivery still fires.
- Paging: the logic was transcribed and walked over a simulated 37-row table — every row seen exactly once, terminates, and the exact-multiple boundaries (10, 20 rows) correctly report no more.

## Worth testing on a second account

The ownership half can't be verified from one login:

- A second user sees only their own integrations
- `Edit` / `Delete` / `Logs` against another user's webhook id are refused
- An existing webhook still delivers after the change
- Logs open at 10, Load more appends, the button disappears on the last page, and opening a second webhook starts a clean list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
