### PR TITLE
feat: carry subtasks through bulk move, and add both convert actions in bulk

### DIFF
--- a/.claude/bulk-convert-test-cases.md
+++ b/.claude/bulk-convert-test-cases.md
@@ -1,0 +1,278 @@
+# Bulk move + bulk Convert to Subtask + bulk Convert to Task — manual test cases
+
+Covers the three changes sitting in the working tree together:
+
+- **AHE-3927** — bulk move was leaving a task's subtasks behind
+- **AHE-3925** — Convert to Subtask added to the bulk action bar
+- **AHE-3926** — Convert to Task added to the bulk action bar
+
+Both dev servers are up (`:4000` API, `:8080` app). The changes are **uncommitted**,
+so make sure nodemon has restarted the API and the app has hot-reloaded before
+starting — the first bulk move you try will tell you either way.
+
+**Use a throwaway project.** These actions reparent, promote and move real tasks.
+
+---
+
+## Part A — Regression: the single-task actions must not have changed
+
+None of the single-task code was touched, and this is the pass that proves it.
+
+| # | Do this | Expect |
+|---|---|---|
+| A1 | On a task with 2 subtasks, use **Move** from the task's own ⋯ menu | Task moves, both subtasks move with it, exactly as before |
+| A2 | Open it in the destination and expand it | Both subtasks are there, each with **its own** assignees |
+| A3 | Move a task that has **no** subtasks | Works as before |
+| A4 | Move a **subtask** on its own from its ⋯ menu | Works as before |
+| A5 | Move a task to a **different project** | The status/type mapping step still appears and still applies |
+| A6 | **Convert to Subtask** on a single task from its ⋯ menu | Picks a parent and converts, exactly as before |
+| A7 | Convert a task that **has** subtasks | Its subtasks come across and sit beside it under the new parent |
+| A8 | Convert a **subtask** to be under a different parent | Works; the old parent's subtask count drops by one |
+| A9 | Drag a task onto another task in the list to make it a subtask | Works as before |
+| A10 | **Convert to Task** on a single subtask from its ⋯ menu | Promotes it, exactly as before |
+| A11 | Convert a subtask to a task **in a different sprint** | Lands in the chosen sprint; the old parent's count drops |
+
+---
+
+## Part B — Bulk move now carries subtasks
+
+### B1 — The bug itself
+
+1. Take a task with **2 subtasks**. Give each subtask a **different assignee** from the parent.
+2. Select only the parent with its checkbox.
+3. Bulk action bar → **Move** → pick another sprint → confirm.
+
+- [ ] Toast reports **3 tasks updated**, not 1
+- [ ] In the destination sprint, expanding the parent shows **both subtasks**
+- [ ] Each subtask still has **its own** assignee — not the parent's ⭐
+- [ ] The old sprint no longer holds them
+- [ ] Both sprints' task-count badges are right **with no reload**
+
+### B2 — Parent and its own subtask selected together
+
+Select a parent **and** one of its own subtasks, then Move.
+
+- [ ] The whole family lands in the destination
+- [ ] The toast counts each task **once** — a parent with 2 subtasks reports 3, not 4
+- [ ] The sprint badges are right
+
+### B3 — Move on subtasks offers parent tasks, not sprints ⭐
+
+Select **only subtasks** (not their parent) and press **Move**.
+
+- [ ] The sidebar lists **parent tasks**, not sprints — the same picker the
+      single-task Move shows for a subtask
+- [ ] The header says "Move task" and the button says **Move**
+- [ ] Choosing a parent moves them under it
+- [ ] The old parent's subtask count drops; the new one's goes up
+- [ ] If the new parent is in another sprint, both sprint badges are right with
+      no reload
+
+Now select **a parent task as well** and press Move again.
+
+- [ ] This time the sidebar lists **sprints**, because the selection is no longer
+      only subtasks
+- [ ] The parent and its subtasks move together
+
+> A subtask has nowhere to go but under another task: the list renders subtasks
+> nested and looks them up one sprint at a time, so a subtask in a sprint its
+> parent is not in shows up in neither. The single-task action has always
+> branched on this — Move on a parent picks a sprint, Move on a subtask picks a
+> parent task. Bulk offered the sprint picker for both, which is what produced
+> the invisible subtasks.
+>
+> A subtask whose parent is also selected is not "loose": it travels with the
+> parent through the ordinary sprint move. Only a selection that is *entirely*
+> loose subtasks switches the picker.
+
+### B4 — Rescuing already-stranded subtasks
+
+If this project has subtasks stranded by the old behaviour — a parent that shows
+"2 subtasks" but opens empty — select that parent and Move it anywhere.
+
+- [ ] The missing subtasks reappear under it in the destination
+- [ ] If you have no stranded ones, skip this — do not create some on purpose
+
+### B5 — Nothing else about bulk move changed
+
+- [ ] A childless task still bulk-moves fine
+- [ ] Moving to a **different project** still maps status and type
+- [ ] Moving to the sprint the task is already in still reports it as skipped
+- [ ] Selecting an **archived** task still skips it
+
+---
+
+## Part C — Bulk Convert to Subtask
+
+### C1 — The button
+
+- [ ] Select two or more tasks → the bar shows **Convert to Subtask**
+- [ ] With a role that lacks convert or subtask-create permission, it is disabled
+      with a reason on hover
+
+### C2 — The happy path
+
+1. Select **3 tasks** in the same sprint
+2. **Convert to Subtask** → pick a parent task from the list → **Convert**
+
+- [ ] Toast reports **3 tasks updated**
+- [ ] All three now sit nested under the chosen parent
+- [ ] The parent's subtask count went up by **3**
+- [ ] They are gone from the top level of the list
+- [ ] The parent's progress bar reflects the new subtasks
+
+### C3 — The skip rules, each with a readable reason
+
+Each of these should be **skipped with a reason in the toast**, not silently ignored:
+
+- [ ] Select a task **and** the task you then choose as the parent → the parent is
+      skipped ("it is the parent you chose")
+- [ ] Select a task that is **already a subtask of that parent** → skipped
+      ("already a subtask of that task")
+- [ ] Select a parent **and one of its own subtasks** → the subtask is skipped
+      ("moved with its parent task"), and the toast counts it once
+
+### C4 — A selected task that has its own subtasks
+
+Select a task that has 2 subtasks of its own, and convert it under a parent.
+
+- [ ] It becomes a subtask of the chosen parent
+- [ ] **Its own 2 subtasks come across and sit beside it** under the same parent —
+      not left behind, because only one level of nesting exists
+- [ ] The parent's subtask count went up by **3**
+
+### C5 — Converting into a parent in a different sprint
+
+Pick a parent that lives in **another sprint**.
+
+- [ ] The converted tasks move to the parent's sprint
+- [ ] **Both sprints' task-count badges are right with no reload** ⭐
+- [ ] The task detail breadcrumb shows the new sprint
+
+### C6 — Converting into a parent in a different project
+
+- [ ] It works, and the tasks land with a valid status and type in the destination
+      project (mapped by name where the names match)
+
+### C7 — Refusals
+
+- [ ] Choosing a **subtask** as the parent is refused
+- [ ] Converting with nothing selected does not offer the action at all
+
+### C8 — Existing subtasks re-parented
+
+Select a subtask that belongs to **another** parent, and convert it under a new one.
+
+- [ ] It moves under the new parent
+- [ ] The **old** parent's subtask count drops by one
+- [ ] The new parent's goes up by one
+
+---
+
+## Part D — Bulk Convert to Task
+
+### D1 — The button
+
+- [ ] Select two or more tasks → the bar shows **Convert to Task**
+- [ ] With a role that lacks convert or task-create permission, it is disabled
+
+### D2 — The happy path
+
+1. Expand a parent and select **3 of its subtasks**
+2. **Convert to Task** → pick a project and sprint → confirm
+
+- [ ] Toast reports **3 tasks updated**
+- [ ] All three are now top-level tasks in the chosen sprint
+- [ ] None of them is nested under anything any more
+- [ ] The old parent's subtask count dropped by **3**
+- [ ] Sprint badges on both sprints are right **with no reload**
+
+### D3 — Promoting into the sprint they are already in
+
+Select subtasks and convert them into **their own current sprint**.
+
+- [ ] They become top-level tasks in that same sprint
+- [ ] The sprint's task count does **not** change — nothing entered or left it ⭐
+
+### D4 — A task that is already top-level
+
+Select a mix: two subtasks and one ordinary task.
+
+- [ ] The two subtasks are promoted
+- [ ] The ordinary task is **skipped** with "already a task, not a subtask"
+- [ ] It is not touched at all — same sprint, same status
+
+### D5 — Subtasks from different parents at once
+
+Select subtasks belonging to **two different parents**.
+
+- [ ] All are promoted
+- [ ] **Each** parent's subtask count drops by the right amount
+
+### D6 — Promoting into a different project
+
+- [ ] It works, and the tasks land with a valid status and type in the destination
+- [ ] Converting within the **same** project does **not** change any status or type ⭐
+      (the two are told apart by a comparison that was easy to get wrong)
+
+### D7 — Nothing disappears ⭐
+
+This is the one that matters most. The conversion marks a task deleted first and
+rewrites it second, so a failure in between used to leave it gone from the board.
+
+- [ ] Convert a batch of subtasks and confirm **every single one** is visible
+      afterwards — either promoted, or still where it was
+- [ ] Count the tasks on the board before and after: nothing has vanished
+- [ ] If any task reports an error in the toast, find it — it should still be on
+      the board, exactly as it was, **not** missing
+
+---
+
+## Part E — The other bulk actions are untouched
+
+The bulk endpoint gained a permission middleware. For anyone signed in through
+the app it does nothing at all, but check the actions still work:
+
+- [ ] Bulk status change
+- [ ] Bulk priority
+- [ ] Bulk assignee add and remove
+- [ ] Bulk due date
+- [ ] Bulk tags
+- [ ] Bulk archive and restore
+- [ ] Bulk delete
+- [ ] Bulk duplicate
+- [ ] Bulk move (Part B already covers it)
+
+---
+
+## Known and expected
+
+- The parent picker for Convert to Subtask lists **every** task, including ones
+  you have selected. The server skips a selected task that turns out to be the
+  parent and says so in the toast, rather than the picker hiding it — that would
+  have meant threading the selection through three components.
+- Converting a parent flattens its subtasks to sit beside it, rather than nesting
+  them two deep. That is the existing single-task behaviour; only one level of
+  nesting exists in the data model.
+- A partial result shows an amber toast ("Updated 2 tasks — 1 skipped — 1 failed"),
+  not a green one.
+- Selecting a parent task also selects its loaded subtasks, and selecting every
+  subtask selects the parent. That is existing behaviour; the bulk actions now
+  count such a family once instead of twice.
+- Moving a parent gathers its subtasks by parentage rather than by sprint, so one
+  that had been separated is pulled back to the family. That also means completing
+  a sprint can pull in a subtask living in another sprint, if its parent is in the
+  sprint being closed.
+- Bulk Move now branches on the selection, exactly as the single-task action
+  does: subtasks get the parent-task picker, anything else gets the sprint
+  picker. The server refuses a loose subtask sent to a sprint regardless, so the
+  invisible state cannot be reached even by a direct request. Sprint completion
+  is unaffected — it only ever hands parent tasks to the move.
+- Convert to Task has no history entry, the same as the single action. Not added
+  here.
+
+## If something fails
+
+Send the step number, the toast text, and — for anything about counts — what the
+sprint badge said before and after. For **D7**, say which task went missing and
+what the toast said.

