### PR TITLE
feat(chat): add audio and video calling to main chat

### DIFF
--- a/.claude/AUDIO-VIDEO-CALLING-PLAN.md
+++ b/.claude/AUDIO-VIDEO-CALLING-PLAN.md
@@ -1,0 +1,212 @@
+# Audio / Video Calling in Main Chat — Approach & Plan
+
+**Task:** AHE-3839 · **Status:** proposal, nothing built
+**Date:** 2026-08-11
+
+---
+
+## 1. What we already have
+
+Investigated before choosing an approach. Three findings change the answer materially.
+
+**Signalling is already built and authenticated.** `socket/socketinit.js` runs a per-user
+Socket.io namespace, `io.of(/^\/userid_\w+$/)`, gated by JWT verification on the handshake.
+That is precisely what a call needs: a reliable, authenticated way to reach *one specific
+user* on all their open devices. Most WebRTC projects spend their first sprint building
+this. We have it.
+
+**The chat model is 1:1.** A main chat is a task with `mainChat: true` and the two
+participants in `AssigneeUserId[0]` / `AssigneeUserId[1]` (`socket/controller/chatSocket.js`).
+So the common case — ring one person from a conversation — maps directly onto peer-to-peer.
+
+**Media capture patterns already exist.** `MainChatRecorder.vue` already calls
+`navigator.mediaDevices.getUserMedia`, enumerates devices, and handles the unsupported case.
+Permission prompts, device pickers and the "no mic" fallback are solved problems in this
+codebase.
+
+**Nothing WebRTC-related is installed.** No peer, RTC, TURN or SFU dependency in
+`package.json`. Greenfield on the media side.
+
+**Deployment is self-hosted Docker** (`Dockerfile`, `docker-compose.yml`), AGPL-3.0. The
+product's stated positioning is "run on your own servers… no vendor lock-in… compliance
+with data residency requirements". That constrains the choice more than any technical
+factor — see below.
+
+---
+
+## 2. The options
+
+### A. Peer-to-peer WebRTC, signalled over our existing Socket.io
+
+Browsers connect directly; media never touches our server. We only pass the offer/answer
+and ICE candidates through the socket namespace that already exists.
+
+- **Cost:** zero per-minute. No media server.
+- **Privacy:** media is end-to-end between the two browsers. Nothing to store, nothing to
+  leak, nothing for a self-hoster to worry about.
+- **Limit:** each peer uploads its stream to every other peer, so quality collapses past
+  roughly 4 participants. Fine for 1:1, poor for a real "meeting".
+- **Requires TURN** for the minority of networks P2P cannot traverse (see §4).
+
+### B. Self-hosted SFU (LiveKit, mediasoup, Jitsi Videobridge)
+
+A media server receives each participant's stream once and forwards it. Scales to real
+meetings (10–50).
+
+- **Scales properly**, supports screen share and server-side recording.
+- **Cost:** a second server to run, size and secure — for us *and for every self-hoster*.
+  LiveKit is Apache-2.0 and Docker-friendly, which makes this the least painful SFU, but it
+  is still new infrastructure in every deployment.
+- **Effort:** high, and most of it is operational rather than code.
+
+### C. Embed Jitsi Meet (iframe / External API)
+
+Point an iframe at `meet.jit.si` or a self-hosted Jitsi.
+
+- **Fastest to ship** by a wide margin — group calls, screen share and recording for free.
+- **But `meet.jit.si` is a third party.** Media and metadata leave the customer's
+  infrastructure, which contradicts the data-residency promise. Self-hosting Jitsi means
+  running Prosody, Jicofo and JVB — heavier than option B's LiveKit.
+- **Little UI control.** It is someone else's product in a frame; ringing, presence and
+  chat integration sit awkwardly around it.
+
+### D. SaaS provider (Twilio, Daily, Agora, 100ms)
+
+- **Most reliable, least code.**
+- **Wrong shape for this product.** Every self-hoster would need their own account, API
+  keys and per-minute billing before calling worked at all — and media would flow through a
+  vendor. It contradicts the two things AlianHub sells: self-hosting and data control.
+
+---
+
+## 3. Recommendation
+
+**Phase 1: peer-to-peer 1:1 calling (option A), signalled over the existing namespace.
+Phase 2: optional self-hosted SFU (option B) for group meetings, behind config.**
+
+Reasons, in order of weight:
+
+1. **It fits what the product promises.** A, and only A, requires no third party and no new
+   paid dependency. For a self-hosted AGPL product this is close to decisive.
+2. **The expensive half is already built.** Authenticated signalling to a specific user is
+   the part teams underestimate; we have it, tested, in production.
+3. **1:1 is the actual shape of main chat today.** We would be building group calling for a
+   module that has no group conversations modelled — solving a problem we do not yet have.
+4. **It is not a dead end.** Ringing, accept/reject, device selection, permissions, the call
+   window, missed-call messages and reconnect logic are all transport-independent. Adding an
+   SFU later swaps what sits under `getUserMedia` → `PeerConnection`; the surrounding 80%
+   carries over untouched.
+
+**What would change this recommendation:** if "Meeting" in the task title means group calls
+are required in v1, skip straight to LiveKit (B) — mesh will not carry a 6-person call and
+building P2P first would be wasted. That is the single biggest open question (§7).
+
+---
+
+## 4. The two things that decide whether this works
+
+Both are commonly discovered late, and both are infrastructure, not code.
+
+### TURN is not optional
+
+P2P fails on symmetric NAT and restrictive corporate firewalls — in practice **15–20% of
+real-world connections**. Those calls need a TURN relay, which is a server that forwards
+media when a direct path cannot be found.
+
+- Ship **coturn** as an optional service in `docker-compose.yml`.
+- Make the ICE server list **env-driven** (`TURN_URL`, `TURN_USER`, `TURN_PASSWORD`), so a
+  self-hoster can point at their own or a managed TURN.
+- Without TURN configured, calls will work for most users and **silently fail for some**.
+  That must be surfaced in the UI ("could not connect — your network may require a relay"),
+  not left as a mystery.
+- TURN relays media, so it costs bandwidth. Size it for concurrent calls, not total users.
+
+### HTTPS is mandatory
+
+`getUserMedia` only works in a secure context. A self-hoster on plain HTTP will find calling
+silently unavailable. Detect it and say so explicitly rather than showing a dead button.
+
+---
+
+## 5. Implementation plan — Phase 1
+
+Sequenced so each step is independently testable.
+
+**1. Signalling channel** — a `callSocket` controller alongside the existing ones. Events:
+`call:invite`, `call:accept`, `call:reject`, `call:cancel`, `call:end`, `call:ice`,
+`call:offer`, `call:answer`. Routed through the per-user namespace.
+
+**2. Authorisation.** The callee must be verified as a participant of that chat, server-side,
+derived from the chat's `AssigneeUserId` — never from the request body. Without this, anyone
+who can guess a user id can ring anyone in the company. This mirrors the rule already
+established elsewhere in this codebase: identity comes from the session, never the payload.
+
+**3. Multi-device ringing.** A user may have several sockets (tabs, desktop). Ring all of
+them, first to answer wins, immediately cancel the rest — otherwise a call answered on the
+phone keeps ringing the laptop.
+
+**4. Call state machine** — `idle → ringing → connecting → active → ended`, with explicit
+timeouts (no answer after ~45s = missed). Encoded once, server-side, so both clients agree.
+
+**5. Media layer.** `RTCPeerConnection` with the env-driven ICE config; device selection
+reusing the patterns in `MainChatRecorder.vue`; audio-only and video modes.
+
+**6. UI.** Call button in `MainChatHeader.vue`; an incoming-call prompt that is reachable
+from anywhere in the app, not only when the chat is open; an in-call window with mute,
+camera toggle and hang-up.
+
+**7. Chat integration.** Post a system message into the conversation on call end —
+"Call · 4m 12s" or "Missed call" — so history is visible where people look for it.
+
+**8. Failure handling.** Permission denied, no device, insecure context, ICE failure, peer
+disconnect. Each with a message that says what to do.
+
+### Phase 2 (later, if group calling is confirmed)
+
+Add LiveKit as an **optional** service. If `LIVEKIT_URL` is configured, group calls route
+through it; if not, group calling is hidden and 1:1 continues to work P2P. Screen share and
+recording become available at the same time, since the SFU provides both.
+
+---
+
+## 6. What this does **not** cover
+
+Stated so scope is explicit, not discovered mid-build: group meetings (Phase 2), screen
+sharing, recording, calls to external/non-member participants, dial-in numbers, live
+captions, and calling from the Electron tracker app.
+
+---
+
+## 7. Decisions needed before building
+
+1. **Is group calling required in v1?** This is the fork. 1:1 only → build P2P now. Group
+   required → go straight to LiveKit and accept the operational cost.
+2. **Is screen sharing required?** It works P2P for 1:1, so it is cheap in Phase 1 — but
+   only if we know now.
+3. **Is call recording required?** If yes, P2P is the wrong base entirely; recording
+   effectively requires a media server.
+4. **Can we mandate HTTPS + a TURN server** for deployments that want calling, and document
+   it as a requirement?
+5. **Audio-only first?** Roughly 60% of the work for most of the value, and it lets the
+   signalling, ringing and state machine be proven before video is added.
+
+---
+
+## 8. Rough sizing
+
+Phase 1, 1:1 audio + video, assuming the answers above are "1:1, no recording":
+
+| Piece | Estimate |
+|---|---|
+| Signalling controller + authorisation + state machine | 2–3 days |
+| WebRTC media layer, ICE/TURN config, device handling | 3–4 days |
+| UI: call button, incoming prompt, in-call window | 3–4 days |
+| Chat history integration, failure states, polish | 2–3 days |
+| coturn in compose + deployment docs | 1 day |
+
+**≈ 11–15 days** for a solid 1:1 implementation, excluding QA across networks — which is the
+part that always takes longer than expected, because NAT traversal only misbehaves on real
+networks, never on localhost.
+
+Note the current task estimate is **6h**, which is not close to any of these options. Worth
+re-estimating once the scope questions are answered.

--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,36 @@ DEMO_EMAIL=""
 DEMO_PASSWORD=""
 
 # ─────────────────────────────────────────
+# AUDIO / VIDEO CALLING (main chat)
+# ─────────────────────────────────────────
+# Calling is peer-to-peer: media goes browser-to-browser and never touches this
+# server. Two things are needed for it to work in the real world.
+#
+# 1. HTTPS. Browsers only grant microphone and camera access in a secure context,
+#    so calling is unavailable over plain HTTP (localhost excepted). Nothing to
+#    configure here — but on http:// the call buttons will not appear.
+#
+# 2. STUN, and in practice TURN. STUN lets each browser discover its own public
+#    address, which is enough on most home and office networks. TURN relays the
+#    media when a direct path cannot be found — symmetric NAT and strict
+#    corporate firewalls, roughly 15-20% of real connections. WITHOUT TURN those
+#    calls simply fail to connect.
+#
+# Leave these empty to run without a relay: most calls still work, some will not.
+STUN_URLS="stun:stun.l.google.com:19302"
+# Comma-separated, e.g. "turn:turn.example.com:3478,turns:turn.example.com:5349"
+TURN_URLS=""
+# PREFERRED: coturn's `use-auth-secret` / REST mode. The server mints a short-lived
+# credential per request, so nothing long-lived is ever handed to a browser.
+# Must match `static-auth-secret` in turnserver.conf.
+TURN_STATIC_AUTH_SECRET=""
+TURN_CREDENTIAL_TTL_SECONDS=3600
+# FALLBACK: static credentials, for managed TURN providers that offer nothing else.
+# Weaker — this username and password are visible to anyone who opens devtools.
+TURN_USERNAME=""
+TURN_PASSWORD=""
+
+# ─────────────────────────────────────────
 # MISC
 # ─────────────────────────────────────────
 NOOFPRESETCOMPANY=10

