### PR TITLE
fix(sprint): archive and restore a sprint nested in a folder

### DIFF
--- a/frontend/src/components/molecules/SubItem/SubItem.vue
+++ b/frontend/src/components/molecules/SubItem/SubItem.vue
@@ -408,8 +408,15 @@ function updateItem(value = null) {
     if(props.folder) {
         axiosData.sprints = sprints.value?.filter((x) => !x.deletedStatusKey || x.deletedStatusKey === 6)?.map((x) => x.id)
     }
+    // Keyed on `props.folder` — is this row ITSELF a folder — the same signal
+    // `type` and `itemId` above already use. It previously keyed on
+    // `props.data.folderId`, which asks a different question: is this row INSIDE
+    // a folder. The two agree for a folder and for a loose sprint, and disagree
+    // for a sprint nested in a folder, which was sent as `updateSprint` to the
+    // folder route. That combination is not on the folder route's whitelist, so
+    // archiving a nested sprint failed with "Invalid type".
     let reqUrl = env.SPRINT+'/'+itemId.value;
-    if (props.data.folderId) {
+    if (props.folder) {
         reqUrl = env.FOLDER+'/'+itemId.value;
     }
     apiRequest("patch", reqUrl, axiosData)


### PR DESCRIPTION
Ships the sprint archive/restore fix to production **without** the audio/video calling feature, which is also sitting on `staging` and is not yet verified cross-machine.

Cherry-picked from `6e578b7`, already merged to `staging` via #477.

## The bug

Archiving *or* restoring a sprint that lives inside a folder failed with **"Invalid type"** in production.

```
PATCH /api/v1/folder/<sprintId>   →  400
{ "status": false, "statusText": "Invalid type" }
```

The request was built from two different questions. `type` and `itemId` key on `props.folder` — *is this row itself a folder* — while the URL keyed on `props.data.folderId` — *is this row inside a folder*.

| Row | `props.folder` | `data.folderId` | Sent as | Result |
|---|---|---|---|---|
| Folder | true | set | `/folder` + `updateFolder` | ✅ |
| **Sprint in a folder** | false | set | `/folder` + `updateSprint` | ❌ **Invalid type** |
| Loose sprint | false | null | `/sprint` + `updateSprint` | ✅ |

It worked before the route whitelists were added, because the handler name was dispatched from the request body regardless of which route it arrived on. **The hardening did not cause the mismatch — it revealed it.**

## The fix

One line: the URL now keys on `props.folder`, the same signal `type` and `itemId` already use, matching `SprintsList.vue` and `SprintListing.vue` which were never affected.

Archive and restore are the same `updateItem()` call with a different argument (nothing vs `0`). The URL is built before that argument is consulted, so both were broken and both are fixed.

`updateSprint` reads `req.params.id` and always operates on the sprints collection, so the route is a dispatch path only — nothing else about the request changes.

## Testing

Confirmed on a local run: archiving and restoring a nested sprint both work, and the previously-working cases (top-level sprint, folder) still do. Lints clean, production build compiles.

## Note on branch state

This is a cherry-pick, so the commit SHA here differs from the one on `staging`. When `staging` is later promoted with the calling feature, that merge will find this change already present with identical content — it should resolve as a no-op rather than a conflict, but it is worth being aware of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected updates for nested sprint items so they continue using the appropriate sprint endpoint.
  * Folder rows now update through the correct folder endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->