### PR TITLE
fix(sprint): archive and restore a sprint nested in a folder

### DIFF
--- a/frontend/src/components/molecules/SubItem/SubItem.vue
+++ b/frontend/src/components/molecules/SubItem/SubItem.vue
@@ -408,8 +408,15 @@ function updateItem(value = null) {
     if(props.folder) {
         axiosData.sprints = sprints.value?.filter((x) => !x.deletedStatusKey || x.deletedStatusKey === 6)?.map((x) => x.id)
     }
+    // Keyed on `props.folder` — is this row ITSELF a folder — the same signal
+    // `type` and `itemId` above already use. It previously keyed on
+    // `props.data.folderId`, which asks a different question: is this row INSIDE
+    // a folder. The two agree for a folder and for a loose sprint, and disagree
+    // for a sprint nested in a folder, which was sent as `updateSprint` to the
+    // folder route. That combination is not on the folder route's whitelist, so
+    // archiving a nested sprint failed with "Invalid type".
     let reqUrl = env.SPRINT+'/'+itemId.value;
-    if (props.data.folderId) {
+    if (props.folder) {
         reqUrl = env.FOLDER+'/'+itemId.value;
     }
     apiRequest("patch", reqUrl, axiosData)


### PR DESCRIPTION
Archiving a sprint that lives inside a folder fails with **"Invalid type"** — in production as well as locally.

```
PATCH /api/v1/folder/<sprintId>   →  400
{ "status": false, "statusText": "Invalid type" }
```

## Cause

The request is built from two different questions:

```js
type:   !props.folder ? "updateSprint" : "updateFolder",   // is this row ITSELF a folder?
itemId: props.folder ? props.data.folderId : props.data.id // (same signal)

let reqUrl = env.SPRINT + '/' + itemId.value;
if (props.data.folderId) {                                  // is this row INSIDE a folder?
    reqUrl = env.FOLDER + '/' + itemId.value;
}
```

Those two signals agree for a folder and for a loose sprint. They disagree for exactly one shape — **a sprint nested in a folder** — which is sent as `updateSprint` to the *folder* route. `ALLOWED_FOLDER_TYPES` is `['editFolderName', 'updateFolder']`, so it is rejected.

| Row | `props.folder` | `data.folderId` | Sent as | Result |
|---|---|---|---|---|
| Folder | true | set | `/folder` + `updateFolder` | ✅ |
| **Sprint in a folder** | false | set | `/folder` + `updateSprint` | ❌ **Invalid type** |
| Loose sprint | false | null | `/sprint` + `updateSprint` | ✅ |

This worked before the route whitelists were introduced, because the handler name was dispatched from the request body regardless of which route it arrived on. **The hardening did not cause the mismatch — it revealed it.**

## Fix

The URL now keys on `props.folder`, the same signal `type` and `itemId` already use. That also matches `SprintsList.vue` and `SprintListing.vue`, which both derive the type and the route from one signal (`isFolder`) and are unaffected by this bug.

`updateSprint` reads `req.params.id` and always operates on the sprints collection, so the route is a dispatch path only — nothing else about the request changes.

## Scope

One line, one file. I checked every other call site that sends a whitelisted type: `deleteChannel`, the second `updateSprint` in this same component, and both sibling list components all pair their route correctly. This was the only mismatch.

## Testing

Verified the pairing for all three row shapes against the real whitelists: the old condition reproduces the failure for a nested sprint and passes the other two; the new condition passes all three and routes identically to the sibling components. Lints clean and the production build compiles.

Worth a manual check on staging: archive a nested sprint, a top-level sprint, and a folder — plus restore, since it goes through the same code path with a different `deletedStatusKey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
