### PR TITLE
fix: show a dragged-in subtask straight away instead of after a reload

### DIFF
--- a/frontend/src/components/organisms/ItemList/ItemList.vue
+++ b/frontend/src/components/organisms/ItemList/ItemList.vue
@@ -763,73 +763,49 @@ function updateItem(type,e, item) {
         const taskObject = JSON.parse(JSON.stringify(e?.added?.element))
         
         if(type === 'subTask' && checkPermission('task.task_convert_to_subtask', props.project?.isGlobalPermission) === true){
-            if(e?.added?.element?.subTasks <= 0 || e?.added?.element?.subTasks === undefined){
-                if(e?.added?.element?.ParentTaskId){
-                    setTimeout(() => {
-                        commit("projectData/mutateUpdateFirebaseTasks",{
-                            snap, 
-                            op: "removed",
-                            pid,
-                            sprintId,
-                            data: {...taskObject,isParentTask:false,ParentTaskId:e?.added?.element?.ParentTaskId},
-                            showAllTasks
-                        });
-                    },800)
-                }
+            // The dropped task always has to be attached locally. This used to be
+            // split three ways with only two of them doing anything: a task that
+            // HAS subtasks but was never expanded — so its subtaskArray was never
+            // loaded — matched neither, and the screen was left untouched while the
+            // server converted it anyway.
+            const attach = (row) => {
                 commit("projectData/mutateUpdateFirebaseTasks",{
-                    snap, 
+                    snap,
                     op: "modified",
                     pid,
                     sprintId,
-                    data: {...taskObject,isParentTask:false,ParentTaskId:item._id},
+                    data: {...row,isParentTask:false,ParentTaskId:item._id},
                     showAllTasks,
                     updatedFields:{
                         deletedStatusKey:1,
                         updatedAt:new Date(),
                         ParentTaskId: item._id,
                         isParentTask: false,
-                        subTasks:item?.subTasks >= 0 ? item?.subTasks + 1 : 1
                     },
                     dragDropcheck:true
                 });
-            }else{
-                if(e?.added?.element?.subtaskArray && e?.added?.element?.subtaskArray.length){
+            };
+
+            // Already a subtask elsewhere: drop it from the old parent's list too.
+            if(e?.added?.element?.ParentTaskId){
+                setTimeout(() => {
                     commit("projectData/mutateUpdateFirebaseTasks",{
                         snap, 
-                        op: "modified",
+                        op: "removed",
                         pid,
                         sprintId,
-                        data: {...e?.added?.element,isParentTask:false,ParentTaskId:item._id},
-                        showAllTasks,
-                        updatedFields:{
-                            deletedStatusKey:1,
-                            updatedAt:new Date(),
-                            ParentTaskId: item._id,
-                            isParentTask: false,
-                            subTasks:item?.subTasks >= 0 ? item?.subTasks + 1 : 0
-                        },
-                        dragDropcheck:true
+                        data: {...taskObject,isParentTask:false,ParentTaskId:e?.added?.element?.ParentTaskId},
+                        showAllTasks
                     });
-                    e?.added?.element?.subtaskArray.forEach((x)=>{
-                        commit("projectData/mutateUpdateFirebaseTasks",{
-                            snap, 
-                            op: "modified",
-                            pid,
-                            sprintId,
-                            data: {...x,isParentTask:false,ParentTaskId:item._id},
-                            showAllTasks,
-                            updatedFields:{
-                                deletedStatusKey:1,
-                                updatedAt:new Date(),
-                                ParentTaskId: item._id,
-                                isParentTask: false,
-                                subTasks:item?.subTasks >= 0 ? item?.subTasks + 1 : 0
-                            },
-                            dragDropcheck:true
-                        });
-                    })
-                }
+                },800)
             }
+
+            attach(taskObject);
+
+            // Its own children come across beside it — only one level of nesting
+            // exists — so each of the loaded ones is attached as well. Any that were
+            // never loaded are reconciled by the parent's own update from the server.
+            (e?.added?.element?.subtaskArray || []).forEach((x) => attach(x));
             taskClass.convertToSubTask({
                 companyId: companyId.value,
                 projectData: {

--- a/frontend/src/store/ProjectData/mutations.js
+++ b/frontend/src/store/ProjectData/mutations.js
@@ -194,6 +194,29 @@ function returnItemCountDetails(tasks, groupBy, updatedFields = null, taskId) {
 }
 
 // HANDLE TASK
+/* A task has just been attached to `taskIndex` as a subtask. Raise that parent's
+   subtask count by one.
+
+   Counted UP rather than recomputed from subtaskArray.length, which is what the
+   line here used to try. That array is paginated at 35 and only filled when a row
+   is expanded, so a parent with 40 subtasks — or one never opened — would have had
+   its count rewritten downwards. That is why the recompute was commented out, and
+   why it stays out.
+
+   Guarded on dragDropcheck so only a genuine re-parent counts. The same branch
+   also runs for every ordinary field change on a subtask, and a partially loaded
+   subtaskArray means "not in the array" cannot be read as "newly added" on its own.
+
+   The parent's own document update follows from the server carrying the
+   authoritative count, and merges straight over this. This exists so the arrow
+   appears immediately rather than after that round trip. */
+function bumpParentSubtaskCount(state, pid, sprintId, taskIndex, dragDropcheck) {
+    if (dragDropcheck !== true) return;
+    const parent = state.tasks?.[pid]?.[sprintId]?.tasks?.[taskIndex];
+    if (!parent) return;
+    parent.subTasks = (Number(parent.subTasks) || 0) + 1;
+}
+
 export const mutateUpdateFirebaseTasks = (state, payload) => {
     const {pid, sprintId, op, data, snap, updatedFields,dragDropcheck, groupBy: payloadGroupBy} = payload;
 
@@ -275,11 +298,16 @@ export const mutateUpdateFirebaseTasks = (state, payload) => {
                             }else{
                                 state.tasks[pid][sprintId].tasks[taskIndex].subtaskArray = [data];
                             }
+                            bumpParentSubtaskCount(state, pid, sprintId, taskIndex, dragDropcheck);
                         }
-                        // state.tasks[pid][sprintId].tasks[taskIndex].subTasks = state?.tasks?.[pid]?.[sprintId]?.tasks[taskIndex]?.subtaskArray?.length || 0;
                     }
-                    else if(dragDropcheck === true && state.tasks[pid][sprintId].tasks[taskIndex].subtaskArray === undefined && data.ParentTaskId){
+                    // taskIndex is -1 when the parent is not in this view — filtered
+                    // out, in another group, or past the 35-row page. Reading
+                    // tasks[-1].subtaskArray threw from inside the mutation, which
+                    // aborts the commit and leaves the drop half applied.
+                    else if(dragDropcheck === true && taskIndex !== -1 && state.tasks[pid][sprintId].tasks[taskIndex].subtaskArray === undefined && data.ParentTaskId){
                         state.tasks[pid][sprintId].tasks[taskIndex].subtaskArray = [data];
+                        bumpParentSubtaskCount(state, pid, sprintId, taskIndex, dragDropcheck);
                     }
                 } else {
                     const taskIndex = state.tasks[pid][sprintId].tasks.findIndex((x) => x._id === data._id);


### PR DESCRIPTION
Fixes **AHE-3928**.

Dragging a task onto another to make it a subtask converted it correctly on the server, then left the screen behind: the task vanished from the top level and did not appear under its new parent, which often had no expand arrow at all. A reload put everything right — which is exactly what made it look random.

Nothing was ever lost or corrupted. The server side is untouched by this PR.

## Three faults, any one of which is enough

### The parent's subtask count was never raised locally

The line that would have done it is commented out in the store. That count is what decides whether the expand arrow renders at all, so dropping onto a task that had no subtasks left it with **no way to open**. The on-demand subtask loader gives up at a count of zero too, so nothing recovered it.

It is now raised **by one** rather than recomputed from `subtaskArray.length`, which is what the commented-out line tried. That array is paginated at 35 and only filled when a row is expanded, so a parent with 40 subtasks — or one never opened — would have had its count rewritten *downwards*. That is presumably why the recompute was commented out, and it stays out.

The bump is guarded on `dragDropcheck`. The same branch runs for every ordinary field change on a subtask, and with a partially loaded array "not in the array" cannot be read as "newly added". The parent's own document update from the server carries the authoritative count and merges straight over the local guess — this exists so the arrow appears *immediately* rather than a round trip later.

### One case updated the screen not at all

The drop handler had three situations and handled two. A task that **has** subtasks but was never expanded — so its children were never loaded — matched neither branch, and nothing was applied locally. The attach is now unconditional, with the loaded children attached alongside it.

### The store mutation could throw

The branch that seeds an empty `subtaskArray` never re-checked that the parent was found. A drop whose parent is **not in the current view** — filtered out, in another group, or past the 35-row page — read `tasks[-1].subtaskArray` and threw from inside a Vuex mutation, aborting the commit and leaving the drop half applied.

Found by the tests, not by reading.

## Why it looked intermittent

| Situation | Before |
| --- | --- |
| The task you drop onto already had subtasks | Worked — the arrow was already there |
| It had none | Subtask invisible until reload |
| The dragged task has subtasks but was never expanded | Nothing updated on screen |
| The parent is filtered out or off the loaded page | Mutation threw; drop half applied |

## Testing

**14 behavioural checks** drive the real store mutation, loaded by stripping its two imports and evaluating the shipped source — no build step, and the code under test is the code that ships.

The ones that matter:

- A partially loaded parent (40 subtasks, 2 loaded) counts **up to 41**, not down to 3
- Field updates on unloaded subtasks do **not** creep the count
- The same drop event arriving twice does not double it
- A parent that is not in the view is left alone rather than crashed into
- Removing a subtask still drops the count — that path is untouched

The same suite was run against the current `staging` code and **fails**, which is how the bug is confirmed pre-existing rather than introduced by recent work.

- jest: **632 passing**. One pre-existing failure in `tests/share-rules.test.js`, unrelated.
- ESLint clean, frontend build passes.

## Checked against the open bulk PR

[#504](https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/pull/504) is open against the same base, so both were put in one tree and everything re-run.

- **No file overlap.** #504 touches the bulk helpers, routes, the action bar and the convert sidebar; this touches the store mutation and the list.
- **The bulk paths never pass `dragDropcheck`**, so the new bump cannot fire for them. Their optimistic commits are unchanged, and a bulk convert still gets its count from the parent's own server update.
- With both applied: **8 behavioural suites pass**, jest 632, ESLint clean, build clean.
- `#504` still merges into `staging` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
