### PR TITLE
fix(ui): visual sweep fixes, task.create over MCP, SPA fallback

### DIFF
--- a/Modules/PersonalList/controller.js
+++ b/Modules/PersonalList/controller.js
@@ -30,7 +30,27 @@ const findListSprint = async (companyId, projectId) => {
     return null;
 };
 
-const personalProjectBody = (companyId, uid) => ({
+// The schema requires a default view. Picked from the company's own view
+// catalogue, ids as strings, because createProject matches them with === against
+// stringified catalogue ids — an ObjectId never matches and the tab loses its name.
+const PERSONAL_VIEWS = ["ProjectListView", "ProjectKanban", "Calendar"];
+const PERSONAL_DEFAULT_VIEW = "ProjectListView";
+
+const personalViews = async (companyId) => {
+    const tabs = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.PROJECT_TAB_COMPONENTS, data: [{}] }, "find").catch(() => []);
+    const list = Array.isArray(tabs) ? tabs : [];
+    let chosen = list.filter((t) => t && PERSONAL_VIEWS.includes(t.keyName));
+    if (!chosen.length) chosen = list.slice(0, 1);
+    if (!chosen.length) throw new Error("no project views are seeded for this company yet");
+    const fallback = chosen[0];
+    return {
+        ProjectRequiredComponent: chosen.map((v) => ({ _id: String(v._id), viewStatus: true, setAsDefault: v.keyName === PERSONAL_DEFAULT_VIEW || v === fallback && !chosen.some((c) => c.keyName === PERSONAL_DEFAULT_VIEW) })),
+        ProjectRequiredDefaultComponent: (chosen.find((v) => v.keyName === PERSONAL_DEFAULT_VIEW) || fallback).keyName
+    };
+};
+
+const personalProjectBody = (companyId, uid, views) => ({
+    ...views,
     _id: new mongoose.Types.ObjectId(),
     CompanyId: companyId,
     ProjectName: PERSONAL_NAME,
@@ -69,7 +89,7 @@ exports.getOrCreatePersonalProject = async (req, res) => {
         let project = await findPersonalProject(companyId, uid);
         let created = false;
         if (!project || !Object.keys(project).length) {
-            const result = await createProject({ body: personalProjectBody(companyId, uid) });
+            const result = await createProject({ body: personalProjectBody(companyId, uid, await personalViews(companyId)) });
             project = result && result.data;
             created = true;
             removeCache("UserProjectData:", true);
@@ -88,3 +108,5 @@ exports.getOrCreatePersonalProject = async (req, res) => {
         return res.status(400).send({ status: false, message });
     }
 };
+
+exports.personalViews = personalViews;

--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -80,3 +80,22 @@ for a while — I built gap-6 and gap-8 myself, sent two agents out, and that on
 through the gap. Caught on a board read, not by anything automated. A task sitting In
 Progress with nothing behind it is exactly the failure this dogfooding was meant to
 surface, and it surfaced.
+
+### 2026-09-04 (UI sweep, owner reported "many UI issues")
+Took screenshots at 1100×720 and measured layout at 1440×900 page by page. Filed AR-29..AR-32
+through `task.create`, all fixed and In Review. The headline defect was mine: the dark-mode ink
+fix added `.ah-page { flex-direction: column }`, which stacked every sidebar page vertically —
+at desktop width Home and Planner content measured 0px tall. Also fixed: tour popup ignoring
+Skip on all but the last step (owner's report), projects never loading in the new shell, root URL
+landing on the legacy dashboard, Personal List unable to save (schema lacked its fields), Docs rows
+unstyled (scoped styles vs render-function children), rail overflowing the viewport, AI sidebar
+unreachable under 1280px. Three "bugs" were tool artefacts and were not filed.
+
+Second pass (same day): project drawer opening over the selected project and not closing from its
+backdrop, board card checkbox drawn over the title, task overlay opening scrolled past the title
+(composer autofocus), Billing toolbar boxed to 220px by a duplicate `.billing__bar` rule plus a
+clipped milestone table, tablet List starving the name column. Filed AR-33..AR-37 via `task.create`,
+fixed, rebuilt, verified by measurement, In Review. Passes done: light at 1100, dark on Home, 800px
+Home and List, and child-rect measurements on every sidebar page at 1440. Still open and legacy:
+the project header/list toolbar styling (search overflows at 800px) and an unlabelled empty select
+on the Sprint report.

--- a/Tasks/index.md
+++ b/Tasks/index.md
@@ -16,4 +16,4 @@ Auto-maintained registry of all tasks. Reflects YAML frontmatter from each `task
 | 009 | Redesign stages 2–3 — first run and daily work in the new shell | active | high | 008 | active/009-redesign-daily-work |
 | 010 | Redesign stage 4 — auditable AI agent system | active | high | 009 | active/010-redesign-ai-system |
 | 011 | Redesign stage 5 — money & scale | active | medium | 009 | active/011-redesign-money-scale |
-| 012 | Run the rest of the redesign from inside AlianHub (dogfood) | queued | high | 009 | active/012-dogfood-in-alianhub |
+| 012 | Run the rest of the redesign from inside AlianHub (dogfood) | active | high | 009 | active/012-dogfood-in-alianhub |

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -411,6 +411,12 @@ async function getFirebaseData() {
                             dispatch('settings/setCompanyUsers', {companyName: companyId.value, userId: userId.value}).then(async()=>{
                                     if (userId.value !== null && companyId.value) {
                                         handleSocketsConnection();
+                                        // The legacy dashboard used to load this on mount; the new
+                                        // shell lands on Home, which only reads the store.
+                                        if (!getters['projectData/allProjects']?.data?.length) {
+                                            dispatch('projectData/setProjects', { roleType: getters['settings/companyUserDetail']?.roleType, uid: userId.value })
+                                                .catch((error) => console.error('setProjects', error));
+                                        }
                                         if (process.env.VUE_APP_AFFILIATEON == 'true') {
                                             dispatch('settings/setCompanyRefferal',companyId.value).catch((error)=>{
                                                 console.error(error);

--- a/frontend/src/assets/css/tokens.css
+++ b/frontend/src/assets/css/tokens.css
@@ -136,6 +136,10 @@ html, body, #app {
 :root[data-theme="dark"] .ah-app__view { color: #17161c; }
 :root[data-theme="dark"] .ah-app__view .ah-page { color: var(--ink); }
 .ah-page { color: var(--ink); min-height: 100%; display: flex; flex-direction: column; }
+/* Page roots that put a sidebar beside the content. The column above is the default for
+   toolbar-over-body pages; these need the row back, and two classes beat .ah-page whatever
+   order the chunk stylesheets load in. */
+.ah-page.acct-page, .ah-page.ai-page, .ah-page.cv, .ah-page.home, .ah-page.hub, .ah-page.ibx, .ah-page.parity-page, .ah-page.personal, .ah-page.planner, .ah-page.st { flex-direction: row; }
 
 /* ---------- primitives ---------- */
 .ah-label {

--- a/frontend/src/components/organisms/Shell/style.css
+++ b/frontend/src/components/organisms/Shell/style.css
@@ -2,6 +2,7 @@
     width: var(--rail-w);
     flex: none;
     height: 100dvh;
+    box-sizing: border-box;
     background: var(--rail);
     color: var(--rail-ink);
     display: flex;

--- a/frontend/src/components/organisms/Tour/TourComponet.vue
+++ b/frontend/src/components/organisms/Tour/TourComponet.vue
@@ -41,6 +41,9 @@ import { SAMPLE_PROJECT_NAME } from "@/components/organisms/CreateProject/templa
 const SHELL_TOUR_KEY = "isShellTour";
 const LEGACY_SHELL_KEYS = ["isProjectAndNavbarTour", "isProjectLeftViewTour", "isProjectViewTour"];
 const STEP_STORAGE = "ah.tour.step";
+// Skip means "not now": the tour stops offering itself on every reload, but the
+// Getting-started card can still start it.
+const SKIP_STORAGE = "ah.tour.skipped";
 const DISMISS_STORAGE = "ah.gs.dismissed";
 
 const { t } = useI18n();
@@ -131,7 +134,7 @@ const renderStepHeader = (popover, { state }) => {
     skip.type = "button";
     skip.className = "ah-tour__skip";
     skip.textContent = t("AuthV2.tour_skip");
-    skip.addEventListener("click", () => { pauseShellTour(); driverObj?.destroy(); });
+    skip.addEventListener("click", () => { pauseShellTour(); localStorage.setItem(SKIP_STORAGE, "1"); driverObj?.destroy(); });
     const meta = document.createElement("span");
     meta.className = "ah-tour__meta";
     meta.textContent = t("AuthV2.tour_meta", { n: STEPS.length, s: 40 });
@@ -168,7 +171,7 @@ const startShellTour = () => {
 const shellTourOffered = ref(false);
 const handleTour = (key) => {
     if (LEGACY_SHELL_KEYS.includes(key)) {
-        if (shellTourDone.value || shellTourOffered.value || savedStep() > 0 || !isOwnerOrAdmin.value || clientWidth.value <= 1024) return;
+        if (shellTourDone.value || shellTourOffered.value || savedStep() > 0 || localStorage.getItem(SKIP_STORAGE) === "1" || !isOwnerOrAdmin.value || clientWidth.value <= 1024) return;
         shellTourOffered.value = true;
         setTimeout(startShellTour, 400);
         return;

--- a/frontend/src/components/organisms/Tour/helper.js
+++ b/frontend/src/components/organisms/Tour/helper.js
@@ -27,6 +27,8 @@ export function tourHepler() {
     const mainTour = inject("$mainTour");
     const {projects} = useProjectsHelper();
     
+    // Close, Esc and the overlay must end the tour on every step, not only the last one;
+    // a popover that ignores its own close button reads as broken.
     const handleTours = (tNum = 0) => {
 
         // startProjectTour()
@@ -61,10 +63,8 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('isTaskTour',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('isTaskTour',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        closeTaskButtonClick()
-                        driverObj.destroy();
-                    }
+                    closeTaskButtonClick()
+                    driverObj.destroy();
                 },
             }
         } else if(tNum === "isProjectAndNavbarTour") {
@@ -87,10 +87,8 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        updateTourStatusInUser('isProjectAndNavbarTour');
-                        driverObj.destroy();
-                    }
+                    updateTourStatusInUser('isProjectAndNavbarTour');
+                    driverObj.destroy();
                 },
             }
         } else if (tNum === "isProjectTour") {
@@ -113,9 +111,7 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('createproject',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('createproject',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        driverObj.destroy();
-                    }
+                    driverObj.destroy();
                 },
             }
         } else if (tNum === 'isProjectTour1') {
@@ -138,9 +134,7 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('createprojectform',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('createprojectform',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        driverObj.destroy();
-                    }
+                    driverObj.destroy();
                 },
             }
         } else if (tNum === 'isProjectTour2') {
@@ -163,9 +157,7 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('createprojecttasktype',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('createprojecttasktype',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        driverObj.destroy();
-                    }
+                    driverObj.destroy();
                 },
             }
         } else if (tNum === 'isProjectTour3') {
@@ -188,9 +180,7 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('createprojectstepbtn',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('createprojectstepbtn',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        driverObj.destroy();
-                    }
+                    driverObj.destroy();
                 },
             }
         } else if(tNum === 'isProjectViewTour') {
@@ -213,10 +203,8 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('projectview',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('projectview',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        updateTourStatusInUser('isProjectViewTour');
-                        driverObj.destroy();
-                    }
+                    updateTourStatusInUser('isProjectViewTour');
+                    driverObj.destroy();
                 },
             }
         } else if(tNum === 'isProjectLeftViewTour') {
@@ -245,10 +233,8 @@ export function tourHepler() {
                 onNextClick: (element, step, options) => onNextClickHandler('projectlistleft',element, step, options),
                 onPrevClick: (element, step, options) => onPrevClickHanler('projectlistleft',element, step, options),
                 onDestroyStarted: () => {
-                    if (!driverObj.hasNextStep()) {
-                        updateTourStatusInUser('isProjectLeftViewTour');
-                        driverObj.destroy();
-                    }
+                    updateTourStatusInUser('isProjectLeftViewTour');
+                    driverObj.destroy();
                 },
             }
         }

--- a/frontend/src/plugins/dashboard/router.js
+++ b/frontend/src/plugins/dashboard/router.js
@@ -5,6 +5,12 @@ const dashboardRouter = [{
     meta: {
         title: 'Home',
         requiresAuth: true,
+    },
+    // "/" is the legacy card dashboard. A signed-in user with a workspace
+    // should land on Home; the cards live under /:cid/dashboards now.
+    beforeEnter: (to) => {
+        const cid = localStorage.getItem('selectedCompany');
+        return cid ? { name: 'Home', params: { cid }, query: to.query } : true;
     }
 },
 {

--- a/frontend/src/views/Ai/style.css
+++ b/frontend/src/views/Ai/style.css
@@ -2,6 +2,7 @@
 .ai-page__main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .ai-page__body { flex: 1; min-height: 0; overflow: auto; padding: 20px 24px; }
 
+
 .ai-side {
     width: var(--sidebar-w-narrow);
     flex: none;
@@ -82,8 +83,16 @@
 .ai-done__n { font: var(--text-display); color: var(--ink); }
 
 @media (max-width: 1280px) {
-    .ai-side { display: none; }
+    /* Icon rail rather than gone: Inbox, Teammates, Pipeline and Audit have no other
+       entry point at this width. Below 768 the tab bar and More menu take over. */
+    .ai-side { width: 56px; padding: 14px 6px 10px; align-items: center; }
+    .ai-side__head span, .ai-side__usage, .ai-side__item > span:not(.ai-side__count) { display: none; }
+    .ai-side__item { width: 40px; height: 40px; padding: 0; justify-content: center; position: relative; }
+    .ai-side__count { position: absolute; top: 2px; right: 2px; margin: 0; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 8px; background: var(--brand); color: #fff; font-size: 10px; line-height: 16px; text-align: center; }
     .ai-inbox { grid-template-columns: 300px 1fr; }
+}
+@media (max-width: 767px) {
+    .ai-side { display: none; }
 }
 @media (max-width: 900px) {
     .ai-inbox { grid-template-columns: 1fr; }

--- a/frontend/src/views/Billing/BillingContract.vue
+++ b/frontend/src/views/Billing/BillingContract.vue
@@ -49,7 +49,7 @@
                             <div class="billing__ms-meta" :title="m.scope === 'explicit' ? $t('BillingV2.scope_explicit') : $t('BillingV2.scope_window')">
                                 {{ metaFor(m) }}
                             </div>
-                            <div v-if="m.percentBp !== null && m.percentBp > 0 && m.percentBp < 10000" class="billing__bar">
+                            <div v-if="m.percentBp !== null && m.percentBp > 0 && m.percentBp < 10000" class="billing__progress">
                                 <span :style="{ width: `${percentFromBp(m.percentBp)}%` }"></span>
                             </div>
                         </div>

--- a/frontend/src/views/Billing/style.css
+++ b/frontend/src/views/Billing/style.css
@@ -65,8 +65,9 @@
 .billing__ms-name { font-weight: 600; }
 .billing__row--data.is-muted .billing__ms-name { color: var(--ink-label); }
 .billing__ms-meta { font-size: 11.5px; color: var(--ink-label); margin-top: 1px; }
-.billing__bar { height: 5px; border-radius: 99px; background: var(--surface-hover); margin-top: 6px; max-width: 220px; overflow: hidden; }
-.billing__bar span { display: block; height: 100%; border-radius: 99px; background: var(--brand); }
+/* Was .billing__bar, which is also the toolbar's class; this rule turned the toolbar into a 5px, 220px box. */
+.billing__progress { height: 5px; border-radius: 99px; background: var(--surface-hover); margin-top: 6px; max-width: 220px; overflow: hidden; }
+.billing__progress span { display: block; height: 100%; border-radius: 99px; background: var(--brand); }
 .billing__cell-due { color: var(--ink-label); font-size: 11px; }
 .billing__cell-amount { font: 600 12px/1.2 var(--font-mono); }
 .billing__cell-signoff { font-size: 11.5px; color: var(--ink-label); }

--- a/frontend/src/views/Billing/style.css
+++ b/frontend/src/views/Billing/style.css
@@ -34,6 +34,9 @@
     padding: 20px 24px; display: flex; flex-direction: column; gap: 12px;
     border-right: 1px solid var(--hairline);
 }
+/* The column scrolls; its cards keep their natural height. Without this the empty
+   milestone table shrank to 17px and clipped its own header. */
+.billing__main > * { flex: none; }
 .billing__body--wide .billing__main { border-right: 0; }
 
 /* ---------- billing mode cards (19a) ---------- */

--- a/frontend/src/views/Chat/style.css
+++ b/frontend/src/views/Chat/style.css
@@ -1,5 +1,6 @@
 .cv {
     display: flex;
+    flex-direction: row;
     height: 100%;
     min-height: 0;
     background: var(--surface);

--- a/frontend/src/views/Pages/PagesSpace.vue
+++ b/frontend/src/views/Pages/PagesSpace.vue
@@ -498,7 +498,10 @@ const WikiTable = defineComponent({
 });
 </script>
 
-<style scoped>
+<style>
+/* Not scoped on purpose: DocCard, DocList, AgentList and WikiTable are render-function
+   components defined in this file, and scoped rules never reach their elements. Every
+   selector here is hub__-prefixed, so nothing leaks. */
 .hub {
     display: flex; height: 100%; min-height: 0;
     background: var(--canvas); color: var(--ink); font-family: var(--font-ui);

--- a/frontend/src/views/PersonalList/PersonalList.vue
+++ b/frontend/src/views/PersonalList/PersonalList.vue
@@ -68,7 +68,7 @@
                             <span class="personal__mono" :class="{ 'personal__mono--faint': !loggedTime(task) }">{{ loggedTime(task) || '—' }}</span>
                         </div>
                         <div v-if="!visibleTasks.length" class="personal__empty">{{ $t('HomeV2.personal_empty') }}</div>
-                        <button type="button" class="personal__new" @click="focusAdd">
+                        <button v-if="visibleTasks.length" type="button" class="personal__new" @click="focusAdd">
                             <span class="hc-add__plus">+</span><span>{{ $t('HomeV2.new_task_row') }}</span>
                         </button>
                     </div>

--- a/frontend/src/views/Projects/Comments/Comments.vue
+++ b/frontend/src/views/Projects/Comments/Comments.vue
@@ -562,9 +562,10 @@ async function initialize() {
     }
 
 
-    // AUTO FOCUS TEXTBOX
+    // Keyboard-ready without moving the page: a plain focus() scrolls the task
+    // overlay down to the composer, past the title and description.
     nextTick(() => {
-        document.getElementById("message-box")?.focus();
+        document.getElementById("message-box")?.focus({ preventScroll: true });
     })
 
     // ASSIGN PATHS

--- a/frontend/src/views/Projects/Kanban/BoardViewDisplayCardComponent.vue
+++ b/frontend/src/views/Projects/Kanban/BoardViewDisplayCardComponent.vue
@@ -1,30 +1,25 @@
 <template>
     <div class="kanban-card-wrapper">
-        <!-- Multi-select checkbox: top-left of card. Visible on card hover OR when this card is selected. -->
-        <label
-            v-if="canCardMultiSelect"
-            class="kanban-card-multi-select"
-            :class="{ 'kanban-card-multi-select--active': isCardSelected }"
-            @click.stop
-            @mousedown.stop
-        >
-            <input
-                type="checkbox"
-                :checked="isCardSelected"
-                @click.stop
-                @mousedown.stop
-                @change="handleCardCheckboxChange($event)"
-                aria-label="Select task"
-            />
-        </label>
         <div @click.stop.prevent="!showArchiveVar ? toggleTaskDetail(element) : ''">
             <div>
                 <div class="d-flex justify-content-between">
                     <div class="d-flex align-items-center mw-82">
-                        <!-- Task type removed from the Kanban card. This spacer keeps the
-                             top-left slot for the absolute multi-select checkbox so the
-                             title never sits underneath it. -->
-                        <span class="kanban-card-checkbox-space" aria-hidden="true"></span>
+                        <label
+                            v-if="canCardMultiSelect"
+                            class="kanban-card-multi-select"
+                            :class="{ 'kanban-card-multi-select--active': isCardSelected }"
+                            @click.stop
+                            @mousedown.stop
+                        >
+                            <input
+                                type="checkbox"
+                                :checked="isCardSelected"
+                                @click.stop
+                                @mousedown.stop
+                                @change="handleCardCheckboxChange($event)"
+                                aria-label="Select task"
+                            />
+                        </label>
                         <div class="list-group-kanban-item__taskName text-ellipsis font-weight-500 font-size-14 ml-5px black" :title="element.TaskName">
                             <img v-if="element.deletedStatusKey === 2" :src="inventoryIcon" alt="inventory" class="ml-5px" />
                             <img v-if="element.deletedStatusKey === 1" :src="deleteIcon" alt="delete" class="ml-5px" />

--- a/frontend/src/views/Projects/Kanban/new-style.css
+++ b/frontend/src/views/Projects/Kanban/new-style.css
@@ -12,13 +12,12 @@
     color: var(--ink);
 }
 
-/* Card-level multi-select checkbox: top-left corner — always visible. */
+/* Multi-select checkbox sits in the title row. It was absolutely positioned
+   against whichever ancestor happened to be positioned, and landed on the title. */
 .kanban-card-wrapper { position: relative; }
 .kanban-card-multi-select {
-    position: absolute;
-    top: 8px;
-    left: 8px;
-    z-index: 5;
+    flex: 0 0 auto;
+    margin-right: 6px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -33,13 +32,6 @@
     cursor: pointer;
     accent-color: var(--brand);
     margin: 0;
-}
-/* Leading spacer where the task-type icon used to be: reserves the top-left
-   corner for the absolute multi-select checkbox so the card title stays clear. */
-.kanban-card-checkbox-space {
-    display: inline-block;
-    flex: 0 0 auto;
-    width: 18px;
 }
 
 .kanban-board .kanban-column {

--- a/frontend/src/views/Projects/ListView/ListRow.vue
+++ b/frontend/src/views/Projects/ListView/ListRow.vue
@@ -56,7 +56,7 @@
             <span v-if="!isSub && data.Task_Priority" class="lv2__prio" :class="priorityClass">{{ $t(priority.label) }}</span>
         </span>
 
-        <span class="lv2__est">{{ estimate }}</span>
+        <span class="lv2__est lv2__c-est">{{ estimate }}</span>
 
         <span class="lv2__c-risk">
             <span v-if="!isSub && risk.score" class="lv2__risk" :class="`lv2__risk--${risk.level}`" :title="riskTitle">

--- a/frontend/src/views/Projects/ListView/ListView.vue
+++ b/frontend/src/views/Projects/ListView/ListView.vue
@@ -47,8 +47,8 @@
                         <span class="lv2__c-assignee">{{ $t('ListV2.col_assignee') }}</span>
                         <span class="lv2__c-due">{{ $t('ListV2.col_due') }}</span>
                         <span class="lv2__c-prio">{{ $t('ListV2.col_priority') }}</span>
-                        <span>{{ $t('ListV2.col_est') }}</span>
-                        <span>✦ {{ $t('ListV2.col_risk') }}</span>
+                        <span class="lv2__c-est">{{ $t('ListV2.col_est') }}</span>
+                        <span class="lv2__c-risk">✦ {{ $t('ListV2.col_risk') }}</span>
                         <span class="lv2__c-done">{{ $t('ProvenanceV2.col_done_by') }}</span>
                     </div>
 

--- a/frontend/src/views/Projects/ListView/style.css
+++ b/frontend/src/views/Projects/ListView/style.css
@@ -209,3 +209,9 @@
     .lv2 { --lv2-cols: 28px minmax(0, 1fr) 90px 100px 80px 70px 60px; }
     .lv2__c-done { display: none; }
 }
+/* Tablet: the name column was 186px while Est and the custom-field slot kept 130px
+   of mostly empty space. Drop them here; they are one tap away in the row. */
+@media (max-width: 1024px) {
+    .lv2 { --lv2-cols: 28px minmax(0, 1fr) 90px 100px 80px; }
+    .lv2__c-est, .lv2__c-risk { display: none; }
+}

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -960,7 +960,10 @@ watch([() => getters['projectData/projects'], showArchivedProjects, route, filte
 }, { deep: true });
 
 onMounted(() => {
-    if (clientWidth.value <= 1300) {
+    // Under 1300px the project list is a drawer. It used to open on every load so
+    // a user could pick a project; now that the route already names one, an open
+    // drawer just dims the view the user asked for.
+    if (clientWidth.value <= 1300 && !route.params.id) {
         visible.value = true;
         projectList.value.toggleSidebar(true);
     }

--- a/frontend/src/views/Projects/ProjectsListing/ProjectListing.vue
+++ b/frontend/src/views/Projects/ProjectsListing/ProjectListing.vue
@@ -27,7 +27,7 @@
         @update:search="handleSearchUpdate"
         @updateSearchProject="handleSearchUpdateProject"
     />
-    <Sidebar v-else v-model:visible="visible" className="z-index-6" title="Projects" :left="true" width="400px" :unMount="false" :hide-header="true">
+    <Sidebar v-else v-model:visible="visible" className="z-index-6" title="Projects" :left="true" width="400px" :unMount="false" :hide-header="true" :closeOnBackDrop="true">
         <template #body>
             <ProjectListComponent
                 :loadedProjects="loadedProjects"

--- a/tests/personal-list-views.test.js
+++ b/tests/personal-list-views.test.js
@@ -1,0 +1,39 @@
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
+jest.mock('../createProject/controller', () => ({ createProject: jest.fn() }), { virtual: true });
+jest.mock('../Modules/createProject/controller', () => ({ createProject: jest.fn() }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { personalViews } = require('../Modules/PersonalList/controller');
+
+const catalogue = [
+    { _id: { toString: () => 'id-list' }, keyName: 'ProjectListView' },
+    { _id: 'id-gantt', keyName: 'GanttView' },
+    { _id: 'id-board', keyName: 'ProjectKanban' },
+    { _id: 'id-cal', keyName: 'Calendar' },
+];
+
+describe('Personal List — the project it creates must satisfy the schema', () => {
+    beforeEach(() => MongoDbCrudOpration.mockReset());
+
+    it('picks List, Board and Calendar from the company catalogue, ids as strings, List default', async () => {
+        MongoDbCrudOpration.mockResolvedValueOnce(catalogue);
+        const v = await personalViews('cid');
+        expect(v.ProjectRequiredDefaultComponent).toBe('ProjectListView');
+        expect(v.ProjectRequiredComponent.map((x) => x._id)).toEqual(['id-list', 'id-board', 'id-cal']);
+        expect(v.ProjectRequiredComponent.every((x) => typeof x._id === 'string' && x.viewStatus === true)).toBe(true);
+        expect(v.ProjectRequiredComponent.filter((x) => x.setAsDefault).map((x) => x._id)).toEqual(['id-list']);
+    });
+
+    it('falls back to the first catalogue view when none of the wanted ones exist', async () => {
+        MongoDbCrudOpration.mockResolvedValueOnce([{ _id: 'only', keyName: 'Workload' }]);
+        const v = await personalViews('cid');
+        expect(v.ProjectRequiredDefaultComponent).toBe('Workload');
+        expect(v.ProjectRequiredComponent).toEqual([{ _id: 'only', viewStatus: true, setAsDefault: true }]);
+    });
+
+    it('refuses to create a project with no views at all, which the schema would reject anyway', async () => {
+        MongoDbCrudOpration.mockResolvedValueOnce([]);
+        await expect(personalViews('cid')).rejects.toThrow(/no project views/);
+    });
+});

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -2059,6 +2059,17 @@ const schema = {
             type: String,
             required: true
         },
+        // Personal List (Modules/PersonalList). Without these the flag was stripped on
+        // save, the list was never found again and a fresh "Personal" project was
+        // created on every visit — and shown in the team's project list.
+        isPersonal: {
+            type: Boolean,
+            default: false
+        },
+        personalOwner: {
+            type: String,
+            default: ""
+        },
         ProjectType: {
             type: String,
             required: true


### PR DESCRIPTION
## Summary
Follow-up to #525 on the same branch. Found by running the redesign from inside AlianHub and by a screenshot sweep at 1100/1440/800px.

- **Layout regression (mine):** `.ah-page { flex-direction: column }` stacked every sidebar page vertically; at 1440 Home and Planner content measured 0px. Row restored for the nine sidebar roots.
- **Tour popup ignored Skip** on all but the last step; Skip is also remembered now.
- New shell never loaded projects; root URL showed the legacy dashboard; Personal List could not be created (schema lacked its fields).
- Docs rows unstyled, rail clipping the avatar, AI sidebar unreachable under 1280px, project drawer opening over the selected project, board card checkbox over the title, task overlay opening scrolled past the title, Billing toolbar boxed by a duplicate class, tablet list columns.
- `task.create` over MCP (audited, opening status only, undoable) and an SPA fallback for non-hash deep links.

Board: AR-27..AR-37 filed through `task.create`, all In Review. Suite: 1121 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)