### PR TITLE
feat(docs): add a Docs project view and share nested sub-pages publicly

### DIFF
--- a/Modules/PublicShares/helpers/shareRules.js
+++ b/Modules/PublicShares/helpers/shareRules.js
@@ -73,12 +73,35 @@ const ALLOWED_TAGS = new Set([
     'blockquote', 'pre', 'code',
     'ol', 'ul', 'li',
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-    'a', 'img',
+    'a', 'img', 'iframe',
     'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption',
 ]);
 const VOID_TAGS = new Set(['br', 'hr', 'img']);
 // Removed WITH their contents. Anything else only loses its tags.
-const STRIPPED_TAGS = 'script|style|svg|math|iframe|object|embed|template|noscript|form|input|button|select|textarea|link|meta|base';
+const STRIPPED_TAGS = 'script|style|svg|math|object|embed|template|noscript|form|input|button|select|textarea|link|meta|base';
+
+/**
+ * The editor's video button stores a provider embed as an <iframe class="ql-video">,
+ * so a doc with a video renders nothing unless iframes are allowed. They are —
+ * but ONLY pointing at these players.
+ *
+ * An arbitrary iframe on a public page is a phishing and clickjacking surface,
+ * so the host is the gate, not the tag: an <iframe> whose src is not on this
+ * list is dropped whole. cspFor() names the same hosts in frame-src, so a src
+ * that ever slipped past this still could not load.
+ */
+const SAFE_EMBED_SRC = new RegExp(
+    '^https://(?:'
+    + 'www\\.youtube\\.com/embed/'
+    + '|youtube\\.com/embed/'
+    + '|www\\.youtube-nocookie\\.com/embed/'
+    + '|player\\.vimeo\\.com/video/'
+    + '|www\\.loom\\.com/embed/'
+    + '|loom\\.com/embed/'
+    + ')[\\w\\-/?=&.%]*$',
+    'i',
+);
+exports.SAFE_EMBED_SRC = SAFE_EMBED_SRC;
 // Inline styles carry the editor's colours and alignment. Layout and anything
 // that can fetch or execute is not on the list.
 const ALLOWED_STYLE_PROPS = new Set([
@@ -154,6 +177,7 @@ const cleanClass = (value) => String(value || '')
 const cleanAttrs = (tag, raw) => {
     const kept = [];
     let hasHref = false;
+    let hasEmbedSrc = false;
     const ATTR = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
     let match;
     while ((match = ATTR.exec(raw))) {
@@ -173,6 +197,17 @@ const cleanAttrs = (tag, raw) => {
             }
         } else if (name === 'src' && tag === 'img') {
             if (SAFE_IMG_SRC.test(decodeForSchemeCheck(value))) kept.push(`src="${attrValue(value)}"`);
+        } else if (name === 'src' && tag === 'iframe') {
+            if (SAFE_EMBED_SRC.test(decodeForSchemeCheck(value))) {
+                kept.push(`src="${attrValue(value)}"`);
+                hasEmbedSrc = true;
+            }
+        } else if (name === 'allowfullscreen' && tag === 'iframe') {
+            kept.push('allowfullscreen');
+        } else if (name === 'data-checked' && tag === 'ul' && (value === 'true' || value === 'false')) {
+            // The editor stores a checklist as <ul data-checked="true|false">.
+            // Dropping it left plain bullets, losing the ticks entirely.
+            kept.push(`data-checked="${value}"`);
         } else if ((name === 'alt' || name === 'title') && (tag === 'img' || tag === 'a')) {
             kept.push(`${name}="${attrValue(value)}"`);
         } else if ((name === 'width' || name === 'height') && tag === 'img' && /^\d{1,4}$/.test(value)) {
@@ -182,6 +217,12 @@ const cleanAttrs = (tag, raw) => {
     }
     // A link out of a public page opens away from it and carries nothing back.
     if (tag === 'a' && hasHref) kept.push('target="_blank"', 'rel="noopener noreferrer nofollow"');
+    // An embed with no accepted src is not an embed — signal the caller to drop
+    // the element rather than emit a bare <iframe> pointing nowhere.
+    if (tag === 'iframe') {
+        if (!hasEmbedSrc) return null;
+        kept.push('loading="lazy"', 'referrerpolicy="strict-origin-when-cross-origin"');
+    }
     return kept.length ? ` ${kept.join(' ')}` : '';
 };
 
@@ -206,6 +247,7 @@ const sanitizeDocHtml = (html) => {
     const TAG = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|'[^']*'|[^>])*)>/g;
     let out = '';
     let last = 0;
+    let droppedEmbed = 0;
     let match;
     while ((match = TAG.exec(working))) {
         out += text(working.slice(last, match.index));
@@ -214,10 +256,15 @@ const sanitizeDocHtml = (html) => {
         const tag = match[2].toLowerCase();
         if (!ALLOWED_TAGS.has(tag)) continue;          // drop the tag, keep the text
         if (closing) {
+            // The opener of a rejected embed was dropped, so its closer must go
+            // too or the output carries a stray </iframe>.
+            if (tag === 'iframe') { if (droppedEmbed > 0) droppedEmbed -= 1; else out += '</iframe>'; continue; }
             if (!VOID_TAGS.has(tag)) out += `</${tag}>`;
             continue;
         }
-        out += `<${tag}${cleanAttrs(tag, match[3])}>`;
+        const attrs = cleanAttrs(tag, match[3]);
+        if (attrs === null) { droppedEmbed += 1; continue; }   // embed with no accepted src
+        out += `<${tag}${attrs}>`;
     }
     return out + text(working.slice(last));
 };

--- a/Modules/PublicShares/helpers/shareRules.js
+++ b/Modules/PublicShares/helpers/shareRules.js
@@ -87,6 +87,24 @@ const ALLOWED_STYLE_PROPS = new Set([
 ]);
 const SAFE_HREF = /^(?:https?:\/\/|mailto:|#|\/)/i;
 const SAFE_IMG_SRC = /^(?:https?:\/\/|data:image\/(?:png|jpe?g|gif|webp);base64,)/i;
+const HREF_HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+/**
+ * Docs written before the editor started absolutising links hold hrefs like
+ * "www.alianhub.com". With no scheme a browser resolves that against the share
+ * page itself, so give it https:// — otherwise the link fails SAFE_HREF below
+ * and is dropped, leaving text that looks like a link and does nothing.
+ *
+ * Only a value with NO scheme is touched. Anything carrying one — javascript:,
+ * data:, vbscript: — is left exactly as it was, so it still faces SAFE_HREF and
+ * is still rejected.
+ */
+const absoluteHref = (value) => {
+    const raw = String(value || '').trim();
+    if (!raw || HREF_HAS_SCHEME.test(decodeForSchemeCheck(raw))) return raw;
+    if (raw.startsWith('#') || raw.startsWith('/')) return raw;
+    return `https://${raw}`;
+};
 
 /**
  * Resolve a URL attribute the way a browser would before deciding it is safe.
@@ -148,8 +166,9 @@ const cleanAttrs = (tag, raw) => {
             const style = cleanStyle(value);
             if (style) kept.push(`style="${attrValue(style)}"`);
         } else if (name === 'href' && tag === 'a') {
-            if (SAFE_HREF.test(decodeForSchemeCheck(value))) {
-                kept.push(`href="${attrValue(value)}"`);
+            const href = absoluteHref(value);
+            if (SAFE_HREF.test(decodeForSchemeCheck(href))) {
+                kept.push(`href="${attrValue(href)}"`);
                 hasHref = true;
             }
         } else if (name === 'src' && tag === 'img') {

--- a/Modules/PublicShares/publicRenderer.js
+++ b/Modules/PublicShares/publicRenderer.js
@@ -28,6 +28,71 @@ const PAGE_STYLE = `
     input,textarea{width:100%;box-sizing:border-box;border:1px solid #ddd;border-radius:6px;padding:8px;font-size:14px;font-family:inherit}
     button{margin-top:14px;background:#7b68ee;border:none;color:#fff;border-radius:6px;padding:9px 18px;font-size:14px;cursor:pointer}
     .footer{margin-top:26px;text-align:center;color:#aaa;font-size:12px}
+    /* ── Docs share ────────────────────────────────────────────────────────
+       Full-bleed: a breadcrumb bar across the top, the page tree down the left,
+       the document on a white sheet to the right. */
+    .wrap--bare{max-width:none;margin:0}
+    /* The window itself never scrolls: the breadcrumb bar and the footer stay put
+       and the two panes scroll on their own. */
+    body.bare{padding:0;background:#fff;height:100vh;overflow:hidden}
+    body.bare .wrap{display:flex;flex-direction:column;height:100vh;min-height:0}
+    body.bare .footer{flex:0 0 auto;margin:0;padding:16px 0 20px;background:#fff;border-top:1px solid #eef0f3}
+    /* Thin scrollbars on the panes — Firefox first, then WebKit/Blink. */
+    .dk__side,.dk__main{scrollbar-width:thin;scrollbar-color:#d3d6de transparent}
+    .dk__side::-webkit-scrollbar,.dk__main::-webkit-scrollbar{width:8px;height:8px}
+    .dk__side::-webkit-scrollbar-track,.dk__main::-webkit-scrollbar-track{background:transparent}
+    .dk__side::-webkit-scrollbar-thumb,.dk__main::-webkit-scrollbar-thumb{background:#d3d6de;border-radius:8px}
+    .dk__side::-webkit-scrollbar-thumb:hover,.dk__main::-webkit-scrollbar-thumb:hover{background:#b9bdc9}
+    .dk__bar{display:flex;align-items:center;gap:6px;flex:0 0 46px;height:46px;padding:0 16px;border-bottom:1px solid #eef0f3;font-size:13px;background:#fff;overflow:hidden;white-space:nowrap}
+    .crumb{display:inline-flex;align-items:center;gap:5px;color:#6b7280;text-decoration:none;max-width:260px;overflow:hidden;text-overflow:ellipsis}
+    a.crumb:hover{color:#111}
+    .crumb.is-last{color:#111;font-weight:600}
+    .crumb-sep{color:#c9ccd6}
+    .ic{flex:0 0 auto;opacity:.75;vertical-align:-2px}
+    /* min-height:0 is what actually lets the panes below scroll — without it a
+       flex child refuses to shrink past its content and the window scrolls instead. */
+    .dk{display:flex;align-items:stretch;flex:1;min-height:0;background:#fff}
+    .dk__side{flex:0 0 320px;min-height:0;overflow-y:auto;background:#fff;border-right:1px solid #eef0f3;padding:14px 8px 20px}
+    .dk__side-label{font-size:12px;color:#8b90a0;padding:2px 10px 8px}
+    .dk__tree{display:flex;flex-direction:column}
+    .dk__row{display:flex;align-items:center;gap:6px;padding:6px 10px;margin:1px 4px;border-radius:6px;font-size:13.5px;color:#3b4252;text-decoration:none;overflow:hidden}
+    .dk__row-title{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    a.dk__row:hover{background:#f4f5f8}
+    .dk__row.is-current{background:#eceef3;font-weight:600;color:#111}
+    .dk__caret{display:inline-flex;width:11px;flex:0 0 11px;color:#9aa0b0}
+    /* The whole right-hand pane is the sheet. The column inside only centres the
+       text — giving IT the white background left a floating white strip on grey. */
+    .dk__main{flex:1;min-width:0;min-height:0;overflow-y:auto;display:flex;justify-content:center;align-items:flex-start;background:#fff;padding:0 40px}
+    /* No min-height here: .dk already guarantees a full-height pane, and having
+       both stack their own min-height plus padding made a short doc scroll. */
+    .dk__doc-col{width:100%;max-width:760px;padding:40px 0 64px}
+    .dk__title{font-size:34px;font-weight:700;letter-spacing:-.4px;margin:0 0 12px;line-height:1.2}
+    .dk__meta{display:flex;align-items:center;gap:8px;font-size:13px;color:#9aa0b0;margin-bottom:26px}
+    .dk__author{color:#4b5162}
+    .dk__dot{color:#c9ccd6}
+    .dk__avatar{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background:#7b68ee;color:#fff;font-size:10px;font-weight:700;flex:0 0 20px}
+    /* The document sits directly on the sheet — no card inside a card. */
+    .dk__doc-col .doc{border:none;border-radius:0;padding:0;background:transparent;font-size:15px;line-height:1.75}
+    .dk__subs{margin-top:40px}
+    .dk__subs table{width:100%;border-collapse:collapse}
+    .dk__subs th{text-align:left;font-size:12.5px;font-weight:500;color:#9aa0b0;padding:0 0 8px;border-bottom:1px solid #eef0f3}
+    .dk__subs td{padding:12px 0;border-bottom:1px solid #f2f3f6;font-size:14px}
+    .dk__owner-col{width:90px;text-align:left}
+    .dk__sub-link{display:inline-flex;align-items:center;gap:10px;color:#111;font-weight:600;text-decoration:none}
+    .dk__sub-link:hover{color:#5b4ccc}
+    .dk__doc-box{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:6px;background:#f2f3f6;color:#6b7280;flex:0 0 26px}
+    /* Side-by-side needs width; below this the tree sits above the document. */
+    /* Stacked, the two panes are no longer side by side, so pane-scrolling makes
+       no sense — hand scrolling back to the page or the content is unreachable. */
+    @media (max-width:860px){
+        body.bare{height:auto;overflow:auto}
+        body.bare .wrap{height:auto;min-height:100vh}
+        .dk{display:block;min-height:0}
+        .dk__side{overflow:visible;border-right:none;border-bottom:1px solid #eef0f3;padding-bottom:10px}
+        .dk__main{overflow:visible;padding:0 16px}
+        .dk__doc-col{padding:22px 0 40px}
+        .dk__title{font-size:26px}
+    }
     .doc{background:#fff;border:1px solid #e6e6e6;border-radius:10px;padding:20px 24px;font-size:15px;line-height:1.7}
     .doc>*:first-child{margin-top:0}
     .doc>*:last-child{margin-bottom:0}
@@ -49,23 +114,31 @@ const PAGE_STYLE = `
     .ql-indent-4{padding-left:12em}.ql-indent-5{padding-left:15em}
 `;
 
+/* Inline SVG rather than an icon font or image: the CSP forbids outside
+ * requests, and these are markup, not script. */
+const ICON_DOC = '<svg class="ic" viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><path fill="currentColor" d="M9.5 1H4a1.5 1.5 0 0 0-1.5 1.5v11A1.5 1.5 0 0 0 4 15h8a1.5 1.5 0 0 0 1.5-1.5V5L9.5 1Zm0 1.6L11.9 5H9.5V2.6ZM5 7.5h6v1H5v-1Zm0 3h6v1H5v-1Z"/></svg>';
+const ICON_DOC_BOX = '<span class="dk__doc-box">' + ICON_DOC + '</span>';
+const ICON_CARET = '<svg viewBox="0 0 12 12" width="9" height="9" aria-hidden="true"><path fill="currentColor" d="M2 4l4 4 4-4z"/></svg>';
+
 /* A shared page is read-only and static: no script of ours, and none of theirs.
  * This is the backstop behind sanitizeDocHtml — anything that slipped past the
  * allow-list still has no way to execute. */
 const CSP = "default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'";
 
-const htmlPage = (title, body) => `<!DOCTYPE html>
+// `bare` drops the centred, padded card shell: a docs share is full-bleed, with
+// its own breadcrumb bar and sidebar. Boards and reports keep the original shell.
+const htmlPage = (title, body, bare) => `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="robots" content="noindex"><title>${escapeHtml(title)}</title><style>${PAGE_STYLE}</style></head>
-<body><div class="wrap">${body}<div class="footer">Shared via AlianHub</div></div></body></html>`;
+<body${bare ? ' class="bare"' : ''}><div class="wrap${bare ? ' wrap--bare' : ''}">${body}<div class="footer">Shared via AlianHub</div></div></body></html>`;
 
 /* Every public response goes out with the same locked-down headers. */
-const sendPage = (res, status, title, body) => res
+const sendPage = (res, status, title, body, bare) => res
     .status(status)
     .set('Content-Security-Policy', CSP)
     .set('X-Content-Type-Options', 'nosniff')
     .set('Referrer-Policy', 'no-referrer')
-    .send(htmlPage(title, body));
+    .send(htmlPage(title, body, bare));
 
 // Password gate (server-rendered) shown when a share is password-protected.
 const passwordForm = (token, wrong) => `<h1>Password required</h1>
@@ -133,7 +206,71 @@ async function renderReport(companyId, share) {
  * reaches the page (see sanitizeDocHtml) and the page is served under a CSP that
  * permits no script at all.
  */
-async function renderPage(companyId, share) {
+// Sharing a doc shares the doc AND everything nested under it, to any depth.
+// Walked level by level from the shared root rather than recursively per page,
+// so depth costs one query per level instead of one per node.
+//
+// Two bounds, because this is reachable without a login: a `visited` set (a
+// corrupt parent chain could otherwise loop forever) and a hard page cap.
+const SHARED_TREE_MAX_DEPTH = 12;
+const SHARED_TREE_MAX_PAGES = 500;
+
+async function collectSharedTree(companyId, rootPage) {
+    const nodes = [{ _id: String(rootPage._id), title: rootPage.title, depth: 0 }];
+    const visited = new Set([String(rootPage._id)]);
+    let frontier = [rootPage._id];
+
+    for (let depth = 1; depth <= SHARED_TREE_MAX_DEPTH && frontier.length; depth += 1) {
+        // A private sub-page stays private: excluded here, and because the walk
+        // never descends into what it excluded, its own children stay out too.
+        // eslint-disable-next-line no-await-in-loop
+        const children = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.PAGES,
+            data: [
+                { parentPageId: { $in: frontier }, deletedStatusKey: 0, visibility: { $ne: 'private' } },
+                'title parentPageId order updatedBy createdBy',
+                { sort: { order: 1 } },
+            ],
+        }, 'find').catch(() => []);
+
+        const next = [];
+        for (const child of (children || [])) {
+            const id = String(child._id);
+            if (visited.has(id) || nodes.length >= SHARED_TREE_MAX_PAGES) continue;
+            visited.add(id);
+            nodes.push({
+                _id: id,
+                title: child.title,
+                depth,
+                parentPageId: String(child.parentPageId || ''),
+                ownerId: String(child.updatedBy || child.createdBy || ''),
+            });
+            next.push(child._id);
+        }
+        frontier = next;
+    }
+    return nodes;
+}
+
+// Order the flat level-by-level list so each page is followed by its own
+// children — the reading order of the tree, not the order it was fetched in.
+function orderTree(nodes) {
+    const byParent = new Map();
+    for (const n of nodes.slice(1)) {
+        const key = n.parentPageId || '';
+        if (!byParent.has(key)) byParent.set(key, []);
+        byParent.get(key).push(n);
+    }
+    const out = [];
+    const walk = (node) => {
+        out.push(node);
+        for (const child of (byParent.get(node._id) || [])) walk(child);
+    };
+    walk(nodes[0]);
+    return out;
+}
+
+async function renderPage(companyId, share, requestedId) {
     const page = await MongoDbCrudOpration(companyId, {
         type: SCHEMA_TYPE.PAGES,
         data: [{ _id: share.entityId }],
@@ -146,13 +283,136 @@ async function renderPage(companyId, share) {
     if (String(page.visibility || '') === 'private') {
         return { title: 'Doc', body: '<h1>This doc is no longer shared.</h1>' };
     }
-    const title = page.title || 'Untitled doc';
-    const html = sanitizeDocHtml(page.content && page.content.html);
-    let body = `<h1>${escapeHtml(title)}</h1>`;
-    body += '<div class="muted">read-only public doc</div>';
-    body += `<div class="doc">${html || '<p style="color:#999">This doc is empty.</p>'}</div>`;
-    return { title, body };
+
+    const tree = orderTree(await collectSharedTree(companyId, page));
+    // The id in the URL is attacker-controlled, so it is only honoured when it
+    // is provably inside this share's own subtree. Anything else falls back to
+    // the root — never fetched — otherwise the token would read any doc in the
+    // company by id.
+    const wanted = String(requestedId || '');
+    const selected = tree.find((n) => n._id === wanted) || tree[0];
+
+    const current = selected._id === String(page._id)
+        ? page
+        : await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.PAGES,
+            data: [{ _id: selected._id, deletedStatusKey: 0 }],
+        }, 'findOne');
+    if (!current) {
+        return { title: 'Doc', body: '<h1>This doc is no longer available.</h1>' };
+    }
+
+    const title = current.title || 'Untitled doc';
+    const html = sanitizeDocHtml(current.content && current.content.html);
+    const byId = new Map(tree.map((n) => [n._id, n]));
+    const hasKids = new Set(tree.map((n) => n.parentPageId).filter(Boolean));
+    const link = (id) => `/share/${escapeHtml(share.token)}?p=${escapeHtml(id)}`;
+    const owner = await resolveOwner(current);
+
+    // Breadcrumb: the path from the shared root down to the page being read.
+    // Walked through the tree we already built, so it can never name a page
+    // outside this share.
+    const trail = [];
+    for (let node = selected; node; node = byId.get(node.parentPageId)) {
+        trail.unshift(node);
+        if (!node.parentPageId) break;
+    }
+    const crumbs = trail.map((node, i) => (i === trail.length - 1
+        ? `<span class="crumb is-last">${ICON_DOC}${escapeHtml(node.title || 'Untitled')}</span>`
+        : `<a class="crumb" href="${link(node._id)}">${ICON_DOC}${escapeHtml(node.title || 'Untitled')}</a>`
+    )).join('<span class="crumb-sep">/</span>');
+
+    let side = '<aside class="dk__side">'
+        + '<div class="dk__side-label">Pages</div><div class="dk__tree">';
+    for (const node of tree) {
+        const isCurrent = node._id === selected._id;
+        const label = escapeHtml(node.title || 'Untitled');
+        const indent = 12 + (node.depth * 16);
+        // The caret marks a page that has children. It is decoration, not a
+        // control: the whole tree is already expanded, and there is no script
+        // on this page to collapse it with.
+        const caret = hasKids.has(node._id) ? `<span class="dk__caret">${ICON_CARET}</span>` : '<span class="dk__caret"></span>';
+        const inner = `${caret}${ICON_DOC}<span class="dk__row-title">${label}</span>`;
+        side += isCurrent
+            ? `<span class="dk__row is-current" style="padding-left:${indent}px">${inner}</span>`
+            : `<a class="dk__row" style="padding-left:${indent}px" href="${link(node._id)}">${inner}</a>`;
+    }
+    side += '</div></aside>';
+
+    // Direct children only — the sidebar already carries the whole tree, so this
+    // is "what is under the page you are reading", as in ClickUp.
+    const children = tree.filter((n) => n.parentPageId === selected._id);
+    let subpages = '';
+    if (children.length) {
+        const names = await resolveNames(children.map((c) => c.ownerId));
+        subpages = '<div class="dk__subs"><table><thead><tr><th>Subpages</th><th class="dk__owner-col">Owner</th></tr></thead><tbody>';
+        for (const child of children) {
+            const who = names.get(child.ownerId) || '';
+            subpages += `<tr><td><a class="dk__sub-link" href="${link(child._id)}">${ICON_DOC_BOX}${escapeHtml(child.title || 'Untitled')}</a></td>`
+                + `<td class="dk__owner-col">${who ? avatar(who) : ''}</td></tr>`;
+        }
+        subpages += '</tbody></table></div>';
+    }
+
+    const meta = `<div class="dk__meta">${owner.name ? `${avatar(owner.name)}<span class="dk__author">${escapeHtml(owner.name)}</span><span class="dk__dot">•</span>` : ''}`
+        + `<span class="dk__updated">Last updated ${escapeHtml(formatStamp(current.updatedAt || current.createdAt))}</span></div>`;
+
+    const main = '<section class="dk__main"><div class="dk__doc-col">'
+        + `<h1 class="dk__title">${escapeHtml(title)}</h1>`
+        + meta
+        + `<div class="doc">${html || ''}</div>`
+        + subpages
+        + '</div></section>';
+
+    return {
+        title,
+        body: `<div class="dk__bar">${crumbs}</div><div class="dk">${side}${main}</div>`,
+        wide: true,
+        bare: true,
+    };
 }
+
+/* Display names for a set of user ids, in ONE query — the subpages table would
+ * otherwise issue a lookup per row. Users live in the GLOBAL db, not the company
+ * one. Best-effort throughout: a name that cannot be resolved is simply omitted
+ * rather than failing the page. */
+async function resolveNames(userIds) {
+    const ids = [...new Set((userIds || []).map(String).filter(Boolean))];
+    const out = new Map();
+    if (!ids.length) return out;
+    try {
+        const users = await MongoDbCrudOpration('global', {
+            type: SCHEMA_TYPE.USERS,
+            data: [{ _id: { $in: ids } }, 'Employee_Name Employee_FName Employee_LName'],
+        }, 'find');
+        for (const u of (users || [])) {
+            const name = u.Employee_Name || [u.Employee_FName, u.Employee_LName].filter(Boolean).join(' ');
+            if (name) out.set(String(u._id), String(name));
+        }
+    } catch (e) { /* names are decoration — never fail the page for them */ }
+    return out;
+}
+
+async function resolveOwner(page) {
+    const uid = String(page.updatedBy || page.createdBy || '');
+    const names = await resolveNames([uid]);
+    return { name: names.get(uid) || '' };
+}
+
+// Initial-in-a-circle. Real avatars live behind signed storage URLs that would
+// expire on a public page, so the initial is the honest version.
+const avatar = (name) => {
+    const initial = escapeHtml(String(name || '?').trim().charAt(0).toUpperCase() || '?');
+    return `<span class="dk__avatar">${initial}</span>`;
+};
+
+const formatStamp = (value) => {
+    const d = value ? new Date(value) : null;
+    if (!d || Number.isNaN(d.getTime())) return 'unknown';
+    const date = d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+    const time = d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+    return `${date} at ${time}`;
+};
 
 /* GET /share/:token — read-only board grouped by status. */
 exports.renderShare = async (req, res) => {
@@ -178,10 +438,12 @@ exports.renderShare = async (req, res) => {
             return sendPage(res, 200, rendered.title, rendered.body);
         }
 
-        // A shared doc renders the document itself.
+        // A shared doc renders the document itself, plus everything nested under
+        // it. `?p=` picks which page of that subtree to show; renderPage rejects
+        // any id that is not inside it.
         if (share.entityType === 'page') {
-            const rendered = await renderPage(companyId, share);
-            return sendPage(res, 200, rendered.title, rendered.body);
+            const rendered = await renderPage(companyId, share, req.query && req.query.p);
+            return sendPage(res, 200, rendered.title, rendered.body, rendered.bare);
         }
 
         const [sprint, tasks] = await Promise.all([

--- a/Modules/PublicShares/publicRenderer.js
+++ b/Modules/PublicShares/publicRenderer.js
@@ -43,6 +43,15 @@ const PAGE_STYLE = `
     .dk__side::-webkit-scrollbar-track,.dk__main::-webkit-scrollbar-track{background:transparent}
     .dk__side::-webkit-scrollbar-thumb,.dk__main::-webkit-scrollbar-thumb{background:#d3d6de;border-radius:8px}
     .dk__side::-webkit-scrollbar-thumb:hover,.dk__main::-webkit-scrollbar-thumb:hover{background:#b9bdc9}
+    /* Every page of the share is in the document; :target picks the one on
+       screen, so switching pages costs no reload and no script. The default
+       pane is last in source order, which lets a targeted pane hide it with a
+       following-sibling selector — no :has() needed, so there is no browser
+       where this degrades to a blank page. */
+    .pane{display:none;flex:1;min-height:0;flex-direction:column}
+    .pane:target{display:flex}
+    .pane--default{display:flex}
+    .pane:target ~ .pane--default{display:none}
     .dk__bar{display:flex;align-items:center;gap:6px;flex:0 0 46px;height:46px;padding:0 16px;border-bottom:1px solid #eef0f3;font-size:13px;background:#fff;overflow:hidden;white-space:nowrap}
     .crumb{display:inline-flex;align-items:center;gap:5px;color:#6b7280;text-decoration:none;max-width:260px;overflow:hidden;text-overflow:ellipsis}
     a.crumb:hover{color:#111}
@@ -302,74 +311,118 @@ async function renderPage(companyId, share, requestedId) {
         return { title: 'Doc', body: '<h1>This doc is no longer available.</h1>' };
     }
 
-    const title = current.title || 'Untitled doc';
-    const html = sanitizeDocHtml(current.content && current.content.html);
+    // Every page of the subtree is rendered into the one response and switched
+    // with :target, so reading a sub-page costs no reload. That only holds while
+    // the payload stays sane — beyond these bounds the panes are dropped and
+    // each page is fetched from the server as before. The sidebar is repeated
+    // per pane (CSS can only restyle the target and what follows it), so the
+    // page count matters as much as the content size.
+    const INLINE_MAX_PAGES = 25;
+    const INLINE_MAX_CONTENT_BYTES = 300 * 1024;
+
+    const docs = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.PAGES,
+        data: [{ _id: { $in: tree.map((n) => n._id) }, deletedStatusKey: 0 }],
+    }, 'find').catch(() => []);
+    const docById = new Map((docs || []).map((d) => [String(d._id), d]));
+    docById.set(String(page._id), page);
+
+    const totalBytes = tree.reduce((sum, n) => {
+        const d = docById.get(n._id);
+        return sum + String((d && d.content && d.content.html) || '').length;
+    }, 0);
+    const inline = tree.length > 1
+        && tree.length <= INLINE_MAX_PAGES
+        && totalBytes <= INLINE_MAX_CONTENT_BYTES
+        && tree.every((n) => docById.has(n._id));
+
+    const names = await resolveNames(tree.map((n) => n.ownerId).concat([page.updatedBy, page.createdBy]));
     const byId = new Map(tree.map((n) => [n._id, n]));
     const hasKids = new Set(tree.map((n) => n.parentPageId).filter(Boolean));
-    const link = (id) => `/share/${escapeHtml(share.token)}?p=${escapeHtml(id)}`;
-    const owner = await resolveOwner(current);
+    // In-page anchor when everything is inlined, a server round-trip otherwise.
+    const link = inline
+        ? (id) => `#pg-${escapeHtml(id)}`
+        : (id) => `/share/${escapeHtml(share.token)}?p=${escapeHtml(id)}`;
 
-    // Breadcrumb: the path from the shared root down to the page being read.
-    // Walked through the tree we already built, so it can never name a page
-    // outside this share.
-    const trail = [];
-    for (let node = selected; node; node = byId.get(node.parentPageId)) {
-        trail.unshift(node);
-        if (!node.parentPageId) break;
-    }
-    const crumbs = trail.map((node, i) => (i === trail.length - 1
-        ? `<span class="crumb is-last">${ICON_DOC}${escapeHtml(node.title || 'Untitled')}</span>`
-        : `<a class="crumb" href="${link(node._id)}">${ICON_DOC}${escapeHtml(node.title || 'Untitled')}</a>`
-    )).join('<span class="crumb-sep">/</span>');
+    const paneFor = (node) => {
+        const doc = docById.get(node._id) || {};
+        const nodeTitle = doc.title || node.title || 'Untitled doc';
 
-    let side = '<aside class="dk__side">'
-        + '<div class="dk__side-label">Pages</div><div class="dk__tree">';
-    for (const node of tree) {
-        const isCurrent = node._id === selected._id;
-        const label = escapeHtml(node.title || 'Untitled');
-        const indent = 12 + (node.depth * 16);
-        // The caret marks a page that has children. It is decoration, not a
-        // control: the whole tree is already expanded, and there is no script
-        // on this page to collapse it with.
-        const caret = hasKids.has(node._id) ? `<span class="dk__caret">${ICON_CARET}</span>` : '<span class="dk__caret"></span>';
-        const inner = `${caret}${ICON_DOC}<span class="dk__row-title">${label}</span>`;
-        side += isCurrent
-            ? `<span class="dk__row is-current" style="padding-left:${indent}px">${inner}</span>`
-            : `<a class="dk__row" style="padding-left:${indent}px" href="${link(node._id)}">${inner}</a>`;
-    }
-    side += '</div></aside>';
-
-    // Direct children only — the sidebar already carries the whole tree, so this
-    // is "what is under the page you are reading", as in ClickUp.
-    const children = tree.filter((n) => n.parentPageId === selected._id);
-    let subpages = '';
-    if (children.length) {
-        const names = await resolveNames(children.map((c) => c.ownerId));
-        subpages = '<div class="dk__subs"><table><thead><tr><th>Subpages</th><th class="dk__owner-col">Owner</th></tr></thead><tbody>';
-        for (const child of children) {
-            const who = names.get(child.ownerId) || '';
-            subpages += `<tr><td><a class="dk__sub-link" href="${link(child._id)}">${ICON_DOC_BOX}${escapeHtml(child.title || 'Untitled')}</a></td>`
-                + `<td class="dk__owner-col">${who ? avatar(who) : ''}</td></tr>`;
+        // Breadcrumb: the path from the shared root down to this page. Walked
+        // through the tree we already built, so it can never name a page
+        // outside this share.
+        const trail = [];
+        for (let n = node; n; n = byId.get(n.parentPageId)) {
+            trail.unshift(n);
+            if (!n.parentPageId) break;
         }
-        subpages += '</tbody></table></div>';
+        const crumbs = trail.map((n, i) => (i === trail.length - 1
+            ? `<span class="crumb is-last">${ICON_DOC}${escapeHtml(n.title || 'Untitled')}</span>`
+            : `<a class="crumb" href="${link(n._id)}">${ICON_DOC}${escapeHtml(n.title || 'Untitled')}</a>`
+        )).join('<span class="crumb-sep">/</span>');
+
+        let side = '<aside class="dk__side">'
+            + '<div class="dk__side-label">Pages</div><div class="dk__tree">';
+        for (const row of tree) {
+            const isCurrent = row._id === node._id;
+            const label = escapeHtml(row.title || 'Untitled');
+            const indent = 12 + (row.depth * 16);
+            // The caret marks a page that has children. It is decoration, not a
+            // control: the whole tree is already expanded, and there is no
+            // script on this page to collapse it with.
+            const caret = hasKids.has(row._id) ? `<span class="dk__caret">${ICON_CARET}</span>` : '<span class="dk__caret"></span>';
+            const inner = `${caret}${ICON_DOC}<span class="dk__row-title">${label}</span>`;
+            side += isCurrent
+                ? `<span class="dk__row is-current" style="padding-left:${indent}px">${inner}</span>`
+                : `<a class="dk__row" style="padding-left:${indent}px" href="${link(row._id)}">${inner}</a>`;
+        }
+        side += '</div></aside>';
+
+        // Direct children only — the sidebar already carries the whole tree, so
+        // this is "what is under the page you are reading", as in ClickUp.
+        const children = tree.filter((n) => n.parentPageId === node._id);
+        let subpages = '';
+        if (children.length) {
+            subpages = '<div class="dk__subs"><table><thead><tr><th>Subpages</th><th class="dk__owner-col">Owner</th></tr></thead><tbody>';
+            for (const child of children) {
+                const who = names.get(child.ownerId) || '';
+                subpages += `<tr><td><a class="dk__sub-link" href="${link(child._id)}">${ICON_DOC_BOX}${escapeHtml(child.title || 'Untitled')}</a></td>`
+                    + `<td class="dk__owner-col">${who ? avatar(who) : ''}</td></tr>`;
+            }
+            subpages += '</tbody></table></div>';
+        }
+
+        const who = names.get(String(doc.updatedBy || doc.createdBy || '')) || '';
+        const meta = `<div class="dk__meta">${who ? `${avatar(who)}<span class="dk__author">${escapeHtml(who)}</span><span class="dk__dot">•</span>` : ''}`
+            + `<span class="dk__updated">Last updated ${escapeHtml(formatStamp(doc.updatedAt || doc.createdAt))}</span></div>`;
+
+        const main = '<section class="dk__main"><div class="dk__doc-col">'
+            + `<h1 class="dk__title">${escapeHtml(nodeTitle)}</h1>`
+            + meta
+            + `<div class="doc">${sanitizeDocHtml(doc.content && doc.content.html) || ''}</div>`
+            + subpages
+            + '</div></section>';
+
+        return `<div class="dk__bar">${crumbs}</div><div class="dk">${side}${main}</div>`;
+    };
+
+    const title = (docById.get(selected._id) || {}).title || selected.title || 'Untitled doc';
+
+    if (!inline) {
+        return { title, body: paneFor(selected), bare: true };
     }
 
-    const meta = `<div class="dk__meta">${owner.name ? `${avatar(owner.name)}<span class="dk__author">${escapeHtml(owner.name)}</span><span class="dk__dot">•</span>` : ''}`
-        + `<span class="dk__updated">Last updated ${escapeHtml(formatStamp(current.updatedAt || current.createdAt))}</span></div>`;
+    // The pane shown when there is no #hash goes LAST and carries the default
+    // class: `.pane:target ~ .pane--default` can then hide it as soon as any
+    // other pane is targeted. Ordering it this way avoids :has(), so the page
+    // does not depend on a selector some browsers may not support — with no
+    // fallback a missing :has() would render nothing at all.
+    const others = tree.filter((n) => n._id !== selected._id);
+    let body = '';
+    for (const node of others) body += `<div class="pane" id="pg-${escapeHtml(node._id)}">${paneFor(node)}</div>`;
+    body += `<div class="pane pane--default" id="pg-${escapeHtml(selected._id)}">${paneFor(selected)}</div>`;
 
-    const main = '<section class="dk__main"><div class="dk__doc-col">'
-        + `<h1 class="dk__title">${escapeHtml(title)}</h1>`
-        + meta
-        + `<div class="doc">${html || ''}</div>`
-        + subpages
-        + '</div></section>';
-
-    return {
-        title,
-        body: `<div class="dk__bar">${crumbs}</div><div class="dk">${side}${main}</div>`,
-        wide: true,
-        bare: true,
-    };
+    return { title, body, bare: true };
 }
 
 /* Display names for a set of user ids, in ONE query — the subpages table would

--- a/Modules/PublicShares/publicRenderer.js
+++ b/Modules/PublicShares/publicRenderer.js
@@ -115,9 +115,21 @@ const PAGE_STYLE = `
     .doc p{margin:0 0 12px}
     .doc ol,.doc ul{margin:0 0 12px;padding-left:26px}
     .doc li{margin:3px 0}
+    /* Checklists. The editor writes a checked run and an unchecked run as two
+       separate <ul data-checked>, so the marker comes from the list and the
+       negative margin keeps consecutive runs reading as one list. */
+    .doc ul[data-checked]>li{list-style:none;position:relative}
+    .doc ul[data-checked]>li::before{content:'\\2610';position:absolute;left:-21px;top:0;color:#6b7280;font-size:15px}
+    .doc ul[data-checked="true"]>li::before{content:'\\2611';color:#4b5162}
+    .doc ul[data-checked]+ul[data-checked]{margin-top:-12px}
     .doc blockquote{margin:0 0 12px;padding:2px 0 2px 14px;border-left:4px solid #e0e0e0;color:#555}
     .doc pre{background:#f6f7f9;border-radius:6px;padding:12px 14px;overflow-x:auto;font-size:13px;white-space:pre-wrap;word-break:break-word}
     .doc img{max-width:100%;height:auto}
+    /* The editor gives a video no dimensions, so without this an embed collapses
+       to a few pixels. 16:9, and it shrinks with the column. */
+    .doc iframe.ql-video{display:block;width:100%;max-width:680px;aspect-ratio:16/9;height:auto;min-height:200px;border:0;border-radius:8px;background:#000}
+    .doc iframe.ql-video.ql-align-center{margin-left:auto;margin-right:auto}
+    .doc iframe.ql-video.ql-align-right{margin-left:auto}
     .doc a{color:#5b4ccc}
     .doc table{border-collapse:collapse}
     .doc td,.doc th{border:1px solid #e6e6e6;padding:6px 10px}
@@ -144,8 +156,14 @@ const ICON_CARET = '<svg viewBox="0 0 12 12" width="9" height="9" aria-hidden="t
  *
  * connect-src 'self' is what lets the page fetch another doc page; nothing else
  * may be reached. */
+const EMBED_HOSTS = 'https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com '
+    + 'https://player.vimeo.com https://www.loom.com https://loom.com';
+
 const cspFor = (nonce) => "default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; "
     + `script-src 'nonce-${nonce}'; connect-src 'self'; `
+    // Video embeds only, and only the players sanitizeDocHtml already accepts —
+    // two independent gates on the same short list.
+    + `frame-src ${EMBED_HOSTS}; `
     + "form-action 'self'; base-uri 'none'; frame-ancestors 'none'";
 
 // `bare` drops the centred, padded card shell: a docs share is full-bleed, with

--- a/Modules/PublicShares/publicRenderer.js
+++ b/Modules/PublicShares/publicRenderer.js
@@ -5,6 +5,7 @@ const logger = require("../../Config/loggerConfig");
 const { isShareToken, validateIntakeSubmission, escapeHtml, sanitizeDocHtml } = require('./helpers/shareRules');
 const reportRules = require('../CustomReports/helpers/reportRules'); // REP-09 — share saved reports
 const bcrypt = require('bcrypt');
+const crypto = require('crypto');
 
 // Unauthenticated public pages, server-rendered as plain HTML so the public
 // surface needs no SPA route, login or token. The share token resolves the
@@ -43,15 +44,10 @@ const PAGE_STYLE = `
     .dk__side::-webkit-scrollbar-track,.dk__main::-webkit-scrollbar-track{background:transparent}
     .dk__side::-webkit-scrollbar-thumb,.dk__main::-webkit-scrollbar-thumb{background:#d3d6de;border-radius:8px}
     .dk__side::-webkit-scrollbar-thumb:hover,.dk__main::-webkit-scrollbar-thumb:hover{background:#b9bdc9}
-    /* Every page of the share is in the document; :target picks the one on
-       screen, so switching pages costs no reload and no script. The default
-       pane is last in source order, which lets a targeted pane hide it with a
-       following-sibling selector — no :has() needed, so there is no browser
-       where this degrades to a blank page. */
-    .pane{display:none;flex:1;min-height:0;flex-direction:column}
-    .pane:target{display:flex}
-    .pane--default{display:flex}
-    .pane:target ~ .pane--default{display:none}
+    /* The one live region: the breadcrumb and the body are replaced together
+       when another page is opened. */
+    .pg-live{display:flex;flex-direction:column;flex:1;min-height:0}
+    .pg-live.is-loading{opacity:.55}
     .dk__bar{display:flex;align-items:center;gap:6px;flex:0 0 46px;height:46px;padding:0 16px;border-bottom:1px solid #eef0f3;font-size:13px;background:#fff;overflow:hidden;white-space:nowrap}
     .crumb{display:inline-flex;align-items:center;gap:5px;color:#6b7280;text-decoration:none;max-width:260px;overflow:hidden;text-overflow:ellipsis}
     a.crumb:hover{color:#111}
@@ -64,11 +60,20 @@ const PAGE_STYLE = `
     .dk__side{flex:0 0 320px;min-height:0;overflow-y:auto;background:#fff;border-right:1px solid #eef0f3;padding:14px 8px 20px}
     .dk__side-label{font-size:12px;color:#8b90a0;padding:2px 10px 8px}
     .dk__tree{display:flex;flex-direction:column}
-    .dk__row{display:flex;align-items:center;gap:6px;padding:6px 10px;margin:1px 4px;border-radius:6px;font-size:13.5px;color:#3b4252;text-decoration:none;overflow:hidden}
+    /* The row is the highlight and the hit area; the link fills what is left of
+       it so the caret beside it stays independently clickable. */
+    .dk__item{display:flex;align-items:center;gap:6px;margin:1px 4px;border-radius:6px;overflow:hidden}
+    .dk__item:hover{background:#f4f5f8}
+    .dk__item.is-current{background:#eceef3}
+    .dk__row{flex:1;min-width:0;display:flex;align-items:center;gap:6px;padding:6px 8px 6px 0;font-size:13.5px;color:#3b4252;text-decoration:none;overflow:hidden}
+    .dk__item.is-current .dk__row{font-weight:600;color:#111}
     .dk__row-title{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-    a.dk__row:hover{background:#f4f5f8}
-    .dk__row.is-current{background:#eceef3;font-weight:600;color:#111}
-    .dk__caret{display:inline-flex;width:11px;flex:0 0 11px;color:#9aa0b0}
+    .dk__caret{display:inline-flex;align-items:center;justify-content:center;width:14px;height:18px;flex:0 0 14px;color:#9aa0b0}
+    .dk__caret--btn{cursor:pointer;border-radius:3px}
+    .dk__caret--btn:hover{background:#e2e5ec;color:#4b5162}
+    .dk__caret svg{transition:transform .12s ease}
+    .dk__item.is-collapsed>.dk__caret svg{transform:rotate(-90deg)}
+    .dk__item.is-hidden{display:none}
     /* The whole right-hand pane is the sheet. The column inside only centres the
        text — giving IT the white background left a floating white strip on grey. */
     .dk__main{flex:1;min-width:0;min-height:0;overflow-y:auto;display:flex;justify-content:center;align-items:flex-start;background:#fff;padding:0 40px}
@@ -129,25 +134,121 @@ const ICON_DOC = '<svg class="ic" viewBox="0 0 16 16" width="13" height="13" ari
 const ICON_DOC_BOX = '<span class="dk__doc-box">' + ICON_DOC + '</span>';
 const ICON_CARET = '<svg viewBox="0 0 12 12" width="9" height="9" aria-hidden="true"><path fill="currentColor" d="M2 4l4 4 4-4z"/></svg>';
 
-/* A shared page is read-only and static: no script of ours, and none of theirs.
- * This is the backstop behind sanitizeDocHtml — anything that slipped past the
- * allow-list still has no way to execute. */
-const CSP = "default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'";
+/* One script of ours, none of theirs.
+ *
+ * script-src carries a per-response nonce and never 'unsafe-inline', so the
+ * navigation script below runs while anything injected does not: an attacker
+ * cannot guess the nonce, and inline handlers (onclick=) stay blocked outright.
+ * That keeps the backstop behind sanitizeDocHtml — which already strips <script>
+ * and every on* attribute by allow-list — rather than trading it away.
+ *
+ * connect-src 'self' is what lets the page fetch another doc page; nothing else
+ * may be reached. */
+const cspFor = (nonce) => "default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; "
+    + `script-src 'nonce-${nonce}'; connect-src 'self'; `
+    + "form-action 'self'; base-uri 'none'; frame-ancestors 'none'";
 
 // `bare` drops the centred, padded card shell: a docs share is full-bleed, with
 // its own breadcrumb bar and sidebar. Boards and reports keep the original shell.
-const htmlPage = (title, body, bare) => `<!DOCTYPE html>
+/* Opens another page of the share without reloading: fetch its markup, swap the
+ * live region, and move the address bar with history so back/forward and a
+ * copied URL keep working.
+ *
+ * Progressive enhancement — every link is a real href, so with this script
+ * blocked, failed or unsupported the page still navigates, just with a reload.
+ * Only the page being read is ever fetched, which is why a shared doc can be
+ * any size. */
+const NAV_SCRIPT = (token) => `
+(function () {
+  var live = document.getElementById('pg-live');
+  if (!live || !window.fetch || !window.history || !history.pushState) return;
+  var base = '/share/${token}';
+  var busy = false;
+  // Which branches the reader folded away. Kept here rather than in the markup
+  // because every page swap replaces the sidebar, and a collapsed tree that
+  // sprang open again on each click would be worse than not collapsing at all.
+  var collapsed = Object.create(null);
+  function applyCollapse() {
+    var items = live.querySelectorAll('.dk__item');
+    for (var i = 0; i < items.length; i++) {
+      var it = items[i];
+      it.classList.remove('is-collapsed', 'is-hidden');
+      if (collapsed[it.getAttribute('data-id')]) it.classList.add('is-collapsed');
+      var anc = (it.getAttribute('data-anc') || '').split(' ');
+      for (var j = 0; j < anc.length; j++) {
+        if (anc[j] && collapsed[anc[j]]) { it.classList.add('is-hidden'); break; }
+      }
+    }
+  }
+  function toggle(id) {
+    if (collapsed[id]) delete collapsed[id]; else collapsed[id] = true;
+    applyCollapse();
+  }
+  function show(data, id, push) {
+    live.innerHTML = '<div class="dk__bar">' + data.bar + '</div>' + data.body;
+    document.title = data.title;
+    var url = id ? base + '?p=' + encodeURIComponent(id) : base;
+    if (push) history.pushState({ p: id }, '', url);
+    applyCollapse();
+  }
+  function open(id, push) {
+    if (busy) return;
+    busy = true;
+    live.className = 'pg-live is-loading';
+    fetch(base + '/page/' + encodeURIComponent(id), { headers: { Accept: 'application/json' } })
+      .then(function (r) { if (!r.ok) throw new Error('http ' + r.status); return r.json(); })
+      .then(function (data) { show(data, id, push); })
+      .catch(function () { window.location.href = base + '?p=' + encodeURIComponent(id); })
+      .then(function () { busy = false; live.className = 'pg-live'; });
+  }
+  document.addEventListener('click', function (e) {
+    if (e.defaultPrevented || !e.target.closest) return;
+    // The twisty is checked first and returns: folding a branch must never also
+    // open the page sitting next to it.
+    var t = e.target.closest('.dk__caret[data-toggle]');
+    if (t) { e.preventDefault(); toggle(t.getAttribute('data-toggle')); return; }
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    var a = e.target.closest('a[data-pg]');
+    if (!a) return;
+    e.preventDefault();
+    open(a.getAttribute('data-pg'), true);
+  });
+  // The twisty carries role="button", so it owes the keyboard the same action.
+  document.addEventListener('keydown', function (e) {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    var t = e.target.closest ? e.target.closest('.dk__caret[data-toggle]') : null;
+    if (!t) return;
+    e.preventDefault();
+    toggle(t.getAttribute('data-toggle'));
+  });
+  window.addEventListener('popstate', function (e) {
+    var id = e.state && e.state.p;
+    if (id) open(id, false); else window.location.reload();
+  });
+})();`;
+
+const htmlPage = (title, body, bare, opts) => {
+    const o = opts || {};
+    const script = o.live && o.nonce
+        ? `<script nonce="${o.nonce}">${NAV_SCRIPT(escapeHtml(o.token || ''))}</` + 'script>'
+        : '';
+    return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="robots" content="noindex"><title>${escapeHtml(title)}</title><style>${PAGE_STYLE}</style></head>
-<body${bare ? ' class="bare"' : ''}><div class="wrap${bare ? ' wrap--bare' : ''}">${body}<div class="footer">Shared via AlianHub</div></div></body></html>`;
+<body${bare ? ' class="bare"' : ''}><div class="wrap${bare ? ' wrap--bare' : ''}">${body}<div class="footer">Shared via AlianHub</div></div>${script}</body></html>`;
+};
 
-/* Every public response goes out with the same locked-down headers. */
-const sendPage = (res, status, title, body, bare) => res
-    .status(status)
-    .set('Content-Security-Policy', CSP)
-    .set('X-Content-Type-Options', 'nosniff')
-    .set('Referrer-Policy', 'no-referrer')
-    .send(htmlPage(title, body, bare));
+/* Every public response goes out with the same locked-down headers. The nonce is
+ * generated per response — a fixed one would be as good as 'unsafe-inline'. */
+const sendPage = (res, status, title, body, bare, opts) => {
+    const nonce = crypto.randomBytes(16).toString('base64');
+    return res
+        .status(status)
+        .set('Content-Security-Policy', cspFor(nonce))
+        .set('X-Content-Type-Options', 'nosniff')
+        .set('Referrer-Policy', 'no-referrer')
+        .send(htmlPage(title, body, bare, { ...(opts || {}), nonce }));
+};
 
 // Password gate (server-rendered) shown when a share is password-protected.
 const passwordForm = (token, wrong) => `<h1>Password required</h1>
@@ -279,25 +380,29 @@ function orderTree(nodes) {
     return out;
 }
 
-async function renderPage(companyId, share, requestedId) {
+/**
+ * Resolve everything a doc share needs to render one page: the shared subtree,
+ * which page was asked for, that page's document, and the display names.
+ *
+ * ONLY the requested page's content is loaded. The tree carries titles, not
+ * bodies, so the work here is independent of how large the other pages are —
+ * a shared doc can be any size.
+ */
+async function buildDocContext(companyId, share, requestedId) {
     const page = await MongoDbCrudOpration(companyId, {
         type: SCHEMA_TYPE.PAGES,
         data: [{ _id: share.entityId }],
     }, 'findOne');
-    if (!page || page.deletedStatusKey === 1) {
-        return { title: 'Doc', body: '<h1>This doc is no longer available.</h1>' };
-    }
+    if (!page || page.deletedStatusKey === 1) return { error: 'This doc is no longer available.' };
     // Marked private after the link was made. Private means private — the link
     // stops working rather than outliving the decision.
-    if (String(page.visibility || '') === 'private') {
-        return { title: 'Doc', body: '<h1>This doc is no longer shared.</h1>' };
-    }
+    if (String(page.visibility || '') === 'private') return { error: 'This doc is no longer shared.' };
 
     const tree = orderTree(await collectSharedTree(companyId, page));
-    // The id in the URL is attacker-controlled, so it is only honoured when it
-    // is provably inside this share's own subtree. Anything else falls back to
-    // the root — never fetched — otherwise the token would read any doc in the
-    // company by id.
+    // The id in the request is attacker-controlled, so it is only honoured when
+    // it is provably inside this share's own subtree. Anything else falls back
+    // to the root — never fetched — otherwise the token would read any doc in
+    // the company by id.
     const wanted = String(requestedId || '');
     const selected = tree.find((n) => n._id === wanted) || tree[0];
 
@@ -307,122 +412,109 @@ async function renderPage(companyId, share, requestedId) {
             type: SCHEMA_TYPE.PAGES,
             data: [{ _id: selected._id, deletedStatusKey: 0 }],
         }, 'findOne');
-    if (!current) {
-        return { title: 'Doc', body: '<h1>This doc is no longer available.</h1>' };
-    }
+    if (!current) return { error: 'This doc is no longer available.' };
 
-    // Every page of the subtree is rendered into the one response and switched
-    // with :target, so reading a sub-page costs no reload. That only holds while
-    // the payload stays sane — beyond these bounds the panes are dropped and
-    // each page is fetched from the server as before. The sidebar is repeated
-    // per pane (CSS can only restyle the target and what follows it), so the
-    // page count matters as much as the content size.
-    const INLINE_MAX_PAGES = 25;
-    const INLINE_MAX_CONTENT_BYTES = 300 * 1024;
+    // One lookup for the byline plus every row of the subpages table.
+    const children = tree.filter((n) => n.parentPageId === selected._id);
+    const names = await resolveNames(
+        children.map((c) => c.ownerId).concat([current.updatedBy, current.createdBy]),
+    );
 
-    const docs = await MongoDbCrudOpration(companyId, {
-        type: SCHEMA_TYPE.PAGES,
-        data: [{ _id: { $in: tree.map((n) => n._id) }, deletedStatusKey: 0 }],
-    }, 'find').catch(() => []);
-    const docById = new Map((docs || []).map((d) => [String(d._id), d]));
-    docById.set(String(page._id), page);
+    return { tree, selected, current, children, names, byId: new Map(tree.map((n) => [n._id, n])) };
+}
 
-    const totalBytes = tree.reduce((sum, n) => {
-        const d = docById.get(n._id);
-        return sum + String((d && d.content && d.content.html) || '').length;
-    }, 0);
-    const inline = tree.length > 1
-        && tree.length <= INLINE_MAX_PAGES
-        && totalBytes <= INLINE_MAX_CONTENT_BYTES
-        && tree.every((n) => docById.has(n._id));
-
-    const names = await resolveNames(tree.map((n) => n.ownerId).concat([page.updatedBy, page.createdBy]));
-    const byId = new Map(tree.map((n) => [n._id, n]));
+/* The breadcrumb bar and the sidebar+document body for one page. Returned
+ * separately so the client can swap them without touching the page shell. */
+function renderDocPane(share, ctx) {
+    const { tree, selected, current, children, names, byId } = ctx;
     const hasKids = new Set(tree.map((n) => n.parentPageId).filter(Boolean));
-    // In-page anchor when everything is inlined, a server round-trip otherwise.
-    const link = inline
-        ? (id) => `#pg-${escapeHtml(id)}`
-        : (id) => `/share/${escapeHtml(share.token)}?p=${escapeHtml(id)}`;
+    const title = current.title || 'Untitled doc';
+    // A real URL, so the link works when opened directly, copied, or when the
+    // script below never runs. data-pg lets the script recognise it without
+    // parsing anything.
+    const link = (id) => `/share/${escapeHtml(share.token)}?p=${escapeHtml(id)}`;
 
-    const paneFor = (node) => {
-        const doc = docById.get(node._id) || {};
-        const nodeTitle = doc.title || node.title || 'Untitled doc';
+    const trail = [];
+    for (let n = selected; n; n = byId.get(n.parentPageId)) {
+        trail.unshift(n);
+        if (!n.parentPageId) break;
+    }
+    const crumbs = trail.map((n, i) => (i === trail.length - 1
+        ? `<span class="crumb is-last">${ICON_DOC}${escapeHtml(n.title || 'Untitled')}</span>`
+        : `<a class="crumb" data-pg="${escapeHtml(n._id)}" href="${link(n._id)}">${ICON_DOC}${escapeHtml(n.title || 'Untitled')}</a>`
+    )).join('<span class="crumb-sep">/</span>');
 
-        // Breadcrumb: the path from the shared root down to this page. Walked
-        // through the tree we already built, so it can never name a page
-        // outside this share.
-        const trail = [];
-        for (let n = node; n; n = byId.get(n.parentPageId)) {
-            trail.unshift(n);
+    // Ancestor ids per row, so collapsing a branch can hide everything beneath it
+    // without the client having to rebuild the tree.
+    const ancestorsOf = (node) => {
+        const out = [];
+        for (let n = byId.get(node.parentPageId); n; n = byId.get(n.parentPageId)) {
+            out.push(n._id);
             if (!n.parentPageId) break;
         }
-        const crumbs = trail.map((n, i) => (i === trail.length - 1
-            ? `<span class="crumb is-last">${ICON_DOC}${escapeHtml(n.title || 'Untitled')}</span>`
-            : `<a class="crumb" href="${link(n._id)}">${ICON_DOC}${escapeHtml(n.title || 'Untitled')}</a>`
-        )).join('<span class="crumb-sep">/</span>');
-
-        let side = '<aside class="dk__side">'
-            + '<div class="dk__side-label">Pages</div><div class="dk__tree">';
-        for (const row of tree) {
-            const isCurrent = row._id === node._id;
-            const label = escapeHtml(row.title || 'Untitled');
-            const indent = 12 + (row.depth * 16);
-            // The caret marks a page that has children. It is decoration, not a
-            // control: the whole tree is already expanded, and there is no
-            // script on this page to collapse it with.
-            const caret = hasKids.has(row._id) ? `<span class="dk__caret">${ICON_CARET}</span>` : '<span class="dk__caret"></span>';
-            const inner = `${caret}${ICON_DOC}<span class="dk__row-title">${label}</span>`;
-            side += isCurrent
-                ? `<span class="dk__row is-current" style="padding-left:${indent}px">${inner}</span>`
-                : `<a class="dk__row" style="padding-left:${indent}px" href="${link(row._id)}">${inner}</a>`;
-        }
-        side += '</div></aside>';
-
-        // Direct children only — the sidebar already carries the whole tree, so
-        // this is "what is under the page you are reading", as in ClickUp.
-        const children = tree.filter((n) => n.parentPageId === node._id);
-        let subpages = '';
-        if (children.length) {
-            subpages = '<div class="dk__subs"><table><thead><tr><th>Subpages</th><th class="dk__owner-col">Owner</th></tr></thead><tbody>';
-            for (const child of children) {
-                const who = names.get(child.ownerId) || '';
-                subpages += `<tr><td><a class="dk__sub-link" href="${link(child._id)}">${ICON_DOC_BOX}${escapeHtml(child.title || 'Untitled')}</a></td>`
-                    + `<td class="dk__owner-col">${who ? avatar(who) : ''}</td></tr>`;
-            }
-            subpages += '</tbody></table></div>';
-        }
-
-        const who = names.get(String(doc.updatedBy || doc.createdBy || '')) || '';
-        const meta = `<div class="dk__meta">${who ? `${avatar(who)}<span class="dk__author">${escapeHtml(who)}</span><span class="dk__dot">•</span>` : ''}`
-            + `<span class="dk__updated">Last updated ${escapeHtml(formatStamp(doc.updatedAt || doc.createdAt))}</span></div>`;
-
-        const main = '<section class="dk__main"><div class="dk__doc-col">'
-            + `<h1 class="dk__title">${escapeHtml(nodeTitle)}</h1>`
-            + meta
-            + `<div class="doc">${sanitizeDocHtml(doc.content && doc.content.html) || ''}</div>`
-            + subpages
-            + '</div></section>';
-
-        return `<div class="dk__bar">${crumbs}</div><div class="dk">${side}${main}</div>`;
+        return out;
     };
 
-    const title = (docById.get(selected._id) || {}).title || selected.title || 'Untitled doc';
+    let side = '<aside class="dk__side"><div class="dk__side-label">Pages</div><div class="dk__tree">';
+    for (const row of tree) {
+        const isCurrent = row._id === selected._id;
+        const label = escapeHtml(row.title || 'Untitled');
+        const indent = 12 + (row.depth * 16);
+        // The caret is a SIBLING of the link, never inside it — nested in the
+        // anchor, every click on the twisty also opened the page.
+        const caret = hasKids.has(row._id)
+            ? `<span class="dk__caret dk__caret--btn" data-toggle="${escapeHtml(row._id)}" role="button" tabindex="0" aria-label="Show or hide sub-pages">${ICON_CARET}</span>`
+            : '<span class="dk__caret"></span>';
+        const body = `${ICON_DOC}<span class="dk__row-title">${label}</span>`;
+        const target = isCurrent
+            ? `<span class="dk__row">${body}</span>`
+            : `<a class="dk__row" data-pg="${escapeHtml(row._id)}" href="${link(row._id)}">${body}</a>`;
+        side += `<div class="dk__item${isCurrent ? ' is-current' : ''}" data-id="${escapeHtml(row._id)}"`
+            + ` data-anc="${escapeHtml(ancestorsOf(row).join(' '))}" style="padding-left:${indent}px">${caret}${target}</div>`;
+    }
+    side += '</div></aside>';
 
-    if (!inline) {
-        return { title, body: paneFor(selected), bare: true };
+    // Direct children only — the sidebar already carries the whole tree, so this
+    // is "what is under the page you are reading", as in ClickUp.
+    let subpages = '';
+    if (children.length) {
+        subpages = '<div class="dk__subs"><table><thead><tr><th>Subpages</th><th class="dk__owner-col">Owner</th></tr></thead><tbody>';
+        for (const child of children) {
+            const who = names.get(child.ownerId) || '';
+            subpages += `<tr><td><a class="dk__sub-link" data-pg="${escapeHtml(child._id)}" href="${link(child._id)}">${ICON_DOC_BOX}${escapeHtml(child.title || 'Untitled')}</a></td>`
+                + `<td class="dk__owner-col">${who ? avatar(who) : ''}</td></tr>`;
+        }
+        subpages += '</tbody></table></div>';
     }
 
-    // The pane shown when there is no #hash goes LAST and carries the default
-    // class: `.pane:target ~ .pane--default` can then hide it as soon as any
-    // other pane is targeted. Ordering it this way avoids :has(), so the page
-    // does not depend on a selector some browsers may not support — with no
-    // fallback a missing :has() would render nothing at all.
-    const others = tree.filter((n) => n._id !== selected._id);
-    let body = '';
-    for (const node of others) body += `<div class="pane" id="pg-${escapeHtml(node._id)}">${paneFor(node)}</div>`;
-    body += `<div class="pane pane--default" id="pg-${escapeHtml(selected._id)}">${paneFor(selected)}</div>`;
+    const who = names.get(String(current.updatedBy || current.createdBy || '')) || '';
+    const meta = `<div class="dk__meta">${who ? `${avatar(who)}<span class="dk__author">${escapeHtml(who)}</span><span class="dk__dot">•</span>` : ''}`
+        + `<span class="dk__updated">Last updated ${escapeHtml(formatStamp(current.updatedAt || current.createdAt))}</span></div>`;
 
-    return { title, body, bare: true };
+    const main = '<section class="dk__main"><div class="dk__doc-col">'
+        + `<h1 class="dk__title">${escapeHtml(title)}</h1>`
+        + meta
+        + `<div class="doc">${sanitizeDocHtml(current.content && current.content.html) || ''}</div>`
+        + subpages
+        + '</div></section>';
+
+    return { title, bar: crumbs, body: `<div class="dk">${side}${main}</div>` };
+}
+
+async function renderPage(companyId, share, requestedId) {
+    const ctx = await buildDocContext(companyId, share, requestedId);
+    if (ctx.error) return { title: 'Doc', body: `<h1>${escapeHtml(ctx.error)}</h1>` };
+    const pane = renderDocPane(share, ctx);
+    return {
+        title: pane.title,
+        body: `<div id="pg-live" class="pg-live"><div class="dk__bar">${pane.bar}</div>${pane.body}</div>`,
+        bare: true,
+        // Swapping pages in the browser is pointless behind a password: the gate
+        // is stateless and re-asked per request, so the fragment endpoint refuses
+        // and every navigation would have to reload anyway.
+        live: !share.passwordHash,
+        pageId: ctx.selected._id,
+    };
 }
 
 /* Display names for a set of user ids, in ONE query — the subpages table would
@@ -467,6 +559,39 @@ const formatStamp = (value) => {
     return `${date} at ${time}`;
 };
 
+/* GET /share/:token/page/:pageId — one page of a shared doc, as JSON, for the
+ * in-page navigation. Everything the full render enforces is enforced here too:
+ * this is a second door into the same data, not a shortcut past the checks.
+ *
+ * The requested id is validated against the share's own subtree by
+ * buildDocContext, which falls back to the root rather than fetching anything
+ * outside it, and the content is sanitised by the same renderer. */
+exports.renderDocFragment = async (req, res) => {
+    try {
+        const resolved = await resolveShare(req.params.token);
+        if (!resolved) return res.status(404).json({ error: 'not found' });
+        const { companyId, share } = resolved;
+        if (share.entityType !== 'page') return res.status(404).json({ error: 'not found' });
+        // The password gate is stateless and re-asked per request, so there is no
+        // unlocked session for this endpoint to trust. Refuse and let the browser
+        // fall back to a full navigation, which asks for the password properly.
+        if (share.passwordHash) return res.status(403).json({ error: 'password required' });
+
+        const ctx = await buildDocContext(companyId, share, req.params.pageId);
+        if (ctx.error) return res.status(404).json({ error: ctx.error });
+        const pane = renderDocPane(share, ctx);
+        return res
+            .set('Content-Security-Policy', "default-src 'none'")
+            .set('X-Content-Type-Options', 'nosniff')
+            .set('Referrer-Policy', 'no-referrer')
+            .set('Cache-Control', 'no-store')
+            .json({ title: pane.title, bar: pane.bar, body: pane.body, id: ctx.selected._id });
+    } catch (error) {
+        logger.error(`ERROR in render doc fragment: ${error.message}`);
+        return res.status(500).json({ error: 'failed' });
+    }
+};
+
 /* GET /share/:token — read-only board grouped by status. */
 exports.renderShare = async (req, res) => {
     try {
@@ -496,7 +621,9 @@ exports.renderShare = async (req, res) => {
         // any id that is not inside it.
         if (share.entityType === 'page') {
             const rendered = await renderPage(companyId, share, req.query && req.query.p);
-            return sendPage(res, 200, rendered.title, rendered.body, rendered.bare);
+            return sendPage(res, 200, rendered.title, rendered.body, rendered.bare, {
+                live: rendered.live, token: share.token,
+            });
         }
 
         const [sprint, tasks] = await Promise.all([

--- a/Modules/PublicShares/routes.js
+++ b/Modules/PublicShares/routes.js
@@ -18,6 +18,7 @@ exports.init = (app) => {
 
     // Unauthenticated public pages (server-rendered HTML), rate-limited by IP.
     app.get('/share/:token', publicReadLimiter, renderer.renderShare);
+    app.get('/share/:token/page/:pageId', publicReadLimiter, renderer.renderDocFragment); // in-page navigation
     app.post('/share/:token', publicReadLimiter, renderer.renderShare);        // password unlock (re-renders)
     app.post('/share/:token/intake', publicWriteLimiter, renderer.submitIntake);
 }

--- a/frontend/src/components/molecules/Pages/PagesPanel.vue
+++ b/frontend/src/components/molecules/Pages/PagesPanel.vue
@@ -385,6 +385,13 @@ function fetchPages() {
         if (!expanded.value.size) {
             expanded.value = new Set(pages.value.filter((p) => p.parentPageId).map((p) => String(p.parentPageId)));
         }
+        // As a view, landing on "pick a doc" reads as an empty project even when
+        // it has docs, so start on the first one. Only when nothing is open and
+        // no doc was asked for — and with no docs at all the empty state is still
+        // the right answer. The panel keeps its picker: it is opened FROM a doc.
+        if (props.embedded && !current.value && !props.openDocId && rows.value.length) {
+            openPage(rows.value[0]._id);
+        }
     })
     .catch((error) => console.error('ERROR in fetch pages: ', error));
 }

--- a/frontend/src/components/molecules/Pages/PagesPanel.vue
+++ b/frontend/src/components/molecules/Pages/PagesPanel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="modelValue" class="pg" @click.self="requestClose">
+    <div v-if="isOpen" class="pg" :class="{ 'pg--embedded': embedded }" @click.self="embedded ? null : requestClose()">
         <div class="pg__shell">
             <!-- ─── Sidebar: the page tree ─────────────────────────────── -->
             <aside class="pg__side">
@@ -87,7 +87,7 @@
                             <button type="button" class="pg__icon-btn pg__icon-btn--danger" :title="$t('Projects.delete')" @click="deletePage">
                                 <span v-html="ICONS.trash"></span>
                             </button>
-                            <button type="button" class="pg__icon-btn" :title="$t('Projects.close')" @click="requestClose">
+                            <button v-if="!embedded" type="button" class="pg__icon-btn" :title="$t('Projects.close')" @click="requestClose">
                                 <span v-html="ICONS.close"></span>
                             </button>
                         </div>
@@ -194,7 +194,7 @@
 
                 <!-- Nothing open yet. -->
                 <div v-else class="pg__blank">
-                    <button type="button" class="pg__icon-btn pg__blank-close" :title="$t('Projects.close')" @click="requestClose">
+                    <button v-if="!embedded" type="button" class="pg__icon-btn pg__blank-close" :title="$t('Projects.close')" @click="requestClose">
                         <span v-html="ICONS.close"></span>
                     </button>
                     <span class="pg__blank-icon" v-html="ICONS.doc"></span>
@@ -251,6 +251,10 @@ const props = defineProps({
     // Open straight onto this doc. Set when the panel is opened from somewhere that
     // already named one — the Docs list on a task, for instance.
     openDocId: { type: String, default: '' },
+    // Rendered as a project view rather than an overlay: no backdrop, fills its
+    // container, and there is nothing to close back to — so the close controls
+    // and click-outside are dropped.
+    embedded: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -347,7 +351,11 @@ const toggle = (id) => {
 
 const nameOf = (id) => (id ? (getUser(String(id))?.Employee_Name || '—') : '—');
 
-watch(() => props.modelValue, (open) => {
+// Embedded as a view there is no open/close cycle, so it is open from the start
+// and the watch below must fire immediately or the tree would never load.
+const isOpen = computed(() => props.embedded || props.modelValue);
+
+watch(isOpen, (open) => {
     if (open) {
         fetchPages();
         // The tree lists this project's docs; a doc opened from a task may be linked from
@@ -360,12 +368,12 @@ watch(() => props.modelValue, (open) => {
         showLinker.value = false;
         showShare.value = false;
     }
-});
+}, { immediate: true });
 
 // Opening the panel twice from two different docs without closing it in between: the
 // watch above only fires on open, so the id changing while open has to be honoured too.
 watch(() => props.openDocId, (id) => {
-    if (id && props.modelValue) openPage(id);
+    if (id && isOpen.value) openPage(id);
 });
 
 function fetchPages() {
@@ -757,6 +765,24 @@ onBeforeUnmount(() => {
     display: flex;
     overflow: hidden;
     box-shadow: 0 18px 48px rgba(23, 25, 35, 0.22);
+}
+/* As a project view it sits in the page flow, so it drops the backdrop, the
+   centring and the floating-card treatment and simply fills its container. */
+.pg--embedded {
+    position: static;
+    inset: auto;
+    background: transparent;
+    z-index: auto;
+    display: block;
+    height: 100%;
+}
+.pg--embedded .pg__shell {
+    width: 100%;
+    height: 100%;
+    min-height: 520px;
+    border-radius: 8px;
+    box-shadow: none;
+    border: 1px solid #eef0f6;
 }
 
 /* ── sidebar ─────────────────────────────────────────── */

--- a/frontend/src/components/molecules/Pages/PagesPanel.vue
+++ b/frontend/src/components/molecules/Pages/PagesPanel.vue
@@ -700,7 +700,29 @@ function openEditor() {
  * and Quill's html are routinely different with nobody having typed a character — which is
  * why closing an untouched doc still asked about unsaved changes.
  */
+// Typing "www.alianhub.com" into the link box stored it verbatim, and a href with
+// no scheme is resolved against the current page — so the link went to
+// localhost:8080/www.alianhub.com instead of the site. Give a scheme-less URL an
+// https:// prefix before Quill stores it.
+//
+// Anything that already carries a scheme is passed straight through to Quill's own
+// sanitiser, so its protocol whitelist still rejects javascript: and friends — this
+// only fills in what the user left out.
+const URL_HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+function patchLinkSanitizer(quill) {
+    const Link = quill && quill.constructor && quill.constructor.import('formats/link');
+    if (!Link || Link.__alianhubAbsolute) return;
+    const original = Link.sanitize.bind(Link);
+    Link.sanitize = (value) => {
+        const url = String(value == null ? '' : value).trim();
+        if (!url || URL_HAS_SCHEME.test(url) || url.startsWith('#') || url.startsWith('/')) return original(url);
+        return original(`https://${url}`);
+    };
+    Link.__alianhubAbsolute = true;
+}
+
 function onEditorReady(quill) {
+    patchLinkSanitizer(quill);
     // Flush first. The stored html was written straight into the element, and Quill only
     // takes it in when its MutationObserver next runs — a microtask later. Reading before
     // that returns our own string rather than Quill's rendering of it, and the difference

--- a/frontend/src/components/molecules/Pages/PagesPanel.vue
+++ b/frontend/src/components/molecules/Pages/PagesPanel.vue
@@ -376,6 +376,30 @@ watch(() => props.openDocId, (id) => {
     if (id && isOpen.value) openPage(id);
 });
 
+// Switching projects does not remount this component — only the injected project
+// changes — so nothing above re-ran and the previous project's tree and open doc
+// stayed on screen until a tab change or reload forced a rebuild.
+watch(() => (props.projectData && props.projectData._id) || '', (id, previous) => {
+    if (!id || !previous || id === previous) return;
+    // Nothing here autosaves (see isDirty), and the switch has already happened,
+    // so a confirm could not undo it. Say plainly that the edits are going rather
+    // than dropping them in silence.
+    if (isDirty.value) {
+        $toast.warning(t('Projects.page_unsaved_lost_on_switch'), { position: 'top-right' });
+    }
+    current.value = null;
+    draftTitle.value = '';
+    contentHtml.value = '';
+    savedSnapshot.value = { title: '', html: '' };
+    baselinePending.value = false;
+    pages.value = [];
+    expanded.value = new Set();
+    query.value = '';
+    showLinker.value = false;
+    showShare.value = false;
+    if (isOpen.value) fetchPages();
+});
+
 function fetchPages() {
     apiRequest('get', `/api/v2/pages?projectId=${props.projectData._id}`)
     .then((response) => {

--- a/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
+++ b/frontend/src/components/molecules/ProjectViews/ViewsDropdown.vue
@@ -96,7 +96,8 @@ const images = {
     WhiteboardView: {image: require('@/assets/images/png/Board.png'), description: 'whiteboard_view'},
     CanvasView: {image: require('@/assets/images/png/Activity.png'), description: 'canvas_view'},
     MapView: {image: require('@/assets/images/png/Workload.png'), description: 'map_view'},
-    ProjectDashboard: {image: require('@/assets/images/png/Workload.png'), description: 'dashboard_view'}
+    ProjectDashboard: {image: require('@/assets/images/png/Workload.png'), description: 'dashboard_view'},
+    DocsView: {image: require('@/assets/images/png/Activity.png'), description: 'docs_view'}
 }
 const viewItem = ref('')
 const companyId = inject('$companyId')

--- a/frontend/src/composable/commonFunction.js
+++ b/frontend/src/composable/commonFunction.js
@@ -207,6 +207,13 @@ export const projectComponentsIcons = (key) => {
             icon: require("@/assets/images/svg/component-inactive-icons/comp_dashboard_inactive.svg"),
             activeIcon: require("@/assets/images/svg/component-active-icons/comp_dashboard_active.svg"),
             keyName: "ProjectDashboard"
+        },
+        {
+            // No dedicated docs icon in the set yet — the project-detail glyph is a
+            // document, so it reads correctly until one is designed.
+            icon: require("@/assets/images/svg/component-inactive-icons/comp_project_detail_inactive.svg"),
+            activeIcon: require("@/assets/images/svg/component-active-icons/comp_project_details_active.svg"),
+            keyName: "DocsView"
         }
     ];
 

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -811,6 +811,7 @@ export default {
         page_unsaved: "Unsaved changes",
         page_edited_by: "Edited by {who} on {when}",
         page_discard_confirm: "This doc has unsaved changes. Leave without saving?",
+        page_unsaved_lost_on_switch: "You switched projects with unsaved changes — they were not saved.",
         page_delete_confirm: "Delete this doc? This cannot be undone.",
         page_delete_with_children: "Delete this doc and every sub-page under it? This cannot be undone.",
         untitled_page: "Untitled doc",

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -986,6 +986,7 @@ export default {
         "Whiteboard View": "Whiteboard",
         "Canvas View": "Canvas",
         "Map View": "Map",
+        Docs: "Docs",
         Comment: "Comment",
         to_unlock_list_view: "To Unlock List View",
         error_message_for_empty: "Please select at least one view",
@@ -1042,6 +1043,8 @@ export default {
             "Pin tasks onto a world map to see where your work happens — placements are saved to your browser.",
         dashboard_view:
             "A project overview at a glance — task totals, completion, and estimated vs remaining hours, scoped to your role.",
+        docs_view:
+            "Write and organise the project's documents — a page tree on the left, the document you are editing on the right.",
         list_view:
             "Use List view to organize your tasks in anyway imaginable – sort, filter, group, and customize columns.",
         kanban_view:

--- a/frontend/src/views/Projects/DocsView/DocsView.vue
+++ b/frontend/src/views/Projects/DocsView/DocsView.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="docs-view">
+        <PagesPanel
+            v-if="projectData && Object.keys(projectData || {}).length"
+            :projectData="projectData"
+            :openDocId="openDocId"
+            embedded
+        />
+    </div>
+</template>
+
+<script setup>
+import { computed, inject } from 'vue';
+import { useRoute } from 'vue-router';
+
+// The docs UI itself is the panel already used from a task's Linked Docs — this
+// view renders the same component embedded rather than as an overlay, so there
+// is one Docs implementation, not two.
+import PagesPanel from '@/components/molecules/Pages/PagesPanel.vue';
+
+const route = useRoute();
+const projectData = inject('selectedProject');
+
+// ?doc=<id> opens straight onto a document, so a link to a specific doc in this
+// view lands on it instead of the "pick something" state.
+const openDocId = computed(() => String(route.query?.doc || ''));
+</script>
+
+<style scoped>
+.docs-view {
+    height: 100%;
+    min-height: 520px;
+    padding: 12px 14px 16px;
+}
+</style>

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -267,6 +267,7 @@
                                             activeTab !== 'CanvasView' &&
                                             activeTab !== 'MapView' &&
                                             activeTab !== 'ProjectDashboard' &&
+                                            activeTab !== 'DocsView' &&
                                             (clientWidth > 767 || activeTab !== 'ProjectDetail')
                                 },
                                 {'board-veiw-main-parent': activeTab === 'ProjectKanban'}
@@ -314,7 +315,7 @@
                             <AiTaskCreator v-if="projectData && projectData._id" v-model="showAiTaskCreator" :projectId="String(projectData._id)" :sprints="aiSprints" :activeSprintId="aiActiveSprintId" @done="onAiTasksCreated" />
                             <component
                                 v-if="(clientWidth <= 767 && isVisible == true && isRuleData == false) || (clientWidth > 767 && isRuleData == false)"
-                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView' && activeTab !== 'MapView' && activeTab !== 'ProjectDashboard'}]"
+                                :class="[{'showProjectDetailRight':activeTab !== 'ProjectListView' && activeTab !== 'Calendar' && activeTab != 'EmbedViewItem' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView' && activeTab !== 'MapView' && activeTab !== 'ProjectDashboard' && activeTab !== 'DocsView'}]"
                                 :is="getView(activeTab)"
                                 :data="selectedEmbedView"
                                 :sprints="sprints"
@@ -336,7 +337,7 @@
                                 :sprintLoading="sprintLoading"
                                 :commentType="'project'"
                             />
-                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView' && activeTab !== 'ProjectDashboard'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
+                            <ProjectDetailRightSide v-if="activeTab !== 'ProjectListView' && clientWidth > 767 && activeTab !== 'Calendar' && activeTab != 'EmbedView' && activeTab !== 'Workload' && activeTab !== 'ProjectKanban' && activeTab !== 'TableView' && activeTab !== 'Reports' && activeTab !== 'GanttView' && activeTab !== 'RecurringTasks' && activeTab !== 'TimelineView' && activeTab !== 'MindMapView' && activeTab !== 'WhiteboardView' && activeTab !== 'CanvasView' && activeTab !== 'ProjectDashboard' && activeTab !== 'DocsView'" :projectData="projectData" @rightSideBarEmit="handleEmitProjectRightSide" @description="handleDescription"/>
                         </div>
                         <div class="position-ab z-index-1 p-5px border-radius-5-px text-center p0x-15px archived_wrapper" v-if="projectData?.deletedStatusKey === 2">
                             <div>
@@ -487,6 +488,7 @@ const WhiteboardViewComp = defineAsyncComponent(() => import(/* webpackChunkName
 const CanvasViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-canvas" */ '@/views/Projects/CanvasView/CanvasView.vue'));
 const MapViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-map" */ '@/views/Projects/MapView/MapView.vue'));
 const DashboardViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-dashboard" */ './DashboardView/DashboardView.vue'));
+const DocsViewComp = defineAsyncComponent(() => import(/* webpackChunkName: "project-docs" */ '@/views/Projects/DocsView/DocsView.vue'));
 import NotFound from '../NotFound.vue';
 
 // EXTRACTED PIECES
@@ -1236,6 +1238,8 @@ function getView(val) {
             return MapViewComp;
         case 'ProjectDashboard':
             return DashboardViewComp;
+        case 'DocsView':
+            return DocsViewComp;
         default:
             return NotFound;
     }

--- a/utils/data.js
+++ b/utils/data.js
@@ -1910,6 +1910,14 @@ exports.importProjectTabComponents = (companyName) => {
             value: "mapview",
             setAsDefault: false,
             viewStatus: false
+        },
+        {
+            name: "Docs",
+            sortIndex: 17,
+            keyName: "DocsView",
+            value: "docsview",
+            setAsDefault: false,
+            viewStatus: false
         }
     ];
     return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
## What this does

Two related pieces of the Docs feature.

**1 — Docs as a project view.** Docs worked already, but only as a panel opened from a task's Linked Docs section. It now appears in the view switcher next to List and Board, so you can sit in a project and write.

**2 — A shared doc now shares everything nested under it.** Previously a public link exposed exactly one page; every sub-page under it was invisible to the reader. The whole subtree now travels with the link, and the reader UI is rebuilt to match what people expect from a shared doc.

## Notable decisions

**Reused the docs UI rather than forking it.** `PagesPanel` gained an `embedded` mode — no backdrop, no centring, no close controls, fills its container. One Docs implementation in two placements.

That mode exposed a real bug: the panel loaded its page tree on a `modelValue` false→true transition, which embedded never has, so it would have rendered permanently empty. It now watches a computed `isOpen` with `immediate: true`.

**The `?p=` id is treated as hostile.** It comes from the URL, so it is honoured only when provably inside this share's own subtree; anything else falls back to the root and is never fetched. Without that check, one doc's token would read any doc in the company by id.

Two rules fall out of the same walk:
- a private sub-page is excluded **and the walk does not descend into it**, so its children stay hidden too
- deleted pages are excluded, and cannot be forced back via the URL

**The walk is bounded** — 12 levels, 500 pages, plus a `visited` set. This endpoint needs no login, and a corrupt parent chain (a page that is its own ancestor) would otherwise loop forever.

**Scrolling.** Only the two panes scroll; the breadcrumb bar and footer stay put. That needs `min-height: 0` on the flex children — without it they refuse to shrink below their content and the window scrolls instead. Below 860px the panes stack and normal page scrolling returns, since pane scrolling would strand the content.

## Testing

45 assertions run against the real functions extracted from the renderer, with a fake Mongo:

- tree walk to depth 3, reading order (a page's children follow it, before its sibling)
- private / deleted / unrelated pages excluded, including a child of a private page
- **eight forced-id attacks** — an unrelated doc, a private page, a deleted page, `../../root`, `' OR 1=1`, a `<script>` payload — all fall back to the root
- a leaf share shows no reachable parent
- a parent cycle terminates rather than hanging
- layout: sidebar before content, breadcrumb marks the current page, subpages table lists direct children only, byline resolved from the global users db in **one** query

Layout verified in a browser rather than by eye: no window scroll, content pane scrolls 400px while the bar holds position, footer pinned to the viewport bottom, sidebar reaching the footer exactly, and no horizontal overflow at 375px.

Frontend build passes; the new view emits its own `project-docs` chunk.

## Deployment note

**Existing companies will not see the new view until the project tab components are reseeded.** `utils/data.js` is the seed for *new* companies — it does not retro-fit existing ones. The catalog is reseeded through the Import Settings flow (`importProjectTabComponents`).

## Not included

The icon is a stand-in — there is no docs glyph in the set, so it borrows the project-detail document icon. Worth a proper icon later.

Only `en.js` is translated; the other locales fall back to the key, consistent with recently added views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
