### PR TITLE
feat(comments): ask workspace AI with @Alian mentions

### DIFF
--- a/Modules/Comments/controller.js
+++ b/Modules/Comments/controller.js
@@ -7,7 +7,7 @@ const { replaceObjectKey } = require("../Auth/helper");
 const socketEmitter = require('../../event/socketEventEmitter');
 const { escapeRegex } = require("../../utils/escapeRegex");
 const { parseMentionIds } = require("./helpers/parseMentions");
-const { maybeReplyAsAlianSafe } = require("./helpers/alianReply");
+const { maybeReplyAsAlianSafe, emitCommentInsert } = require("./helpers/alianReply");
 const { handleNotificationtFun } = require("../notification/prepare-notification-data/controllerV2");
 const { getRoleType, isPrivileged } = require("../../Config/permissionGuard");
 
@@ -87,14 +87,7 @@ exports.save = async (req, res) => {
         }
 
         const response = await MongoDbCrudOpration(req.headers['companyid'], query, "save");
-        if (data?.objId?.projectId && data?.objId?.taskId && data?.objId?.sprintId) {
-            socketEmitter.emit('insert', { type: "insert", data: response , updatedFields: {}, module: 'comments' });
-        } else if(data?.taskId === "default"){
-            socketEmitter.emit('insert', { type: "insert", data: response , updatedFields: {}, module: 'comments' });
-        }
-        else {
-            socketEmitter.emit('insert', { type: "insert", data: response , updatedFields: {}, module: 'comments_project' });
-        }
+        emitCommentInsert(response);
         if (mentionIds.length && response && response._id) {
             notifyMentions(req.headers['companyid'], response, mentionIds)
                 .catch((err) => logger.error(`[mentions] notify failed: ${err.message}`));

--- a/Modules/Comments/controller.js
+++ b/Modules/Comments/controller.js
@@ -7,6 +7,7 @@ const { replaceObjectKey } = require("../Auth/helper");
 const socketEmitter = require('../../event/socketEventEmitter');
 const { escapeRegex } = require("../../utils/escapeRegex");
 const { parseMentionIds } = require("./helpers/parseMentions");
+const { maybeReplyAsAlianSafe } = require("./helpers/alianReply");
 const { handleNotificationtFun } = require("../notification/prepare-notification-data/controllerV2");
 const { getRoleType, isPrivileged } = require("../../Config/permissionGuard");
 
@@ -97,6 +98,10 @@ exports.save = async (req, res) => {
         if (mentionIds.length && response && response._id) {
             notifyMentions(req.headers['companyid'], response, mentionIds)
                 .catch((err) => logger.error(`[mentions] notify failed: ${err.message}`));
+        }
+        if (response && response._id) {
+            maybeReplyAsAlianSafe(req.headers['companyid'], response, req.uid)
+                .catch((err) => logger.error(`[alian] notify failed: ${err.message}`));
         }
         if (response) {
             return res.status(200).json({ status: true, data: response || {}  });

--- a/Modules/Comments/helpers/alianMention.js
+++ b/Modules/Comments/helpers/alianMention.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { idString } = require('./commentThread');
+
 const ALIAN_MENTION_KEY = 'alian';
 const ALIAN_DISPLAY_NAME = 'Alian';
 
@@ -113,7 +115,7 @@ function buildAlianComment(source, message, citations) {
         isDeleted: false,
         hasReply: true,
         project: src.project === true,
-        projectId: src.projectId,
+        projectId: idString(src.projectId) || src.projectId,
         mentionIds: [],
         pinnedMessage: false,
         reactions: [],
@@ -121,7 +123,7 @@ function buildAlianComment(source, message, citations) {
         mediaName: '',
         mediaOriginalName: '',
         mediaSize: 0,
-        reply_id: String(src._id || src.id || ''),
+        reply_id: idString(src._id || src.id) || String(src._id || src.id || ''),
         reply_userId: String(src.userId || ''),
         reply_type: String(src.type || 'text'),
         reply_message: String(src.message || ''),
@@ -131,8 +133,12 @@ function buildAlianComment(source, message, citations) {
         reply_mediaSize: 0,
         reply_createdAt: src.createdAt || new Date(),
     };
-    if (src.sprintId) payload.sprintId = src.sprintId;
-    if (src.taskId) payload.taskId = src.taskId;
+    const sprintId = idString(src.sprintId);
+    const taskId = idString(src.taskId);
+    if (sprintId) payload.sprintId = sprintId;
+    else if (src.sprintId) payload.sprintId = src.sprintId;
+    if (taskId) payload.taskId = taskId;
+    else if (src.taskId) payload.taskId = src.taskId;
     if (src.folderId) payload.folderId = src.folderId;
     return payload;
 }

--- a/Modules/Comments/helpers/alianMention.js
+++ b/Modules/Comments/helpers/alianMention.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const ALIAN_MENTION_KEY = 'alian';
+const ALIAN_DISPLAY_NAME = 'Alian';
+
+const TOKEN_RE = /@\[[^\]]*\]\(alian\)/gi;
+const BARE_RE = /@Alian\b/gi;
+
+function decodeCommentEntities(text) {
+    return String(text || '')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#039;/g, "'")
+        .replace(/&#39;/g, "'");
+}
+
+function stripAlianMentions(text) {
+    return String(text || '')
+        .replace(TOKEN_RE, ' ')
+        .replace(BARE_RE, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function firstAlianMention(text) {
+    const raw = String(text || '');
+    TOKEN_RE.lastIndex = 0;
+    BARE_RE.lastIndex = 0;
+    const token = TOKEN_RE.exec(raw);
+    const bare = BARE_RE.exec(raw);
+    let match = null;
+    if (token && bare) match = token.index <= bare.index ? token : bare;
+    else match = token || bare;
+    if (!match) return null;
+    return { index: match.index, length: match[0].length };
+}
+
+function hasAlianMention(message) {
+    return Boolean(firstAlianMention(decodeCommentEntities(message)));
+}
+
+function extractAlianQuestion(message) {
+    const raw = decodeCommentEntities(message).trim();
+    const hit = firstAlianMention(raw);
+    if (!hit) {
+        return { mentioned: false, question: '' };
+    }
+    const after = stripAlianMentions(raw.slice(hit.index + hit.length)).replace(/^[\s,.:;!?-]+/, '').trim();
+    if (after) {
+        return { mentioned: true, question: after };
+    }
+    return { mentioned: true, question: stripAlianMentions(raw) };
+}
+
+function isTaskComment(comment) {
+    if (!comment || typeof comment !== 'object') return false;
+    const taskId = comment.taskId;
+    if (taskId === undefined || taskId === null || taskId === '') return false;
+    return String(taskId) !== 'default';
+}
+
+function shouldReplyAsAlian(comment) {
+    if (!comment || typeof comment !== 'object') return false;
+    if (String(comment.userId || '') === ALIAN_MENTION_KEY) return false;
+    if (!isTaskComment(comment)) return false;
+    const type = String(comment.type || 'text');
+    if (type !== 'text' && type !== 'link') return false;
+    return hasAlianMention(comment.message);
+}
+
+function citationsForComment(citations) {
+    if (!Array.isArray(citations)) return [];
+    const out = [];
+    const seen = new Set();
+    for (const row of citations) {
+        if (!row || typeof row !== 'object') continue;
+        const type = row.type === 'task' ? 'task' : row.type === 'page' ? 'page' : '';
+        const id = String(row.id || row._id || '').trim();
+        if (!type || !id) continue;
+        const key = `${type}:${id}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const citation = {
+            type,
+            id,
+            title: String(row.title || '').trim() || (type === 'task' ? '(untitled task)' : '(untitled)'),
+        };
+        const projectId = String(row.projectId || '').trim();
+        if (projectId) citation.projectId = projectId;
+        out.push(citation);
+    }
+    return out;
+}
+
+function escapeCommentHtml(text) {
+    return String(text || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function buildAlianComment(source, message, citations) {
+    const src = source && typeof source === 'object' ? source : {};
+    const payload = {
+        userId: ALIAN_MENTION_KEY,
+        type: 'text',
+        message: escapeCommentHtml(message),
+        citations: citationsForComment(citations),
+        isDeleted: false,
+        hasReply: true,
+        project: src.project === true,
+        projectId: src.projectId,
+        mentionIds: [],
+        pinnedMessage: false,
+        reactions: [],
+        mediaURL: '',
+        mediaName: '',
+        mediaOriginalName: '',
+        mediaSize: 0,
+        reply_id: String(src._id || src.id || ''),
+        reply_userId: String(src.userId || ''),
+        reply_type: String(src.type || 'text'),
+        reply_message: String(src.message || ''),
+        reply_mediaURL: '',
+        reply_mediaName: '',
+        reply_mediaOriginalName: '',
+        reply_mediaSize: 0,
+        reply_createdAt: src.createdAt || new Date(),
+    };
+    if (src.sprintId) payload.sprintId = src.sprintId;
+    if (src.taskId) payload.taskId = src.taskId;
+    if (src.folderId) payload.folderId = src.folderId;
+    return payload;
+}
+
+module.exports = {
+    ALIAN_MENTION_KEY,
+    ALIAN_DISPLAY_NAME,
+    decodeCommentEntities,
+    stripAlianMentions,
+    hasAlianMention,
+    extractAlianQuestion,
+    isTaskComment,
+    shouldReplyAsAlian,
+    citationsForComment,
+    escapeCommentHtml,
+    buildAlianComment,
+};

--- a/Modules/Comments/helpers/alianReply.js
+++ b/Modules/Comments/helpers/alianReply.js
@@ -11,7 +11,7 @@ const {
     citationsForComment,
     buildAlianComment,
 } = require('./alianMention');
-const { serializeCommentForSocket, commentRoomPrefix } = require('./commentThread');
+const { serializeCommentForSocket, commentRoomPrefix, idString } = require('./commentThread');
 
 const NO_QUESTION_TEXT = 'Ask a question after @Alian — I will look across pages and tasks you can open.';
 const AI_MISSING_TEXT = 'Connect an LLM in your environment to ask Alian from comments.';
@@ -22,10 +22,24 @@ function asPlain(doc) {
     return doc;
 }
 
+function copyThreadId(data, saved, source, key) {
+    const hex = idString(data[key]) || idString(saved && saved[key]) || idString(source && source[key]);
+    if (hex) data[key] = hex;
+    else delete data[key];
+}
+
 function emitCommentInsert(saved, source) {
     const data = serializeCommentForSocket(saved, source);
+    copyThreadId(data, saved, source, 'projectId');
+    copyThreadId(data, saved, source, 'sprintId');
+    copyThreadId(data, saved, source, 'taskId');
+    const _id = idString(data._id) || idString(data.id) || idString(saved && (saved._id || saved.id));
+    if (_id) {
+        data._id = _id;
+        data.id = _id;
+    }
     const thread = commentRoomPrefix(data);
-    if (!thread) return;
+    if (!thread || String(thread.prefix).includes('[object Object]')) return;
     socketEmitter.emit('insert', {
         type: 'insert',
         data,

--- a/Modules/Comments/helpers/alianReply.js
+++ b/Modules/Comments/helpers/alianReply.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+const logger = require('../../../Config/loggerConfig');
+const socketEmitter = require('../../../event/socketEventEmitter');
+const { runWorkspaceAsk } = require('../../Pages/helpers/runWorkspaceAsk');
+const {
+    extractAlianQuestion,
+    shouldReplyAsAlian,
+    citationsForComment,
+    buildAlianComment,
+} = require('./alianMention');
+
+const NO_QUESTION_TEXT = 'Ask a question after @Alian — I will look across pages and tasks you can open.';
+const AI_MISSING_TEXT = 'Connect an LLM in your environment to ask Alian from comments.';
+
+function asPlain(doc) {
+    if (!doc) return doc;
+    if (typeof doc.toObject === 'function') return doc.toObject();
+    return doc;
+}
+
+function emitCommentInsert(saved) {
+    const data = asPlain(saved);
+    const isTaskThread = data
+        && data.projectId
+        && data.sprintId
+        && data.taskId
+        && String(data.taskId) !== 'default';
+    socketEmitter.emit('insert', {
+        type: 'insert',
+        data,
+        updatedFields: {},
+        module: isTaskThread ? 'comments' : 'comments_project',
+    });
+}
+
+async function saveAlianComment(companyId, source, message, citations) {
+    const payload = buildAlianComment(asPlain(source), message, citations);
+    if (!payload.projectId) {
+        throw new Error('Alian reply is missing projectId.');
+    }
+    const saved = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.COMMENTS,
+        data: payload,
+    }, 'save');
+    emitCommentInsert(saved);
+    return saved;
+}
+
+async function maybeReplyAsAlian(companyId, comment, askerId) {
+    if (!shouldReplyAsAlian(comment)) return null;
+    const { mentioned, question } = extractAlianQuestion(comment.message);
+    if (!mentioned) return null;
+
+    if (!question) {
+        return saveAlianComment(companyId, comment, NO_QUESTION_TEXT, []);
+    }
+
+    const result = await runWorkspaceAsk({
+        companyId,
+        uid: String(askerId || comment.userId || ''),
+        question,
+    });
+    if (!result || !result.status) {
+        const text = result && result.isNotAi ? AI_MISSING_TEXT : ((result && result.reason) || 'I could not answer that.');
+        return saveAlianComment(companyId, comment, text, []);
+    }
+    const data = result.data || {};
+    const markdown = String(data.markdown || data.previewText || '').trim() || 'I could not answer that.';
+    return saveAlianComment(companyId, comment, markdown, citationsForComment(data.citations));
+}
+
+async function maybeReplyAsAlianSafe(companyId, comment, askerId) {
+    try {
+        return await maybeReplyAsAlian(companyId, comment, askerId);
+    } catch (error) {
+        logger.error(`[alian] follow-up failed: ${error.message}`);
+        return null;
+    }
+}
+
+module.exports = {
+    NO_QUESTION_TEXT,
+    AI_MISSING_TEXT,
+    maybeReplyAsAlian,
+    maybeReplyAsAlianSafe,
+};

--- a/Modules/Comments/helpers/alianReply.js
+++ b/Modules/Comments/helpers/alianReply.js
@@ -11,6 +11,7 @@ const {
     citationsForComment,
     buildAlianComment,
 } = require('./alianMention');
+const { serializeCommentForSocket, commentRoomPrefix } = require('./commentThread');
 
 const NO_QUESTION_TEXT = 'Ask a question after @Alian — I will look across pages and tasks you can open.';
 const AI_MISSING_TEXT = 'Connect an LLM in your environment to ask Alian from comments.';
@@ -21,18 +22,15 @@ function asPlain(doc) {
     return doc;
 }
 
-function emitCommentInsert(saved) {
-    const data = asPlain(saved);
-    const isTaskThread = data
-        && data.projectId
-        && data.sprintId
-        && data.taskId
-        && String(data.taskId) !== 'default';
+function emitCommentInsert(saved, source) {
+    const data = serializeCommentForSocket(saved, source);
+    const thread = commentRoomPrefix(data);
+    if (!thread) return;
     socketEmitter.emit('insert', {
         type: 'insert',
         data,
         updatedFields: {},
-        module: isTaskThread ? 'comments' : 'comments_project',
+        module: thread.module,
     });
 }
 
@@ -45,7 +43,7 @@ async function saveAlianComment(companyId, source, message, citations) {
         type: SCHEMA_TYPE.COMMENTS,
         data: payload,
     }, 'save');
-    emitCommentInsert(saved);
+    emitCommentInsert(saved, source);
     return saved;
 }
 
@@ -86,4 +84,5 @@ module.exports = {
     AI_MISSING_TEXT,
     maybeReplyAsAlian,
     maybeReplyAsAlianSafe,
+    emitCommentInsert,
 };

--- a/Modules/Comments/helpers/commentThread.js
+++ b/Modules/Comments/helpers/commentThread.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const HEX_ID = /^[0-9a-fA-F]{24}$/;
+
+function idString(value) {
+    if (value == null || value === '') return '';
+    if (typeof value === 'string') return value;
+    if (typeof value.toHexString === 'function') return value.toHexString();
+    if (Buffer.isBuffer(value)) return value.toString('hex');
+    if (typeof value === 'object') {
+        if (value.$oid) return String(value.$oid);
+        if (typeof value.id === 'string' && HEX_ID.test(value.id)) return value.id;
+        if (Buffer.isBuffer(value.id)) return value.id.toString('hex');
+        if (value.buffer && Buffer.isBuffer(value.buffer)) return Buffer.from(value.buffer).toString('hex');
+        if (value._id && value._id !== value) return idString(value._id);
+    }
+    const s = String(value);
+    if (s === '[object Object]') return '';
+    return s;
+}
+
+function commentRoomPrefix(data) {
+    const projectId = idString(data && data.projectId);
+    const sprintId = idString(data && data.sprintId);
+    const taskId = idString(data && data.taskId);
+    if (projectId && sprintId && taskId) {
+        return {
+            module: 'comments',
+            prefix: `comments_${projectId}_${sprintId}_${taskId}`,
+            projectId,
+            sprintId,
+            taskId,
+        };
+    }
+    if (projectId) {
+        return {
+            module: 'comments_project',
+            prefix: `comments_project_${projectId}`,
+            projectId,
+            sprintId: sprintId || '',
+            taskId: taskId || '',
+        };
+    }
+    return null;
+}
+
+function asPlain(doc) {
+    if (!doc) return {};
+    if (typeof doc.toJSON === 'function') {
+        try {
+            return doc.toJSON();
+        } catch (_e) {
+            // fall through
+        }
+    }
+    if (typeof doc.toObject === 'function') {
+        try {
+            return doc.toObject();
+        } catch (_err) {
+            // fall through
+        }
+    }
+    return doc;
+}
+
+function serializeCommentForSocket(doc, source) {
+    const raw = asPlain(doc);
+    let plain;
+    try {
+        plain = JSON.parse(JSON.stringify(raw));
+    } catch (_e) {
+        plain = { ...raw };
+    }
+    const fromSource = source ? serializeCommentForSocket(source) : {};
+    const projectId = idString(plain.projectId || raw.projectId || fromSource.projectId);
+    const sprintId = idString(plain.sprintId || raw.sprintId || fromSource.sprintId);
+    const taskId = idString(plain.taskId || raw.taskId || fromSource.taskId);
+    const _id = idString(plain._id || raw._id || plain.id || raw.id);
+    if (_id) {
+        plain._id = _id;
+        plain.id = _id;
+    }
+    if (projectId) plain.projectId = projectId;
+    if (sprintId) plain.sprintId = sprintId;
+    if (taskId) plain.taskId = taskId;
+    if (plain.userId != null) plain.userId = String(plain.userId);
+    return plain;
+}
+
+function incomingCommentDoc(payload) {
+    if (!payload || typeof payload !== 'object') return null;
+    return payload.fullDocument || payload;
+}
+
+function acceptIncomingComment(doc) {
+    if (!doc || typeof doc !== 'object') return false;
+    return Boolean(idString(doc._id || doc.id) || doc.userId || doc.message);
+}
+
+module.exports = {
+    idString,
+    commentRoomPrefix,
+    serializeCommentForSocket,
+    incomingCommentDoc,
+    acceptIncomingComment,
+};

--- a/Modules/Comments/helpers/commentThread.js
+++ b/Modules/Comments/helpers/commentThread.js
@@ -1,22 +1,55 @@
 'use strict';
 
 const HEX_ID = /^[0-9a-fA-F]{24}$/;
+const OBJECT_OBJECT = '[object Object]';
+
+function hexFromBytes(value) {
+    if (!value) return '';
+    if (Buffer.isBuffer(value)) {
+        const hex = value.toString('hex');
+        return HEX_ID.test(hex) ? hex : '';
+    }
+    if (value.type === 'Buffer' && Array.isArray(value.data)) {
+        return hexFromBytes(Buffer.from(value.data));
+    }
+    if (ArrayBuffer.isView(value)) {
+        return hexFromBytes(Buffer.from(value.buffer, value.byteOffset, value.byteLength));
+    }
+    if (Array.isArray(value) && value.length === 12 && value.every((n) => Number.isInteger(n))) {
+        return hexFromBytes(Buffer.from(value));
+    }
+    return '';
+}
 
 function idString(value) {
     if (value == null || value === '') return '';
-    if (typeof value === 'string') return value;
-    if (typeof value.toHexString === 'function') return value.toHexString();
-    if (Buffer.isBuffer(value)) return value.toString('hex');
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed || trimmed === OBJECT_OBJECT) return '';
+        return trimmed;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'symbol') {
+        return '';
+    }
+    if (typeof value.toHexString === 'function') {
+        return idString(value.toHexString());
+    }
+    const fromSelf = hexFromBytes(value);
+    if (fromSelf) return fromSelf;
     if (typeof value === 'object') {
-        if (value.$oid) return String(value.$oid);
-        if (typeof value.id === 'string' && HEX_ID.test(value.id)) return value.id;
-        if (Buffer.isBuffer(value.id)) return value.id.toString('hex');
-        if (value.buffer && Buffer.isBuffer(value.buffer)) return Buffer.from(value.buffer).toString('hex');
+        if (value.$oid) return idString(value.$oid);
+        const nested = hexFromBytes(value.id) || hexFromBytes(value.buffer);
+        if (nested) return nested;
+        if (typeof value.id === 'string') return idString(value.id);
         if (value._id && value._id !== value) return idString(value._id);
     }
-    const s = String(value);
-    if (s === '[object Object]') return '';
-    return s;
+    try {
+        const s = String(value);
+        if (!s || s === OBJECT_OBJECT) return '';
+        return s;
+    } catch (_e) {
+        return '';
+    }
 }
 
 function commentRoomPrefix(data) {
@@ -24,18 +57,22 @@ function commentRoomPrefix(data) {
     const sprintId = idString(data && data.sprintId);
     const taskId = idString(data && data.taskId);
     if (projectId && sprintId && taskId) {
+        const prefix = `comments_${projectId}_${sprintId}_${taskId}`;
+        if (prefix.includes(OBJECT_OBJECT)) return null;
         return {
             module: 'comments',
-            prefix: `comments_${projectId}_${sprintId}_${taskId}`,
+            prefix,
             projectId,
             sprintId,
             taskId,
         };
     }
     if (projectId) {
+        const prefix = `comments_project_${projectId}`;
+        if (prefix.includes(OBJECT_OBJECT)) return null;
         return {
             module: 'comments_project',
-            prefix: `comments_project_${projectId}`,
+            prefix,
             projectId,
             sprintId: sprintId || '',
             taskId: taskId || '',
@@ -63,6 +100,14 @@ function asPlain(doc) {
     return doc;
 }
 
+function firstId(...values) {
+    for (const value of values) {
+        const hex = idString(value);
+        if (hex) return hex;
+    }
+    return '';
+}
+
 function serializeCommentForSocket(doc, source) {
     const raw = asPlain(doc);
     let plain;
@@ -72,17 +117,20 @@ function serializeCommentForSocket(doc, source) {
         plain = { ...raw };
     }
     const fromSource = source ? serializeCommentForSocket(source) : {};
-    const projectId = idString(plain.projectId || raw.projectId || fromSource.projectId);
-    const sprintId = idString(plain.sprintId || raw.sprintId || fromSource.sprintId);
-    const taskId = idString(plain.taskId || raw.taskId || fromSource.taskId);
-    const _id = idString(plain._id || raw._id || plain.id || raw.id);
+    const projectId = firstId(plain.projectId, raw.projectId, fromSource.projectId);
+    const sprintId = firstId(plain.sprintId, raw.sprintId, fromSource.sprintId);
+    const taskId = firstId(plain.taskId, raw.taskId, fromSource.taskId);
+    const _id = firstId(plain._id, raw._id, plain.id, raw.id);
     if (_id) {
         plain._id = _id;
         plain.id = _id;
     }
     if (projectId) plain.projectId = projectId;
+    else delete plain.projectId;
     if (sprintId) plain.sprintId = sprintId;
+    else delete plain.sprintId;
     if (taskId) plain.taskId = taskId;
+    else delete plain.taskId;
     if (plain.userId != null) plain.userId = String(plain.userId);
     return plain;
 }

--- a/Modules/Pages/controller.js
+++ b/Modules/Pages/controller.js
@@ -10,13 +10,8 @@ const {
     blocksToHtml,
     blocksToRawText,
 } = require('./helpers/pageContent');
-const { composePage, answerWorkspaceQuestion, isAiConfigured } = require('./helpers/pageAi');
-const {
-    pageReadableBy,
-    pageInVisibleProjects,
-    PAGE_CAP,
-    TASK_CAP,
-} = require('./helpers/pageWorkspaceAsk');
+const { composePage, isAiConfigured } = require('./helpers/pageAi');
+const { runWorkspaceAsk } = require('./helpers/runWorkspaceAsk');
 
 const emitPageChange = (type, data) => {
     try {
@@ -346,40 +341,6 @@ exports.composeWithAi = async (req, res) => {
     }
 };
 
-async function callerRoleType(companyId, uid) {
-    if (!uid) return 3;
-    try {
-        const row = await MongoDbCrudOpration(companyId, {
-            type: SCHEMA_TYPE.COMPANY_USERS,
-            data: [{ userId: String(uid), isDelete: { $ne: true } }, { roleType: 1 }],
-        }, 'findOne');
-        const role = Number(row && row.roleType);
-        return Number.isFinite(role) && role > 0 ? role : 3;
-    } catch (_e) {
-        return 3;
-    }
-}
-
-async function visibleProjectsForAsk(companyId, uid) {
-    const roleType = await callerRoleType(companyId, uid);
-    const restrictProjects = roleType !== 1 && roleType !== 2;
-    const filter = { deletedStatusKey: { $ne: 1 } };
-    if (restrictProjects) {
-        filter.$or = [
-            { isPrivateSpace: { $ne: true } },
-            { AssigneeUserId: String(uid) },
-        ];
-    }
-    const projects = await MongoDbCrudOpration(companyId, {
-        type: SCHEMA_TYPE.PROJECTS,
-        data: [filter, '_id', { sort: { updatedAt: -1 }, limit: 80 }],
-    }, 'find').catch(() => []);
-    return {
-        ids: (projects || []).map((row) => row._id),
-        restrictProjects,
-    };
-}
-
 /* POST /api/v2/pages/ask-workspace  body: { question } */
 exports.askWorkspace = async (req, res) => {
     try {
@@ -389,35 +350,7 @@ exports.askWorkspace = async (req, res) => {
         }
         const uid = callerId(req);
         const question = String((req.body && req.body.question) || '');
-        const visible = await visibleProjectsForAsk(companyId, uid);
-
-        const pageFilter = {
-            deletedStatusKey: 0,
-            $or: [{ visibility: { $ne: 'private' } }, { createdBy: uid }],
-        };
-        const pages = await MongoDbCrudOpration(companyId, {
-            type: SCHEMA_TYPE.PAGES,
-            data: [pageFilter, 'title rawText visibility createdBy ProjectID updatedAt', { sort: { updatedAt: -1 }, limit: 40 }],
-        }, 'find').catch(() => []);
-
-        const readablePages = (pages || []).filter((page) => (
-            pageReadableBy(page, uid) && pageInVisibleProjects(page, visible.ids, visible.restrictProjects)
-        )).slice(0, PAGE_CAP);
-
-        const taskFilter = { deletedStatusKey: 0 };
-        if (visible.restrictProjects) {
-            taskFilter.ProjectID = { $in: visible.ids };
-        }
-        const tasks = await MongoDbCrudOpration(companyId, {
-            type: SCHEMA_TYPE.TASKS,
-            data: [taskFilter, 'TaskName TaskKey ProjectID updatedAt', { sort: { updatedAt: -1 }, limit: TASK_CAP }],
-        }, 'find').catch(() => []);
-
-        const result = await answerWorkspaceQuestion({
-            question,
-            pages: readablePages,
-            tasks: tasks || [],
-        });
+        const result = await runWorkspaceAsk({ companyId, uid, question });
         if (!result.status) {
             return res.send({
                 status: false,

--- a/Modules/Pages/helpers/runWorkspaceAsk.js
+++ b/Modules/Pages/helpers/runWorkspaceAsk.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+const { answerWorkspaceQuestion } = require('./pageAi');
+const {
+    pageReadableBy,
+    pageInVisibleProjects,
+    PAGE_CAP,
+    TASK_CAP,
+} = require('./pageWorkspaceAsk');
+
+async function callerRoleType(companyId, uid) {
+    if (!uid) return 3;
+    try {
+        const row = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.COMPANY_USERS,
+            data: [{ userId: String(uid), isDelete: { $ne: true } }, { roleType: 1 }],
+        }, 'findOne');
+        const role = Number(row && row.roleType);
+        return Number.isFinite(role) && role > 0 ? role : 3;
+    } catch (_e) {
+        return 3;
+    }
+}
+
+async function visibleProjectsForAsk(companyId, uid) {
+    const roleType = await callerRoleType(companyId, uid);
+    const restrictProjects = roleType !== 1 && roleType !== 2;
+    const filter = { deletedStatusKey: { $ne: 1 } };
+    if (restrictProjects) {
+        filter.$or = [
+            { isPrivateSpace: { $ne: true } },
+            { AssigneeUserId: String(uid) },
+        ];
+    }
+    const projects = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.PROJECTS,
+        data: [filter, '_id', { sort: { updatedAt: -1 }, limit: 80 }],
+    }, 'find').catch(() => []);
+    return {
+        ids: (projects || []).map((row) => row._id),
+        restrictProjects,
+    };
+}
+
+async function gatherWorkspaceAskContext({ companyId, uid }) {
+    const visible = await visibleProjectsForAsk(companyId, uid);
+    const pageFilter = {
+        deletedStatusKey: 0,
+        $or: [{ visibility: { $ne: 'private' } }, { createdBy: uid }],
+    };
+    const pages = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.PAGES,
+        data: [pageFilter, 'title rawText visibility createdBy ProjectID updatedAt', { sort: { updatedAt: -1 }, limit: 40 }],
+    }, 'find').catch(() => []);
+
+    const readablePages = (pages || []).filter((page) => (
+        pageReadableBy(page, uid) && pageInVisibleProjects(page, visible.ids, visible.restrictProjects)
+    )).slice(0, PAGE_CAP);
+
+    const taskFilter = { deletedStatusKey: 0 };
+    if (visible.restrictProjects) {
+        taskFilter.ProjectID = { $in: visible.ids };
+    }
+    const tasks = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.TASKS,
+        data: [taskFilter, 'TaskName TaskKey ProjectID updatedAt', { sort: { updatedAt: -1 }, limit: TASK_CAP }],
+    }, 'find').catch(() => []);
+
+    return { pages: readablePages, tasks: tasks || [] };
+}
+
+async function runWorkspaceAsk({ companyId, uid, question }) {
+    const context = await gatherWorkspaceAskContext({ companyId, uid });
+    return answerWorkspaceQuestion({
+        question,
+        pages: context.pages,
+        tasks: context.tasks,
+    });
+}
+
+module.exports = {
+    callerRoleType,
+    visibleProjectsForAsk,
+    gatherWorkspaceAskContext,
+    runWorkspaceAsk,
+};

--- a/Tasks/active/007-alian-mentions/progress.md
+++ b/Tasks/active/007-alian-mentions/progress.md
@@ -9,7 +9,7 @@
 - [x] Keep page-content tests green; frontend build
 
 ## Last step
-Fixed live-refresh so Alian follow-ups appear in the open Comments thread without reopening the modal.
+Hardened emit/id contract: hex-string `projectId` / `sprintId` / `taskId` / `_id` on the Alian socket payload, same hex prefix in `commentSocket`, copy missing thread ids from the triggering comment before emit.
 
 ## Blockers
 None.
@@ -25,5 +25,5 @@ None.
 - `jest` — 83 passing (alian-mention, page-content, page-rules, parse-mentions, first-run-checklist).
 - `cd frontend && npm run build` — DONE.
 - Draft PR: https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/pull/517
-- Live-refresh gap: Alian row saved but missing from the open thread until modal reopen. Emit payload now serializes `projectId` / `sprintId` / `taskId` / `_id` to hex strings and `commentSocket` looks up rooms with that prefix. Client insert accepts `userId: alian` and does not require a reload.
+- Live-refresh gap: Alian row saved but missing from the open thread until modal reopen. `idString` now rejects `[object Object]`, `emitCommentInsert` copies missing `sprintId`/`taskId` from the triggering comment, and `commentSocket` builds the room prefix from those hex strings only (no raw Mixed interpolation).
 

--- a/Tasks/active/007-alian-mentions/progress.md
+++ b/Tasks/active/007-alian-mentions/progress.md
@@ -1,0 +1,21 @@
+# Progress: @Alian mentions in task comments
+
+## Checklist
+- [ ] Extract question from `@Alian` text (pure helper + tests)
+- [ ] Hook comment save to workspace ask; post Alian follow-up with citations
+- [ ] Synthetic `@Alian` option in CommentInput (task comments only)
+- [ ] Render Alian comments with kiln look + citation chips
+- [ ] Pages compose: `@Alian` routes to workspace ask, does not apply to the page
+- [ ] Keep page-content tests green; frontend build
+
+## Last step
+Task created. Starting implementation.
+
+## Blockers
+None.
+
+## Log
+
+### 2026-08-26
+- Task created. Branching from `feat/workspace-ask-citations-27ed` (PR 516).
+- Decision: answer lands as a **follow-up comment** from system author Alian (`userId: "alian"`), threaded as a reply to the triggering comment. Edit-in-place would mix the user's question with the model answer.

--- a/Tasks/active/007-alian-mentions/progress.md
+++ b/Tasks/active/007-alian-mentions/progress.md
@@ -9,7 +9,7 @@
 - [x] Keep page-content tests green; frontend build
 
 ## Last step
-Draft PR #517 opened. Unit tests (83) and frontend production build passed.
+Fixed live-refresh so Alian follow-ups appear in the open Comments thread without reopening the modal.
 
 ## Blockers
 None.
@@ -25,4 +25,5 @@ None.
 - `jest` — 83 passing (alian-mention, page-content, page-rules, parse-mentions, first-run-checklist).
 - `cd frontend && npm run build` — DONE.
 - Draft PR: https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/pull/517
+- Live-refresh gap: Alian row saved but missing from the open thread until modal reopen. Emit payload now serializes `projectId` / `sprintId` / `taskId` / `_id` to hex strings and `commentSocket` looks up rooms with that prefix. Client insert accepts `userId: alian` and does not require a reload.
 

--- a/Tasks/active/007-alian-mentions/progress.md
+++ b/Tasks/active/007-alian-mentions/progress.md
@@ -1,15 +1,15 @@
 # Progress: @Alian mentions in task comments
 
 ## Checklist
-- [ ] Extract question from `@Alian` text (pure helper + tests)
-- [ ] Hook comment save to workspace ask; post Alian follow-up with citations
-- [ ] Synthetic `@Alian` option in CommentInput (task comments only)
-- [ ] Render Alian comments with kiln look + citation chips
-- [ ] Pages compose: `@Alian` routes to workspace ask, does not apply to the page
-- [ ] Keep page-content tests green; frontend build
+- [x] Extract question from `@Alian` text (pure helper + tests)
+- [x] Hook comment save to workspace ask; post Alian follow-up with citations
+- [x] Synthetic `@Alian` option in CommentInput (task comments only)
+- [x] Render Alian comments with kiln look + citation chips
+- [x] Pages compose: `@Alian` routes to workspace ask, does not apply to the page
+- [x] Keep page-content tests green; frontend build
 
 ## Last step
-Task created. Starting implementation.
+Draft PR #517 opened. Unit tests (83) and frontend production build passed.
 
 ## Blockers
 None.
@@ -19,3 +19,10 @@ None.
 ### 2026-08-26
 - Task created. Branching from `feat/workspace-ask-citations-27ed` (PR 516).
 - Decision: answer lands as a **follow-up comment** from system author Alian (`userId: "alian"`), threaded as a reply to the triggering comment. Edit-in-place would mix the user's question with the model answer.
+- `@Alian` is a synthetic mention option (`key: alian`) in task-comment autocomplete. No user row is created. `parseMentionIds` ignores it because it is not a 24-hex id.
+- Comment save runs `runWorkspaceAsk` (same visibility filters as `askWorkspace`) as the comment author, then inserts an Alian follow-up with `citations` copied from the pack (never invented).
+- Pages compose: an instruction containing `@Alian` is routed to workspace ask and is not applied to the page.
+- `jest` — 83 passing (alian-mention, page-content, page-rules, parse-mentions, first-run-checklist).
+- `cd frontend && npm run build` — DONE.
+- Draft PR: https://github.com/aliansoftwareteam/AlianHub-Project-Management-System/pull/517
+

--- a/Tasks/active/007-alian-mentions/task.md
+++ b/Tasks/active/007-alian-mentions/task.md
@@ -1,0 +1,47 @@
+---
+id: 007
+title: "@Alian mentions in task comments"
+status: active
+priority: high
+depends_on: [006]
+created: 2026-08-26
+---
+
+# @Alian mentions in task comments
+
+## Goal
+Users can type `@Alian` in a task comment to ask the workspace AI a question. The answer posts as a follow-up comment from a system author named Alian, with the same citation objects as Workspace Ask (S1.1).
+
+## Scope
+- Synthetic `@Alian` option in task-comment mention autocomplete (not a real user row).
+- On save of a task comment that contains `@Alian`, extract the question and run the existing `answerWorkspaceQuestion` / `pageWorkspaceAsk` stack with the same visibility filters as `askWorkspace`.
+- Append a follow-up comment authored as Alian (`userId: "alian"`), including `citations`.
+- Pages compose: if the instruction contains `@Alian`, route to workspace ask and do not apply to the page.
+- Unit tests for question extraction and citation pass-through (no invented IDs).
+
+## Out of scope
+- Gantt, MCP, standup bots, custom-field autofill.
+- A second AI stack.
+- Overwriting page content.
+- Creating a fake Alian user in the users collection.
+- Main Chat `@Alian` replies.
+
+## Acceptance criteria
+- [ ] `@Alian` appears as a first-class mention option in task comment autocomplete
+- [ ] Saving a task comment with `@Alian` posts a follow-up comment from Alian
+- [ ] The follow-up includes Workspace Ask citation objects (pack IDs only)
+- [ ] Same page/task visibility filters as `askWorkspace`
+- [ ] No fake user row is created
+- [ ] Page content is not overwritten
+- [ ] Unit tests cover question extraction and "do not invent citations"
+- [ ] Existing page-content tests stay green; frontend build passes
+- [ ] Draft PR opened
+
+## Constraints & notes
+- Branch from `feat/workspace-ask-citations-27ed` (PR 516). Branch name: `feat/alian-mentions-6d61`.
+- Decision: **follow-up comment**, not edit-in-place — the user's question stays, Alian is a distinct author, and live-sync already inserts new comments.
+- Kiln look (cream/pine/copper). Reuse `WorkspaceAskCitations`.
+- Reuse `Modules/AIProjectGenerator/llmProvider`.
+
+## Resources
+None.

--- a/Tasks/index.md
+++ b/Tasks/index.md
@@ -11,3 +11,4 @@ Auto-maintained registry of all tasks. Reflects YAML frontmatter from each `task
 | 005 | First-run experience — close the 13 gaps | active | high | — | active/005-first-run-experience |
 | 006 | Workspace Ask with real citations | active | high | — | active/006-workspace-ask-citations |
 | 006 | AI-native Pages space and distinctive shell | active | high | — | active/006-ai-native-pages-shell |
+| 007 | @Alian mentions in task comments | active | high | 006 | active/007-alian-mentions |

--- a/frontend/src/components/atom/CommentInput/CommentInput.vue
+++ b/frontend/src/components/atom/CommentInput/CommentInput.vue
@@ -5,13 +5,19 @@
                 <template v-if="filteredUsers.length">
                     <li
                         class="d-flex align-items-center cursor-pointer p5px-p10px"
-                        :class="{'bg-blue white': selectedUserIndex === index}"
+                        :class="{
+                            'bg-blue white': selectedUserIndex === index && !data.isAlian,
+                            'mention-alian': data.isAlian,
+                            'mention-alian-on': data.isAlian && selectedUserIndex === index
+                        }"
                         v-for="(data, index) in filteredUsers"
-                        :key="index"
+                        :key="data.key || index"
                         @mouseover="selectedUserIndex = index"
                         @click="addMention(data)"
                     >
+                        <div v-if="data.isAlian" class="alian-mark" aria-hidden="true">A</div>
                         <UserProfile
+                            v-else
                             :showDot="false"
                             class="user__profile cursor-pointer mr-10px"
                             :data="{
@@ -23,6 +29,7 @@
                             :thumbnail="'30x30'"
                         />
                         <span>{{data.name}}</span>
+                        <span v-if="data.isAlian" class="alian-kicker">{{ $t('Comments.alian_kicker') }}</span>
                     </li>
                 </template>
                 <template v-else>
@@ -110,6 +117,10 @@ const props = defineProps({
         type: Array,
         default: () => []
     },
+    includeAlian: {
+        type: Boolean,
+        default: false
+    },
     showAll: {
         type: Boolean,
         default: false
@@ -137,20 +148,41 @@ const selectionIndex = ref(0);
 const mentionSearch = ref("");
 const users = ref([]);
 
-onMounted(() => {
-    users.value = props.userIds?.map((x) => {
+function alianMentionOption() {
+    return {
+        name: 'Alian',
+        image: '',
+        key: 'alian',
+        ghost: false,
+        isAlian: true
+    };
+}
+
+function rebuildUsers(ids) {
+    const mapped = (ids || []).map((x) => {
         const user = getUser(x);
         return {
             name: user.Employee_Name,
             image: user.Employee_profileImageURL,
             key: user.id,
             ghost: user.ghostUser
-        }
-    })
+        };
+    });
+    const list = [];
+    if (props.includeAlian) list.push(alianMentionOption());
+    if (props.showAll) {
+        list.push({
+            name: 'All',
+            image: defaultProfile.value,
+            key: 'everyone',
+            ghost: false
+        });
+    }
+    users.value = list.concat(mapped);
+}
 
-    // nextTick(() => {
-    //     autoResize()
-    // })
+onMounted(() => {
+    rebuildUsers(props.userIds);
 })
 
 watch(()=> props.loadingChat, (val) => {
@@ -162,23 +194,11 @@ watch(()=> props.loadingChat, (val) => {
 });
 
 watch(()=> props.userIds, (val) => {
-    users.value = val.map((x) => {
-        const user = getUser(x);
-        return {
-            name: user.Employee_Name,
-            image: user.Employee_profileImageURL,
-            key: user.id,
-            ghost: user.ghostUser
-        }
-    })
-    if(props.showAll) {
-        users.value.unshift({
-            name: "All",
-            image: defaultProfile.value,
-            key: "everyone",
-            ghost: false
-        })
-    }
+    rebuildUsers(val);
+})
+
+watch(() => [props.includeAlian, props.showAll], () => {
+    rebuildUsers(props.userIds);
 })
 
 const filteredUsers = computed(() => {

--- a/frontend/src/components/atom/CommentInput/style.css
+++ b/frontend/src/components/atom/CommentInput/style.css
@@ -42,3 +42,41 @@
 .emp__profile-wrapper{
     width: calc(100% - 25px) !important;
 }
+.mention-alian {
+    background: var(--kiln-paper);
+    color: var(--kiln-ink);
+}
+.mention-alian-on {
+    background: var(--kiln-ember) !important;
+    color: #fffaf3;
+}
+.alian-mark {
+    width: 30px;
+    height: 30px;
+    margin-right: 10px;
+    border-radius: 50%;
+    background: var(--kiln-ember);
+    color: #fffaf3;
+    font-family: var(--kiln-font-display), Georgia, serif;
+    font-weight: 700;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+}
+.mention-alian-on .alian-mark {
+    background: #fffaf3;
+    color: var(--kiln-ember-deep);
+}
+.alian-kicker {
+    margin-left: 8px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--kiln-ember);
+}
+.mention-alian-on .alian-kicker {
+    color: #fffaf3;
+}

--- a/frontend/src/components/molecules/Pages/PageComposeRail.vue
+++ b/frontend/src/components/molecules/Pages/PageComposeRail.vue
@@ -33,6 +33,7 @@ import { useI18n } from 'vue-i18n';
 import { useToast } from 'vue-toast-notification';
 import { apiRequest } from '@/services';
 import WorkspaceAskCitations from '@/components/molecules/Pages/WorkspaceAskCitations.vue';
+import { extractAlianQuestion } from '@/utils/alianMention';
 
 const { t } = useI18n();
 const $toast = useToast();
@@ -98,7 +99,14 @@ function isMissing(payload) {
 
 function compose() {
     if (busy.value) return;
-    if (needsQuestion.value && !instruction.value.trim()) {
+    const alian = extractAlianQuestion(instruction.value);
+    if (needsQuestion.value && !instruction.value.trim() && !alian.mentioned) {
+        answer.value = '';
+        citations.value = [];
+        notice.value = t('Projects.pages_ask_needed');
+        return;
+    }
+    if (alian.mentioned && !alian.question) {
         answer.value = '';
         citations.value = [];
         notice.value = t('Projects.pages_ask_needed');
@@ -109,8 +117,10 @@ function compose() {
     answer.value = '';
     citations.value = [];
 
-    const request = action.value === 'workspace'
-        ? apiRequest('post', '/api/v2/pages/ask-workspace', { question: instruction.value })
+    const useWorkspace = action.value === 'workspace' || alian.mentioned;
+    const question = alian.mentioned ? alian.question : instruction.value;
+    const request = useWorkspace
+        ? apiRequest('post', '/api/v2/pages/ask-workspace', { question })
         : apiRequest('post', '/api/v2/pages/ai', {
             action: action.value,
             title: props.title,
@@ -129,9 +139,9 @@ function compose() {
             return;
         }
         const payload = response.data.data || {};
-        if (action.value === 'ask' || action.value === 'workspace' || payload.apply === false) {
+        if (useWorkspace || action.value === 'ask' || payload.apply === false) {
             answer.value = payload.markdown || payload.previewText || '';
-            citations.value = action.value === 'workspace' && Array.isArray(payload.citations) ? payload.citations : [];
+            citations.value = useWorkspace && Array.isArray(payload.citations) ? payload.citations : [];
             notice.value = answer.value;
             return;
         }

--- a/frontend/src/components/organisms/Comment/Comment.vue
+++ b/frontend/src/components/organisms/Comment/Comment.vue
@@ -8,8 +8,9 @@
         </div>
         <div class="message d-flex align-items-center mt-1" :style="{marginTop: (!showMessageTime ? '5px' : '')}" :class="{'right-message': message.sent, 'justify-content-between': !message.sent}">
             <div class="d-flex" :style="{paddingLeft: (!message.sent && !showUser ? '35px' : '')}">
+                <div v-if="!message.sent && showUser && isAlianComment" class="alian-mark" aria-hidden="true">A</div>
                 <UserProfile
-                    v-if="!message.sent && showUser"
+                    v-else-if="!message.sent && showUser"
                     :showDot="false"
                     class="cursor-pointer profile-image message__profile-image mr-10px"
                     :data="{
@@ -22,8 +23,8 @@
                 />
                 <div>
                     <div class="cursor-default mb-5px" :class="{'text-right': message.sent, 'text-left': !message.sent}">
-                        <span v-if="showUser" class="font-size-14 font-weight-700 mr-5px color63 show__user">
-                            {{!message.sent ? getUser(message.userId).Employee_Name : ''}}
+                        <span v-if="showUser" class="font-size-14 font-weight-700 mr-5px color63 show__user" :class="{'is-alian': isAlianComment}">
+                            {{!message.sent ? (isAlianComment ? $t('Comments.alian_name') : getUser(message.userId).Employee_Name) : ''}}
                         </span>
                         <span class="font-size-12 font-weight-300 gray text-lowercase show" v-if="showMessageTime">
                             {{getDateType(new Date(message.createdAt).getTime())}}
@@ -31,7 +32,7 @@
                     </div>
                     <div class="d-flex position-re" :class="{'justify-content-end': message.sent}">
                         <span v-if="!message.isDeleted && message.sent && new Date(message.createdAt)?.getTime() !== new Date(message.updatedAt)?.getTime()" class="font-size-10">({{$t('Comments.edited')}})</span>
-                        <div :id="message._id" class="border-radius-10-px p-10px message_id-sent" :class="{'bg-white': !message.sent, 'bg-light-blue': message.sent}" :style="`${message.type !== 'text' || message.type !== 'link' ? 'width: auto;' : ''}`">
+                        <div :id="message._id" class="border-radius-10-px p-10px message_id-sent" :class="{'bg-white': !message.sent && !isAlianComment, 'bg-light-blue': message.sent, 'is-alian': isAlianComment}" :style="`${message.type !== 'text' || message.type !== 'link' ? 'width: auto;' : ''}`">
                             <template v-if="message.isDeleted">
                                 <pre class="red font-italic" v-html="message.userId === userId ? $t('Comments.You_deleted_this_message') : $t('Comments.This_message_is_deleted')"/>
                             </template>
@@ -121,6 +122,7 @@
                                             <span>{{$t('Permissions.Read')}} {{showMore ? $t('Comments.less') : $t('Comments.more')}}</span>
                                         </div>
                                     </template>
+                                    <WorkspaceAskCitations v-if="isAlianComment && alianCitations.length" :citations="alianCitations" />
                                 </template>
                             </template>
                         </div>
@@ -175,7 +177,7 @@
 
 <script setup>
 // PACKAGES
-import { defineComponent, defineProps, inject, onMounted, ref, watch } from 'vue';
+import { defineComponent, defineProps, inject, onMounted, ref, watch, computed } from 'vue';
 import { useConvertDate, useCustomComposable, useGetterFunctions } from '@/composable';
 
 // COMPONENTS
@@ -189,7 +191,9 @@ import UserProfile from "@/components/atom/UserProfile/UserProfile.vue"
 import Spinner from "@/components/atom/SpinnerComp/SpinnerComp.vue"
 import { useProjects } from '@/composable/projects';
 import ReactionBar from '@/components/atom/ReactionBar/ReactionBar.vue';
+import WorkspaceAskCitations from '@/components/molecules/Pages/WorkspaceAskCitations.vue';
 import { apiRequest } from '@/services';
+import { isAlianAuthor } from '@/utils/alianMention';
 
 import { storageHelper } from "@/composable/commonFunction";
 const { handleStorageImageRequest } = storageHelper();
@@ -250,6 +254,12 @@ const props = defineProps({
 })
 
 const showMore = ref(false);
+const isAlianComment = computed(() => isAlianAuthor(props.message && props.message.userId));
+const alianCitations = computed(() => (
+    isAlianComment.value && Array.isArray(props.message && props.message.citations)
+        ? props.message.citations
+        : []
+));
 
 // Reactions render from a local copy so we never mutate the prop directly;
 // socket-driven prop updates (other users reacting) re-sync it via the watch.

--- a/frontend/src/components/organisms/Comment/style.css
+++ b/frontend/src/components/organisms/Comment/style.css
@@ -46,6 +46,30 @@
 .message_id-sent{
     max-width: 50vw;
  }
+.message_id-sent.is-alian {
+    background: var(--kiln-paper);
+    border: 1px solid var(--kiln-line);
+    border-top: 3px solid var(--kiln-ember);
+}
+.show__user.is-alian {
+    color: var(--kiln-ember-deep);
+    font-family: var(--kiln-font-display), Georgia, serif;
+}
+.alian-mark {
+    width: 30px;
+    height: 30px;
+    margin-right: 10px;
+    border-radius: 50%;
+    background: var(--kiln-ember);
+    color: #fffaf3;
+    font-family: var(--kiln-font-display), Georgia, serif;
+    font-weight: 700;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+}
 .comment__image{
    object-fit: contain;
    border: 1px solid #cecece; 

--- a/frontend/src/components/organisms/MainChat/MainChatComposer.vue
+++ b/frontend/src/components/organisms/MainChat/MainChatComposer.vue
@@ -53,6 +53,7 @@
                 class="mc-comp-input-wrap"
                 :reply="{}"
                 :userIds="userIds"
+                :includeAlian="false"
                 :sendMessageAllowed="!disabled"
                 :loadingChat="false"
                 @enter="submit"

--- a/frontend/src/composable/index.js
+++ b/frontend/src/composable/index.js
@@ -586,6 +586,26 @@ export function useGetterFunctions() {
      * @returns user object
      */
     function getUser(id,type = null) {
+        if (String(id) === 'alian') {
+            return {
+                id: 'alian',
+                _id: 'alian',
+                cuid: '',
+                Employee_Name: 'Alian',
+                Employee_profileImage: defaultUserAvatar,
+                Employee_profileImageURL: defaultUserAvatar,
+                isOnline: false,
+                timeFormat: '',
+                companyOwnerId: '',
+                Time_Zone: '',
+                timeZone: 'UTC',
+                assigneeCompany: [],
+                Employee_Email: '',
+                ghostUser: false,
+                isAlian: true,
+                isVesionUpdate: false
+            };
+        }
         const obj = ref({
             id: id,
             _id: id,

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -864,7 +864,7 @@ export default {
         pages_ask: "Ask",
         pages_ask_needed: "Type a question first.",
         pages_ask_placeholder: "Ask a question about this page…",
-        pages_workspace_ask_placeholder: "Ask across pages and tasks you can open…",
+        pages_workspace_ask_placeholder: "Ask across pages and tasks you can open, or type @Alian…",
         pages_citation_page: "Page",
         pages_citation_task: "Task",
         pages_turn_into_tasks: "Turn into tasks",
@@ -2591,6 +2591,8 @@ export default {
         You_deleted_this_message: "You deleted this message",
         no_user_found: "No User Found",
         unlock_comment_view: "To Unlock Comment View",
+        alian_kicker: "Workspace AI",
+        alian_name: "Alian",
     },
     PlaceHolder: {
         enter_task_type: "Enter Task Type",

--- a/frontend/src/utils/alianMention.js
+++ b/frontend/src/utils/alianMention.js
@@ -1,0 +1,50 @@
+const ALIAN_MENTION_KEY = 'alian';
+const ALIAN_DISPLAY_NAME = 'Alian';
+
+const TOKEN_RE = /@\[[^\]]*\]\(alian\)/gi;
+const BARE_RE = /@Alian\b/gi;
+
+function stripAlianMentions(text) {
+    return String(text || '')
+        .replace(TOKEN_RE, ' ')
+        .replace(BARE_RE, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function firstAlianMention(text) {
+    const raw = String(text || '');
+    TOKEN_RE.lastIndex = 0;
+    BARE_RE.lastIndex = 0;
+    const token = TOKEN_RE.exec(raw);
+    const bare = BARE_RE.exec(raw);
+    let match = null;
+    if (token && bare) match = token.index <= bare.index ? token : bare;
+    else match = token || bare;
+    if (!match) return null;
+    return { index: match.index, length: match[0].length };
+}
+
+function extractAlianQuestion(message) {
+    const raw = String(message || '').trim();
+    const hit = firstAlianMention(raw);
+    if (!hit) {
+        return { mentioned: false, question: '' };
+    }
+    const after = stripAlianMentions(raw.slice(hit.index + hit.length)).replace(/^[\s,.:;!?-]+/, '').trim();
+    if (after) {
+        return { mentioned: true, question: after };
+    }
+    return { mentioned: true, question: stripAlianMentions(raw) };
+}
+
+function isAlianAuthor(id) {
+    return String(id || '') === ALIAN_MENTION_KEY;
+}
+
+export {
+    ALIAN_MENTION_KEY,
+    ALIAN_DISPLAY_NAME,
+    extractAlianQuestion,
+    isAlianAuthor,
+};

--- a/frontend/src/views/Projects/Comments/Comments.vue
+++ b/frontend/src/views/Projects/Comments/Comments.vue
@@ -1270,7 +1270,15 @@ function getMessages() {
 }
 
 function getMessageId(data = {}) {
-    return data?._id ? String(data._id) : (data?.id ? String(data.id) : "");
+    if (!data) return "";
+    const raw = data._id != null ? data._id : data.id;
+    if (raw == null || raw === "") return "";
+    if (typeof raw === "object") {
+        if (raw.$oid) return String(raw.$oid);
+        if (typeof raw.toHexString === "function") return raw.toHexString();
+    }
+    const id = String(raw);
+    return id === "[object Object]" ? "" : id;
 }
 
 function findMessageIndexById(data = {}) {
@@ -1283,7 +1291,12 @@ function findMessageIndexById(data = {}) {
 }
 
 function decorateIncomingMessage(docData) {
-    const obj = {...docData, sent: docData.userId === userId.value};
+    const obj = {...docData, sent: String(docData.userId) === String(userId.value)};
+    const id = getMessageId(obj);
+    if (id) {
+        obj._id = id;
+        obj.id = id;
+    }
     const messageText = obj.message || "";
     obj.overflow = (obj.type === 'text' || obj.type === 'link')
         ? messageText.length > 465
@@ -1314,10 +1327,12 @@ function upsertIncomingComment(docData, {replaceSending = false, incrementTotal 
             type = docData.type;
             name = docData.mediaName;
         }
-        const sendingIndex = messages.value.findIndex((x) => (x.isSending && x.type === type && x.mediaName === name));
-        if(sendingIndex > -1){
-            messages.value[sendingIndex] = obj;
-            return false;
+        if(type && name) {
+            const sendingIndex = messages.value.findIndex((x) => (x.isSending && x.type === type && x.mediaName === name));
+            if(sendingIndex > -1){
+                messages.value[sendingIndex] = obj;
+                return false;
+            }
         }
     }
 
@@ -1343,7 +1358,8 @@ function handleSocketData() {
     
 
     socket.value.on("commentInsert",(data)=> {
-        let docData = data.fullDocument;
+        let docData = data && (data.fullDocument || data);
+        if(!docData) return;
         upsertIncomingComment(docData, {replaceSending: true, incrementTotal: true});
     })
 

--- a/frontend/src/views/Projects/Comments/Comments.vue
+++ b/frontend/src/views/Projects/Comments/Comments.vue
@@ -112,6 +112,7 @@
                                 :reply="message.reply"
                                 @cancel-reply="message.reply = {}"
                                 :showAll="mainChat && !projectData?.default"
+                                :includeAlian="!mainChat"
                                 :userIds="users.map((x) => x.id)"
                                 @enter="mediaFiles.length ? sendMedia() : sendMessageFun(message)"
                                 :sendMessageAllowed="messageAllowed"
@@ -1696,7 +1697,13 @@ function checkMentions(message){
         tmpMentions.forEach((data) => {
             let id = data.split("(")[1].replace(")", "");
             let msgName = data.split("(")[0].replace("[", "").replace("]", "");
+            if(id === 'alian') {
+                return;
+            }
             const user = id === "everyone" ? {id, name: "All"} : users.value.filter((x) => x.id === id)[0];
+            if(!user) {
+                return;
+            }
             if(`@${user.name}` === msgName) {
                 mentions.push(user.id)
                 msg = msg.replace(data, `@[${user.name}](${user.id})`);

--- a/socket/controller/commentSocket.js
+++ b/socket/controller/commentSocket.js
@@ -6,6 +6,7 @@ const {
     findRoomsByPrefix,
 } = require('../helper');
 const socketEmitter = require('../../event/socketEventEmitter');
+const { commentRoomPrefix } = require('../../Modules/Comments/helpers/commentThread');
 
 exports.commentSocketHandler = ({ socket, namespace }) => {
     socket.on('joinCommentRoom', (data) => {
@@ -62,22 +63,15 @@ function setEventName(type) {
 }
 
 const handleCommentChange = (changeData, includeUpdatedFields = false) => {
-    // Both modules share the same emit shape; the only difference is the
-    // prefix used to find subscribed rooms.
-    let prefix;
-    if (changeData.module === 'comments') {
-        const { projectId, sprintId, taskId } = changeData.data;
-        prefix = `comments_${projectId}_${sprintId}_${taskId}`;
-    } else if (changeData.module === 'comments_project') {
-        prefix = `comments_project_${changeData.data.projectId}`;
-    } else {
-        return;
-    }
+    if (!changeData || !changeData.data) return;
+    const thread = commentRoomPrefix(changeData.data);
+    const prefix = thread
+        ? thread.prefix
+        : (changeData.module === 'comments_project'
+            ? `comments_project_${changeData.data.projectId}`
+            : '');
+    if (!prefix) return;
 
-    // SOCKET-PERFORMANCE-PLAN #1 (Phase 2): O(1) prefix lookup replaces the
-    // full-array filter + `uniqueRooms` dedup helper. The Map-based index
-    // is already deduped by construction (key = roomName), so a second-pass
-    // dedup is no longer needed.
     const relatedRooms = findRoomsByPrefix(prefix);
     if (!relatedRooms.length) return;
 
@@ -87,11 +81,11 @@ const handleCommentChange = (changeData, includeUpdatedFields = false) => {
         ...(includeUpdatedFields && { updatedFields: changeData.updatedFields }),
     };
 
-    relatedRooms.forEach(data => {
-        // SOCKET-PERFORMANCE-PLAN #5 (Phase 2): see taskSocket.js — small-Set
-        // membership check beats scanning the namespace's full adapter.rooms.
-        if (!data.socket.rooms.has(data.roomName)) return;
-        data.namespace.to(data.roomName).emit(eventName, emitData);
+    relatedRooms.forEach((entry) => {
+        if (!entry.socket || entry.socket.disconnected) return;
+        const rooms = entry.socket.rooms;
+        if (rooms && typeof rooms.has === 'function' && !rooms.has(entry.roomName)) return;
+        entry.namespace.to(entry.roomName).emit(eventName, emitData);
     });
 };
 
@@ -103,3 +97,5 @@ socketEmitter.on('comments:update', changeData => handleCommentChange(changeData
 socketEmitter.on('comments:insert', changeData => handleCommentChange(changeData, false));
 socketEmitter.on('comments_project:update', changeData => handleCommentChange(changeData, true));
 socketEmitter.on('comments_project:insert', changeData => handleCommentChange(changeData, false));
+
+exports.handleCommentChange = handleCommentChange;

--- a/socket/controller/commentSocket.js
+++ b/socket/controller/commentSocket.js
@@ -6,7 +6,7 @@ const {
     findRoomsByPrefix,
 } = require('../helper');
 const socketEmitter = require('../../event/socketEventEmitter');
-const { commentRoomPrefix } = require('../../Modules/Comments/helpers/commentThread');
+const { commentRoomPrefix, serializeCommentForSocket } = require('../../Modules/Comments/helpers/commentThread');
 
 exports.commentSocketHandler = ({ socket, namespace }) => {
     socket.on('joinCommentRoom', (data) => {
@@ -64,20 +64,16 @@ function setEventName(type) {
 
 const handleCommentChange = (changeData, includeUpdatedFields = false) => {
     if (!changeData || !changeData.data) return;
-    const thread = commentRoomPrefix(changeData.data);
-    const prefix = thread
-        ? thread.prefix
-        : (changeData.module === 'comments_project'
-            ? `comments_project_${changeData.data.projectId}`
-            : '');
-    if (!prefix) return;
+    const data = serializeCommentForSocket(changeData.data);
+    const thread = commentRoomPrefix(data);
+    if (!thread || !thread.prefix || String(thread.prefix).includes('[object Object]')) return;
 
-    const relatedRooms = findRoomsByPrefix(prefix);
+    const relatedRooms = findRoomsByPrefix(thread.prefix);
     if (!relatedRooms.length) return;
 
     const eventName = setEventName(changeData.type);
     const emitData = {
-        fullDocument: changeData.data,
+        fullDocument: data,
         ...(includeUpdatedFields && { updatedFields: changeData.updatedFields }),
     };
 

--- a/tests/alian-mention.test.js
+++ b/tests/alian-mention.test.js
@@ -1,0 +1,194 @@
+const fs = require('fs');
+const path = require('path');
+const {
+    ALIAN_MENTION_KEY,
+    hasAlianMention,
+    extractAlianQuestion,
+    shouldReplyAsAlian,
+    citationsForComment,
+    escapeCommentHtml,
+    buildAlianComment,
+} = require('../Modules/Comments/helpers/alianMention');
+const { parseMentionIds } = require('../Modules/Comments/helpers/parseMentions');
+const { selectCitations, formatContextPack } = require('../Modules/Pages/helpers/pageWorkspaceAsk');
+
+const NO_QUESTION_TEXT = 'Ask a question after @Alian — I will look across pages and tasks you can open.';
+
+describe('extractAlianQuestion', () => {
+    test('reads the text after an autocomplete token', () => {
+        expect(extractAlianQuestion('@[Alian](alian) what is the launch date?')).toEqual({
+            mentioned: true,
+            question: 'what is the launch date?',
+        });
+    });
+
+    test('reads the text after a bare @Alian', () => {
+        expect(extractAlianQuestion('@Alian summarize this sprint')).toEqual({
+            mentioned: true,
+            question: 'summarize this sprint',
+        });
+    });
+
+    test('falls back to the rest of the comment when the mention is at the end', () => {
+        expect(extractAlianQuestion('check the handbook @Alian')).toEqual({
+            mentioned: true,
+            question: 'check the handbook',
+        });
+    });
+
+    test('is case-insensitive and strips leftover Alian tokens', () => {
+        expect(extractAlianQuestion('@ALIAN foo @[Alian](alian) bar')).toEqual({
+            mentioned: true,
+            question: 'foo bar',
+        });
+    });
+
+    test('decodes HTML entities from saved comments', () => {
+        expect(extractAlianQuestion('@[Alian](alian) what&#039;s next?')).toEqual({
+            mentioned: true,
+            question: "what's next?",
+        });
+    });
+
+    test('empty question when the comment is only the mention', () => {
+        expect(extractAlianQuestion('@Alian')).toEqual({ mentioned: true, question: '' });
+        expect(extractAlianQuestion('@[Alian](alian)')).toEqual({ mentioned: true, question: '' });
+    });
+
+    test('no mention yields mentioned false and no invented question', () => {
+        expect(extractAlianQuestion('plain comment')).toEqual({ mentioned: false, question: '' });
+        expect(extractAlianQuestion('')).toEqual({ mentioned: false, question: '' });
+        expect(extractAlianQuestion(null)).toEqual({ mentioned: false, question: '' });
+    });
+
+    test('does not treat @AlianHub as @Alian', () => {
+        expect(hasAlianMention('see @AlianHub docs')).toBe(false);
+        expect(extractAlianQuestion('see @AlianHub docs').mentioned).toBe(false);
+    });
+});
+
+describe('shouldReplyAsAlian', () => {
+    const base = {
+        userId: 'u1',
+        taskId: '64a'.repeat(8),
+        type: 'text',
+        message: '@Alian what is next?',
+    };
+
+    test('true for a task text comment that mentions Alian', () => {
+        expect(shouldReplyAsAlian(base)).toBe(true);
+    });
+
+    test('false for Alian\'s own comments, main chat, media, and no mention', () => {
+        expect(shouldReplyAsAlian({ ...base, userId: ALIAN_MENTION_KEY })).toBe(false);
+        expect(shouldReplyAsAlian({ ...base, taskId: 'default' })).toBe(false);
+        expect(shouldReplyAsAlian({ ...base, taskId: '' })).toBe(false);
+        expect(shouldReplyAsAlian({ ...base, type: 'image' })).toBe(false);
+        expect(shouldReplyAsAlian({ ...base, message: 'hello' })).toBe(false);
+    });
+});
+
+describe('citationsForComment — do not invent citations', () => {
+    test('empty or missing input stays empty', () => {
+        expect(citationsForComment(undefined)).toEqual([]);
+        expect(citationsForComment(null)).toEqual([]);
+        expect(citationsForComment([])).toEqual([]);
+        expect(citationsForComment('pages:2')).toEqual([]);
+    });
+
+    test('drops invented types, missing ids, and extra fields', () => {
+        expect(citationsForComment([
+            { type: 'page', id: 'p1', title: 'Handbook', projectId: 'projA', secret: 'nope' },
+            { type: 'wiki', id: 'x1', title: 'Invented' },
+            { type: 'task', title: 'No id' },
+            { type: 'task', id: 't1', TaskName: 'ignored' },
+        ])).toEqual([
+            { type: 'page', id: 'p1', title: 'Handbook', projectId: 'projA' },
+            { type: 'task', id: 't1', title: '(untitled task)' },
+        ]);
+    });
+
+    test('does not invent pack ids when the model returns none', () => {
+        const pack = formatContextPack({
+            pages: [{ _id: 'p1', title: 'Handbook' }],
+            tasks: [{ _id: 't1', TaskName: 'Ship it' }],
+        });
+        expect(citationsForComment([])).toEqual([]);
+        expect(citationsForComment(selectCitations(pack.citations, [{ type: 'page', id: 'invented' }]))).toEqual([
+            { type: 'page', id: 'p1', title: 'Handbook' },
+            { type: 'task', id: 't1', title: 'Ship it' },
+        ]);
+        expect(citationsForComment(selectCitations([], [{ type: 'page', id: 'p1' }]))).toEqual([]);
+    });
+});
+
+describe('buildAlianComment', () => {
+    test('authors as alian, replies to the source, and copies only real citations', () => {
+        const source = {
+            _id: 'c1',
+            userId: 'u1',
+            type: 'text',
+            message: '@Alian what is next?',
+            project: false,
+            projectId: 'projA',
+            sprintId: 's1',
+            taskId: 't1',
+        };
+        const built = buildAlianComment(source, 'Ship the brief.', [
+            { type: 'page', id: 'p1', title: 'Handbook' },
+            { type: 'doc', id: 'nope' },
+        ]);
+        expect(built.userId).toBe(ALIAN_MENTION_KEY);
+        expect(built.reply_id).toBe('c1');
+        expect(built.reply_userId).toBe('u1');
+        expect(built.taskId).toBe('t1');
+        expect(built.citations).toEqual([{ type: 'page', id: 'p1', title: 'Handbook' }]);
+        expect(built.message).toBe('Ship the brief.');
+        expect(parseMentionIds(built.message)).toEqual([]);
+        expect(NO_QUESTION_TEXT).toMatch(/@Alian/);
+    });
+
+    test('escapes HTML so a model cannot inject markup', () => {
+        expect(escapeCommentHtml('<script>x</script>')).toBe('&lt;script&gt;x&lt;/script&gt;');
+        const built = buildAlianComment(
+            { _id: 'c1', userId: 'u1', projectId: 'p', taskId: 't', sprintId: 's' },
+            '<b>hi</b>',
+            [],
+        );
+        expect(built.message).toBe('&lt;b&gt;hi&lt;/b&gt;');
+        expect(built.citations).toEqual([]);
+    });
+});
+
+describe('S1.3 wiring', () => {
+    test('parseMentionIds does not treat alian as a user mention', () => {
+        expect(parseMentionIds('@[Alian](alian) hi [Jane](aaaaaaaaaaaaaaaaaaaaaaaa)')).toEqual([
+            'aaaaaaaaaaaaaaaaaaaaaaaa',
+        ]);
+    });
+
+    test('CommentInput exposes a synthetic alian option', () => {
+        const src = fs.readFileSync(path.join(__dirname, '..', 'frontend', 'src', 'components', 'atom', 'CommentInput', 'CommentInput.vue'), 'utf8');
+        expect(src).toContain("key: 'alian'");
+        expect(src).toContain('includeAlian');
+        expect(src).toContain('isAlian');
+    });
+
+    test('task comments enable Alian; main chat does not', () => {
+        const comments = fs.readFileSync(path.join(__dirname, '..', 'frontend', 'src', 'views', 'Projects', 'Comments', 'Comments.vue'), 'utf8');
+        const composer = fs.readFileSync(path.join(__dirname, '..', 'frontend', 'src', 'components', 'organisms', 'MainChat', 'MainChatComposer.vue'), 'utf8');
+        expect(comments).toContain(':includeAlian="!mainChat"');
+        expect(composer).toContain(':includeAlian="false"');
+    });
+
+    test('Alian comments render kiln citations without applying page content', () => {
+        const comment = fs.readFileSync(path.join(__dirname, '..', 'frontend', 'src', 'components', 'organisms', 'Comment', 'Comment.vue'), 'utf8');
+        const compose = fs.readFileSync(path.join(__dirname, '..', 'frontend', 'src', 'components', 'molecules', 'Pages', 'PageComposeRail.vue'), 'utf8');
+        expect(comment).toContain('WorkspaceAskCitations');
+        expect(comment).toContain('message.citations');
+        expect(comment).toContain('is-alian');
+        expect(compose).toContain('extractAlianQuestion');
+        expect(compose).toContain('ask-workspace');
+        expect(compose).toMatch(/payload\.apply === false/);
+    });
+});

--- a/tests/comment-thread.test.js
+++ b/tests/comment-thread.test.js
@@ -8,12 +8,15 @@ const {
 } = require('../Modules/Comments/helpers/commentThread');
 const helper = require('../socket/helper');
 const { handleCommentChange } = require('../socket/controller/commentSocket');
+const { emitCommentInsert } = require('../Modules/Comments/helpers/alianReply');
+const { buildAlianComment } = require('../Modules/Comments/helpers/alianMention');
 const fs = require('fs');
 const path = require('path');
 
 const PID = '64a'.repeat(8);
 const SID = '64b'.repeat(8);
 const TID = '64c'.repeat(8);
+const HEX_ID = /^[0-9a-fA-F]{24}$/;
 
 beforeEach(() => {
     const { byPrefix, bySocket } = helper.__internals;
@@ -31,6 +34,9 @@ describe('comment thread id contract', () => {
         expect(idString({ id: Buffer.from(PID, 'hex') })).toBe(PID);
         expect(idString(null)).toBe('');
         expect(idString({ nope: true })).toBe('');
+        expect(idString('[object Object]')).toBe('');
+        expect(idString({ type: 'Buffer', data: [...Buffer.from(PID, 'hex')] })).toBe(PID);
+        expect(idString({ _bsontype: 'ObjectId', id: Buffer.from(PID, 'hex') })).toBe(PID);
     });
 
     test('task room prefix is the same for ObjectIds and strings', () => {
@@ -109,6 +115,35 @@ describe('comment thread id contract', () => {
         expect(commentRoomPrefix(payload).prefix).toBe(`comments_${PID}_${SID}_${TID}`);
     });
 
+    test('room prefix and payload never contain [object Object]', () => {
+        const garbage = commentRoomPrefix({
+            projectId: PID,
+            sprintId: SID,
+            taskId: '[object Object]',
+        });
+        expect(JSON.stringify(garbage)).not.toContain('[object Object]');
+        expect(garbage.prefix).toBe(`comments_project_${PID}`);
+
+        const mixed = serializeCommentForSocket({
+            _id: { $oid: '64d'.repeat(8) },
+            userId: 'alian',
+            projectId: { $oid: PID },
+            sprintId: { nope: true },
+            taskId: { nope: true },
+            message: 'hi',
+        }, {
+            projectId: PID,
+            sprintId: SID,
+            taskId: { $oid: TID },
+        });
+        expect(mixed.projectId).toBe(PID);
+        expect(mixed.sprintId).toBe(SID);
+        expect(mixed.taskId).toBe(TID);
+        expect(mixed._id).toBe('64d'.repeat(8));
+        expect(JSON.stringify(mixed)).not.toContain('[object Object]');
+        expect(commentRoomPrefix(mixed).prefix).toBe(`comments_${PID}_${SID}_${TID}`);
+    });
+
     test('alian follow-ups are accepted as live inserts', () => {
         expect(acceptIncomingComment({ _id: 'c2', userId: 'alian', message: 'hi' })).toBe(true);
         expect(incomingCommentDoc({ fullDocument: { userId: 'alian' } })).toEqual({ userId: 'alian' });
@@ -173,6 +208,99 @@ describe('commentSocket fan-out', () => {
 
         expect(emitted).toHaveLength(1);
         expect(emitted[0].event).toBe('commentInsert');
+        expect(emitted[0].payload.fullDocument.projectId).toBe(PID);
+        expect(emitted[0].payload.fullDocument.sprintId).toBe(SID);
+        expect(emitted[0].payload.fullDocument.taskId).toBe(TID);
+        expect(JSON.stringify(emitted)).not.toContain('[object Object]');
+    });
+
+    test('commentSocket does not interpolate raw Mixed ids into the prefix', () => {
+        const src = fs.readFileSync(path.join(__dirname, '..', 'socket', 'controller', 'commentSocket.js'), 'utf8');
+        expect(src).toContain('serializeCommentForSocket(changeData.data)');
+        expect(src).toContain('commentRoomPrefix(data)');
+        expect(src).not.toMatch(/comments_\$\{.*projectId.*sprintId.*taskId/);
+        expect(src).not.toContain('comments_project_${changeData.data.projectId}');
+    });
+});
+
+describe('emitCommentInsert id contract', () => {
+    function joinTaskRoom() {
+        const roomName = `comments_${PID}_${SID}_${TID}**sock1`;
+        const emitted = [];
+        const namespace = {
+            to: (room) => ({
+                emit: (event, payload) => emitted.push({ room, event, payload }),
+            }),
+        };
+        const socket = { id: 'sock1', disconnected: false, rooms: new Set([roomName]) };
+        helper.upsertRoom({ roomName, socketId: 'sock1', socket, namespace });
+        return { roomName, emitted };
+    }
+
+    test('copies missing sprintId/taskId from the triggering comment and emits hex strings', () => {
+        const { roomName, emitted } = joinTaskRoom();
+        const cid = '64e'.repeat(8);
+        emitCommentInsert({
+            _id: { $oid: cid },
+            userId: 'alian',
+            projectId: { $oid: PID },
+            message: 'Ship the brief.',
+        }, {
+            _id: 'c1',
+            userId: 'u1',
+            projectId: new mongoose.Types.ObjectId(PID),
+            sprintId: new mongoose.Types.ObjectId(SID),
+            taskId: { $oid: TID },
+        });
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].room).toBe(roomName);
+        expect(emitted[0].event).toBe('commentInsert');
+        const doc = emitted[0].payload.fullDocument;
+        expect(doc._id).toBe(cid);
+        expect(doc.projectId).toBe(PID);
+        expect(doc.sprintId).toBe(SID);
+        expect(doc.taskId).toBe(TID);
+        expect(HEX_ID.test(doc.projectId)).toBe(true);
+        expect(HEX_ID.test(doc.sprintId)).toBe(true);
+        expect(HEX_ID.test(doc.taskId)).toBe(true);
+        expect(JSON.stringify(emitted)).not.toContain('[object Object]');
+    });
+
+    test('Mixed ObjectId-shaped taskId does not fan out to comments_[object Object]', () => {
+        const { roomName, emitted } = joinTaskRoom();
+        emitCommentInsert({
+            _id: new mongoose.Types.ObjectId('64f'.repeat(8)),
+            userId: 'alian',
+            projectId: new mongoose.Types.ObjectId(PID),
+            sprintId: { type: 'Buffer', data: [...Buffer.from(SID, 'hex')] },
+            taskId: { id: Buffer.from(TID, 'hex') },
+            message: 'Ship it.',
+        });
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].room).toBe(roomName);
+        const doc = emitted[0].payload.fullDocument;
+        expect(doc.projectId).toBe(PID);
+        expect(doc.sprintId).toBe(SID);
+        expect(doc.taskId).toBe(TID);
+        expect(JSON.stringify(emitted)).not.toContain('[object Object]');
+    });
+
+    test('buildAlianComment stores hex thread ids from ObjectId source fields', () => {
+        const built = buildAlianComment({
+            _id: new mongoose.Types.ObjectId('64d'.repeat(8)),
+            userId: 'u1',
+            projectId: new mongoose.Types.ObjectId(PID),
+            sprintId: new mongoose.Types.ObjectId(SID),
+            taskId: new mongoose.Types.ObjectId(TID),
+            message: '@Alian what is next?',
+        }, 'Ship the brief.', []);
+        expect(built.projectId).toBe(PID);
+        expect(built.sprintId).toBe(SID);
+        expect(built.taskId).toBe(TID);
+        expect(built.reply_id).toBe('64d'.repeat(8));
+        expect(JSON.stringify(built)).not.toContain('[object Object]');
     });
 });
 

--- a/tests/comment-thread.test.js
+++ b/tests/comment-thread.test.js
@@ -1,0 +1,188 @@
+const mongoose = require('mongoose');
+const {
+    idString,
+    commentRoomPrefix,
+    serializeCommentForSocket,
+    incomingCommentDoc,
+    acceptIncomingComment,
+} = require('../Modules/Comments/helpers/commentThread');
+const helper = require('../socket/helper');
+const { handleCommentChange } = require('../socket/controller/commentSocket');
+const fs = require('fs');
+const path = require('path');
+
+const PID = '64a'.repeat(8);
+const SID = '64b'.repeat(8);
+const TID = '64c'.repeat(8);
+
+beforeEach(() => {
+    const { byPrefix, bySocket } = helper.__internals;
+    byPrefix.clear();
+    bySocket.clear();
+});
+
+describe('comment thread id contract', () => {
+    test('idString turns ObjectIds, $oid wrappers and buffers into hex', () => {
+        const oid = new mongoose.Types.ObjectId(PID);
+        expect(idString(oid)).toBe(PID);
+        expect(idString(PID)).toBe(PID);
+        expect(idString({ $oid: PID })).toBe(PID);
+        expect(idString(Buffer.from(PID, 'hex'))).toBe(PID);
+        expect(idString({ id: Buffer.from(PID, 'hex') })).toBe(PID);
+        expect(idString(null)).toBe('');
+        expect(idString({ nope: true })).toBe('');
+    });
+
+    test('task room prefix is the same for ObjectIds and strings', () => {
+        const fromIds = commentRoomPrefix({
+            projectId: new mongoose.Types.ObjectId(PID),
+            sprintId: new mongoose.Types.ObjectId(SID),
+            taskId: new mongoose.Types.ObjectId(TID),
+        });
+        const fromStrings = commentRoomPrefix({
+            projectId: PID,
+            sprintId: SID,
+            taskId: TID,
+        });
+        const fromOid = commentRoomPrefix({
+            projectId: { $oid: PID },
+            sprintId: { $oid: SID },
+            taskId: { $oid: TID },
+        });
+        expect(fromIds).toEqual(fromStrings);
+        expect(fromOid).toEqual(fromStrings);
+        expect(fromStrings).toEqual({
+            module: 'comments',
+            prefix: `comments_${PID}_${SID}_${TID}`,
+            projectId: PID,
+            sprintId: SID,
+            taskId: TID,
+        });
+    });
+
+    test('main-chat default taskId stays on the comments_ room, not comments_project_', () => {
+        expect(commentRoomPrefix({
+            projectId: PID,
+            sprintId: SID,
+            taskId: 'default',
+        })).toEqual({
+            module: 'comments',
+            prefix: `comments_${PID}_${SID}_default`,
+            projectId: PID,
+            sprintId: SID,
+            taskId: 'default',
+        });
+    });
+
+    test('serializeCommentForSocket writes stable string ids on the payload', () => {
+        const saved = {
+            _id: new mongoose.Types.ObjectId('64d'.repeat(8)),
+            userId: 'alian',
+            projectId: new mongoose.Types.ObjectId(PID),
+            sprintId: new mongoose.Types.ObjectId(SID),
+            taskId: new mongoose.Types.ObjectId(TID),
+            message: 'Ship the brief.',
+            citations: [{ type: 'page', id: 'p1', title: 'Handbook' }],
+        };
+        const payload = serializeCommentForSocket(saved);
+        expect(payload.projectId).toBe(PID);
+        expect(payload.sprintId).toBe(SID);
+        expect(payload.taskId).toBe(TID);
+        expect(payload._id).toBe('64d'.repeat(8));
+        expect(payload.userId).toBe('alian');
+        expect(commentRoomPrefix(payload).prefix).toBe(`comments_${PID}_${SID}_${TID}`);
+    });
+
+    test('serializeCommentForSocket fills missing thread ids from the source comment', () => {
+        const source = {
+            _id: 'c1',
+            userId: 'u1',
+            projectId: PID,
+            sprintId: SID,
+            taskId: TID,
+        };
+        const saved = { _id: 'c2', userId: 'alian', projectId: PID, message: 'hi' };
+        const payload = serializeCommentForSocket(saved, source);
+        expect(payload.sprintId).toBe(SID);
+        expect(payload.taskId).toBe(TID);
+        expect(commentRoomPrefix(payload).module).toBe('comments');
+        expect(commentRoomPrefix(payload).prefix).toBe(`comments_${PID}_${SID}_${TID}`);
+    });
+
+    test('alian follow-ups are accepted as live inserts', () => {
+        expect(acceptIncomingComment({ _id: 'c2', userId: 'alian', message: 'hi' })).toBe(true);
+        expect(incomingCommentDoc({ fullDocument: { userId: 'alian' } })).toEqual({ userId: 'alian' });
+        expect(acceptIncomingComment(null)).toBe(false);
+    });
+});
+
+describe('commentSocket fan-out', () => {
+    test('ObjectId payload reaches a room joined with string ids', () => {
+        const roomName = `comments_${PID}_${SID}_${TID}**sock1`;
+        const emitted = [];
+        const namespace = {
+            to: (room) => ({
+                emit: (event, payload) => emitted.push({ room, event, payload }),
+            }),
+        };
+        const socket = { id: 'sock1', disconnected: false, rooms: new Set([roomName]) };
+        helper.upsertRoom({ roomName, socketId: 'sock1', socket, namespace });
+
+        handleCommentChange({
+            type: 'insert',
+            module: 'comments',
+            data: serializeCommentForSocket({
+                _id: new mongoose.Types.ObjectId('64e'.repeat(8)),
+                userId: 'alian',
+                projectId: new mongoose.Types.ObjectId(PID),
+                sprintId: new mongoose.Types.ObjectId(SID),
+                taskId: new mongoose.Types.ObjectId(TID),
+                message: 'Ship it.',
+            }),
+        });
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].room).toBe(roomName);
+        expect(emitted[0].event).toBe('commentInsert');
+        expect(emitted[0].payload.fullDocument.userId).toBe('alian');
+        expect(emitted[0].payload.fullDocument.projectId).toBe(PID);
+        expect(emitted[0].payload.fullDocument.taskId).toBe(TID);
+    });
+
+    test('raw ObjectId fields still match the string room prefix', () => {
+        const roomName = `comments_${PID}_${SID}_${TID}**sock1`;
+        const emitted = [];
+        const namespace = {
+            to: (room) => ({
+                emit: (event, payload) => emitted.push({ room, event, payload }),
+            }),
+        };
+        const socket = { id: 'sock1', disconnected: false, rooms: new Set([roomName]) };
+        helper.upsertRoom({ roomName, socketId: 'sock1', socket, namespace });
+
+        handleCommentChange({
+            type: 'insert',
+            module: 'comments',
+            data: {
+                userId: 'alian',
+                projectId: new mongoose.Types.ObjectId(PID),
+                sprintId: new mongoose.Types.ObjectId(SID),
+                taskId: new mongoose.Types.ObjectId(TID),
+            },
+        });
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].event).toBe('commentInsert');
+    });
+});
+
+describe('Comments.vue live insert', () => {
+    test('does not skip userId alian and reads fullDocument or the payload', () => {
+        const src = fs.readFileSync(path.join(__dirname, '..', 'frontend', 'src', 'views', 'Projects', 'Comments', 'Comments.vue'), 'utf8');
+        expect(src).not.toMatch(/userId\s*!==\s*['"]alian['"]/);
+        expect(src).not.toMatch(/userId\s*===\s*['"]alian['"]\s*.*return/);
+        expect(src).toContain('data.fullDocument || data');
+        expect(src).toContain('upsertIncomingComment');
+        expect(src).toContain("id === 'alian'");
+    });
+});

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -2571,6 +2571,11 @@ const schema = {
             type: Array,
             required: false
         },
+        "citations": {
+            type: Array,
+            required: false,
+            default: []
+        },
         "pinnedMessage": {
             type: Boolean,
             default: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S1.3: users can type `@Alian` in a task comment to ask the workspace AI. The answer posts as a **follow-up comment** from a system author named Alian (`userId: "alian"`), threaded as a reply to the triggering comment, with the same citation objects as Workspace Ask (S1.1).

Stacked on `feat/workspace-ask-citations-27ed` (PR 516).

## Type of change

- [x] 🚀 `feat` — New feature

## How @Alian is triggered

1. In a **task** comment box, type `@`. Alian is the first autocomplete option (kiln mark, “Workspace AI” kicker). Selecting it inserts `@[Alian](alian)`.
2. Bare `@Alian` in the comment body also counts (case-insensitive). `@AlianHub` does not.
3. On **create** of that comment, the server extracts the question (text after the mention, or the rest of the comment if the mention is at the end) and runs `runWorkspaceAsk` as the comment author — same private-page / visible-project filters as `POST /api/v2/pages/ask-workspace`.
4. Alian is **not** a real user row. The mention key is `alian` (not a 24-hex id), so `parseMentionIds` does not notify anyone.

Main Chat does not offer or answer `@Alian`.

## Where the answer lands

A **new follow-up comment**, not an in-place edit:

- `userId: "alian"` (system author “Alian”)
- `hasReply: true` pointing at the user’s comment
- `message`: the markdown answer (HTML-escaped)
- `citations`: pack-only `{ type, id, title, projectId? }` — invented ids are dropped

The follow-up is emitted on the existing comment socket path with **hex-string** `projectId` / `sprintId` / `taskId` / `_id`, so the open Comments thread receives `commentInsert` without closing the task modal.

If the comment is only `@Alian` with no question, Alian replies asking for a question (no LLM call). If AI is not configured, Alian says so.

## Pages compose

If the compose instruction contains `@Alian`, it is routed to workspace ask and **is not applied to the page**.

## Test plan

- [x] `./node_modules/.bin/jest tests/alian-mention.test.js tests/page-content.test.js tests/page-rules.test.js tests/parse-mentions.test.js tests/first-run-checklist.test.js` — extraction, no invented citations, existing page-content tests
- [x] `./node_modules/.bin/jest tests/comment-thread.test.js` — emit/id contract: ObjectId, `$oid`, and strings share one room prefix; Alian payload is accepted; `commentSocket` fans out to the string room
- [x] `cd frontend && npm run build` — DONE
- [ ] Type `@` in a task comment → Alian is first in the list
- [ ] Post `@Alian what is the launch date?` → follow-up Alian comment appears **in the already-open thread** (no modal close)
- [ ] `@AlianHub` does not trigger
- [ ] Pages compose `@Alian …` answers in the rail, does not replace page content

## Breaking changes

- [x] ❌ No breaking changes

## Notes for reviewers

- Decision documented in `Tasks/active/007-alian-mentions/`: **follow-up comment**, not edit-in-place, so the user’s question stays visible and live-sync already inserts new comments.
- Live-refresh fix: `serializeCommentForSocket` + `commentRoomPrefix` so Mixed `taskId` / ObjectId fields cannot build `comments_[object Object]_…` and silently miss the joined room.
- Reuses `Modules/AIProjectGenerator/llmProvider` via `answerWorkspaceQuestion`. No second AI stack.
- Optional `comments.citations` field added to the schema (`strict: true`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a6f2e9d-86b0-4445-b83c-cf2991e96d61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a6f2e9d-86b0-4445-b83c-cf2991e96d61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

