### PR TITLE
fix(public-share): keep a link that carries a port

### DIFF
--- a/Modules/PublicShares/helpers/shareRules.js
+++ b/Modules/PublicShares/helpers/shareRules.js
@@ -110,7 +110,13 @@ const ALLOWED_STYLE_PROPS = new Set([
 ]);
 const SAFE_HREF = /^(?:https?:\/\/|mailto:|#|\/)/i;
 const SAFE_IMG_SRC = /^(?:https?:\/\/|data:image\/(?:png|jpe?g|gif|webp);base64,)/i;
-const HREF_HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+// A colon alone does not mean a scheme: in "www.alianhub.com:8443/docs" it
+// introduces a port. Requiring a non-digit after it separates the two, so a
+// host:port link is absolutised instead of being read as an unknown scheme and
+// dropped. A dangerous scheme is never followed by a digit ("javascript:alert"),
+// and one that were — "javascript:1234" — becomes https://javascript:1234, an
+// ordinary https url to a host called javascript, not an executable one.
+const HREF_HAS_SCHEME = /^[a-z][a-z0-9+.-]*:(?!\d)/i;
 
 /**
  * Docs written before the editor started absolutising links hold hrefs like


### PR DESCRIPTION
## The bug

A link like `www.alianhub.com:8443/docs` or `localhost:3000` lost its href entirely on a shared page, leaving text that looked like a link and did nothing.

Raised by review on #488, and confirmed against the real sanitiser before fixing:

```
www.alianhub.com:8443/docs  ->  (href DROPPED)
localhost:3000              ->  (href DROPPED)
www.alianhub.com/docs       ->  https://www.alianhub.com/docs   ← worked
```

## Cause

The scheme check treated any leading `text:` as a scheme. In `www.alianhub.com:8443` that colon introduces a **port**, so the value was read as scheme-bearing, skipped absolutising, then failed `SAFE_HREF` and was dropped.

A scheme is now recognised only when the colon is followed by something other than a digit.

## Why this cannot smuggle a scheme through

A dangerous scheme is never followed by a digit — `javascript:alert`, `data:text/html`, `vbscript:msgbox` all still match and are still dropped, including the obfuscated forms (`java&#09;script:`, `javascript&#58;`).

The one shape the relaxation does change is `javascript:1234`, which now becomes `https://javascript:1234` — an ordinary https URL to a host named "javascript", inert rather than executable.

```
www.alianhub.com:8443/docs  ->  https://www.alianhub.com:8443/docs
localhost:3000              ->  https://localhost:3000
mailto:a@b.com              ->  mailto:a@b.com
javascript:alert(1)         ->  (DROPPED)
javascript:1234             ->  https://javascript:1234   (inert)
data:text/html,x            ->  (DROPPED)
vbscript:msgbox             ->  (DROPPED)
java&#09;script:alert(1)    ->  (DROPPED)
javascript&#58;alert(1)     ->  (DROPPED)
```

Five regression tests added; the full link/embed/checklist suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
