### PR TITLE
feat: show a parent task's estimate as its own plus its subtasks'

### DIFF
--- a/frontend/src/components/molecules/EstimatedTimeInput/EstimatedTimeInput.vue
+++ b/frontend/src/components/molecules/EstimatedTimeInput/EstimatedTimeInput.vue
@@ -3,6 +3,7 @@
     v-if="!isEditing"
     class="time-display"
     :class="{ 'time-display--readonly': !editable }"
+    :title="breakdownTitle"
     @click="startEditing"
 >
     {{ displayTime }}
@@ -45,7 +46,9 @@
 </template>
 
 <script setup>
-import { ref, computed, nextTick, onUnmounted } from 'vue'
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { apiRequest } from '@/services'
+import * as env from '@/config/env'
 
 const props = defineProps({
   task: {
@@ -73,13 +76,61 @@ const editHours = ref(0)
 const editMinutes = ref(0)
 const blurTimer = ref(null)
 
-// Computed property for display time
-const displayTime = computed(() => {
-  const totalMinutes = props.task.totalEstimatedTime || 0
+// Sum of this task's subtasks' estimates.
+//
+// Asked of the server rather than added up from the subtask list on screen: that
+// list is a loaded slice (TaskDetail fetches a limited number and counts the rest
+// separately), so summing it would quietly undercount a task with many subtasks.
+// The query mirrors fetchSubtaskCount in views/TaskDetail/TaskDetail.vue, which
+// already aggregates children by ParentTaskId the same way.
+const subtaskMinutes = ref(0)
+
+const loadSubtaskEstimate = () => {
+  const parentId = props.task && props.task._id
+  // task.subTasks is the count the sidebar already trusts for its progress badge.
+  // No children means no request at all, which is the common case.
+  if (!parentId || !(Number(props.task.subTasks) > 0)) {
+    subtaskMinutes.value = 0
+    return
+  }
+  const findQuery = [
+    { $match: { ParentTaskId: String(parentId), deletedStatusKey: { $in: [0, undefined] } } },
+    { $group: { _id: null, estimate: { $sum: { $ifNull: ['$totalEstimatedTime', 0] } } } },
+  ]
+  apiRequest('post', `${env.TASK}/find`, { findQuery })
+    .then((response) => {
+      const row = response && response.data && response.data[0]
+      subtaskMinutes.value = row ? (Number(row.estimate) || 0) : 0
+    })
+    .catch((error) => {
+      // Fall back to the task's own estimate — the figure shown before this
+      // existed — rather than leaving the field broken.
+      subtaskMinutes.value = 0
+      console.error('ERROR loading subtask estimate total: ', error)
+    })
+}
+
+onMounted(loadSubtaskEstimate)
+// Reload when the sidebar switches task, and when a subtask is added or removed.
+watch(() => [props.task && props.task._id, Number(props.task && props.task.subTasks) || 0].join(':'), loadSubtaskEstimate)
+
+const ownMinutes = computed(() => props.task.totalEstimatedTime || 0)
+
+const asHm = (totalMinutes) => {
   const hours = Math.floor(totalMinutes / 60)
   const minutes = totalMinutes % 60
   return `${String(hours).padStart(2, '0')}h ${String(minutes).padStart(2, '0')}m`
-})
+}
+
+// A parent's estimate is its own plus its subtasks'.
+const displayTime = computed(() => asHm(ownMinutes.value + subtaskMinutes.value))
+
+// Editing writes only the task's own value (see startEditing / saveTime below),
+// so typing 2h against 8h of subtasks shows 10h. The tooltip says so, otherwise
+// the number looks like it ignored what was typed.
+const breakdownTitle = computed(() => (subtaskMinutes.value
+  ? `This task ${asHm(ownMinutes.value)} + subtasks ${asHm(subtaskMinutes.value)} = ${displayTime.value}`
+  : ''))
 
 // Validation functions
 const validateHours = () => {


### PR DESCRIPTION
Closes AHE-3924.

## The problem

The **Estimated** field in the task sidebar showed only the task's own `totalEstimatedTime`. A parent broken into estimated subtasks read `00h 00m` no matter how much work was planned underneath it:

```
Create GitHub account and organization      00h 00m   ← the parent
   ├─ GitHub Sub Task 1                     01h 00m
   └─ GitHub Sub Task 2                     01h 00m
```

## What it does now

The field shows the task's **own estimate plus the sum of its subtasks'**. With the parent set to 2h and 8h across its subtasks, it reads `10h 00m`.

## Why the sum comes from the server

It matches children by `ParentTaskId` and excludes deleted ones, rather than adding up the subtask list rendered in the sidebar. That list is a **loaded slice** — `views/TaskDetail/TaskDetail.vue` fetches a limited number and counts the rest separately — so summing it would have quietly undercounted any task with many subtasks. The query mirrors `fetchSubtaskCount` in that same file, which already aggregates children this way.

## Why it cannot compound

Storing the combined figure would be a trap: 10h recalculated becomes 18h, then 26h. Only the *displayed* value changed here.

- `startEditing` still seeds the inputs from the task's **own** estimate
- `saveTime` still emits only what was typed

So the stored value never contains the roll-up. Both are covered by assertions.

One consequence: typing 2h against 8h of subtasks makes the field read 10h, which can look as though the input was ignored. Hovering it now shows `This task 02h 00m + subtasks 08h 00m = 10h 00m`.

## Scope

**One file**, `EstimatedTimeInput.vue`, which is rendered in exactly one place — the task sidebar. Nothing outside it changed, so no sprint total, workload or burndown figure moves and there is no double-counting to chase.

- A task with no subtasks makes **no** extra request (the common case)
- A failed request falls back to the task's own estimate rather than leaving the field broken
- Deleted subtasks are excluded from the sum

## Verification

21 assertions, including executing the real computed properties rather than only grepping for them:

| Case | Expected |
|---|---|
| 2h own + 8h subtasks | `10h 00m` |
| 0h own + 2h subtasks (the reported bug) | `02h 00m` |
| own estimate, no subtasks | unchanged, and no tooltip |
| 1h30 + 1h35 | `03h 05m` — minutes carry |
| missing own estimate | treated as 0, not `NaN` |

Also asserted: the edit and save paths never see the rolled-up value, and only one source file is touched. ESLint clean.

## Testing notes

Reload the frontend, then open a parent task with estimated subtasks. Worth checking a parent whose subtask count exceeds the sidebar's loaded slice — that is the case the server-side sum exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
