### PR TITLE
feat(tracker): tell people the estimate was passed, even when tracking is not capped

### DIFF
--- a/time-tracker-app/main/background.js
+++ b/time-tracker-app/main/background.js
@@ -447,7 +447,12 @@ ipcMain.on('estimate:limit', (event, data) => {
   const d = data || {}
   if (d.reason === 'autostopped') {
     try {
-      showTrackerStoppedAlert({ reason: 'estimate', taskName: d.taskName || (lastTaskCtx && lastTaskCtx.taskName) || '' })
+      showTrackerStoppedAlert({
+        reason: 'estimate',
+        taskName: d.taskName || (lastTaskCtx && lastTaskCtx.taskName) || '',
+        // Absent means stopped, which is what every caller before this one meant.
+        stopped: d.stopped !== false,
+      })
     } catch (e) { /* best-effort */ }
     return
   }
@@ -672,7 +677,7 @@ function closeStoppedAlert() {
   stoppedAlertWindow = null
 }
 
-function showTrackerStoppedAlert({ reason, taskName = '', stoppedAt = Date.now() } = {}) {
+function showTrackerStoppedAlert({ reason, taskName = '', stoppedAt = Date.now(), stopped = true } = {}) {
   closeStoppedAlert() // never let alerts stack in the corner
 
   const { width, height } = screen.getPrimaryDisplay().workAreaSize
@@ -713,7 +718,7 @@ function showTrackerStoppedAlert({ reason, taskName = '', stoppedAt = Date.now()
 
   win.loadFile(notificationAlertHtmlPath)
   win.webContents.on('did-finish-load', () => {
-    win.webContents.send('alert:render', { reason, taskName, stoppedAt })
+    win.webContents.send('alert:render', { reason, taskName, stoppedAt, stopped })
     setTimeout(showOnce, 400) // fallback if no size report arrives
   })
 

--- a/time-tracker-app/package.json
+++ b/time-tracker-app/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "alianhubtimetracker",
   "description": "My application description",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "author": "Alian Software",
   "homepage": "https://aliansoftware.com",
   "main": "app/background.js",

--- a/time-tracker-app/renderer/components/NavBar/Header.jsx
+++ b/time-tracker-app/renderer/components/NavBar/Header.jsx
@@ -228,8 +228,7 @@ function Header() {
                                         </li>
                                     </ul>
                                     <div className="flex items-center leading-none text-white overflow-hidden text-ellipsis whitespace-nowrap">
-                                        {/* <img src={project?.selectedTaskType} className="h-4 w-4" alt="task type" /> */}
-                                        {(timeLog?.taskTypeData || timeLog?.taskTypeImage) && <TaskTypeIcon taskType={timeLog?.taskTypeData || { taskImage: timeLog?.taskTypeImage }} className="!w-[15px] !h-[15px]" />}
+                                        {(timeLog?.taskTypeData || timeLog?.taskTypeImage) && <TaskTypeIcon taskType={timeLog?.taskTypeData || { taskImage: timeLog?.taskTypeImage }} color="#fff" className="!w-[15px] !h-[15px]" />}
                                         <span className="ml-2 font-medium text-sm overflow-hidden text-ellipsis whitespace-nowrap">
                                             {timeLog?.taskName}
                                         </span>

--- a/time-tracker-app/renderer/components/TaskTypeIcon/TaskTypeIcon.jsx
+++ b/time-tracker-app/renderer/components/TaskTypeIcon/TaskTypeIcon.jsx
@@ -6,7 +6,12 @@ import { loadIconSet, isLoaded, iconLoaded, DEFAULT_ICON, DEFAULT_ICON_COLOR } f
 // Single renderer for a task type's icon — library (Iconify mdi) or uploaded image —
 // mirroring the web app's TaskTypeIcon so the tracker shows the same icons.
 // Pass the matched taskTypeCounts entry as `taskType` ({ iconType, iconValue, iconColor, taskImage }).
-const TaskTypeIcon = ({ taskType = {}, className = '' }) => {
+//
+// `color` overrides the task type's own colour, and exists for callers drawing on a dark
+// surface. A task type with no colour of its own falls back to the app navy — the exact
+// navy of the running-tracker header — so the icon was being painted in its background and
+// disappeared. Only that one caller passes it; everywhere else is unchanged.
+const TaskTypeIcon = ({ taskType = {}, className = '', color }) => {
     const isLibrary = taskType?.iconType === 'library' && !!taskType?.iconValue;
     const [ready, setReady] = useState(isLoaded());
 
@@ -26,11 +31,11 @@ const TaskTypeIcon = ({ taskType = {}, className = '' }) => {
     // Placeholder until the mdi set is registered → no layout jump, no CDN lookup.
     if (!ready) return <span className={`inline-block ${className}`} />;
 
-    const color = taskType?.iconColor || DEFAULT_ICON_COLOR;
+    const resolvedColor = color || taskType?.iconColor || DEFAULT_ICON_COLOR;
     // Only render names that resolved offline; anything else (lucide/tabler/unknown)
     // shows the default mdi icon instead of triggering an Iconify API fetch.
     const name = iconLoaded(taskType.iconValue) ? taskType.iconValue : DEFAULT_ICON;
-    return <Icon icon={name} color={color} className={className} />;
+    return <Icon icon={name} color={resolvedColor} className={className} />;
 };
 
 export default TaskTypeIcon;

--- a/time-tracker-app/renderer/pages/trackerRunning.jsx
+++ b/time-tracker-app/renderer/pages/trackerRunning.jsx
@@ -4,7 +4,7 @@ import Router from 'next/router';
 import { setCaptures, setActivityTick, setTrackerStopTime, removeExtraClicks, setComment, setTrackerStartTime, removeAllTimeLog } from '../store/timelog';
 import { TrackerController } from '../controller/tracker/tracker';
 import { apiRequest } from '../utils/services';
-import { fetchEstimateStatus } from '../utils/estimateLimit';
+import { fetchEstimateStatus, isEstimateLimitEnabled } from '../utils/estimateLimit';
 import store from '../store/store';
 import moment from 'moment';
 import { DateTime } from 'luxon';
@@ -291,15 +291,24 @@ function TimeTrackerView() {
     // Set the guard synchronously so the next 1s tick can't double-stop.
     autoStoppedRef.current = true;
     const taskName = currentTimeLog.taskName;
-    try {
-      await TrackerController.TrackerStop();
-    } catch (e) {
-      console.error('Estimate auto-stop failed', e);
+
+    // The company switch decides whether the session is CUT SHORT here, not whether the
+    // person is told. With it off the tracker keeps running and the alert still appears.
+    const capEnabled = isEstimateLimitEnabled(store.getState()?.company?.currentCompany);
+
+    if (capEnabled) {
+      try {
+        await TrackerController.TrackerStop();
+      } catch (e) {
+        console.error('Estimate auto-stop failed', e);
+      }
+      dispatch(setTrackerStopTime());
+      dispatch(removeAllTimeLog());
     }
-    dispatch(setTrackerStopTime());
-    dispatch(removeAllTimeLog());
-    try { window.ipc.send('estimate:limit', { reason: 'autostopped', taskName }); } catch (e) { /* best-effort */ }
-    Router.push('/home');
+    // `stopped` tells the alert whether tracking actually ended. With the cap off it did
+    // not, and the card drops its Resume button — there is nothing to resume.
+    try { window.ipc.send('estimate:limit', { reason: 'autostopped', taskName, stopped: capEnabled }); } catch (e) { /* best-effort */ }
+    if (capEnabled) Router.push('/home');
   };
 
   const setActivityEvent = (e) => {

--- a/time-tracker-app/renderer/public/notification-alert.html
+++ b/time-tracker-app/renderer/public/notification-alert.html
@@ -73,6 +73,9 @@
     .a-dot { width: 7px; height: 7px; border-radius: 50%; background: #F59E0B; box-shadow: 0 0 0 3px #FEF3C7; flex-shrink: 0; }
 
     .a-actions { display: flex; gap: 9px; margin-top: 14px; }
+    /* Nothing stopped, so there is no Resume and Dismiss stands alone — put it where a
+       single dialog action belongs. */
+    .a-actions.solo { justify-content: flex-end; }
     .btn {
       height: 34px; border-radius: 9px; font-size: 13px; font-weight: 700; cursor: pointer;
       border: 1px solid transparent; display: inline-flex; align-items: center; justify-content: center; gap: 7px;
@@ -93,12 +96,12 @@
 <body>
   <div class="alert" id="alert">
     <div class="alert-head">
-      <div class="a-icon">
+      <div class="a-icon" id="head_icon">
         <!-- stop glyph -->
         <svg viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="2.5"/></svg>
       </div>
       <div class="a-head-text">
-        <div class="a-title">Time tracking stopped</div>
+        <div class="a-title" id="title">Time tracking stopped</div>
         <div class="a-kicker">AlianHub Time Tracker</div>
       </div>
       <div class="a-close" id="close_icon" title="Dismiss">
@@ -124,6 +127,8 @@
     const OUT_MS = 200;
     let closing = false;
     let stoppedAt = null;
+    // True when the estimate was passed but tracking carried on (company cap off).
+    let stillRunning = false;
 
     // Fit the window to the card's real laid-out height (task names/reasons vary
     // in length), keeping the bottom edge anchored above the taskbar.
@@ -140,8 +145,11 @@
     }
 
     // Build the human reason line from the stop reason + (optional) task name.
-    function reasonText(reason, taskName) {
+    function reasonText(reason, taskName, stillRunning) {
       const t = taskName ? ' on <b>“' + escapeHtml(taskName) + '”</b>' : '';
+      // Nothing was stopped — the company allows tracking past the estimate. Saying
+      // "stopped" here reads as though the timer died, which is the opposite of the truth.
+      if (stillRunning) return 'Went past the estimated hours' + t + '. Tracking is still running.';
       switch (reason) {
         case 'estimate':
           return 'Reached the estimated hours' + (taskName ? ' on <b>“' + escapeHtml(taskName) + '”</b>' : '') + ' — tracking has stopped.';
@@ -154,16 +162,18 @@
       }
     }
 
-    // Live "Stopped X ago" so a returning user instantly knows how long it's been off.
+    // Live "Stopped X ago" so a returning user instantly knows how long it's been off — or
+    // "Over by X" when nothing stopped, which is how long the task has run past its estimate.
     function fmtAgo() {
-      if (!stoppedAt) return 'Stopped just now';
+      const word = stillRunning ? 'Over by' : 'Stopped';
+      if (!stoppedAt) return stillRunning ? 'Over the estimate just now' : 'Stopped just now';
       const s = Math.max(0, Math.floor((Date.now() - stoppedAt) / 1000));
-      if (s < 5) return 'Stopped just now';
-      if (s < 60) return 'Stopped ' + s + ' second' + (s > 1 ? 's' : '') + ' ago';
+      if (s < 5) return stillRunning ? 'Over the estimate just now' : 'Stopped just now';
+      if (s < 60) return word + ' ' + s + ' second' + (s > 1 ? 's' : '') + (stillRunning ? '' : ' ago');
       const m = Math.floor(s / 60);
-      if (m < 60) return 'Stopped ' + m + ' minute' + (m > 1 ? 's' : '') + ' ago';
+      if (m < 60) return word + ' ' + m + ' minute' + (m > 1 ? 's' : '') + (stillRunning ? '' : ' ago');
       const h = Math.floor(m / 60);
-      return 'Stopped ' + h + ' hour' + (h > 1 ? 's' : '') + ' ago';
+      return word + ' ' + h + ' hour' + (h > 1 ? 's' : '') + (stillRunning ? '' : ' ago');
     }
     function tickAgo() {
       const el = document.getElementById('ago');
@@ -175,7 +185,21 @@
     ipcRenderer.on('alert:render', (event, data) => {
       data = data || {};
       stoppedAt = typeof data.stoppedAt === 'number' ? data.stoppedAt : Date.now();
-      document.getElementById('reason').innerHTML = reasonText(data.reason, data.taskName);
+      // Only an explicit false means "still running" — an older caller that sends no flag
+      // at all is reporting a real stop, and every word below stays as it was.
+      stillRunning = data.stopped === false;
+
+      if (stillRunning) {
+        // The card exists to say the estimate is past, not that anything ended: the title,
+        // the stop glyph and the Resume button all otherwise read as "your timer died".
+        document.getElementById('title').textContent = 'Estimate exceeded';
+        document.getElementById('head_icon').innerHTML =
+          '<svg viewBox="0 0 24 24"><path d="M12 5.2a1.5 1.5 0 0 1 1.5 1.63l-.5 6.4a1 1 0 0 1-2 0l-.5-6.4A1.5 1.5 0 0 1 12 5.2zm0 10.3a1.55 1.55 0 1 1 0 3.1 1.55 1.55 0 0 1 0-3.1z"/></svg>';
+        document.getElementById('resume_btn').style.display = 'none';
+        document.querySelector('.a-actions').classList.add('solo');
+      }
+
+      document.getElementById('reason').innerHTML = reasonText(data.reason, data.taskName, stillRunning);
       tickAgo();
       // Wait for layout to settle, then fit the window. (No auto-dismiss — this
       // card is PERSISTENT: it stays until the user acts.)

--- a/time-tracker-app/renderer/utils/estimateLimit.js
+++ b/time-tracker-app/renderer/utils/estimateLimit.js
@@ -38,17 +38,17 @@ export function estimateStatusFromTask(task, limitEnabled = true) {
   const hasEstimate = estimate > 0;
 
   if (limitEnabled === false) {
+    // The estimate is still reported with the switch off, because reaching it is worth
+    // saying either way — the alert fires from these numbers. What the switch governs is
+    // the auto-stop, and that reads `limitEnabled`; a session is never capped by the mere
+    // presence of a number here.
     return {
-      // FALSE even when the task does have an estimate. Every call site uses this as
-      // `est.hasEstimate ? est.remainingMinutes : null` — the one decision it drives is
-      // whether to arm the auto-stop for the session about to start. Reporting the task's
-      // real state here would leave the deep-link path (which passes a real task rather
-      // than going through fetchEstimateStatus) still capping the session with the setting
-      // off. Nothing else reads it.
-      hasEstimate: false,
+      hasEstimate,
       estimateMinutes: estimate,
-      remainingMinutes: null,
-      reached: false,
+      remainingMinutes: hasEstimate ? Math.max(remaining, 0) : null,
+      reached: hasEstimate && remaining <= 0,
+      // Nothing is ever refused with the switch off: not a task without an estimate, and
+      // not one already over it.
       blockStart: false,
       blockReason: null,
       blockMessage: null,
@@ -82,23 +82,21 @@ export async function fetchEstimateStatus(companyId, taskId) {
   // four call sites keep the signature they already have.
   const limitEnabled = isEstimateLimitEnabled(store.getState()?.company?.currentCompany);
 
-  // Nothing to check when the company has the cap off: the task read exists only to find
-  // out how much estimate is left, and no answer to that can block anything now. Skipping
-  // it also means turning the setting off removes a request from every tracker start.
-  if (!limitEnabled) return { ...estimateStatusFromTask(null, false), ok: true };
-
+  // The task is read whether or not the cap is on. With it off nothing can be blocked, but
+  // the estimate is still what the alert is measured against, so skipping the read would
+  // leave the alert with nothing to fire from.
   try {
-    if (!companyId || !taskId) return { ...estimateStatusFromTask(null), ok: false };
+    if (!companyId || !taskId) return { ...estimateStatusFromTask(null, limitEnabled), ok: false };
     const res = await apiRequest('post', `/api/v1/task/find`, {
       findQuery: [
         { $match: { objId: { _id: taskId, CompanyId: companyId } } },
       ],
     });
     const task = res && res.data && res.data[0];
-    if (!task) return { ...estimateStatusFromTask(null), ok: false };
-    return { ...estimateStatusFromTask(task), ok: true };
+    if (!task) return { ...estimateStatusFromTask(null, limitEnabled), ok: false };
+    return { ...estimateStatusFromTask(task, limitEnabled), ok: true };
   } catch (e) {
     console.error('fetchEstimateStatus error', e);
-    return { ...estimateStatusFromTask(null), ok: false };
+    return { ...estimateStatusFromTask(null, limitEnabled), ok: false };
   }
 }


### PR DESCRIPTION
AHE-3931.

## The problem

A company can turn the estimate cap off. Do that, and the tracker runs past a
task's estimated hours with nobody told anything at all — no stop, and no warning
either.

The warning only ever appeared as a side effect of the auto-stop, so turning the
stop off turned the warning off with it. Underneath, both were the same signal:
`remainingMinutes` arrives as `null` when the cap is off, and that one `null`
meant *"do not stop"* **and** *"do not warn"*. There was no way to have one
without the other.

## What changed

The two are separate now. The estimate is still reported with the cap off, and
the company switch is read where the stop is actually decided rather than
inferred from a missing number.

That also means the task is read on every tracker start, not only when the cap is
on — one extra request. The read used to be skipped as pointless once nothing
could be blocked; the alert needs the estimate, so it is not pointless any more.

**Three situations reach this**, and only the first is obvious:

| | |
|---|---|
| The cap is off | Tracking runs past the estimate by design |
| A colleague logs time on the same task mid-session | The armed stop is stale; the task is genuinely over |
| The estimate is lowered mid-session | Same |

The last two happen with the cap **on** and were silent too.

## The card

It no longer claims tracking ended when it did not.

| | Cap ON — a real stop | Cap OFF — still running |
|---|---|---|
| Title | Time tracking stopped | **Estimate exceeded** |
| Glyph | stop square | **attention mark** |
| Body | … — tracking has stopped. | … **Tracking is still running.** |
| Meta | Stopped 38 seconds ago | **Over by 38 seconds** |
| Actions | Resume + Dismiss | **Dismiss alone, right-aligned** |

Every one of those is conditional on the new flag. A real stop — including the
screen-lock and sleep alerts, which never send the flag — is untouched. Both
states were rendered and looked at before the installer was cut, not after.

## Also here: an invisible icon

A task type with no colour of its own falls back to `#2F3990`, and the header
card it sits on is `#2F3990`. The icon was painted in its own background, so it
was not hard to see — it was not there. The container sets `text-white`, which
would have handled it, but the icon passes an explicit colour and that beats
`currentColor`.

Not from this work. It surfaced because **this is the first build to include the
icon at all**: the Iconify packages it imports were added weeks after the last
installer was cut, so the code had never been through a build and nobody had seen
it. Worth knowing on its own — the tracker can carry unbuilt code for a long time.

The component takes a colour now and only the header passes it; everywhere else
the icon renders exactly as before. An uploaded image is still shown as-is, since
a colour cannot tint one.

## Version

`5.1.6`. There is no auto-updater, so the version in Settings is the only way to
tell an installed build from the one before it — and the installer filename would
otherwise have collided with the previous release.

## Testing

Installer built and installed from this branch.

- Cap **off** → the new card appears at the estimate and **tracking continues**
- Cap **on** → the tracker stops and the old card appears, Resume included
- Cap off, task with **no** estimate → nothing, correctly
- Screen-lock / sleep alerts → unchanged
- Header icon visible on the navy card; home list and log-entry icons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)