--- a/Modules/Sprints/scrum.js
+++ b/Modules/Sprints/scrum.js
@@ -618,8 +618,10 @@ exports.completeSprint = async (req, res) => {
             // module load would hand back a half-built export.
             const { taskMongo } = require('../Tasks/helpers/task_class_Mongo');
 
-            // isSubTask: true so a moved parent takes its subtasks with it —
-            // otherwise they orphan in the sprint that just closed.
+            // bulkMove carries a parent's subtasks with it, so nothing orphans in
+            // the sprint that just closed. It used to need isSubTask: true here;
+            // bulk move now does it unconditionally, because a subtask in a
+            // different sprint from its parent renders in neither.
             const result = await taskMongo.bulkMove({
                 companyId,
                 userData: actor,
@@ -635,7 +637,6 @@ exports.completeSprint = async (req, res) => {
                     ProjectName: plan.project.ProjectName || '',
                     ProjectCode: plan.project.ProjectCode || '',
                 },
-                isSubTask: true,
             });
 
             moveSummary = (result && result.totals) || moveSummary;

--- a/Modules/Tasks/helpers/taskMongo/bulk.js
+++ b/Modules/Tasks/helpers/taskMongo/bulk.js
@@ -29,6 +29,11 @@ const {
     taskStatusChange, taskPriorityChange,
 } = require('../notificationTemplate');
 
+// convertToTask's inner failure path neither resolves nor rejects, so awaiting
+// it can hang forever. Long enough that a slow-but-working conversion is never
+// cut short, short enough that one bad task cannot hold a request open.
+const CONVERT_DEADLINE_MS = 20000;
+
 // ----------------- Internal helpers (not exported on the mixin) -----------------
 
 const toObjectId = (id) => {
@@ -756,7 +761,7 @@ module.exports = {
     },
 
     // ---------------------- MOVE ----------------------
-    // payload: { companyId, userData, taskIds, sprintObj, projectData, isSubTask }
+    // payload: { companyId, userData, taskIds, sprintObj, projectData }
     //   sprintObj   — destination sprint object (same shape the single-task
     //                 picker builds: { id, name, folderId?, folderName?, ... }).
     //   projectData — destination project summary { id, ProjectCode, ProjectName }.
@@ -773,7 +778,9 @@ module.exports = {
     //                        the destination project, falling back to the
     //                        destination's first status/type when no name
     //                        matches. Same-project moves skip conversion.
-    bulkMove({ companyId, userData, taskIds, sprintObj, projectData, isSubTask = false }) {
+    //   • subtasks — a selected parent's subtasks travel with it, each
+    //                        keeping its own assignees and watchers.
+    bulkMove({ companyId, userData, taskIds, sprintObj, projectData }) {
         return new Promise(async (resolve, reject) => {
             try {
                 if (!companyId) return reject(new Error('companyId required'));
@@ -823,13 +830,90 @@ module.exports = {
                     return built;
                 };
 
-                // Sequential per single-task behavior to avoid sprint-count races.
+                // A subtask lives in its parent's sprint and is only ever rendered
+                // nested under it, so a parent that moves alone leaves its subtasks
+                // somewhere nobody can reach: the destination looks them up by the
+                // DESTINATION's sprintId and finds none, and the source list only
+                // renders parents. The parent still advertises "2 subtasks" and opens
+                // empty. Single-task move has always carried them — the sidebar sets
+                // isSubTask whenever the task has any — and bulk passed false.
+                //
+                // They are enumerated here rather than handed to moveTask's own
+                // isSubTask branch on purpose. That branch applies ONE
+                // assignee/watcher pair across the whole family, which is right for
+                // the single-task sidebar (a person picked them for this move) and
+                // wrong here, where every task has to keep its own. So each task,
+                // parent or subtask, moves on its own values.
+                const selectedIds = new Set(tasks.map((t) => String(t._id)));
+                const queue = [];
+                const queued = new Set();
+                const enqueue = (task, carried) => {
+                    const key = String(task._id);
+                    if (queued.has(key)) return;
+                    queued.add(key);
+                    queue.push({ task, carried });
+                };
+
                 for (const task of tasks) {
+                    if (task.isParentTask !== true) {
+                        // Its parent is selected too, so the parent's pass below picks
+                        // it up. Moving it here as well would move it twice.
+                        if (selectedIds.has(String(task.ParentTaskId || ''))) continue;
+
+                        // On its own, though, it does not move at all. A subtask has no
+                        // existence outside its parent: the list renders subtasks nested
+                        // under the parent and looks them up one sprint at a time, so a
+                        // subtask sitting in a sprint its parent is not in appears in
+                        // neither. The single-task action refuses this outright — a
+                        // subtask's own Move opens a picker of PARENT TASKS, never a
+                        // bare sprint. Bulk used to allow it and quietly produce exactly
+                        // the state this whole change exists to stop.
+                        //
+                        // Giving a subtask a different parent is a real thing to want;
+                        // it is just a different action, and the bar has it.
+                        skipped.push({ taskId: String(task._id), reason: 'subtask-moves-with-its-parent' });
+                        continue;
+                    }
+
+                    // Looked up BEFORE the parent is queued: a failed lookup must not
+                    // quietly move the parent on its own and strand them, which is the
+                    // bug being fixed.
+                    //
+                    // Deliberately NOT scoped to the parent's own sprint. A subtask in
+                    // a different sprint from its parent renders in neither, so that
+                    // state is only ever corruption — and every selection that has
+                    // been bulk-moved before this fix has some. Matching on parentage
+                    // alone means selecting the parent gathers them all back, which is
+                    // the one way an already-stranded subtask can be reached at all.
+                    //
+                    // ParentTaskId is a String on the task schema, not an ObjectId.
+                    const children = await MongoDbCrudOpration(companyId, {
+                        type: dbCollections.TASKS,
+                        data: [{
+                            ParentTaskId: String(task._id),
+                            isParentTask: false,
+                            deletedStatusKey: { $nin: [1] },
+                        }],
+                    }, 'find').catch((error) => {
+                        logger.error(`bulkMove subtasks of ${task._id}: ${error.message}`);
+                        return null;
+                    });
+
+                    if (children === null) {
+                        errors.push({ taskId: String(task._id), reason: 'could not read its subtasks' });
+                        continue;
+                    }
+                    enqueue(task, false);
+                    children.forEach((child) => enqueue(child, true));
+                }
+
+                // Sequential per single-task behavior to avoid sprint-count races.
+                for (const { task, carried } of queue) {
                     try {
                         // No-op guard: already in the destination sprint/folder.
                         if (String(task.sprintId) === String(sprintObj.id) &&
                             String(task.folderObjId || '') === String(sprintObj.folderId || '')) {
-                            skipped.push({ taskId: String(task._id), reason: 'already-in-target' });
+                            if (!carried) skipped.push({ taskId: String(task._id), reason: 'already-in-target' });
                             continue;
                         }
                         const oldProject = await buildOldProject(task.ProjectID);
@@ -850,7 +934,8 @@ module.exports = {
                             moveTaskId: task._id,
                             oldSprintObj,
                             oldProject,
-                            isSubTask,
+                            // Each task moves as itself; the family was expanded above.
+                            isSubTask: false,
                             assignee: Array.isArray(task.AssigneeUserId) ? task.AssigneeUserId : [],
                             watcher: Array.isArray(task.watchers) ? task.watchers : [],
                             userData,
@@ -866,6 +951,327 @@ module.exports = {
                 resolve(summarize({ updated, skipped, errors }));
             } catch (error) {
                 logger.error(`bulkMove error: ${error.message}`);
+                reject(error);
+            }
+        });
+    },
+
+    // ---------------------- CONVERT TO SUBTASK ----------------------
+    // payload: { companyId, userData, taskIds, parentTaskId }
+    //
+    // Makes every selected task a subtask of one chosen parent. The destination
+    // sprint, folder and project are NOT parameters: a subtask lives where its
+    // parent lives, so they are read off the parent and the existing
+    // convertToSubTask path does the relocation.
+    //
+    // Reuses that path per task rather than reimplementing it, so history, the
+    // parent's subTasks counter, comment counts, the per-task socket events and
+    // the cross-project status/type remap all behave exactly as the single-task
+    // action does.
+    //
+    // It does NOT inherit that path's reporting. convertToSubTask settles its
+    // per-task promises with Promise.allSettled and then resolves success
+    // regardless of what rejected inside, so a partial failure reads as a clean
+    // run. Every conversion here is verified by re-reading the task, and only a
+    // task that actually ended up under the parent is counted as updated.
+    bulkConvertToSubTask({ companyId, userData, taskIds, parentTaskId }) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                if (!companyId) return reject(new Error('companyId required'));
+                const parentObjId = toObjectId(parentTaskId);
+                if (!parentObjId) return reject(new Error('a valid parentTaskId is required'));
+
+                const parent = await MongoDbCrudOpration(companyId, {
+                    type: dbCollections.TASKS,
+                    data: [{ _id: parentObjId }],
+                }, 'findOne');
+                if (!parent) return reject(new Error('parent task not found'));
+                if (parent.deletedStatusKey === 1) return reject(new Error('that parent task has been deleted'));
+                // Only one level of nesting exists, so a subtask cannot take children.
+                if (parent.isParentTask !== true) return reject(new Error('a subtask cannot be a parent'));
+
+                const { tasks, skipped } = await loadScopedTasks(companyId, taskIds, { includeArchived: false });
+                const updated = [];
+                const errors = [];
+
+                const loadProject = makeProjectLoader(companyId);
+                const destProject = await loadProject(parent.ProjectID);
+                if (!destProject) return reject(new Error('the parent task\'s project could not be read'));
+
+                const destStatuses = Array.isArray(destProject.taskStatusData) ? destProject.taskStatusData : [];
+                const destTypes = Array.isArray(destProject.taskTypeCounts) ? destProject.taskTypeCounts : [];
+                const norm = (s) => String(s || '').trim().toLowerCase();
+                const defaultStatus = destStatuses.find((s) => s.type !== 'close') || destStatuses[0] || null;
+                const mapStatus = (srcStatus) => {
+                    const pick = destStatuses.find((d) => norm(d.name) === norm(srcStatus?.name)) || defaultStatus;
+                    return pick ? { key: pick.key, name: pick.name, type: pick.type, bgColor: pick.bgColor, textColor: pick.textColor } : null;
+                };
+                const mapType = (srcType) => {
+                    const pick = destTypes.find((d) => norm(d.name) === norm(srcType?.name)) || destTypes[0] || null;
+                    return pick ? { value: pick.value, key: pick.key, name: pick.name } : null;
+                };
+
+                // convertToSubTaskFunction reads the SOURCE project's lists and
+                // applies the `.convertStatus`/`.convertType` grafted onto each
+                // entry when the task crosses projects. Same shape bulkMove builds.
+                const oldProjectCache = new Map();
+                const buildOldProject = async (srcProjectId) => {
+                    const key = String(srcProjectId);
+                    if (oldProjectCache.has(key)) return oldProjectCache.get(key);
+                    const src = await loadProject(srcProjectId);
+                    const built = src ? {
+                        id: src._id,
+                        ProjectName: src.ProjectName,
+                        taskStatusData: (Array.isArray(src.taskStatusData) ? src.taskStatusData : [])
+                            .map((s) => ({ ...s, convertStatus: mapStatus(s) })),
+                        taskTypeCounts: (Array.isArray(src.taskTypeCounts) ? src.taskTypeCounts : [])
+                            .map((t) => ({ ...t, convertType: mapType(t) })),
+                    } : null;
+                    oldProjectCache.set(key, built);
+                    return built;
+                };
+
+                const selectedIds = new Set(tasks.map((t) => String(t._id)));
+                const candidates = [];
+                for (const task of tasks) {
+                    const id = String(task._id);
+                    if (id === String(parent._id)) {
+                        skipped.push({ taskId: id, reason: 'is-the-chosen-parent' });
+                        continue;
+                    }
+                    if (String(task.ParentTaskId || '') === String(parent._id)) {
+                        skipped.push({ taskId: id, reason: 'already-a-subtask-of-this-parent' });
+                        continue;
+                    }
+                    // Converting a parent carries its own subtasks across, so a
+                    // subtask whose parent is also selected is handled by that pass.
+                    // Doing it again would reparent it twice and count it twice.
+                    if (task.isParentTask !== true && selectedIds.has(String(task.ParentTaskId || ''))) {
+                        skipped.push({ taskId: id, reason: 'carried-with-its-parent' });
+                        continue;
+                    }
+                    candidates.push(task);
+                }
+
+                // Sequential, per bulkMove: the sprint counters and the parent's
+                // subTasks counter are read-modify-write and would race.
+                for (const task of candidates) {
+                    const id = String(task._id);
+                    try {
+                        const oldProject = await buildOldProject(task.ProjectID);
+                        if (!oldProject) {
+                            skipped.push({ taskId: id, reason: 'project-not-found' });
+                            continue;
+                        }
+                        await this.convertToSubTask({
+                            companyId,
+                            projectData: { id: destProject._id, ProjectName: destProject.ProjectName },
+                            sprintId: parent.sprintId,
+                            selectedTaskId: id,
+                            taskId: parent._id,
+                            oldProject,
+                            // A converted parent's own subtasks come across with it and
+                            // land beside it under the new parent, because only one
+                            // level of nesting exists. Leaving them behind would strand
+                            // them under a task that is no longer a parent.
+                            isSubTask: task.isParentTask === true && Number(task.subTasks || 0) > 0,
+                            userData,
+                        });
+
+                        // Verified rather than trusted — see the note above.
+                        const after = await MongoDbCrudOpration(companyId, {
+                            type: dbCollections.TASKS,
+                            data: [{ _id: task._id }, 'ParentTaskId isParentTask deletedStatusKey'],
+                        }, 'findOne').catch(() => null);
+
+                        if (after && after.isParentTask === false
+                            && String(after.ParentTaskId || '') === String(parent._id)
+                            && after.deletedStatusKey !== 1) {
+                            updated.push(id);
+                        } else {
+                            errors.push({ taskId: id, reason: 'conversion did not take effect' });
+                        }
+                    } catch (error) {
+                        logger.error(`bulkConvertToSubTask task ${id}: ${error.message}`);
+                        errors.push({ taskId: id, reason: error.message });
+                    }
+                }
+
+                emitBulkSummary('bulkConvertToSubTask', { taskIds: updated, parentTaskId: String(parent._id) });
+                resolve(summarize({ updated, skipped, errors }));
+            } catch (error) {
+                logger.error(`bulkConvertToSubTask error: ${error.message}`);
+                reject(error);
+            }
+        });
+    },
+
+    // ---------------------- CONVERT TO TASK ----------------------
+    // payload: { companyId, userData, taskIds, sprintObj, projectData }
+    //   sprintObj / projectData — where the promoted tasks land, same shape and
+    //   same picker as bulkMove.
+    //
+    // Promotes selected subtasks to top-level tasks. Reuses the single-task
+    // convertToTask per subtask, so the parent's subTasks counter, the sprint
+    // counters, the comment count, the per-task socket events and the
+    // cross-project status/type remap all behave as they do today.
+    //
+    // Two things about that path this has to defend against, both harmless once
+    // and dangerous twenty times:
+    //
+    //   1. It marks the task deletedStatusKey:1 FIRST and rewrites it as
+    //      top-level second. A failure in between leaves the task deleted —
+    //      gone from the board. Every task is verified afterwards, and one left
+    //      deleted is put back the way it was rather than reported as lost.
+    //
+    //   2. Its inner failure path only logs: it neither resolves nor rejects, so
+    //      the promise never settles and an await on it hangs forever. One bad
+    //      task would otherwise hang the whole request. Each call is raced
+    //      against a deadline and judged on the task's actual state instead.
+    bulkConvertToTask({ companyId, userData, taskIds, sprintObj, projectData }) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                if (!companyId) return reject(new Error('companyId required'));
+                if (!sprintObj || !sprintObj.id) return reject(new Error('sprintObj required'));
+                if (!projectData || !projectData.id) return reject(new Error('projectData required'));
+
+                const { tasks, skipped } = await loadScopedTasks(companyId, taskIds, { includeArchived: false });
+                const updated = [];
+                const errors = [];
+
+                const loadProject = makeProjectLoader(companyId);
+                const destProject = await loadProject(projectData.id);
+                if (!destProject) return reject(new Error('destination project not found'));
+
+                const destStatuses = Array.isArray(destProject.taskStatusData) ? destProject.taskStatusData : [];
+                const destTypes = Array.isArray(destProject.taskTypeCounts) ? destProject.taskTypeCounts : [];
+                const norm = (s) => String(s || '').trim().toLowerCase();
+                const defaultStatus = destStatuses.find((s) => s.type !== 'close') || destStatuses[0] || null;
+                const mapStatus = (srcStatus) => {
+                    const pick = destStatuses.find((d) => norm(d.name) === norm(srcStatus?.name)) || defaultStatus;
+                    return pick ? { key: pick.key, name: pick.name, type: pick.type, bgColor: pick.bgColor, textColor: pick.textColor } : null;
+                };
+                const mapType = (srcType) => {
+                    const pick = destTypes.find((d) => norm(d.name) === norm(srcType?.name)) || destTypes[0] || null;
+                    return pick ? { value: pick.value, key: pick.key, name: pick.name } : null;
+                };
+
+                // convertToTask decides "is this cross-project?" with a plain !==
+                // on these two ids. An ObjectId is never !== equal to another
+                // ObjectId instance, so a same-project conversion would take the
+                // remapping branch. Both sides are handed over as strings, which
+                // is what the single-task callers pass.
+                const destProjectId = String(destProject._id);
+                const oldProjectCache = new Map();
+                const buildOldProject = async (srcProjectId) => {
+                    const key = String(srcProjectId);
+                    if (oldProjectCache.has(key)) return oldProjectCache.get(key);
+                    const src = await loadProject(srcProjectId);
+                    const built = src ? {
+                        id: String(src._id),
+                        ProjectName: src.ProjectName,
+                        taskStatusData: (Array.isArray(src.taskStatusData) ? src.taskStatusData : [])
+                            .map((s) => ({ ...s, convertStatus: mapStatus(s) })),
+                        taskTypeCounts: (Array.isArray(src.taskTypeCounts) ? src.taskTypeCounts : [])
+                            .map((t) => ({ ...t, convertType: mapType(t) })),
+                    } : null;
+                    oldProjectCache.set(key, built);
+                    return built;
+                };
+
+                const candidates = [];
+                for (const task of tasks) {
+                    if (task.isParentTask === true) {
+                        skipped.push({ taskId: String(task._id), reason: 'already-a-top-level-task' });
+                        continue;
+                    }
+                    candidates.push(task);
+                }
+
+                // Sequential, per bulkMove: the sprint counters and each parent's
+                // subTasks counter are read-modify-write and would race.
+                for (const task of candidates) {
+                    const id = String(task._id);
+                    const wasDeletedStatusKey = task.deletedStatusKey;
+                    try {
+                        const oldProject = await buildOldProject(task.ProjectID);
+                        if (!oldProject) {
+                            skipped.push({ taskId: id, reason: 'project-not-found' });
+                            continue;
+                        }
+
+                        let timer = null;
+                        const deadline = new Promise((settle) => {
+                            timer = setTimeout(() => settle('timeout'), CONVERT_DEADLINE_MS);
+                        });
+                        try {
+                            await Promise.race([
+                                this.convertToTask({
+                                    companyId,
+                                    projectData: { id: destProjectId, ProjectName: destProject.ProjectName },
+                                    taskId: id,
+                                    sprintObj,
+                                    parentTaskId: task.ParentTaskId,
+                                    oldSprintObj: {
+                                        id: task.sprintId,
+                                        folderId: task.folderObjId || null,
+                                        name: task.sprintArray?.name || '',
+                                        folderName: task.sprintArray?.folderName || '',
+                                    },
+                                    oldProject,
+                                    userData,
+                                }).catch((error) => {
+                                    logger.error(`bulkConvertToTask convert ${id}: ${error && error.message}`);
+                                }),
+                                deadline,
+                            ]);
+                        } finally {
+                            if (timer) clearTimeout(timer);
+                        }
+
+                        // Judged on the task itself, never on what the call said.
+                        const after = await MongoDbCrudOpration(companyId, {
+                            type: dbCollections.TASKS,
+                            data: [{ _id: task._id }, 'isParentTask ParentTaskId deletedStatusKey sprintId'],
+                        }, 'findOne').catch(() => null);
+
+                        const landed = after && after.isParentTask === true
+                            && !String(after.ParentTaskId || '')
+                            && after.deletedStatusKey !== 1;
+
+                        if (landed) {
+                            updated.push(id);
+                            continue;
+                        }
+
+                        // Left mid-flight. Put it back on the board rather than
+                        // leaving it deleted and calling it a failure.
+                        if (after && after.deletedStatusKey === 1 && wasDeletedStatusKey !== 1) {
+                            await MongoDbCrudOpration(companyId, {
+                                type: dbCollections.TASKS,
+                                data: [{ _id: task._id }, { $set: { deletedStatusKey: wasDeletedStatusKey } }, { returnDocument: 'after' }],
+                            }, 'findOneAndUpdate').then((restored) => {
+                                socketEmitter.emit('update', {
+                                    type: 'update', data: restored,
+                                    updatedFields: { deletedStatusKey: wasDeletedStatusKey }, module: 'task',
+                                });
+                            }).catch((error) => {
+                                logger.error(`bulkConvertToTask restore ${id}: ${error && error.message}`);
+                            });
+                            errors.push({ taskId: id, reason: 'conversion failed; the task was restored where it was' });
+                            continue;
+                        }
+                        errors.push({ taskId: id, reason: 'conversion did not take effect' });
+                    } catch (error) {
+                        logger.error(`bulkConvertToTask task ${id}: ${error.message}`);
+                        errors.push({ taskId: id, reason: error.message });
+                    }
+                }
+
+                emitBulkSummary('bulkConvertToTask', { taskIds: updated, targetSprintId: sprintObj?.id, targetProjectId: projectData?.id });
+                resolve(summarize({ updated, skipped, errors }));
+            } catch (error) {
+                logger.error(`bulkConvertToTask error: ${error.message}`);
                 reject(error);
             }
         });

--- a/Modules/Tasks/routes.js
+++ b/Modules/Tasks/routes.js
@@ -71,7 +71,11 @@ exports.init = (app) => {
     // Body: { action: 'bulkUpdateStatus' | 'bulkDelete' | ..., taskIds: [..], ...payload }
     // CompanyId comes from the verified header set by the auth middleware;
     // it overrides anything the client put in the body to prevent spoofing.
-    app.post('/api/v2/tasks/bulk', (req, res) => {
+    // requireTaskActionPermission mirrors the single PATCH above: it enforces only
+    // for PAT/MCP requests, and only for actions named in TASK_ACTION_PERMISSION.
+    // No bulk action is named there yet, so nothing changes today — the point is
+    // that the map now governs both endpoints instead of only the single one.
+    app.post('/api/v2/tasks/bulk', requireTaskActionPermission(), (req, res) => {
         try {
             const action = req.body && req.body.action;
             if (!action || typeof action !== 'string' || !action.startsWith('bulk')) {

--- a/frontend/src/components/molecules/BulkActionBar/BulkActionBar.vue
+++ b/frontend/src/components/molecules/BulkActionBar/BulkActionBar.vue
@@ -197,16 +197,42 @@
                 </div>
             </BulkMenu>
 
-            <!-- MOVE — opens the shared move sidebar (project + sprint/folder
-                 picker) in bulk mode; backend auto-maps status/type. -->
+            <!-- MOVE — the sprint/folder picker for tasks, or the parent-task
+                 picker when everything selected is a subtask. Same branch the
+                 single-task action makes. See openMove. -->
             <button
                 class="bulk-action-bar__btn"
                 :class="{ 'bulk-action-bar__btn--disabled': !canMove }"
                 :title="canMove ? 'Move selected tasks' : 'No permission to move'"
                 :disabled="!canMove"
-                @click="canMove && (showMove = true, closeMenu())"
+                @click="canMove && openMove()"
             >
                 <span>Move</span>
+            </button>
+
+            <!-- CONVERT TO SUBTASK — opens the same task picker the single
+                 action uses, in bulk mode; it returns the chosen parent task. -->
+            <button
+                class="bulk-action-bar__btn"
+                :class="{ 'bulk-action-bar__btn--disabled': !canConvertToSubTask }"
+                :title="canConvertToSubTask ? 'Make selected tasks subtasks of one task' : 'No permission to convert'"
+                :disabled="!canConvertToSubTask"
+                @click="canConvertToSubTask && (showConvertToSubTask = true, closeMenu())"
+            >
+                <span>Convert to Subtask</span>
+            </button>
+
+            <!-- CONVERT TO TASK — promotes selected subtasks to top level. Reuses
+                 the same sprint picker bulk move uses, since a promoted task needs
+                 somewhere to land. -->
+            <button
+                class="bulk-action-bar__btn"
+                :class="{ 'bulk-action-bar__btn--disabled': !canConvertToTask }"
+                :title="canConvertToTask ? 'Promote selected subtasks to tasks' : 'No permission to convert'"
+                :disabled="!canConvertToTask"
+                @click="canConvertToTask && (showConvertToTask = true, closeMenu())"
+            >
+                <span>Convert to Task</span>
             </button>
 
             <!-- DELETE -->
@@ -273,6 +299,45 @@
         @isConvertSubtaskOPen="showMove = false"
         @bulkMoveConfirm="onBulkMoveConfirm"
     />
+
+    <!-- Bulk convert to subtask: the same sidebar, showing the task list rather
+         than the sprint picker. isMoveTask/isDuplicate/isConvertTask all stay
+         false because that combination is what makes it list tasks. -->
+    <ConvertToSubTaskSidebar
+        v-if="showConvertToSubTask"
+        :closeSideBar="showConvertToSubTask"
+        :isOpenSubTask="true"
+        :isBulkConvert="true"
+        :task="{}"
+        @isConvertSubtaskOPen="showConvertToSubTask = false"
+        @bulkConvertConfirm="onBulkConvertConfirm"
+    />
+
+    <!-- Move, when everything selected is a subtask. openMoveSubTask is the mode
+         the single-task action uses for exactly this: it lists PARENT TASKS and
+         labels the button Move, because a subtask has nowhere to go but under
+         another task. -->
+    <ConvertToSubTaskSidebar
+        v-if="showMoveSubtask"
+        :closeSideBar="showMoveSubtask"
+        :openMoveSubTask="true"
+        :isBulkConvert="true"
+        :task="{}"
+        @isConvertSubtaskOPen="showMoveSubtask = false"
+        @bulkConvertConfirm="onMoveSubtaskConfirm"
+    />
+
+    <!-- Bulk convert to task: the destination picker, identical to bulk move —
+         a promoted subtask becomes a top-level task and needs a sprint. -->
+    <ConvertToSubTaskSidebar
+        v-if="showConvertToTask"
+        :closeSideBar="showConvertToTask"
+        :isMoveTask="true"
+        :isBulkMove="true"
+        :task="{}"
+        @isConvertSubtaskOPen="showConvertToTask = false"
+        @bulkMoveConfirm="onBulkConvertToTaskConfirm"
+    />
 </template>
 
 <script setup>
@@ -305,6 +370,9 @@ const userId = inject('$userId', null);
 const showDeleteConfirm = ref(false);
 const showArchiveConfirm = ref(false);
 const showMove = ref(false);
+const showConvertToSubTask = ref(false);
+const showConvertToTask = ref(false);
+const showMoveSubtask = ref(false);
 const isWorking = ref(false);
 const barRef = ref(null);
 
@@ -363,6 +431,16 @@ const canChangeTags = computed(() => checkPermission('task.task_tag', projectDat
 const canDelete = computed(() => checkPermission('task.task_delete', projectData?.value?.isGlobalPermission) === true);
 const canArchive = computed(() => checkPermission('task.task_archive', projectData?.value?.isGlobalPermission) === true);
 const canMove = computed(() => checkPermission('task.task_move', projectData?.value?.isGlobalPermission) === true);
+// Both keys, exactly as the single-task action gates itself: one to convert, one
+// to create a subtask.
+const canConvertToSubTask = computed(() =>
+    checkPermission('task.task_convert_to_subtask', projectData?.value?.isGlobalPermission) === true
+    && checkPermission('task.sub_task_create', projectData?.value?.isGlobalPermission) === true);
+// Both keys, exactly as the single action gates itself: one to convert, one to
+// create a task.
+const canConvertToTask = computed(() =>
+    checkPermission('task.convert_to_task', projectData?.value?.isGlobalPermission) === true
+    && checkPermission('task.task_create', projectData?.value?.isGlobalPermission) === true);
 
 const availableStatuses = computed(() => {
     const data = projectData?.value?.taskStatusData;
@@ -609,6 +687,12 @@ function reportResult(action, response) {
             'project-not-found': 'project not found',
             'invalid-id': 'invalid id',
             'invalid-type': 'invalid operation',
+            'already-in-target': 'already there',
+            'is-the-chosen-parent': 'it is the parent you chose',
+            'already-a-subtask-of-this-parent': 'already a subtask of that task',
+            'carried-with-its-parent': 'moved with its parent task',
+            'already-a-top-level-task': 'already a task, not a subtask',
+            'subtask-moves-with-its-parent': 'a subtask moves with its parent — use Convert to Task or Convert to Subtask',
         })[topReason] || topReason || 'skipped';
         msg += ` — ${skipped} skipped (${reasonLabel})`;
     }
@@ -696,9 +780,13 @@ function onBulkMoveConfirm({ project, sprint } = {}) {
     const proj = projectData?.value;
     const sourceGroups = new Map(); // `${folderId}::${sprintId}` -> { ref, units }
     let totalUnits = 0;
+    // A parent counts itself plus its subtasks, so a subtask never counts on its
+    // own: either its parent is selected too and is already counting it, or the
+    // subtask does not move at all — a subtask goes where its parent goes.
     for (const id of selection.selectedTaskIds.value) {
         const t = findTaskInStore(id)?.task;
         if (!t) continue;
+        if (!t.isParentTask) continue;
         const folderId = t.folderObjId || '';
         const sid = String(t.sprintId);
         const ref = folderId
@@ -720,7 +808,6 @@ function onBulkMoveConfirm({ project, sprint } = {}) {
             ProjectName: project.ProjectName,
         },
         sprintObj: sprint,
-        isSubTask: false,
     }, {
         onSuccess: () => {
             // Decrement each source sprint badge (mirrors single-move's
@@ -741,6 +828,112 @@ function onBulkMoveConfirm({ project, sprint } = {}) {
                 commit('projectData/mutateSprints', { op: 'modified', data: { ...destRef } });
             }
         },
+    });
+}
+
+// A subtask cannot be moved into a bare sprint — it is rendered nested under its
+// parent and looked up one sprint at a time, so a subtask away from its parent
+// shows up nowhere. The single-task action already branches on this: Move on a
+// parent opens the sprint picker, Move on a subtask opens a picker of parent
+// tasks. Bulk does the same.
+//
+// A subtask whose parent is also selected is not "loose": it travels with the
+// parent through the ordinary sprint move.
+const looseSubtaskIds = computed(() => {
+    const ids = [...selection.selectedTaskIds.value].map(String);
+    const selected = new Set(ids);
+    return ids.filter((id) => {
+        const t = findTaskInStore(id)?.task;
+        return t && t.isParentTask !== true && !selected.has(String(t.ParentTaskId || ''));
+    });
+});
+const movingOnlySubtasks = computed(() =>
+    selection.selectedTaskIds.value.length > 0
+    && looseSubtaskIds.value.length === selection.selectedTaskIds.value.length);
+
+function openMove() {
+    closeMenu();
+    if (movingOnlySubtasks.value) {
+        showMoveSubtask.value = true;
+        return;
+    }
+    showMove.value = true;
+}
+
+// Moving subtasks under a chosen parent IS a re-parent, so it runs the same
+// request the convert action does. The wording follows the single-task flow,
+// which calls this Move.
+function onMoveSubtaskConfirm({ task } = {}) {
+    if (!task || !task._id) return;
+    showMoveSubtask.value = false;
+
+    const crossesSprints = [...selection.selectedTaskIds.value].some((id) => {
+        const t = findTaskInStore(id)?.task;
+        return t && String(t.sprintId) !== String(task.sprintId);
+    });
+
+    runBulk('bulkConvertToSubTask', { parentTaskId: String(task._id) }, {
+        onSuccess: () => { if (crossesSprints) refreshSprintCounts(); },
+    });
+}
+
+// Bulk convert to subtask. The sidebar returns the parent task; the sprint,
+// folder and project all follow from it on the server, because a subtask lives
+// where its parent lives.
+function onBulkConvertConfirm({ task } = {}) {
+    if (!task || !task._id) return;
+    showConvertToSubTask.value = false;
+
+    // Converting into a parent that sits in another sprint moves the task there,
+    // and the sidebar sprint badges are not socket-driven. Rather than replay the
+    // server's arithmetic here — a converted parent takes its own subtasks along,
+    // so it is not simply one per selected task — re-read the sprints afterwards.
+    // Costs one request and cannot drift.
+    const crossesSprints = [...selection.selectedTaskIds.value].some((id) => {
+        const t = findTaskInStore(id)?.task;
+        return t && String(t.sprintId) !== String(task.sprintId);
+    });
+
+    runBulk('bulkConvertToSubTask', { parentTaskId: String(task._id) }, {
+        onSuccess: () => { if (crossesSprints) refreshSprintCounts(); },
+    });
+}
+
+// mutateSprints ignores an 'added' op for a sprint it already holds, so the
+// ordinary load would not refresh anything — each row is committed as modified.
+async function refreshSprintCounts() {
+    const pid = projectData?.value?._id;
+    if (!pid) return;
+    try {
+        const res = await apiRequest('get', `/api/v1/${env.GET_SPRINT_OR_PROJECT}/${pid}?collection=sprints`);
+        (res?.data || []).forEach((row) => {
+            commit('projectData/mutateSprints', { op: 'modified', data: { ...row, id: row._id } });
+        });
+    } catch (error) {
+        // The badges stay stale until the next load; not worth an error toast on
+        // top of a conversion that succeeded.
+        console.error('ERROR in refresh sprint counts: ', error);
+    }
+}
+
+// Bulk convert to task. The picker returns a project and sprint, exactly as it
+// does for bulk move; the server promotes each selected subtask into it.
+function onBulkConvertToTaskConfirm({ project, sprint } = {}) {
+    if (!project || !sprint || !sprint.id) return;
+    showConvertToTask.value = false;
+
+    // The sprint badges are not socket-driven, and a promotion into a different
+    // sprint moves the task there. Re-read them rather than replaying the
+    // server's arithmetic — see refreshSprintCounts.
+    runBulk('bulkConvertToTask', {
+        projectData: {
+            id: project._id,
+            ProjectCode: project.ProjectCode,
+            ProjectName: project.ProjectName,
+        },
+        sprintObj: sprint,
+    }, {
+        onSuccess: () => refreshSprintCounts(),
     });
 }
 

--- a/frontend/src/components/molecules/ConvertToSubTaskSidebar/ConvertToSubTaskSidebar.vue
+++ b/frontend/src/components/molecules/ConvertToSubTaskSidebar/ConvertToSubTaskSidebar.vue
@@ -228,6 +228,14 @@
             type: Boolean,
             default: false
         },
+        // Bulk convert to subtask. Same task picker, but the sidebar performs
+        // nothing: it hands the chosen parent task back and the caller
+        // (BulkActionBar) fires one bulkConvertToSubTask request for the whole
+        // selection. Mirrors isBulkMove.
+        isBulkConvert: {
+            type: Boolean,
+            default: false
+        },
         item: {
             type: Object,
             default: () => {}
@@ -264,6 +272,7 @@
     const selectedIndex = ref(0);
     const selecteFolderIndex = ref(0);
     const isTaskSelected = ref(false);
+    const selectedParentTask = ref(null);
     const selectedValue = ref('');
     const taskData = ref({
         value: props.content,
@@ -283,7 +292,7 @@
             else { return projectsGetter.value.data; }
         }
     });
-    const emit = defineEmits(["isConvertSubtaskOPen","dataToMainComp","createTask","bulkMoveConfirm"])
+    const emit = defineEmits(["isConvertSubtaskOPen","dataToMainComp","createTask","bulkMoveConfirm","bulkConvertConfirm"])
     const projectData = (props.selectedProjectObject == undefined || Object.keys(props.selectedProjectObject).length == 0) ? inject("selectedProject") : '';
     const isSidebarOPen = ref(props.closeSideBar);
     const selectedProjectData = ref(props.selectedProjectObject == undefined ? projectData.value : props.selectedProjectObject);
@@ -1097,6 +1106,17 @@
     }
 
     function callMergeTaskForItem(value) {
+        // Bulk convert: hand the chosen parent back instead of converting one
+        // task through the nested refs. Deliberately before those calls, so the
+        // per-task path is never entered in bulk mode.
+        if (props.isBulkConvert === true) {
+            if (!selectedParentTask.value || !selectedParentTask.value._id) {
+                return;
+            }
+            emit('bulkConvertConfirm', { task: selectedParentTask.value });
+            closeSidebar();
+            return;
+        }
         if (selectedValue.value === 'sprint' && sprintRefs.value[selectedIndex.value] && sprintRefs.value[selectedIndex.value].taskOperationFun) {
             sprintRefs.value[selectedIndex.value].taskOperationFun(value);
         }
@@ -1112,6 +1132,9 @@
     function taskSelctFun (e) {
         if(e && Object.keys(e).length > 0){
             isTaskSelected.value = true;
+            // Kept for the bulk picker, which needs the task itself rather than
+            // just knowing that one was chosen.
+            selectedParentTask.value = e;
         }
     }
 


### PR DESCRIPTION
Three tracker items, kept in one PR because the last depends on the second.

| | |
| --- | --- |
| **AHE-3927** | Bulk move left a task's subtasks behind |
| **AHE-3925** | Convert to Subtask, in bulk |
| **AHE-3926** | Convert to Task, in bulk |

## AHE-3927 — the bug

Bulk-moving a parent moved only the parent. Single move has always carried the subtasks; bulk hard-coded `isSubTask: false`.

Once separated, the subtasks were reachable from **nowhere**. The destination looks subtasks up by the *destination's* `sprintId` and finds none; the source list only renders parents. The parent still showed "2 subtasks" and opened empty. The sprint badge was wrong too — the client subtracted the parent *plus* its subtasks while only the parent moved.

The subtasks are enumerated inside `bulkMove` rather than handed to `moveTask`'s own `isSubTask` branch, deliberately: that branch applies **one** assignee/watcher pair across the whole family. Right for the single-task sidebar, where a person picked those people for that move — and it would have wiped every subtask's own assignees here.

Selecting a parent together with one of its own subtasks moves it once, not twice. Subtasks are gathered **by parentage rather than by sprint**, so one that was already separated is pulled back — the only way an existing stranded subtask can be reached at all.

## AHE-3925 — Convert to Subtask

No destination parameter. A subtask lives where its parent lives, so sprint, folder and project are read off the chosen parent.

It reuses the single-task path per task, so history, the parent's `subTasks` counter, comment counts, the socket events and the cross-project status/type remap all behave as they do today. It does **not** reuse that path's reporting: `convertToSubTask` settles with `Promise.allSettled` and then resolves success regardless of what rejected inside, so a partial failure reads as a clean run. Every conversion is verified by re-reading the task.

Skip rules, each with a reason in the toast: the parent you chose, a task already under it, and a task whose own parent is also selected.

## AHE-3926 — Convert to Task

Two things about that path needed defending against before repeating it across a selection.

**It marks the task deleted first and rewrites it second.** A failure in between leaves it gone from the board. Harmless once; twenty times is not. Every task is verified afterwards, and one left deleted is **restored to the state it was in** — archived stays archived — rather than reported as lost.

**Its inner failure path only logs.** It neither resolves nor rejects, so awaiting it hangs forever and one bad task would hold the whole request open. Each call is raced against a deadline and judged on the task's real state instead.

It also decides "is this cross-project?" with a plain `!==` on two ids. Two `ObjectId` instances are never `!==`-equal, so a same-project conversion would have taken the remapping branch. Both sides are passed as strings, which is what the single-task callers pass.

## Bulk Move now branches like the single action

Offering a **sprint** picker for a subtask is what produced the invisible state in the first place. `useTaskActions.moveTask` has always branched on `isParentTask` — a parent picks a sprint, a subtask picks a *parent task*. Bulk does the same now, reusing the same sidebar mode (`openMoveSubTask`), so the header, the button label and the list are identical to the single flow.

A subtask whose parent is also selected is not "loose" — it travels with the parent through the ordinary sprint move. Only a selection that is *entirely* loose subtasks switches the picker. The server refuses a loose subtask sent to a sprint regardless, so the state cannot be reached even by a direct request.

## Permissions

The bulk endpoint gained `requireTaskActionPermission`, which the single `PATCH /api/v2/tasks` has always had. No bulk action is named in `TASK_ACTION_PERMISSION`, so **nothing changes today** — the map now governs both endpoints instead of one. Both new buttons check the same permission keys their single-task counterparts do.

## Nothing existing changes

`structural.js`, `mongo_helper.js`, `TaskInSidebar` and `SideBarSprintFolderData` are **untouched** — the entire single-task path is unchanged.

Verified rather than assumed:

- **`ConvertToSubTaskSidebar` has 7 consumers.** Only `BulkActionBar` passes the new `isBulkConvert` prop; the other six get the default `false`, so the new early return never fires. The "move a subtask" mode shares the same confirm button and was checked specifically.
- **`TASK_ACTION_PERMISSION` has zero bulk entries**, so the new middleware returns `next()` for every existing bulk action.
- **`bulkMove` has two callers** — the action bar and the Scrum sprint completion. Sprint completion only ever hands it parent tasks, so the loose-subtask rule cannot affect it; it no longer passes `isSubTask` because `bulkMove` now carries subtasks unconditionally.

## Testing

**82 behavioural checks** across three suites drive the real handlers with the data layer stubbed — including the cases the single paths cannot express: a conversion that reports success but changed nothing, a call that never settles, a half-done conversion that must be restored rather than lost, and an archived task that must come back archived.

- jest: **632 passing**. One pre-existing failure in `tests/share-rules.test.js`, reproduced with this branch stashed and unrelated.
- ESLint clean, frontend build passes.

Manual checklist in `.claude/bulk-convert-test-cases.md`. Part A is the regression pass over the single-task actions and needs no console. **D7** is the one that matters most: after a batch Convert to Task, every selected task must still be on the board.

## Known and deliberate

- The Convert to Subtask parent picker lists every task, including selected ones. The server skips a selected task that turns out to be the parent and says so, rather than the picker hiding it — that would have meant threading the selection through three components.
- Converting a parent flattens its subtasks to sit beside it rather than nesting two deep. Existing single-task behaviour; only one level of nesting exists.
- Convert to Task writes no history entry. Same as the single action; not added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
