### PR TITLE
fix(public-share): keep a link that carries a port

### DIFF
--- a/Modules/PublicShares/helpers/shareRules.js
+++ b/Modules/PublicShares/helpers/shareRules.js
@@ -110,7 +110,13 @@ const ALLOWED_STYLE_PROPS = new Set([
 ]);
 const SAFE_HREF = /^(?:https?:\/\/|mailto:|#|\/)/i;
 const SAFE_IMG_SRC = /^(?:https?:\/\/|data:image\/(?:png|jpe?g|gif|webp);base64,)/i;
-const HREF_HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+// A colon alone does not mean a scheme: in "www.alianhub.com:8443/docs" it
+// introduces a port. Requiring a non-digit after it separates the two, so a
+// host:port link is absolutised instead of being read as an unknown scheme and
+// dropped. A dangerous scheme is never followed by a digit ("javascript:alert"),
+// and one that were — "javascript:1234" — becomes https://javascript:1234, an
+// ordinary https url to a host called javascript, not an executable one.
+const HREF_HAS_SCHEME = /^[a-z][a-z0-9+.-]*:(?!\d)/i;
 
 /**
  * Docs written before the editor started absolutising links hold hrefs like


### PR DESCRIPTION
Promotion of staging → main. One fix.

A link like `www.alianhub.com:8443/docs` or `localhost:3000` lost its href entirely on a shared page, leaving text that looked like a link and did nothing. The scheme check read the colon before the port as a scheme separator, so the value skipped absolutising and then failed `SAFE_HREF`.

A scheme is now recognised only when the colon is followed by a non-digit, which separates a scheme from a host:port.

This cannot smuggle a scheme through — dangerous ones are never followed by a digit, so `javascript:`, `data:` and `vbscript:` are still dropped, including the obfuscated forms. The one shape that changes is `javascript:1234`, which becomes `https://javascript:1234`: an ordinary https URL to a host named "javascript", inert rather than executable.

Raised by review on #489, confirmed against the real sanitiser before fixing, and covered by five regression tests. Full link/embed/checklist suite passes.

Merged to staging in #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
