### PR TITLE
fix(mobile): show the Planner tray and size the Board add glyph at 375px

### DIFF
--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -106,3 +106,9 @@ the filesystem: 111 built, 0 in flight, 0 not started (2 cut, 15 with no screen)
 frozen before wave 2 landed. The one real gap it exposed: the four-step import wizard existed but the
 project List toolbar still opened the legacy modal, so nobody could reach it. Toolbar wired to the
 wizard, legacy modal deleted, verified from the List (AR-38, In Review).
+
+Mobile pass at 375×812 (the stage-2 criterion nobody had ticked): Home checklist card ~500px tall
+(AR-39), Planner's unscheduled tray collapsed to 1px and then rendered empty because the ≤1280 rule
+that hides the desktop tray also hid it inside the sheet, Board column "+" stretched to 44px by the
+generic tap-target rule (AR-40). All fixed and measured. Still legacy at 375: the project header/list
+toolbar (search overflows, duplicate ••• menus).

--- a/frontend/src/views/Planner/style.css
+++ b/frontend/src/views/Planner/style.css
@@ -207,7 +207,9 @@
     }
     .planner__day.is-active { background: var(--brand-tint); color: var(--brand); font-weight: 700; }
 
-    .planner__grid-wrap { flex: 1; border-right: 0; }
+    /* min-height: 0 lets the hour grid shrink; without it the grid keeps its content
+       height and pushes the tray under the tab bar. */
+    .planner__grid-wrap { flex: 1; min-height: 0; border-right: 0; }
     /* The column template is set inline from the day count; only the desktop
        minimum has to go so one day fits a 375px screen. */
     .planner__grid { min-width: 0; }
@@ -218,11 +220,16 @@
     .planner__sheet {
         display: flex;
         flex-direction: column;
+        /* The hour grid above is flex: 1 and content-tall; without a floor the tray
+           shrank to 1px with its cards inside. */
+        flex: none;
+        min-height: 168px;
         max-height: 45vh;
         border-top: 1px solid var(--hairline);
         background: var(--surface);
     }
-    .planner__sheet .planner__tray { min-height: 0; }
+    /* The <=1280 rule hides the desktop tray; inside the sheet it must show. */
+    .planner__sheet .planner__tray { display: flex; min-height: 0; }
     .planner__sheet .planner__card { min-height: 44px; justify-content: center; }
     .planner__pick {
         display: flex;

--- a/frontend/src/views/Projects/Kanban/new-style.css
+++ b/frontend/src/views/Projects/Kanban/new-style.css
@@ -374,3 +374,9 @@
     border: 1.5px solid var(--surface);
     z-index: 2;
 }
+
+/* 375px: a generic 44px tap-target rule stretched the 13x12 plus glyph to 44px tall.
+   Keep the target, shrink the glyph: padding makes up the difference. */
+@media (max-width: 767px) {
+    .kanban-board .add-task-icon { width: 14px; height: 14px; min-width: 0; min-height: 0; padding: 15px; box-sizing: content-box; object-fit: contain; }
+}


### PR DESCRIPTION
## Summary
Mobile pass at 375px. Planner's unscheduled tray collapsed to 1px and then rendered empty (the ≤1280 desktop-tray rule also hid it inside the mobile sheet); the Board column "+" was stretched to 44px by the tap-target rule. Both fixed and measured. Board: AR-40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)