--- a/Config/setMiddleware.js
+++ b/Config/setMiddleware.js
@@ -44,6 +44,10 @@ const verifyJWTTokenWithCRoute = [
     // added under it is guarded by default — these were unauthenticated and took the
     // company purely from a header, which is a company id anyone can type.
     "/api/v2/sprints",
+    // Call signalling support (Modules/Calls). The ICE endpoint mints a short-lived TURN
+    // credential, so it must be behind a login — an unauthenticated relay credential is a
+    // relay for the whole internet.
+    "/api/v2/calls",
     "/api/v1/folder",
     "/api/v1/folder/:id",
     "/api/v1/taskIndex",

--- a/Modules/Calls/iceConfig.js
+++ b/Modules/Calls/iceConfig.js
@@ -1,0 +1,88 @@
+const logger = require('../../Config/loggerConfig');
+
+/**
+ * ICE configuration for the browser's RTCPeerConnection (AHE-3839).
+ *
+ * WebRTC needs to find a path between two browsers that are usually both behind NAT.
+ * STUN lets each side discover its own public address, which is enough for most home and
+ * office networks. TURN relays the media when it is not — symmetric NAT and restrictive
+ * corporate firewalls, which is roughly 15-20% of real-world connections.
+ *
+ * Both are read from the environment rather than hardcoded, because this product is
+ * self-hosted: an operator has to be able to point at their own relay, and a deployment
+ * that handles company traffic should not be sending anything to a public STUN server.
+ *
+ * TURN CREDENTIALS ARE NOT SENT AS-IS. A long-lived TURN username and password handed to
+ * the browser is a relay anyone can borrow — it is readable in devtools and works from
+ * anywhere until the day it is rotated. Instead this mints the short-lived HMAC
+ * credential coturn supports (`use-auth-secret` / REST API), so what reaches the client
+ * expires within the hour and the shared secret never leaves the server.
+ */
+
+const DEFAULT_TTL_SECONDS = 3600;
+
+/** coturn's REST scheme: username is "<expiry-unix>:<user>", password is its HMAC-SHA1. */
+const buildTurnCredential = (secret, userId, ttlSeconds) => {
+    const crypto = require('crypto');
+    const expiry = Math.floor(Date.now() / 1000) + ttlSeconds;
+    const username = `${expiry}:${userId || 'anon'}`;
+    const credential = crypto.createHmac('sha1', secret).update(username).digest('base64');
+    return { username, credential };
+};
+
+/**
+ * Build the iceServers array. Exported separately so it can be unit-tested without
+ * standing up Express.
+ */
+const buildIceServers = (env, userId) => {
+    const servers = [];
+
+    const stun = String(env.STUN_URLS || '').split(',').map((s) => s.trim()).filter(Boolean);
+    if (stun.length) servers.push({ urls: stun });
+
+    const turnUrls = String(env.TURN_URLS || '').split(',').map((s) => s.trim()).filter(Boolean);
+    if (turnUrls.length) {
+        const secret = String(env.TURN_STATIC_AUTH_SECRET || '').trim();
+        const ttl = Number(env.TURN_CREDENTIAL_TTL_SECONDS) > 0
+            ? Number(env.TURN_CREDENTIAL_TTL_SECONDS) : DEFAULT_TTL_SECONDS;
+
+        if (secret) {
+            const { username, credential } = buildTurnCredential(secret, userId, ttl);
+            servers.push({ urls: turnUrls, username, credential });
+        } else if (env.TURN_USERNAME && env.TURN_PASSWORD) {
+            // Static credentials. Supported because some managed TURN providers only
+            // offer this, but it is the weaker option — the credential is long-lived and
+            // visible to anyone who opens devtools.
+            servers.push({ urls: turnUrls, username: String(env.TURN_USERNAME), credential: String(env.TURN_PASSWORD) });
+        } else {
+            logger.warn('TURN_URLS is set but no credentials are configured — TURN will be ignored. Set TURN_STATIC_AUTH_SECRET (preferred) or TURN_USERNAME/TURN_PASSWORD.');
+        }
+    }
+
+    return servers;
+};
+
+/* GET /api/v2/calls/ice-config */
+exports.getIceConfig = (req, res) => {
+    try {
+        const iceServers = buildIceServers(process.env, req.uid);
+        return res.status(200).json({
+            status: true,
+            data: {
+                iceServers,
+                // The client shows a plain warning when there is no relay: without TURN a
+                // minority of calls will fail to connect for reasons the user cannot see
+                // or fix, and a silent failure is the worst possible version of that.
+                hasTurn: iceServers.some((s) => String(s.urls).includes('turn')),
+                ttlSeconds: Number(process.env.TURN_CREDENTIAL_TTL_SECONDS) > 0
+                    ? Number(process.env.TURN_CREDENTIAL_TTL_SECONDS) : DEFAULT_TTL_SECONDS,
+            },
+        });
+    } catch (error) {
+        logger.error(`getIceConfig error: ${error && error.message ? error.message : error}`);
+        return res.status(500).json({ status: false, statusText: 'Could not build the ICE configuration.' });
+    }
+};
+
+exports.buildIceServers = buildIceServers;
+exports.buildTurnCredential = buildTurnCredential;

--- a/Modules/Calls/init.js
+++ b/Modules/Calls/init.js
@@ -1,0 +1,5 @@
+const routes = require('./routes');
+
+exports.init = (app) => {
+    routes.init(app);
+}

--- a/Modules/Calls/routes.js
+++ b/Modules/Calls/routes.js
@@ -1,0 +1,8 @@
+const iceConfig = require('./iceConfig');
+
+exports.init = (app) => {
+    // Read-only: the STUN/TURN servers the browser should use, with a short-lived TURN
+    // credential minted per request. Authenticated — a relay handed to anonymous callers
+    // is a relay for the whole internet.
+    app.get('/api/v2/calls/ice-config', iceConfig.getIceConfig);
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,43 @@ services:
     networks:
       - alianhub
 
+  # ── TURN relay for audio/video calling (optional) ──────────────────
+  #
+  # Calls are peer-to-peer, so most connect browser-to-browser with no help.
+  # A minority cannot — symmetric NAT and strict corporate firewalls, roughly
+  # 15-20% of real connections — and those need a relay or they simply fail.
+  #
+  # Disabled by default because it only works with real configuration: a
+  # public IP the relay can advertise, and open ports. Enable with:
+  #
+  #   docker compose --profile calling up -d
+  #
+  # then set in .env:
+  #   TURN_URLS="turn:<your-public-host>:3478"
+  #   TURN_STATIC_AUTH_SECRET="<the same secret as below>"
+  #
+  # NOTE: host networking is used because a relay has to hand out addresses
+  # that are reachable from the outside; behind Docker's NAT it would
+  # advertise an address only the container can reach.
+  coturn:
+    image: coturn/coturn:4.6-alpine
+    container_name: alianhub-coturn
+    restart: unless-stopped
+    profiles: ["calling"]
+    network_mode: host
+    command: >
+      -n
+      --realm=${TURN_REALM:-alianhub}
+      --use-auth-secret
+      --static-auth-secret=${TURN_STATIC_AUTH_SECRET:?set TURN_STATIC_AUTH_SECRET in .env}
+      --external-ip=${TURN_PUBLIC_IP:?set TURN_PUBLIC_IP in .env}
+      --listening-port=3478
+      --min-port=49160
+      --max-port=49200
+      --no-cli
+      --no-tlsv1
+      --no-tlsv1_1
+
 volumes:
   alianhub_mongo_data:
     name: alianhub_mongo_data

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,6 +4,9 @@
 		<DemoBanner/>
 		<template v-if="$route.meta.requiresAuth">
 			<template v-if="logged && (rules && Object.keys(rules).length && companyUserDetail && Object.keys(companyUserDetail).length) && socket">
+                <!-- Mounted at the root so an incoming call rings wherever the user is,
+                     not only when the conversation that called them is on screen. -->
+                <CallOverlay />
                 <HeaderComponent v-if="!$route.meta.hideHeader" @change="changeCompany($event)" @filter="handleFilter"/>
                 <div :style="`height: calc(100dvh - ${$route.meta.hideHeader ? '0' : '46'}px);`" class="billing__history-wrapper style-scroll overflow-auto">
                     <AdvanceSearchModal
@@ -74,6 +77,7 @@ import { computed, defineComponent, onMounted, provide, ref, watch, inject} from
 // COMPONENTS
 import TourCom from "@/components/organisms/Tour/TourComponet.vue"
 import HeaderComponent from '@/components/organisms/Header/Header.vue'
+import CallOverlay from '@/components/organisms/CallOverlay/CallOverlay.vue'
 import AdvanceSearchModal from '@/components/atom/Modal/Modal.vue'
 import Modal from "@/components/atom/Modal/Modal.vue"
 import MainSearchComponent from '@/components/molecules/AdvanceSearch/MainComponent.vue'

--- a/frontend/src/components/organisms/CallOverlay/CallAvatar.vue
+++ b/frontend/src/components/organisms/CallOverlay/CallAvatar.vue
@@ -1,0 +1,79 @@
+<template>
+    <!-- What a camera-off participant looks like: their photo if we have one, otherwise
+         the initial on a colour derived from their name. A black rectangle reads as a
+         broken call; a face or a letter reads as "they turned the camera off". -->
+    <div class="call-av" :style="{ width: px, height: px }">
+        <!-- A direct URL or an inline data: image can go straight into an <img>. -->
+        <img
+            v-if="directSrc && !failed"
+            :src="directSrc"
+            alt=""
+            class="call-av__img"
+            @error="failed = true"
+        />
+        <!-- Anything else is a storage key, not a URL. Putting one in an <img> makes the
+             browser resolve it against the current page, 404, and render the alt text —
+             which is what put a stray name in the middle of the call window. -->
+        <WasabiImage
+            v-else-if="storageKey && !failed"
+            :userImage="true"
+            class="call-av__img"
+            :style="{ width: px, height: px }"
+            :data="{ title: name, url: storageKey, filename: storageKey, extension: extensionOf(storageKey) }"
+            :thumbnail="thumb"
+        />
+        <span v-else class="call-av__letter" :style="{ background: tint, fontSize: letterSize }">{{ initial }}</span>
+    </div>
+</template>
+
+<script setup>
+import { computed, ref, watch, defineProps } from 'vue';
+import WasabiImage from '@/components/atom/WasabiIamgeCompp/WasabiIamgeCompp.vue';
+
+const props = defineProps({
+    name: { type: String, default: '' },
+    image: { type: String, default: '' },
+    size: { type: Number, default: 96 },
+});
+
+// A picture that will not load must fall back to the letter. Without this the browser
+// renders the alt text instead, which looks like a layout bug rather than a missing photo.
+const failed = ref(false);
+watch(() => props.image, () => { failed.value = false; });
+
+// Profile images come in two shapes: a real URL (or an inline data: image), and a bare
+// storage key that only means something to the storage layer.
+const isDirect = (v) => /^(https?:|data:|blob:)/i.test(String(v || ''));
+const directSrc = computed(() => (isDirect(props.image) ? props.image : ''));
+const storageKey = computed(() => (props.image && !isDirect(props.image) ? props.image : ''));
+const extensionOf = (v) => String(v || '').split('.').pop();
+// Ask for a thumbnail near the rendered size rather than the full image.
+const thumb = computed(() => (props.size > 60 ? '80x80' : '40x40'));
+
+const px = computed(() => `${props.size}px`);
+const letterSize = computed(() => `${Math.round(props.size * 0.42)}px`);
+const initial = computed(() => (props.name || '?').trim().charAt(0).toUpperCase() || '?');
+
+/**
+ * A stable colour per person, so the same name always gets the same tile and the letter
+ * becomes recognisable rather than decorative. Hand-picked hues rather than a random
+ * hash: white text has to stay readable on every one of them.
+ */
+const TINTS = ['#3f6fd8', '#2f8f6b', '#a8563f', '#6a4fb3', '#b0863a', '#2f7f96', '#a34a72'];
+const tint = computed(() => {
+    const n = props.name || '';
+    let sum = 0;
+    for (let i = 0; i < n.length; i++) sum += n.charCodeAt(i);
+    return TINTS[sum % TINTS.length];
+});
+</script>
+
+<style scoped>
+.call-av { border-radius: 50%; overflow: hidden; flex: none; }
+.call-av__img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.call-av__letter {
+    width: 100%; height: 100%;
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-weight: 500; line-height: 1; user-select: none;
+}
+</style>

--- a/frontend/src/components/organisms/CallOverlay/CallIcon.vue
+++ b/frontend/src/components/organisms/CallOverlay/CallIcon.vue
@@ -1,0 +1,67 @@
+<template>
+    <!-- Inline SVG rather than image files: these render on both the white ringing card
+         and the dark call window, so they have to take their colour from the button. -->
+    <svg :width="size" :height="size" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+        stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <template v-if="name === 'phone'">
+            <path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3.1 19.5 19.5 0 0 1-6-6A19.8 19.8 0 0 1 2.1 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1.9.3 1.8.6 2.6a2 2 0 0 1-.4 2.1L8.1 9.6a16 16 0 0 0 6 6l1.2-1.2a2 2 0 0 1 2.1-.4c.8.3 1.7.5 2.6.6a2 2 0 0 1 1.7 2Z" />
+        </template>
+        <template v-else-if="name === 'hangup'">
+            <!-- The same handset, rotated — the universal "end call" shape. -->
+            <g transform="rotate(135 12 12)">
+                <path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3.1 19.5 19.5 0 0 1-6-6A19.8 19.8 0 0 1 2.1 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1.9.3 1.8.6 2.6a2 2 0 0 1-.4 2.1L8.1 9.6a16 16 0 0 0 6 6l1.2-1.2a2 2 0 0 1 2.1-.4c.8.3 1.7.5 2.6.6a2 2 0 0 1 1.7 2Z" />
+            </g>
+        </template>
+        <template v-else-if="name === 'video'">
+            <path d="m23 7-7 5 7 5V7Z" />
+            <rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
+        </template>
+        <template v-else-if="name === 'videoOff'">
+            <path d="M16 16v2a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h2m4 0h5a2 2 0 0 1 2 2v3l4-3v9" />
+            <line x1="2" y1="2" x2="22" y2="22" />
+        </template>
+        <template v-else-if="name === 'mic'">
+            <path d="M12 2a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+            <path d="M19 10v1a7 7 0 0 1-14 0v-1" />
+            <line x1="12" y1="19" x2="12" y2="22" />
+        </template>
+        <template v-else-if="name === 'screen'">
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+            <line x1="8" y1="21" x2="16" y2="21" />
+            <line x1="12" y1="17" x2="12" y2="21" />
+        </template>
+        <template v-else-if="name === 'screenOff'">
+            <path d="M22 15V5a2 2 0 0 0-2-2H8m-4 0a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12" />
+            <line x1="8" y1="21" x2="16" y2="21" />
+            <line x1="12" y1="17" x2="12" y2="21" />
+            <line x1="2" y1="2" x2="22" y2="22" />
+        </template>
+        <template v-else-if="name === 'expand'">
+            <polyline points="15 3 21 3 21 9" />
+            <polyline points="9 21 3 21 3 15" />
+            <line x1="21" y1="3" x2="14" y2="10" />
+            <line x1="3" y1="21" x2="10" y2="14" />
+        </template>
+        <template v-else-if="name === 'collapse'">
+            <polyline points="4 14 10 14 10 20" />
+            <polyline points="20 10 14 10 14 4" />
+            <line x1="14" y1="10" x2="21" y2="3" />
+            <line x1="3" y1="21" x2="10" y2="14" />
+        </template>
+        <template v-else-if="name === 'micOff'">
+            <line x1="2" y1="2" x2="22" y2="22" />
+            <path d="M9 9v2a3 3 0 0 0 5.1 2.1M15 9.3V5a3 3 0 0 0-5.9-.7" />
+            <path d="M19 10v1a7 7 0 0 1-.6 2.8M5 10v1a7 7 0 0 0 10.3 6.2" />
+            <line x1="12" y1="19" x2="12" y2="22" />
+        </template>
+    </svg>
+</template>
+
+<script setup>
+import { defineProps } from 'vue';
+
+defineProps({
+    name: { type: String, required: true },
+    size: { type: [Number, String], default: 18 },
+});
+</script>

--- a/frontend/src/components/organisms/CallOverlay/CallIcon.vue
+++ b/frontend/src/components/organisms/CallOverlay/CallIcon.vue
@@ -36,6 +36,16 @@
             <line x1="12" y1="17" x2="12" y2="21" />
             <line x1="2" y1="2" x2="22" y2="22" />
         </template>
+        <template v-else-if="name === 'bell'">
+            <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M13.7 21a2 2 0 0 1-3.4 0" />
+        </template>
+        <template v-else-if="name === 'bellOff'">
+            <path d="M13.7 21a2 2 0 0 1-3.4 0" />
+            <path d="M18.6 13A17 17 0 0 1 18 8a6 6 0 0 0-9.3-5" />
+            <path d="M6.3 6.3A6 6 0 0 0 6 8c0 7-3 9-3 9h14" />
+            <line x1="2" y1="2" x2="22" y2="22" />
+        </template>
         <template v-else-if="name === 'expand'">
             <polyline points="15 3 21 3 21 9" />
             <polyline points="9 21 3 21 3 15" />

--- a/frontend/src/components/organisms/CallOverlay/CallOverlay.vue
+++ b/frontend/src/components/organisms/CallOverlay/CallOverlay.vue
@@ -1,0 +1,357 @@
+<template>
+    <!-- Mounted once at the app root, not inside the chat panel: a call has to be
+         answerable wherever the user happens to be, and an incoming ring that only
+         appears when the right conversation is open is a missed call. -->
+    <Teleport to="body">
+        <!-- Ringing: a compact card, so it interrupts without taking the screen. -->
+        <div v-if="isIncoming" class="call-ring">
+            <div class="call-ring__who">
+                <CallAvatar :name="peerName" :image="peerImage" :size="40" />
+                <div class="call-ring__text">
+                    <span class="call-ring__name">{{ peerName }}</span>
+                    <span class="call-ring__sub">{{ media === 'video' ? $t('call.incoming_video') : $t('call.incoming_audio') }}</span>
+                </div>
+            </div>
+            <div class="call-ring__actions">
+                <button type="button" class="call-btn call-btn--decline" :title="$t('call.decline')" @click="rejectCall">
+                    <CallIcon name="hangup" />
+                </button>
+                <button type="button" class="call-btn call-btn--accept" :title="$t('call.accept')" @click="acceptCall">
+                    <CallIcon :name="media === 'video' ? 'video' : 'phone'" />
+                </button>
+            </div>
+        </div>
+
+        <!-- Connected or dialling: the full window. -->
+        <div v-else-if="isBusy" class="call-win" :class="{ 'call-win--audio': !hasPicture, 'call-win--max': maximized }">
+            <div class="call-win__head">
+                <div class="call-win__id">
+                    <span class="call-win__name">{{ peerName }}</span>
+                    <span class="call-win__status">{{ statusLabel }}</span>
+                </div>
+                <!-- Only worth offering once there is something to look at — which now
+                     includes an audio call that someone is sharing a screen into. -->
+                <button
+                    v-if="hasPicture"
+                    type="button"
+                    class="call-win__expand"
+                    :title="maximized ? $t('call.restore') : $t('call.maximize')"
+                    @click="maximized = !maximized"
+                ><CallIcon :name="maximized ? 'collapse' : 'expand'" :size="15" /></button>
+            </div>
+
+            <div class="call-win__stage">
+                <!-- Remote first: it is the person you are talking to. -->
+                <video
+                    v-show="showRemoteVideo"
+                    ref="remoteVideo"
+                    class="call-win__remote"
+                    autoplay
+                    playsinline
+                ></video>
+                <!-- Their camera being off is a state worth showing, not a black frame.
+                     A disabled track still sends, so without this the other side just
+                     looks broken. -->
+                <div v-if="!showRemoteVideo" class="call-win__avatar">
+                    <CallAvatar :name="peerName" :image="peerImage" :size="maximized ? 140 : 96" />
+                </div>
+                <!-- Their mic, on the stage where their face is — the same place Meet
+                     puts it, because that is where you are already looking. -->
+                <span v-if="isActive && !peerMicOn" class="call-win__badge" :title="$t('call.peer_muted')">
+                    <CallIcon name="micOff" :size="13" />
+                </span>
+                <!-- Muted, or the local mic feeds back into the local speakers. -->
+                <video
+                    v-show="showLocalVideo"
+                    ref="localVideo"
+                    class="call-win__local"
+                    autoplay
+                    playsinline
+                    muted
+                ></video>
+                <!-- Your own tile when your camera is off, in the same spot the preview
+                     occupies, so the corner does not just go black. Only when there is a
+                     picture on the stage — on a plain audio call the whole window is
+                     already the two of you, and a corner tile adds nothing. -->
+                <div v-if="hasPicture && !showLocalVideo" class="call-win__local call-win__local--off">
+                    <CallAvatar :name="myName" :image="myImage" :size="maximized ? 56 : 38" />
+                </div>
+                <!-- Audio calls get a real audio element rather than riding on a hidden
+                     video one. A display:none <video> is not a reliable place to put
+                     sound — this is the element that actually has to make noise. -->
+                <audio ref="remoteAudio" autoplay></audio>
+            </div>
+
+            <p v-if="!hasTurn && !isActive" class="call-win__warn">{{ $t('call.no_turn_warning') }}</p>
+
+            <div class="call-win__actions">
+                <button type="button" class="call-btn" :class="{ 'call-btn--off': !micOn }" :title="micOn ? $t('call.mute') : $t('call.unmute')" @click="toggleMic">
+                    <CallIcon :name="micOn ? 'mic' : 'micOff'" />
+                </button>
+                <button v-if="media === 'video'" type="button" class="call-btn" :class="{ 'call-btn--off': !camOn }" :title="camOn ? $t('call.camera_off') : $t('call.camera_on')" @click="toggleCam">
+                    <CallIcon :name="camOn ? 'video' : 'videoOff'" />
+                </button>
+                <!-- Available on audio calls too: createPeer reserves a video slot even
+                     when there is no camera, so there is always something to swap into. -->
+                <button type="button" class="call-btn" :class="{ 'call-btn--on': isSharing }" :title="isSharing ? $t('call.stop_share') : $t('call.share_screen')" @click="toggleShare">
+                    <CallIcon :name="isSharing ? 'screenOff' : 'screen'" />
+                </button>
+                <button type="button" class="call-btn call-btn--decline" :title="$t('call.hang_up')" @click="hangUp">
+                    <CallIcon name="hangup" />
+                </button>
+            </div>
+        </div>
+
+        <!-- Why the last call did not happen. Dismissible, and never on top of a live call. -->
+        <div v-else-if="errorMessage" class="call-toast" @click="errorMessage = ''">{{ errorMessage }}</div>
+    </Teleport>
+</template>
+
+<script setup>
+import { ref, computed, watch, inject, nextTick, onMounted, onBeforeUnmount } from 'vue';
+import { useStore } from 'vuex';
+import { useCall } from '@/composable/useCall';
+import { useGetterFunctions } from '@/composable';
+import CallAvatar from './CallAvatar.vue';
+import CallIcon from './CallIcon.vue';
+
+const socket = inject('$socket');
+const myUserId = inject('$userId');
+const { getUser } = useGetterFunctions();
+useStore();
+
+const {
+    state, media, peerUserId, errorMessage, micOn, camOn, hasTurn, startedAt,
+    localStream, remoteStream, shareStream, isSharing,
+    peerCamOn, peerMicOn, peerSharing,
+    isIncoming, isBusy, isActive, isOutgoing,
+    bindSocket, acceptCall, rejectCall, hangUp, toggleMic, toggleCam, toggleShare, STATE,
+} = useCall();
+
+// Purely presentational, so it stays here rather than in the call engine.
+const maximized = ref(false);
+
+const remoteVideo = ref(null);
+const remoteAudio = ref(null);
+const localVideo = ref(null);
+const elapsed = ref(0);
+let ticker = null;
+
+const nameOf = (u) => (u && (u.Employee_Name || `${u.Employee_FName || ''} ${u.Employee_LName || ''}`.trim())) || '';
+
+const peerUser = computed(() => (peerUserId.value ? getUser(peerUserId.value) : null));
+const peerName = computed(() => nameOf(peerUser.value) || '—');
+const peerImage = computed(() => (peerUser.value && peerUser.value.Employee_profileImageURL) || '');
+
+const me = computed(() => (myUserId && myUserId.value ? getUser(myUserId.value) : null));
+const myName = computed(() => nameOf(me.value) || '—');
+const myImage = computed(() => (me.value && me.value.Employee_profileImageURL) || '');
+
+// Show the remote picture when there is one: their camera on a video call, or their
+// screen — which can happen on an audio call too, since sharing is allowed there.
+const showRemoteVideo = computed(() => isActive.value
+    && (peerSharing.value || (media.value === 'video' && peerCamOn.value)));
+// Sharing keeps the self-view alive even with the camera off — the screen is the video.
+const showLocalVideo = computed(() => isSharing.value || (media.value === 'video' && camOn.value));
+// An audio call is a narrow window until a screen turns up in it.
+const hasPicture = computed(() => showRemoteVideo.value || showLocalVideo.value);
+
+const statusLabel = computed(() => {
+    if (isActive.value) {
+        const m = Math.floor(elapsed.value / 60);
+        const s = elapsed.value % 60;
+        return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    }
+    if (isOutgoing.value) return 'Ringing…';
+    if (state.value === STATE.CONNECTING) return 'Connecting…';
+    return '';
+});
+
+// The socket is created after login and replaced on a company switch, so bind on both.
+watch(socket, (s) => { if (s) bindSocket(socket); }, { immediate: true });
+
+/**
+ * Attach the streams to their elements.
+ *
+ * srcObject is a property, not an attribute, so it cannot be bound in the template. This
+ * runs on every relevant change because the elements do not exist until the window has
+ * rendered — the stream is often ready before there is anywhere to put it.
+ *
+ * The remote stream goes to exactly ONE element: the video for a video call, the audio
+ * element otherwise. Attaching it to both would play the same voice twice.
+ */
+const attachStreams = async () => {
+    await nextTick();
+    // While sharing, the self-view shows the screen — otherwise you cannot tell what the
+    // other person is actually seeing, which is how people share the wrong window.
+    if (localVideo.value) localVideo.value.srcObject = shareStream.value || localStream.value || null;
+
+    // The remote stream goes wherever it can be seen AND heard. Once a picture is on
+    // screen that is the <video> element, which plays the audio too; until then it is the
+    // <audio> element. Keyed on what is actually visible rather than on the call type,
+    // because a screen shared into an audio call puts a picture on an audio call.
+    const remote = remoteStream.value || null;
+    const useVideo = showRemoteVideo.value;
+    if (remoteVideo.value) remoteVideo.value.srcObject = useVideo ? remote : null;
+    if (remoteAudio.value) remoteAudio.value.srcObject = useVideo ? null : remote;
+
+    // Autoplay can be refused. Say so rather than presenting a silent call as a working
+    // one — a muted call with no explanation is indistinguishable from a broken one.
+    const target = useVideo ? remoteVideo.value : remoteAudio.value;
+    if (target && remote) {
+        try { await target.play(); } catch (e) { errorMessage.value = 'Click anywhere to allow audio playback.'; }
+    }
+};
+
+watch(localStream, attachStreams);
+watch(remoteStream, attachStreams);
+watch(shareStream, attachStreams);
+watch(isBusy, (busy) => { if (busy) attachStreams(); else maximized.value = false; });
+// The window changes size, so the elements re-lay-out and need re-attaching.
+watch(maximized, attachStreams);
+// A hidden <video> is given a null srcObject, so the moment one becomes visible — the
+// far side turning a camera on, or starting to share into an audio call — the stream has
+// to be put back. Without this the element appears with nothing in it and stays black.
+watch(showRemoteVideo, attachStreams);
+watch(showLocalVideo, attachStreams);
+
+/**
+ * Clear the failure toast on its own after a few seconds.
+ *
+ * It reports something that has already finished — the call did not connect, they
+ * declined — so it needs to be read, not acknowledged. Making someone click it leaves a
+ * stale message sitting over the UI until they notice it. Clicking still dismisses it
+ * early. The timer restarts on each new message so a second one gets its full time.
+ */
+const ERROR_VISIBLE_MS = 3000;
+let errorTimer = null;
+watch(errorMessage, (msg) => {
+    clearTimeout(errorTimer);
+    if (!msg) return;
+    errorTimer = setTimeout(() => { errorMessage.value = ''; }, ERROR_VISIBLE_MS);
+});
+
+watch(isActive, (active) => {
+    clearInterval(ticker);
+    if (!active) { elapsed.value = 0; return; }
+    ticker = setInterval(() => {
+        elapsed.value = startedAt.value ? Math.round((Date.now() - startedAt.value) / 1000) : 0;
+    }, 1000);
+});
+
+// A ringing call must survive a page the user is leaving; a live one must not outlive it.
+const warnOnUnload = (e) => { if (isBusy.value) { e.preventDefault(); e.returnValue = ''; } };
+onMounted(() => window.addEventListener('beforeunload', warnOnUnload));
+onBeforeUnmount(() => {
+    window.removeEventListener('beforeunload', warnOnUnload);
+    clearInterval(ticker);
+    clearTimeout(errorTimer);
+});
+</script>
+
+<style scoped>
+/* These three are teleported to <body>, which puts them OUTSIDE #app — and #app is where
+   the app's font-family lives. Without restating it here the text falls back to the
+   browser's default serif, which is why every teleported surface has to set its own. */
+.call-ring,
+.call-win,
+.call-toast {
+    font-family: 'Roboto', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+/* Ringing card — bottom right, above everything, small enough to ignore for a moment. */
+.call-ring {
+    position: fixed; right: 20px; bottom: 20px; z-index: 3000;
+    display: flex; align-items: center; gap: 18px;
+    padding: 14px 16px; border-radius: 14px;
+    background: #fff; box-shadow: 0 12px 34px rgba(23, 30, 52, .22);
+    animation: call-ring-in .18s ease-out;
+}
+@keyframes call-ring-in { from { transform: translateY(8px); opacity: 0; } to { transform: none; opacity: 1; } }
+.call-ring__who { display: flex; align-items: center; gap: 11px; }
+.call-ring__text { display: flex; flex-direction: column; }
+.call-ring__name { font-size: 13.5px; font-weight: 600; color: #1e2436; }
+.call-ring__sub { font-size: 11.5px; color: #7b8496; }
+.call-ring__actions { display: flex; gap: 9px; }
+
+/* In-call window. */
+.call-win {
+    position: fixed; right: 20px; bottom: 20px; z-index: 3000;
+    width: 340px; border-radius: 14px; overflow: hidden;
+    background: #171e2e; color: #fff;
+    box-shadow: 0 16px 40px rgba(23, 30, 52, .32);
+    display: flex; flex-direction: column;
+}
+.call-win--audio { width: 280px; }
+/* Maximised: fills the viewport bar a margin, so it reads as a window rather than as the
+   browser having gone fullscreen. The stage takes the slack, which is the only thing
+   worth enlarging. */
+.call-win--max {
+    right: 24px; bottom: 24px; left: 24px; top: 24px;
+    width: auto; max-height: none;
+}
+.call-win--max .call-win__stage { flex: 1 1 auto; min-height: 0; }
+.call-win--max .call-win__remote { max-height: none; height: 100%; }
+.call-win--max .call-win__local { width: 190px; height: 132px; right: 16px; bottom: 16px; }
+.call-win__head { padding: 12px 14px 8px; display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+.call-win__id { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.call-win__expand {
+    flex: none; width: 26px; height: 26px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border: none; border-radius: 6px; background: transparent;
+    color: #97a1b5; cursor: pointer; transition: background .12s ease, color .12s ease;
+}
+.call-win__expand:hover { background: #2b3448; color: #fff; }
+.call-win__name { font-size: 13.5px; font-weight: 600; }
+.call-win__status { font-size: 11.5px; color: #97a1b5; font-variant-numeric: tabular-nums; }
+.call-win__stage { position: relative; background: #0f1421; min-height: 150px; display: flex; align-items: center; justify-content: center; }
+.call-win--audio .call-win__stage { min-height: 120px; }
+.call-win__remote { width: 100%; max-height: 240px; object-fit: cover; display: block; background: #0f1421; }
+.call-win__avatar { padding: 22px 0; }
+/* Picture-in-picture, deliberately small: the point of the window is the other person. */
+.call-win__local {
+    position: absolute; right: 10px; bottom: 10px;
+    width: 84px; height: 62px; object-fit: cover;
+    border-radius: 8px; border: 2px solid rgba(255, 255, 255, .18); background: #0f1421;
+}
+.call-win__local--off { display: flex; align-items: center; justify-content: center; }
+/* Their mic state, pinned to the stage. Top-left so it never collides with the
+   self-view in the opposite corner. */
+.call-win__badge {
+    position: absolute; left: 10px; top: 10px;
+    width: 26px; height: 26px; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: rgba(214, 69, 80, .92); color: #fff;
+}
+.call-win__warn { margin: 0; padding: 8px 14px; font-size: 11px; color: #f0b46b; background: rgba(240, 180, 107, .1); }
+.call-win__actions { display: flex; align-items: center; justify-content: center; gap: 12px; padding: 12px; }
+
+.call-btn {
+    width: 42px; height: 42px; border: none; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: #2b3448; color: #fff; cursor: pointer;
+    transition: background .12s ease, transform .08s ease;
+}
+.call-btn:hover { background: #384360; }
+.call-btn:active { transform: scale(.94); }
+.call-btn--off { background: #4a5268; color: #c4cbd9; }
+/* Sharing is a state worth seeing at a glance — it is the one control that keeps
+   broadcasting after you have looked away from the window. */
+.call-btn--on { background: #2f7de1; }
+.call-btn--on:hover { background: #2a6ec8; }
+.call-btn--accept { background: #22a06b; }
+.call-btn--accept:hover { background: #1c8a5b; }
+.call-btn--decline { background: #d64550; }
+.call-btn--decline:hover { background: #bb3a44; }
+/* The ringing card sits on white, so its buttons need their own resting colour. */
+.call-ring .call-btn { box-shadow: 0 2px 8px rgba(23, 30, 52, .18); }
+
+.call-toast {
+    position: fixed; right: 20px; bottom: 20px; z-index: 3000;
+    max-width: 300px; padding: 11px 14px; border-radius: 10px;
+    background: #1e2436; color: #fff; font-size: 12.5px; cursor: pointer;
+    box-shadow: 0 10px 26px rgba(23, 30, 52, .22);
+}
+</style>

--- a/frontend/src/components/organisms/CallOverlay/CallOverlay.vue
+++ b/frontend/src/components/organisms/CallOverlay/CallOverlay.vue
@@ -13,6 +13,17 @@
                 </div>
             </div>
             <div class="call-ring__actions">
+                <!-- Silence the ringer, remembered for next time. Offered here because
+                     this is the moment somebody wants it, not buried in a settings page
+                     they would have to go and find while the phone is ringing. -->
+                <button
+                    type="button"
+                    class="call-ring__quiet"
+                    :title="sound.muted.value ? $t('call.sound_on') : $t('call.sound_off')"
+                    @click="sound.toggleMuted()"
+                >
+                    <CallIcon :name="sound.muted.value ? 'bellOff' : 'bell'" :size="15" />
+                </button>
                 <button type="button" class="call-btn call-btn--decline" :title="$t('call.decline')" @click="rejectCall">
                     <CallIcon name="hangup" />
                 </button>
@@ -111,6 +122,7 @@
 import { ref, computed, watch, inject, nextTick, onMounted, onBeforeUnmount } from 'vue';
 import { useStore } from 'vuex';
 import { useCall } from '@/composable/useCall';
+import { useCallSound } from '@/composable/useCallSound';
 import { useGetterFunctions } from '@/composable';
 import CallAvatar from './CallAvatar.vue';
 import CallIcon from './CallIcon.vue';
@@ -127,6 +139,8 @@ const {
     isIncoming, isBusy, isActive, isOutgoing,
     bindSocket, acceptCall, rejectCall, hangUp, toggleMic, toggleCam, toggleShare, STATE,
 } = useCall();
+
+const sound = useCallSound();
 
 // Purely presentational, so it stays here rather than in the call engine.
 const maximized = ref(false);
@@ -231,6 +245,22 @@ watch(errorMessage, (msg) => {
     errorTimer = setTimeout(() => { errorMessage.value = ''; }, ERROR_VISIBLE_MS);
 });
 
+/**
+ * The tones follow the call's own state machine rather than individual events, so every
+ * way out — answered, declined, cancelled, timed out, taken on another device, the socket
+ * dropping — lands here and silences the ring. A ring that outlives its call is worse than
+ * no ring at all, and hanging it off the happy path is how that happens.
+ */
+watch(state, (now, was) => {
+    if (now === STATE.INCOMING) { sound.startIncoming(); return; }
+    if (now === STATE.OUTGOING) { sound.startRingback(); return; }
+    sound.stop();
+    if (now === STATE.ACTIVE && was !== STATE.ACTIVE) sound.connected();
+    // Only a call that actually connected is worth a goodbye; a declined one already
+    // said what it had to say.
+    if (now === STATE.IDLE && was === STATE.ACTIVE) sound.ended();
+});
+
 watch(isActive, (active) => {
     clearInterval(ticker);
     if (!active) { elapsed.value = 0; return; }
@@ -246,6 +276,9 @@ onBeforeUnmount(() => {
     window.removeEventListener('beforeunload', warnOnUnload);
     clearInterval(ticker);
     clearTimeout(errorTimer);
+    // A ring is on a timer, not tied to this component's life — without this it keeps
+    // going after the overlay is gone.
+    sound.stop();
 });
 </script>
 
@@ -274,7 +307,16 @@ onBeforeUnmount(() => {
 .call-ring__text { display: flex; flex-direction: column; }
 .call-ring__name { font-size: 13.5px; font-weight: 600; color: #1e2436; }
 .call-ring__sub { font-size: 11.5px; color: #7b8496; }
-.call-ring__actions { display: flex; gap: 9px; }
+.call-ring__actions { display: flex; align-items: center; gap: 9px; }
+/* Deliberately plain next to accept and decline: silencing the ringer is a preference,
+   not one of the two answers being asked for. */
+.call-ring__quiet {
+    width: 28px; height: 28px; flex: none;
+    display: inline-flex; align-items: center; justify-content: center;
+    border: none; border-radius: 50%; background: transparent;
+    color: #9aa3b4; cursor: pointer; transition: background .12s ease, color .12s ease;
+}
+.call-ring__quiet:hover { background: #eef0f5; color: #5b6472; }
 
 /* In-call window. */
 .call-win {

--- a/frontend/src/components/organisms/MainChat/MainChatHeader.vue
+++ b/frontend/src/components/organisms/MainChat/MainChatHeader.vue
@@ -1,5 +1,10 @@
 <template>
     <header class="mc-head">
+        <!-- Anything that has to sit left of the conversation, e.g. the button that
+             brings the list back on a narrow screen. Empty on wide layouts, where the
+             list is always visible and there is nothing to go back to. -->
+        <slot name="lead"></slot>
+
         <MainChatConversationIcon
             :title="title"
             :avatar-src="avatarSrc"

--- a/frontend/src/components/organisms/MainChat/MainChatPanel.vue
+++ b/frontend/src/components/organisms/MainChat/MainChatPanel.vue
@@ -15,9 +15,31 @@
             @pinned="toggleRightPane('pinned')"
             @info="toggleRightPane('info')"
         >
-            <!-- forwarded so the parent can drop in call buttons later without
-                 this panel knowing about calling -->
-            <template #call-actions><slot name="call-actions"></slot></template>
+            <!-- Forwarded so the page that owns the layout can put its own control here.
+                 The panel does not know whether a conversation list exists beside it. -->
+            <template #lead><slot name="header-lead"></slot></template>
+            <template #call-actions>
+                <!-- Calling is one-to-one only: a channel has many members and no peer to
+                     ring. It also needs a real conversation task to authorise against, so
+                     a chat that has not sent its first message yet cannot start one. -->
+                <template v-if="canCall">
+                    <button
+                        type="button"
+                        class="mc-icon-btn"
+                        :disabled="callBusy"
+                        :title="$t('call.start_audio')"
+                        @click="startCall(effectiveTaskId, 'audio')"
+                    ><CallIcon name="phone" :size="16" /></button>
+                    <button
+                        type="button"
+                        class="mc-icon-btn"
+                        :disabled="callBusy"
+                        :title="$t('call.start_video')"
+                        @click="startCall(effectiveTaskId, 'video')"
+                    ><CallIcon name="video" :size="16" /></button>
+                </template>
+                <slot name="call-actions"></slot>
+            </template>
             <template #actions><slot name="header-actions"></slot></template>
         </MainChatHeader>
 
@@ -143,6 +165,8 @@ import MainChatMessageList from './MainChatMessageList.vue';
 import MainChatComposer from './MainChatComposer.vue';
 import MainChatInfo from './MainChatInfo.vue';
 import MainChatSearch from './MainChatSearch.vue';
+import CallIcon from '@/components/organisms/CallOverlay/CallIcon.vue';
+import { useCall } from '@/composable/useCall';
 import { useMainChatConversation } from './useMainChatConversation';
 
 const props = defineProps({
@@ -214,6 +238,18 @@ const effectiveTaskId = computed(() => {
 });
 
 const conversationKey = computed(() => `${(projectData && projectData.value && projectData.value._id) || ''}:${props.sprintId}:${effectiveTaskId.value || props.taskId}`);
+
+// ─── Calling ────────────────────────────────────────────────────────────────────
+// One-to-one only, and only once the conversation task exists — the server authorises
+// a call by loading that task and checking the caller is one of its two participants,
+// so there is nothing to authorise against before the first message is sent.
+const { startCall, isBusy: callBusy, isSupported: callSupported, isSecure: callSecure } = useCall();
+const canCall = computed(() => !props.isChannel
+    && isDefaultProject.value
+    && !!effectiveTaskId.value
+    && effectiveTaskId.value !== 'default'
+    && callSupported()
+    && callSecure());
 
 const emptyTitle = computed(() => (props.isChannel
     ? t('MainChat.empty_channel')

--- a/frontend/src/components/organisms/MainChat/style.css
+++ b/frontend/src/components/organisms/MainChat/style.css
@@ -51,6 +51,16 @@
     min-height: var(--mc-header-h);
     box-sizing: border-box;
 }
+/* The back-to-list control on narrow screens. Sits before the conversation icon, so it
+   reads as "out of here" rather than as one more action on the conversation. */
+.mc-head-back {
+    flex: none;
+    width: 20px; height: 20px;
+    cursor: pointer;
+    opacity: .7;
+    transition: opacity .12s ease;
+}
+.mc-head-back:hover { opacity: 1; }
 .mc-head-id { min-width: 0; display: flex; flex-direction: column; }
 .mc-head-name {
     font-size: 14.5px; font-weight: 700; color: var(--mc-ink);

--- a/frontend/src/composable/useCall.js
+++ b/frontend/src/composable/useCall.js
@@ -1,0 +1,532 @@
+import { ref, computed, readonly } from 'vue';
+import { apiRequest } from '@/services';
+import * as env from '@/config/env';
+
+/**
+ * Audio / video calling for main chat (AHE-3839).
+ *
+ * One call at a time, one engine for the whole app. It is a module-level singleton rather
+ * than per-component state because an incoming call has to be answerable from wherever the
+ * user happens to be — not only when the conversation that rang them is on screen.
+ *
+ * Media is peer-to-peer: the two browsers connect directly and the server only carries the
+ * offer, the answer and ICE candidates. Nothing to record, nothing to store, nothing that
+ * leaves a self-hoster's network.
+ *
+ *   idle → outgoing → connecting → active → idle        (caller)
+ *   idle → incoming → connecting → active → idle        (callee)
+ */
+
+const STATE = { IDLE: 'idle', OUTGOING: 'outgoing', INCOMING: 'incoming', CONNECTING: 'connecting', ACTIVE: 'active' };
+
+const state = ref(STATE.IDLE);
+const callId = ref('');
+const chatId = ref('');
+const media = ref('audio');            // 'audio' | 'video'
+const peerUserId = ref('');
+const errorMessage = ref('');
+const micOn = ref(true);
+const camOn = ref(true);
+const hasTurn = ref(true);             // assume yes until told otherwise
+const startedAt = ref(0);
+const localStream = ref(null);
+const remoteStream = ref(null);
+const isSharing = ref(false);
+const shareStream = ref(null);     // what the local preview shows while sharing
+// The far side's mic/camera. Assume on until told otherwise, so a peer whose browser
+// never sends state is shown normally rather than permanently "camera off".
+const peerCamOn = ref(true);
+const peerMicOn = ref(true);
+const peerSharing = ref(false);
+
+let pc = null;                         // RTCPeerConnection
+let socketRef = null;
+let boundSocket = null;                // so listeners are bound exactly once per socket
+let iceServers = [];
+// Candidates can arrive before the remote description is set; applying one then throws.
+let pendingCandidates = [];
+// The camera track, parked while the screen is being shared so it can be put back.
+let cameraTrack = null;
+// The transceiver carrying our outgoing video — the camera on a video call, an empty slot
+// on an audio one. Kept so screen sharing has something to swap into either way.
+let videoTx = null;
+
+const isSupported = () => typeof navigator !== 'undefined'
+    && !!navigator.mediaDevices
+    && typeof navigator.mediaDevices.getUserMedia === 'function'
+    && typeof window.RTCPeerConnection === 'function';
+
+// getUserMedia only exists in a secure context. On plain HTTP the API is simply absent,
+// which reads as "your browser is broken" unless we name the real reason.
+const isSecure = () => (typeof window !== 'undefined')
+    && (window.isSecureContext || ['localhost', '127.0.0.1'].includes(window.location.hostname));
+
+const emit = (event, payload) => { if (socketRef && socketRef.value) socketRef.value.emit(event, payload); };
+
+const stopStream = (streamRef) => {
+    if (streamRef.value) {
+        streamRef.value.getTracks().forEach((t) => { try { t.stop(); } catch (e) { /* already stopped */ } });
+        streamRef.value = null;
+    }
+};
+
+/**
+ * Share the screen instead of the camera.
+ *
+ * Swaps the track on the existing sender rather than adding a second one. replaceTrack
+ * needs no renegotiation — no new offer, no answer, nothing for the other side to do —
+ * so the switch is instant and cannot fail halfway. Adding a track would mean a fresh
+ * offer/answer round trip, and a call that has to renegotiate mid-flight is a call that
+ * can break mid-flight.
+ */
+/**
+ * The sender that carries our outgoing video.
+ *
+ * Held from when the connection was built rather than searched for. On an audio call the
+ * slot exists but its track is null, so any search that matches on `track.kind === video`
+ * would miss precisely the case screen sharing needs.
+ */
+const videoSender = () => (videoTx && videoTx.sender)
+    || (pc && pc.getSenders().find((s) => s.track && s.track.kind === 'video'))
+    || null;
+
+/**
+ * Take the video transceiver the offer created, and make sure we are allowed to send on it.
+ *
+ * Run by the ANSWERER right after setRemoteDescription. The offer carries a video m-line,
+ * which creates a transceiver on this side; on an audio call it arrives with no track of
+ * ours attached. Its direction may be 'recvonly' from our point of view, which would let
+ * us receive their screen but silently drop ours — the exact asymmetry where the caller's
+ * share is visible and the callee's is not. Setting it to sendrecv before building the
+ * answer is what makes sharing work in both directions.
+ */
+const adoptVideoTransceiver = () => {
+    if (!pc || videoTx) return;
+    const tx = pc.getTransceivers().find((t) => {
+        const rk = t.receiver && t.receiver.track && t.receiver.track.kind;
+        const sk = t.sender && t.sender.track && t.sender.track.kind;
+        return rk === 'video' || sk === 'video';
+    });
+    if (!tx) return;
+    videoTx = tx;
+    if (tx.direction !== 'sendrecv') {
+        try { tx.direction = 'sendrecv'; } catch (e) { /* fixed by the browser */ }
+    }
+};
+
+const startScreenShare = async () => {
+    if (!pc || isSharing.value) return;
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
+        errorMessage.value = 'This browser cannot share the screen.';
+        return;
+    }
+    // In a video call the sender already carries the camera; in an audio call it is the
+    // empty slot reserved in createPeer, whose track is null — so match on the
+    // transceiver, not on a track that may not be there yet.
+    const sender = videoSender();
+    if (!sender) { errorMessage.value = 'Screen sharing is not available on this call.'; return; }
+
+    let display;
+    try {
+        display = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false });
+    } catch (e) {
+        // Cancelling the picker is a normal outcome, not a failure to report.
+        return;
+    }
+
+    const track = display.getVideoTracks()[0];
+    if (!track) return;
+    cameraTrack = sender.track;
+    await sender.replaceTrack(track);
+    shareStream.value = display;
+    isSharing.value = true;
+    sendMediaState();
+
+    // The browser draws its own "Stop sharing" bar; ending it there must end it here too,
+    // or the UI keeps claiming to share a screen that is already gone.
+    track.onended = () => { stopScreenShare(); };
+};
+
+const stopScreenShare = async () => {
+    if (!isSharing.value) return;
+    isSharing.value = false;
+    sendMediaState();
+    // Put the camera back on a video call; on an audio call there was never one, so the
+    // slot goes back to sending nothing (replaceTrack(null) is how that is said).
+    const sender = videoSender();
+    if (sender) {
+        try { await sender.replaceTrack(cameraTrack || null); } catch (e) { /* call already gone */ }
+    }
+    cameraTrack = null;
+    if (shareStream.value) {
+        shareStream.value.getTracks().forEach((t) => { try { t.stop(); } catch (e) { /* stopped */ } });
+        shareStream.value = null;
+    }
+};
+
+const toggleShare = () => (isSharing.value ? stopScreenShare() : startScreenShare());
+
+const teardown = () => {
+    if (pc) {
+        // Drop the handlers before closing: a closing connection still fires state events,
+        // and a late onconnectionstatechange would reset a call that has already started.
+        pc.onicecandidate = null;
+        pc.ontrack = null;
+        pc.onconnectionstatechange = null;
+        try { pc.close(); } catch (e) { /* already closed */ }
+        pc = null;
+    }
+    stopStream(localStream);
+    stopStream(shareStream);
+    remoteStream.value = null;
+    isSharing.value = false;
+    cameraTrack = null;
+    videoTx = null;
+    peerCamOn.value = true;
+    peerMicOn.value = true;
+    peerSharing.value = false;
+    pendingCandidates = [];
+    callId.value = '';
+    chatId.value = '';
+    peerUserId.value = '';
+    startedAt.value = 0;
+    micOn.value = true;
+    camOn.value = true;
+    state.value = STATE.IDLE;
+};
+
+const loadIceServers = async () => {
+    try {
+        const res = await apiRequest('get', `${env.CALL_ICE_CONFIG}`);
+        const d = (res && res.data && res.data.data) || {};
+        iceServers = Array.isArray(d.iceServers) ? d.iceServers : [];
+        hasTurn.value = d.hasTurn !== false;
+    } catch (e) {
+        // A missing relay config is not fatal — most networks connect without one.
+        iceServers = [];
+        hasTurn.value = false;
+    }
+};
+
+const getMedia = async (kind) => {
+    const constraints = kind === 'video'
+        ? { audio: true, video: { width: { ideal: 1280 }, height: { ideal: 720 } } }
+        : { audio: true, video: false };
+    return navigator.mediaDevices.getUserMedia(constraints);
+};
+
+/**
+ * @param {boolean} isOfferer  true for the side that creates the offer.
+ *
+ * Only the OFFERER reserves the spare video slot. The answerer must not: an
+ * addTransceiver on the answering side does not reliably associate with the video m-line
+ * already in the offer, so it can end up sending on a transceiver the offerer never
+ * negotiated — which looks exactly like "their screen share works, mine doesn't". The
+ * answerer instead adopts the transceiver the offer brings with it (see the offer
+ * handler), which is what already makes video calls work in both directions: there, both
+ * sides get their video transceiver from addTrack.
+ */
+const createPeer = (isOfferer) => {
+    pc = new RTCPeerConnection({ iceServers });
+
+    pc.onicecandidate = (e) => {
+        if (e.candidate) emit('call:signal', { callId: callId.value, kind: 'ice', payload: e.candidate });
+    };
+
+    pc.ontrack = (e) => {
+        // Take the stream the sender attached (addTrack was given one), not a stream we
+        // build here. Assigning an EMPTY MediaStream to the element and then adding
+        // tracks to it is a race: the element can latch on to it while it still has no
+        // tracks and then never play. Using e.streams[0] means the object already has
+        // its tracks by the time it reaches the element.
+        const incoming = (e.streams && e.streams[0]) || null;
+        if (incoming) {
+            remoteStream.value = incoming;
+            return;
+        }
+        // A NEW MediaStream, not the existing one mutated in place. Reassigning the same
+        // object to the ref is not a change as far as Vue is concerned, so the watcher
+        // that attaches it to the element would never fire and the track would arrive
+        // with nowhere to go.
+        const merged = new MediaStream(remoteStream.value ? remoteStream.value.getTracks() : []);
+        merged.addTrack(e.track);
+        remoteStream.value = merged;
+    };
+
+    // Loud on purpose. When a call connects but nobody can hear anything, the answer is
+    // almost always in these two lines, and without them there is nothing to go on.
+    pc.oniceconnectionstatechange = () => {
+        if (pc) console.info('[call] ice:', pc.iceConnectionState);
+    };
+
+    pc.onconnectionstatechange = () => {
+        if (!pc) return;
+        console.info('[call] connection:', pc.connectionState);
+        if (pc.connectionState === 'connected') {
+            state.value = STATE.ACTIVE;
+            if (!startedAt.value) startedAt.value = Date.now();
+            // Announce our starting state. Someone who muted before the call connected
+            // would otherwise be shown as unmuted until they touched a control.
+            sendMediaState();
+        } else if (['failed', 'closed'].includes(pc.connectionState)) {
+            // 'failed' after ICE has exhausted its candidates is the no-relay case.
+            if (state.value !== STATE.IDLE) {
+                errorMessage.value = hasTurn.value
+                    ? 'The call could not connect.'
+                    : 'The call could not connect. This network needs a TURN relay, which is not configured.';
+            }
+            hangUp();
+        }
+    };
+
+    localStream.value.getTracks().forEach((track) => pc.addTrack(track, localStream.value));
+
+    // An audio call has no video track, so there would be no sender to swap when someone
+    // wants to share their screen — sharing would need a mid-call renegotiation, and a
+    // call that renegotiates mid-flight is a call that can break mid-flight. Reserving an
+    // empty video slot now makes sharing the same instant replaceTrack in both kinds of
+    // call. It costs one extra m-line in the SDP and nothing at runtime.
+    const localVideoTrack = localStream.value.getVideoTracks()[0] || null;
+    videoTx = localVideoTrack
+        ? pc.getTransceivers().find((t) => t.sender && t.sender.track === localVideoTrack) || null
+        : null;
+    if (!videoTx && isOfferer) {
+        try {
+            // `streams` matters: without it the far side receives a video track that
+            // belongs to no MediaStream, so e.streams is empty and the track never joins
+            // the stream their <video> is bound to. Naming the same stream as the audio
+            // means both tracks arrive together, in one object.
+            videoTx = pc.addTransceiver('video', { direction: 'sendrecv', streams: [localStream.value] });
+        } catch (e) {
+            videoTx = null;
+        }
+    }
+};
+
+const flushPendingCandidates = async () => {
+    const queued = pendingCandidates;
+    pendingCandidates = [];
+    for (const c of queued) {
+        try { await pc.addIceCandidate(c); } catch (e) { /* candidate no longer applies */ }
+    }
+};
+
+/** Ring someone in a conversation. `kind` is 'audio' or 'video'. */
+const startCall = async (conversationId, kind = 'audio') => {
+    errorMessage.value = '';
+    if (state.value !== STATE.IDLE) return;
+    if (!isSecure()) { errorMessage.value = 'Calling needs a secure (HTTPS) connection.'; return; }
+    if (!isSupported()) { errorMessage.value = 'This browser cannot make calls.'; return; }
+
+    try {
+        await loadIceServers();
+        localStream.value = await getMedia(kind);
+    } catch (e) {
+        errorMessage.value = e && e.name === 'NotAllowedError'
+            ? 'Microphone and camera access was blocked.'
+            : 'No microphone or camera was found.';
+        return;
+    }
+
+    chatId.value = String(conversationId);
+    media.value = kind;
+    state.value = STATE.OUTGOING;
+    emit('call:invite', { chatId: chatId.value, media: kind });
+};
+
+/** Answer the call currently ringing. */
+const acceptCall = async () => {
+    if (state.value !== STATE.INCOMING) return;
+    try {
+        await loadIceServers();
+        localStream.value = await getMedia(media.value);
+    } catch (e) {
+        errorMessage.value = e && e.name === 'NotAllowedError'
+            ? 'Microphone and camera access was blocked.'
+            : 'No microphone or camera was found.';
+        emit('call:reject', { callId: callId.value, reason: 'no_media' });
+        teardown();
+        return;
+    }
+    state.value = STATE.CONNECTING;
+    emit('call:accept', { callId: callId.value });
+};
+
+const rejectCall = () => {
+    if (state.value !== STATE.INCOMING) return;
+    emit('call:reject', { callId: callId.value, reason: 'declined' });
+    teardown();
+};
+
+/** Hang up, whatever stage we are at — the server works out what that means. */
+const hangUp = () => {
+    if (state.value === STATE.IDLE) return;
+    if (state.value === STATE.OUTGOING) emit('call:cancel', { callId: callId.value });
+    else if (state.value === STATE.INCOMING) emit('call:reject', { callId: callId.value, reason: 'declined' });
+    else emit('call:end', { callId: callId.value });
+    teardown();
+};
+
+/**
+ * Tell the other side what our mic and camera are doing.
+ *
+ * A disabled track is not a stopped track — it keeps sending black frames and silence.
+ * So "camera off" has to be said out loud; the far side cannot infer it from the media,
+ * and without this it just sees a black rectangle and assumes the call is broken.
+ */
+const sendMediaState = () => {
+    if (!callId.value) return;
+    emit('call:signal', {
+        callId: callId.value,
+        kind: 'state',
+        payload: { camOn: camOn.value, micOn: micOn.value, sharing: isSharing.value },
+    });
+};
+
+const toggleMic = () => {
+    if (!localStream.value) return;
+    micOn.value = !micOn.value;
+    localStream.value.getAudioTracks().forEach((t) => { t.enabled = micOn.value; });
+    sendMediaState();
+};
+
+const toggleCam = () => {
+    if (!localStream.value) return;
+    camOn.value = !camOn.value;
+    localStream.value.getVideoTracks().forEach((t) => { t.enabled = camOn.value; });
+    sendMediaState();
+};
+
+/**
+ * Bind the socket listeners. Safe to call repeatedly — App re-creates the socket on a
+ * company switch, and binding twice would double every event.
+ */
+const bindSocket = (socket) => {
+    socketRef = socket;
+    const s = socket && socket.value;
+    if (!s || boundSocket === s) return;
+    boundSocket = s;
+
+    s.on('call:incoming', ({ callId: id, chatId: cid, media: kind, from }) => {
+        // Already busy: let the server's own busy check stand, but never let a second
+        // ring overwrite the call in progress.
+        if (state.value !== STATE.IDLE) return;
+        callId.value = id;
+        chatId.value = String(cid || '');
+        media.value = kind === 'video' ? 'video' : 'audio';
+        peerUserId.value = String(from || '');
+        state.value = STATE.INCOMING;
+    });
+
+    s.on('call:ringing', ({ callId: id, to }) => {
+        callId.value = id;
+        // Who we are ringing. Only the server knows — the caller picked a conversation,
+        // not a person — so without this the outgoing window has no name to show.
+        if (to) peerUserId.value = String(to);
+    });
+
+    // The caller creates the offer once the callee has picked up — not before, so the
+    // media only starts flowing to someone who actually answered.
+    s.on('call:accepted', async ({ callId: id, by }) => {
+        if (state.value !== STATE.OUTGOING) return;
+        callId.value = id;
+        peerUserId.value = String(by || '');
+        state.value = STATE.CONNECTING;
+        try {
+            createPeer(true);
+            const offer = await pc.createOffer();
+            await pc.setLocalDescription(offer);
+            emit('call:signal', { callId: id, kind: 'offer', payload: offer });
+        } catch (e) {
+            errorMessage.value = 'Could not start the connection.';
+            hangUp();
+        }
+    });
+
+    s.on('call:signal', async ({ callId: id, kind, payload }) => {
+        if (!id || id !== callId.value) return;
+        try {
+            if (kind === 'offer') {
+                if (!pc) createPeer(false);
+                await pc.setRemoteDescription(new RTCSessionDescription(payload));
+                await flushPendingCandidates();
+                adoptVideoTransceiver();
+                const answer = await pc.createAnswer();
+                await pc.setLocalDescription(answer);
+                emit('call:signal', { callId: id, kind: 'answer', payload: answer });
+            } else if (kind === 'answer') {
+                if (!pc) return;
+                await pc.setRemoteDescription(new RTCSessionDescription(payload));
+                await flushPendingCandidates();
+            } else if (kind === 'state') {
+                const p = payload || {};
+                peerCamOn.value = p.camOn !== false;
+                peerMicOn.value = p.micOn !== false;
+                peerSharing.value = p.sharing === true;
+            } else if (kind === 'ice') {
+                const candidate = new RTCIceCandidate(payload);
+                // Before the remote description exists there is nothing to attach a
+                // candidate to, so hold it rather than throwing it away.
+                if (pc && pc.remoteDescription && pc.remoteDescription.type) await pc.addIceCandidate(candidate);
+                else pendingCandidates.push(candidate);
+            }
+        } catch (e) {
+            errorMessage.value = 'The connection failed.';
+            hangUp();
+        }
+    });
+
+    s.on('call:rejected', () => { errorMessage.value = 'Call declined.'; teardown(); });
+    s.on('call:cancelled', () => { teardown(); });
+    s.on('call:unavailable', () => { errorMessage.value = 'They are not online.'; teardown(); });
+    s.on('call:missed', () => { errorMessage.value = 'No answer.'; teardown(); });
+    s.on('call:takenElsewhere', () => { teardown(); });
+    s.on('call:ended', () => { teardown(); });
+    s.on('call:error', ({ message }) => {
+        // Surface the server's own words — a generic failure here is undiagnosable.
+        errorMessage.value = message || 'The call failed.';
+        teardown();
+    });
+};
+
+export function useCall() {
+    return {
+        // state
+        state: readonly(state),
+        callId: readonly(callId),
+        chatId: readonly(chatId),
+        media: readonly(media),
+        peerUserId: readonly(peerUserId),
+        errorMessage,
+        micOn: readonly(micOn),
+        camOn: readonly(camOn),
+        hasTurn: readonly(hasTurn),
+        startedAt: readonly(startedAt),
+        localStream,
+        remoteStream,
+        shareStream,
+        isSharing: readonly(isSharing),
+        peerCamOn: readonly(peerCamOn),
+        peerMicOn: readonly(peerMicOn),
+        peerSharing: readonly(peerSharing),
+        // derived
+        isIdle: computed(() => state.value === STATE.IDLE),
+        isIncoming: computed(() => state.value === STATE.INCOMING),
+        isOutgoing: computed(() => state.value === STATE.OUTGOING),
+        isBusy: computed(() => state.value !== STATE.IDLE),
+        isActive: computed(() => state.value === STATE.ACTIVE),
+        // actions
+        bindSocket,
+        startCall,
+        acceptCall,
+        rejectCall,
+        hangUp,
+        toggleMic,
+        toggleCam,
+        toggleShare,
+        stopScreenShare,
+        isSupported,
+        isSecure,
+        STATE,
+    };
+}

--- a/frontend/src/composable/useCallSound.js
+++ b/frontend/src/composable/useCallSound.js
@@ -1,0 +1,120 @@
+import { ref } from 'vue';
+
+/**
+ * Call tones (AHE-3839).
+ *
+ * Synthesised with the Web Audio API rather than played from an audio file. That is a
+ * licensing decision as much as a technical one: shipping a ringtone in an AGPL-3.0 repo
+ * means shipping something we hold redistribution rights to, and most "free ringtone"
+ * downloads are not that. A generated tone has no such question, adds no binary, never
+ * 404s, and loops without a seam.
+ *
+ * ── The autoplay problem ────────────────────────────────────────────────────────────
+ * Browsers refuse to start audio on a page the user has not interacted with — which is
+ * exactly an incoming call, since not touching the tab is why you need the ring. An
+ * AudioContext may be CREATED at any time but starts suspended, and only a real user
+ * gesture can resume it. So the first click or keypress anywhere in the app unlocks it
+ * for the rest of the session. Anyone who has been using AlianHub has clicked something;
+ * the case that stays silent is a tab loaded and never touched.
+ */
+
+const STORAGE_KEY = 'alianhub.callSound';
+const muted = ref((() => {
+    try { return localStorage.getItem(STORAGE_KEY) === 'off'; } catch (e) { return false; }
+})());
+
+let ctx = null;
+let loopTimer = null;
+
+const ensureCtx = () => {
+    if (typeof window === 'undefined') return null;
+    const Ctor = window.AudioContext || window.webkitAudioContext;
+    if (!Ctor) return null;
+    if (!ctx) ctx = new Ctor();
+    // Created before a gesture, a context starts suspended and stays silent until resumed.
+    if (ctx.state === 'suspended') ctx.resume().catch(() => { /* still locked */ });
+    return ctx;
+};
+
+/** Unlock on the first real gesture, then get out of the way. */
+if (typeof window !== 'undefined') {
+    const unlock = () => {
+        ensureCtx();
+        window.removeEventListener('pointerdown', unlock);
+        window.removeEventListener('keydown', unlock);
+    };
+    window.addEventListener('pointerdown', unlock);
+    window.addEventListener('keydown', unlock);
+}
+
+/**
+ * One pulse: a chord held for `duration`, faded in and out.
+ *
+ * The ramps are not decoration. Starting or stopping a sine at full amplitude produces a
+ * step in the waveform, which is heard as a click at the start and end of every ring.
+ */
+const pulse = (freqs, duration, level) => {
+    const c = ensureCtx();
+    if (!c || c.state !== 'running') return;
+    const now = c.currentTime;
+    const gain = c.createGain();
+    gain.connect(c.destination);
+    gain.gain.setValueAtTime(0, now);
+    gain.gain.linearRampToValueAtTime(level, now + 0.02);
+    gain.gain.setValueAtTime(level, now + Math.max(0.05, duration - 0.05));
+    gain.gain.linearRampToValueAtTime(0, now + duration);
+
+    freqs.forEach((f) => {
+        const osc = c.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.value = f;
+        osc.connect(gain);
+        osc.start(now);
+        osc.stop(now + duration + 0.02);
+    });
+};
+
+const stop = () => {
+    clearInterval(loopTimer);
+    loopTimer = null;
+};
+
+const startLoop = (freqs, duration, level, everyMs) => {
+    stop();
+    if (muted.value) return;
+    pulse(freqs, duration, level);
+    loopTimer = setInterval(() => pulse(freqs, duration, level), everyMs);
+};
+
+// 440 + 480 Hz is the tone pair a desk phone rings on; two frequencies beat against each
+// other and carry better than one, which is why telephones have always used a pair.
+const startIncoming = () => startLoop([440, 480], 1.1, 0.16, 3000);
+// The caller's own ringback: same cadence, quieter, so it reads as "still trying" rather
+// than as another call coming in.
+const startRingback = () => startLoop([440, 480], 1.0, 0.07, 3000);
+
+/** Two notes rising — the call is up. */
+const connected = () => {
+    if (muted.value) return;
+    pulse([523.25], 0.09, 0.12);
+    setTimeout(() => pulse([659.25], 0.12, 0.12), 100);
+};
+
+/** Two notes falling — it is over. */
+const ended = () => {
+    if (muted.value) return;
+    pulse([523.25], 0.09, 0.1);
+    setTimeout(() => pulse([392], 0.14, 0.1), 100);
+};
+
+const setMuted = (value) => {
+    muted.value = !!value;
+    try { localStorage.setItem(STORAGE_KEY, muted.value ? 'off' : 'on'); } catch (e) { /* storage blocked */ }
+    if (muted.value) stop();
+};
+
+const toggleMuted = () => setMuted(!muted.value);
+
+export function useCallSound() {
+    return { muted, startIncoming, startRingback, stop, connected, ended, setMuted, toggleMuted };
+}

--- a/frontend/src/config/env.js
+++ b/frontend/src/config/env.js
@@ -58,6 +58,7 @@ module.exports.TASKTYPE = '/api/v1/projectSetting/taskType';
 module.exports.TASKSTATUS = '/api/v1/projectSetting/taskStatus';
 module.exports.SPRINT = '/api/v1/sprint';
 module.exports.SPRINT_HOURS = '/api/v2/sprints/hours';
+module.exports.CALL_ICE_CONFIG = '/api/v2/calls/ice-config';
 module.exports.FOLDER = '/api/v1/folder';
 module.exports.REMOVE_USER_NOTIFICATION = '/api/v1/removeUserNotification';
 module.exports.GENERATETOKEN = '/api/v1/generateToken';

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1143,6 +1143,8 @@ export default {
         camera_off: "Turn camera off",
         camera_on: "Turn camera on",
         peer_muted: "Their microphone is off",
+        sound_off: "Silence the ringer",
+        sound_on: "Turn the ringer back on",
         share_screen: "Share your screen",
         stop_share: "Stop sharing",
         maximize: "Maximise",

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1130,6 +1130,25 @@ export default {
     },
     // Main Chat module (components/organisms/MainChat). Kept in its own namespace
     // so the chat UI owns its strings instead of borrowing from Comments.
+    call: {
+        start_audio: "Start an audio call",
+        start_video: "Start a video call",
+        incoming_audio: "Incoming audio call",
+        incoming_video: "Incoming video call",
+        accept: "Accept",
+        decline: "Decline",
+        hang_up: "Hang up",
+        mute: "Mute",
+        unmute: "Unmute",
+        camera_off: "Turn camera off",
+        camera_on: "Turn camera on",
+        peer_muted: "Their microphone is off",
+        share_screen: "Share your screen",
+        stop_share: "Stop sharing",
+        maximize: "Maximise",
+        restore: "Restore",
+        no_turn_warning: "No TURN relay is configured. Calls may fail to connect on restrictive networks.",
+    },
     MainChat: {
         search: "Search in conversation",
         user_info: "View profile",

--- a/frontend/src/views/Chat/Chat.vue
+++ b/frontend/src/views/Chat/Chat.vue
@@ -143,7 +143,23 @@
                             :avatarSrc="selectedProject?.default ? (getUser(selectedChat?.receiverId)?.Employee_profileImageURL || '') : ''"
                             :sendMessageAllowed="sendMessageAllowed"
                             @created="onChatCreated"
-                        />
+                        >
+                            <!-- The way back to the conversation list on a narrow screen.
+                                 The legacy header carried this button, but the new UI
+                                 hides that header — which left an open conversation with
+                                 no way out, since the only other trigger lives on the
+                                 "no chat selected" screen. -->
+                            <template #header-lead>
+                                <img
+                                    v-if="clientWidth <= responseWidth"
+                                    :src="sidebarArrowIcon"
+                                    alt=""
+                                    class="mc-head-back"
+                                    :title="$t('Chat.chats')"
+                                    @click="visible = !visible"
+                                />
+                            </template>
+                        </MainChatPanel>
                         <Comments
                             v-else-if="selectedChat?.id && !loadingChats"
                             :taskId="selectedProject?.default ? selectedChat?.id : 'default'"

--- a/index.js
+++ b/index.js
@@ -194,6 +194,7 @@ function initializeControllers() {
     require('./Modules/ImportSettings/init').init(app);
     require('./Modules/Tasks/init.js').init(app);
     require('./Modules/Sprints/init.js').init(app);
+    require('./Modules/Calls/init.js').init(app);
     require('./Modules/AgileReports/init').init(app);
     require('./Modules/Export/init').init(app);
     require('./Modules/RecurringTasks/init').init(app);

--- a/socket/controller/callSocket.js
+++ b/socket/controller/callSocket.js
@@ -1,0 +1,359 @@
+const crypto = require('crypto');
+const {
+    joinRoom,
+    leaveRoom,
+    upsertRoom,
+    removeRoom,
+    findRoomsByPrefix,
+} = require('../helper');
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const logger = require('../../Config/loggerConfig');
+
+/**
+ * Call signalling for main chat (AHE-3839).
+ *
+ * WebRTC needs two peers to exchange an offer, an answer and a trickle of ICE candidates
+ * before media can flow. This carries those messages and nothing else — no audio or video
+ * ever passes through the server. That is the whole point of the peer-to-peer approach:
+ * a self-hoster's media never leaves the two browsers.
+ *
+ * ── Reaching a person, not a socket ────────────────────────────────────────────────
+ * Every client joins `call_<companyId>_<userId>**<socketId>` on connect, so one person
+ * with three tabs open has three entries under the same prefix. Ringing looks the prefix
+ * up and rings all of them; the first to answer wins and the rest are told to stop. Any
+ * other design leaves a call answered on the laptop still ringing on the phone.
+ *
+ * ── Identity ───────────────────────────────────────────────────────────────────────
+ * The caller is ALWAYS `socket.user.uid` from the verified JWT, and the callee is ALWAYS
+ * derived from the conversation's own participant list. Neither is ever read from the
+ * payload. A caller-supplied callee id would let anyone ring anyone in the company, and a
+ * caller-supplied caller id would let them do it wearing somebody else's name. This is
+ * the same rule the HTTP side already follows (see Modules/MainChats — AHE-3834).
+ *
+ * ── State ──────────────────────────────────────────────────────────────────────────
+ * Calls live in memory for their lifetime, which is right for a signalling handshake
+ * measured in seconds. NOTE: that makes this single-node. Behind more than one Node
+ * process, two participants may land on different instances and never find each other —
+ * see the ops note at the bottom of the calling plan.
+ */
+
+const RING_TIMEOUT_MS = 45000;   // unanswered after this = missed
+const MEDIA = new Set(['audio', 'video']);
+
+// callId -> { callId, companyId, chatId, media, from, to, state, startedAt, answeredAt,
+//             timer, callerSocketId, calleeSocketId }
+const calls = new Map();
+// A person can only be in one call at a time; this keeps ring collisions honest.
+const activeByUser = new Map();  // `${companyId}:${userId}` -> callId
+
+const callRoomPrefix = (companyId, userId) => `call_${companyId}_${userId}`;
+const userKey = (companyId, userId) => `${companyId}:${userId}`;
+
+/**
+ * The company this socket is really allowed to act in.
+ *
+ * The namespace name is chosen by the client (`/userid_<companyId>_<userId>`), so it is a
+ * request, not a fact. The JWT's audience is the fact — it lists the companies the token
+ * was actually issued for. Cross-checking the two is what stops a logged-in user from
+ * connecting to another tenant's namespace and ringing its members.
+ */
+const resolveCompanyId = (socket) => {
+    const match = /^\/userid_([^_]+)_/.exec(socket.nsp && socket.nsp.name ? socket.nsp.name : '');
+    if (!match) return '';
+    const claimed = match[1];
+    const aud = socket.user && socket.user.aud;
+    const allowed = Array.isArray(aud) ? aud.map(String) : String(aud || '').split(',');
+    return allowed.some((c) => c.trim() === claimed) ? claimed : '';
+};
+
+const emitToUser = (companyId, userId, event, payload) => {
+    const rooms = findRoomsByPrefix(callRoomPrefix(companyId, userId));
+    rooms.forEach((entry) => {
+        entry.namespace.to(entry.roomName).emit(event, payload);
+    });
+    return rooms.length;
+};
+
+const emitToSocketOwner = (socket, event, payload) => socket.emit(event, payload);
+
+const clearCall = (call) => {
+    if (!call) return;
+    if (call.timer) clearTimeout(call.timer);
+    calls.delete(call.callId);
+    activeByUser.delete(userKey(call.companyId, call.from));
+    activeByUser.delete(userKey(call.companyId, call.to));
+};
+
+/**
+ * Resolve the conversation and the person on the other end of it.
+ *
+ * The lookup itself is the authorisation: the filter demands that the CALLER is one of the
+ * conversation's assignees, so a chat they are not part of simply does not come back. The
+ * callee is then whichever assignee is not the caller — never a value from the payload.
+ */
+const resolvePeer = async (companyId, callerUid, chatId) => {
+    const chat = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.TASKS,
+        data: [{
+            _id: chatId,
+            mainChat: true,
+            AssigneeUserId: callerUid,
+            deletedStatusKey: 0,
+        }, { _id: 1, AssigneeUserId: 1, ProjectID: 1, sprintId: 1 }],
+    }, 'findOne').catch((e) => {
+        logger.error(`callSocket chat lookup failed: ${e && e.message ? e.message : e}`);
+        return null;
+    });
+    if (!chat) return null;
+    const parties = (Array.isArray(chat.AssigneeUserId) ? chat.AssigneeUserId : [])
+        .map(String).filter(Boolean);
+    const peer = parties.find((p) => p !== String(callerUid));
+    // A conversation with only one distinct party is a note to self, not a call.
+    if (!peer) return null;
+    return { peer, projectId: String(chat.ProjectID || ''), sprintId: String(chat.sprintId || '') };
+};
+
+/**
+ * Leave a line in the conversation so the call shows up where people look for history.
+ *
+ * Written by the server, once, when the call ends — not by whichever client hung up. The
+ * client that ends a call is often the one whose tab just closed, and two clients writing
+ * it would put the same line in the chat twice.
+ *
+ * Sent as an ordinary text message on purpose: the chat already renders those, so call
+ * history appears with no client change. A dedicated `call` message type would look
+ * better and is the natural follow-up.
+ */
+const postCallMessage = async (call, text) => {
+    if (!call.projectId || !call.chatId) return;
+    await MongoDbCrudOpration(call.companyId, {
+        type: SCHEMA_TYPE.COMMENTS,
+        data: {
+            message: text,
+            userId: call.from,
+            type: 'text',
+            projectId: call.projectId,
+            project: false,
+            taskId: call.chatId,
+            sprintId: call.sprintId,
+            mediaURL: '', mediaName: '', mediaSize: 0,
+            isDeleted: false, hasReply: false, mentionIds: [],
+            replyMessageId: '', reply_id: '', reply_message: '', reply_type: '',
+            reply_mediaName: '', reply_mediaURL: '', reply_mediaSize: 0,
+            reply_mediaOriginalName: '', reply_createdAt: 0, reply_userId: '',
+            createdAt: new Date(), updatedAt: new Date(),
+        },
+    }, 'save').catch((e) => {
+        // History is a nicety; never let it take the call down with it.
+        logger.error(`callSocket history write failed: ${e && e.message ? e.message : e}`);
+    });
+};
+
+const durationText = (sec) => {
+    const m = Math.floor(sec / 60);
+    const s = sec % 60;
+    return m ? `${m}m ${s}s` : `${s}s`;
+};
+
+const endCall = (call, reason, endedByUid) => {
+    if (!call || call.state === 'ended') return;
+    const durationSec = call.answeredAt ? Math.round((Date.now() - call.answeredAt) / 1000) : 0;
+    call.state = 'ended';
+    const payload = { callId: call.callId, reason, durationSec, endedBy: endedByUid || null };
+    emitToUser(call.companyId, call.from, 'call:ended', payload);
+    emitToUser(call.companyId, call.to, 'call:ended', payload);
+    const label = call.media === 'video' ? 'Video call' : 'Call';
+    postCallMessage(call, `${label} · ${durationText(durationSec)}`);
+    clearCall(call);
+};
+
+/** The party on the other side of a call from `uid`, or '' if uid is not in it. */
+const otherParty = (call, uid) => {
+    if (String(call.from) === String(uid)) return call.to;
+    if (String(call.to) === String(uid)) return call.from;
+    return '';
+};
+
+exports.callSocketHandler = ({ socket, namespace }) => {
+    const uid = String((socket.user && socket.user.uid) || '');
+    const companyId = resolveCompanyId(socket);
+
+    // No verified identity or a namespace this token has no claim to: register nothing.
+    // The handler stays inert rather than half-wired.
+    if (!uid || !companyId) return;
+
+    const myPrefix = callRoomPrefix(companyId, uid);
+    const roomName = `${myPrefix}**${socket.id}`;
+    joinRoom(socket, roomName);
+    upsertRoom({ roomName, socketId: socket.id, namespace, socket });
+
+    /** Start a call: authorise, register, ring every device the callee has open. */
+    socket.on('call:invite', async ({ chatId, media } = {}) => {
+        try {
+            const kind = MEDIA.has(media) ? media : 'audio';
+            if (!chatId) return emitToSocketOwner(socket, 'call:error', { code: 'BAD_REQUEST', message: 'chatId is required.' });
+
+            if (activeByUser.has(userKey(companyId, uid))) {
+                return emitToSocketOwner(socket, 'call:error', { code: 'BUSY_SELF', message: 'You are already on a call.' });
+            }
+
+            const resolved = await resolvePeer(companyId, uid, chatId);
+            if (!resolved) {
+                // Same answer whether the chat does not exist or the caller is not in it —
+                // telling them apart would confirm which conversations exist.
+                return emitToSocketOwner(socket, 'call:error', { code: 'NOT_ALLOWED', message: 'Conversation not available.' });
+            }
+            const { peer, projectId, sprintId } = resolved;
+
+            if (activeByUser.has(userKey(companyId, peer))) {
+                return emitToSocketOwner(socket, 'call:error', { code: 'BUSY_PEER', message: 'They are already on a call.' });
+            }
+
+            const callId = crypto.randomUUID();
+            const call = {
+                callId,
+                companyId,
+                chatId: String(chatId),
+                projectId,
+                sprintId,
+                media: kind,
+                from: uid,
+                to: peer,
+                state: 'ringing',
+                startedAt: Date.now(),
+                answeredAt: null,
+                callerSocketId: socket.id,
+                calleeSocketId: null,
+                timer: null,
+            };
+            calls.set(callId, call);
+            activeByUser.set(userKey(companyId, uid), callId);
+            activeByUser.set(userKey(companyId, peer), callId);
+
+            const reached = emitToUser(companyId, peer, 'call:incoming', {
+                callId, chatId: call.chatId, media: kind, from: uid,
+            });
+
+            if (!reached) {
+                // Nobody home. Fail immediately rather than ringing out for 45 seconds.
+                emitToSocketOwner(socket, 'call:unavailable', { callId, reason: 'offline' });
+                clearCall(call);
+                return;
+            }
+
+            // `to` so the caller can show who they are ringing. They cannot be told this
+            // from their own side: the client only knows the conversation, and the peer is
+            // resolved here.
+            emitToSocketOwner(socket, 'call:ringing', { callId, devices: reached, to: peer });
+            call.timer = setTimeout(() => {
+                const live = calls.get(callId);
+                if (!live || live.state !== 'ringing') return;
+                emitToUser(companyId, peer, 'call:cancelled', { callId, reason: 'timeout' });
+                emitToUser(companyId, uid, 'call:missed', { callId, chatId: call.chatId });
+                postCallMessage(live, 'Missed call');
+                clearCall(live);
+            }, RING_TIMEOUT_MS);
+        } catch (error) {
+            logger.error(`call:invite failed: ${error && error.message ? error.message : error}`);
+            emitToSocketOwner(socket, 'call:error', { code: 'SERVER_ERROR', message: 'Could not start the call.' });
+        }
+    });
+
+    /** Answer. First device to get here wins; the rest are told to stop ringing. */
+    socket.on('call:accept', ({ callId } = {}) => {
+        const call = calls.get(callId);
+        if (!call || String(call.to) !== uid) return;
+        if (call.state !== 'ringing') return;   // already answered, cancelled or timed out
+
+        call.state = 'active';
+        call.answeredAt = Date.now();
+        call.calleeSocketId = socket.id;
+        if (call.timer) { clearTimeout(call.timer); call.timer = null; }
+
+        // Silence this person's other devices before anything else.
+        findRoomsByPrefix(callRoomPrefix(companyId, uid)).forEach((entry) => {
+            if (entry.socketId === socket.id) return;
+            entry.namespace.to(entry.roomName).emit('call:takenElsewhere', { callId });
+        });
+
+        emitToUser(companyId, call.from, 'call:accepted', { callId, by: uid });
+        emitToSocketOwner(socket, 'call:accepted', { callId, by: uid });
+    });
+
+    socket.on('call:reject', ({ callId, reason } = {}) => {
+        const call = calls.get(callId);
+        if (!call || String(call.to) !== uid || call.state !== 'ringing') return;
+        findRoomsByPrefix(callRoomPrefix(companyId, uid)).forEach((entry) => {
+            if (entry.socketId === socket.id) return;
+            entry.namespace.to(entry.roomName).emit('call:takenElsewhere', { callId });
+        });
+        emitToUser(companyId, call.from, 'call:rejected', { callId, reason: reason || 'declined' });
+        clearCall(call);
+    });
+
+    /** Caller gives up before it was answered. */
+    socket.on('call:cancel', ({ callId } = {}) => {
+        const call = calls.get(callId);
+        if (!call || String(call.from) !== uid || call.state !== 'ringing') return;
+        emitToUser(companyId, call.to, 'call:cancelled', { callId, reason: 'cancelled' });
+        clearCall(call);
+    });
+
+    /** Either party hangs up a connected call. */
+    socket.on('call:end', ({ callId } = {}) => {
+        const call = calls.get(callId);
+        if (!call || !otherParty(call, uid)) return;
+        endCall(call, 'hangup', uid);
+    });
+
+    /**
+     * Relay one signalling message to the other party.
+     *
+     * The sender must be in this call, and the destination is derived from the call rather
+     * than from the message — otherwise this becomes an open relay for pushing arbitrary
+     * payloads at any user in the company.
+     */
+    socket.on('call:signal', ({ callId, kind, payload } = {}) => {
+        const call = calls.get(callId);
+        if (!call) return;
+        const peer = otherParty(call, uid);
+        if (!peer) return;
+        // 'state' carries mic/camera on-off. It has to travel out-of-band because a
+        // disabled track keeps sending — black frames and silence — so the far side
+        // cannot tell "camera off" from "dark room" by looking at the media alone.
+        if (!['offer', 'answer', 'ice', 'state'].includes(kind)) return;
+        emitToUser(companyId, peer, 'call:signal', { callId, kind, payload, from: uid });
+    });
+
+    /**
+     * A dropped socket ends the call it was in — but only if this was the device actually
+     * on the call. Closing a second tab must not hang up a call running in the first.
+     */
+    socket.on('disconnect', () => {
+        removeRoom(roomName);
+        leaveRoom(socket, roomName);
+
+        const callId = activeByUser.get(userKey(companyId, uid));
+        if (!callId) return;
+        const call = calls.get(callId);
+        if (!call) return;
+
+        if (call.state === 'ringing') {
+            if (String(call.from) === uid && call.callerSocketId === socket.id) {
+                emitToUser(companyId, call.to, 'call:cancelled', { callId, reason: 'caller_disconnected' });
+                clearCall(call);
+            }
+            // A ringing callee's tab closing is not an answer — their other devices keep
+            // ringing, and the timeout still governs.
+            return;
+        }
+
+        const onThisDevice = (String(call.from) === uid && call.callerSocketId === socket.id)
+            || (String(call.to) === uid && call.calleeSocketId === socket.id);
+        if (onThisDevice) endCall(call, 'disconnected', uid);
+    });
+};
+
+// Exposed for tests and diagnostics — never mutate these from outside.
+exports.__internals = { calls, activeByUser, resolveCompanyId, callRoomPrefix };

--- a/socket/socketinit.js
+++ b/socket/socketinit.js
@@ -5,6 +5,7 @@ const {commentSocketHandler} = require('./controller/commentSocket');
 const {companiesSocketHandler} = require('./controller/companiesSocket');
 const {userNotificationCountHandler} = require('./controller/userNotificationCount');
 const {generalReminderSocketHandler} = require('./controller/generalReminderSocket');
+const {callSocketHandler} = require('./controller/callSocket');
 const { instrument } = require('@socket.io/admin-ui');
 const jwt = require('jsonwebtoken');
 const logger = require('../Config/loggerConfig');
@@ -128,6 +129,7 @@ exports.initSocket = (server) => {
         generalReminderSocketHandler({socket, namespace});
         commentSocketHandler({socket, namespace});
         companiesSocketHandler({socket, namespace});
+        callSocketHandler({socket, namespace});
     });
     
 };


### PR DESCRIPTION
One-to-one audio and video calling in main chat, with screen sharing and a ringer. Peer-to-peer, signalled over the Socket.io namespace that already exists.

Tracker: **AHE-3839** · approach written up in [.claude/AUDIO-VIDEO-CALLING-PLAN.md](.claude/AUDIO-VIDEO-CALLING-PLAN.md)

## Why peer-to-peer

**Media goes browser to browser and never touches the server.** Nothing is stored, nothing leaves a self-hoster's network. That is the only approach that fits a self-hosted AGPL product that sells data residency:

- A **SaaS provider** (Twilio / Daily / Agora) would make every self-hoster create their own account, keys and per-minute billing before calling worked at all — and route media through a vendor.
- **Embedding `meet.jit.si`** is fastest to ship but sends media and metadata to a third party.
- A **self-hosted SFU** is the right answer for group calls, and is Phase 2. Building it now would mean new infrastructure in every deployment for a module that has no group conversations.

The expensive half was already built: the per-user Socket.io namespace is authenticated and can reach one specific person on all their devices.

## What is in it

**Signalling** — `socket/controller/callSocket.js` on the existing `/userid_*` namespace: invite / accept / reject / cancel / end, offer / answer / ICE, plus a mic-camera state message. Rings every device a person has open; first to answer wins and the rest are told to stop. 45s ring-out, one call per person.

**Calling UI** — ringing card, in-call window, mute, camera toggle, maximise, live duration, and a `Call · 4m 12s` / `Missed call` line written into the conversation by the **server** (the client that ends a call is often the one whose tab just closed).

**Screen sharing on audio calls as well as video.**

**Camera-off avatar tiles** — photo where we have one, initial otherwise.

**A ringer** — incoming ring, ringback while dialling, short tones on connect and end, and a toggle on the incoming card remembered per browser.

## Four decisions worth reviewing

**1. Identity is never taken from the payload.** The caller is the verified socket's `uid`; the callee is derived by loading the conversation filtered by that uid, so the lookup *is* the authorisation — the same rule `Modules/MainChats` already follows (AHE-3834). A caller-supplied callee id would let anyone ring anyone in the company.

The company is also cross-checked against the **JWT audience**, because the namespace name is chosen by the client and is a request, not a fact.

> **Pre-existing gap, not fixed here:** the namespace middleware verifies the JWT but never checks that the namespace you connect to is yours, so a logged-in user can connect to `/userid_<anyCompany>_<anyUser>`. My handler defends itself, but this deserves its own task.

**2. TURN credentials are minted short-lived.** A static TURN username and password handed to a browser is a relay anyone can read out of devtools and use from anywhere. This issues coturn's HMAC pair (~1h) so the shared secret never leaves the server. Static credentials still work for managed providers, with a logged warning.

**3. Screen sharing uses `replaceTrack`, never renegotiation.** The offerer reserves an empty video transceiver so sharing is an instant track swap in either kind of call. The answerer must **not** add its own — it adopts the transceiver the offer brings and forces `sendrecv`. Adding a second does not reliably associate with the offered m-line, which is why the callee's share was invisible to the caller while the caller's worked. Video calls were unaffected because both sides get their transceiver from `addTrack`.

**4. The ringtone is synthesised, not an audio file** — a licensing decision as much as a technical one. Shipping a ringtone in an AGPL-3.0 repo means shipping something we hold redistribution rights to, and most "free ringtone" downloads are not that. A generated tone raises no such question, adds no binary and loops without a seam.

Autoplay is handled by unlocking the AudioContext on the first click or keypress anywhere in the app — a browser will create one at any time but starts it suspended, and only a real gesture resumes it, which an incoming call is not. A tab loaded and never touched stays silent; that is the browser's rule, not ours.

The tones follow the call's **state machine** rather than individual events, so every way out lands in one place that silences the ring. Hanging it off the happy path is how a phone ends up ringing after the call is over.

## Also included

- `/api/v2/sprints` and `/api/v2/calls` added to the JWT list. **`/api/v2/sprints` was in neither list**, so the existing burndown endpoint was unauthenticated and took the company from a header alone.
- Optional **coturn** service behind a `calling` compose profile, plus the env block.
- **The way back to the conversation list on a narrow screen.** The trigger lived in the legacy chat header, which the new chat UI hides — leaving an open conversation with no way out.

## Deployment requirements

- **HTTPS.** `getUserMedia` needs a secure context; on plain HTTP the call buttons do not render at all, by design.
- **STUN, and in practice TURN.** Direct connections fail on symmetric NAT and strict corporate firewalls — roughly 15-20% of real connections. Without a relay those calls fail, and the UI says so rather than failing silently.

## Tested

Two accounts, two browsers, on localhost: audio both ways, video both ways, mute, camera off, maximise, and screen share from **both** sides on both call types.

**Not yet verified:** missed / declined, multi-device ring-cancel, the call-history message, the ringer's exit paths, and **cross-machine** — two browsers on one machine always connect via host candidates, so NAT traversal has never actually been exercised.

## Not in scope

Group calls, recording, calls to non-members, and calling from the tracker app. The open questions are in §7 of the plan — if group calling is needed, the media layer is replaced by an SFU and the signalling, ringing, state machine and UI all carry over.

Channel calling was discussed and deliberately left out: a **public** channel's membership resolves to every user in the company, so "call this channel" would ring the whole company. That wants a join-not-ring model (a card in the channel people opt into) and an SFU behind it, not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)