### PR TITLE
feat(project): re-skin the filters toolbar on the tokens

### DIFF
--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -112,3 +112,11 @@ Mobile pass at 375×812 (the stage-2 criterion nobody had ticked): Home checklis
 that hides the desktop tray also hid it inside the sheet, Board column "+" stretched to 44px by the
 generic tap-target rule (AR-40). All fixed and measured. Still legacy at 375: the project header/list
 toolbar (search overflows, duplicate ••• menus).
+
+### 2026-09-04 (AR-41: the last legacy surface)
+The project header was already on the tokens via ProjectHeader; the filters row under it was not.
+Re-skinned under a `pft` root with its own stylesheet, every control/ref/tour anchor/emit kept. One
+row from 1024px (search shrinks first), icon-collapse search under 800px, phone rows of 40px pills.
+Found on the way: the tablet List column rule (mine, yesterday) was declared after the phone rule and
+won, so at 375px the name column was 0px wide — restored. Left cosmetic: the Group-by pill's legacy
+inner box adds 2px at phone width.

--- a/frontend/src/views/Projects/ListView/style.css
+++ b/frontend/src/views/Projects/ListView/style.css
@@ -215,3 +215,8 @@
     .lv2 { --lv2-cols: 28px minmax(0, 1fr) 90px 100px 80px; }
     .lv2__c-est, .lv2__c-risk { display: none; }
 }
+
+/* Declared last so it wins over the tablet rule above: at phone width the name keeps the row. */
+@media (max-width: 767px) {
+    .lv2 { --lv2-cols: 28px minmax(0, 1fr) 60px 56px; }
+}

--- a/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
+++ b/frontend/src/views/Projects/components/ProjectFiltersToolbar.vue
@@ -1,14 +1,17 @@
 <template>
-    <div class="task-assigneesearch-groupbywrapper" :class="{'overflow-auto' : clientWidth <=767}">
+    <div class="task-assigneesearch-groupbywrapper pft" :class="{ 'pft--search-open': searchOpen }">
         <div class="d-flex align-items-center justify-content-between flex-wrap task-filtersearchassignee-wrapper" :class="{'w-545' : clientWidth <=767 }" v-if="['ProjectListView', 'Calendar', 'ProjectKanban','TableView'].includes(activeTab)">
-            <div class="d-flex align-items-center justify-content-start task-filtersearch" :class="[{ 'mb-10px': clientWidth <= 767 }]" :style="{width: (clientWidth <= 767 ? '100%' : '')}" v-if="!showArchived">
+            <div class="d-flex align-items-center justify-content-start task-filtersearch" :class="[{ 'mb-10px': clientWidth <= 767 }]" v-if="!showArchived">
                 <TaskFilter :projectData="projectData" @apply="(q) => $emit('applyFilter', q)" @clear="$emit('clearFilter')" v-if="Object.keys(projectData).length > 0"/>
-                <div class="position-re task-fitler-search" id="projectviewfiltersearch_driver">
+                <button type="button" class="pft__search-toggle" :aria-label="$t('PlaceHolder.search')" @click="searchOpen = !searchOpen">
+                    <ShellIcon name="search" :size="15" />
+                </button>
+                <div class="position-re task-fitler-search pft__search" id="projectviewfiltersearch_driver">
+                    <ShellIcon name="search" :size="14" class="pft__search-icon" />
                     <input
                         type="text"
                         :placeHolder="$t('PlaceHolder.search')"
-                        class="form-control"
-                        :style="{width: (clientWidth > 767 ? '260px' : '90%')}"
+                        class="form-control pft__input"
                         :value="taskSearch"
                         @input="$emit('update:taskSearch', $event.target.value)"
                     >
@@ -72,8 +75,8 @@
                         <template #button>
                             <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="group_by_status" @click="currentActive='group'">
                                 <div class="group-by-dropdown" :class="{'active' : clientWidth <= 767 && currentActive == 'group' }">
-                                    <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.group_by') }} : </strong>
-                                    <span :style="{color: (clientWidth <= 767 ? '#535358' : '#818181')}" :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}">{{ $t(`Projects.${groupByOptions.find(x => x.id === groupBy).label}`) }}</span>
+                                    <strong :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.group_by') }} : </strong>
+                                    <span :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}">{{ $t(`Projects.${groupByOptions.find(x => x.id === groupBy).label}`) }}</span>
                                 </div>
                             </button>
                         </template>
@@ -90,8 +93,8 @@
                         <template #button>
                             <button class="text-nowrap btn-white border-groupBy border-radius-6-px cursor-pointer" ref="expand_collapse" @click="currentActive='subtask'">
                                 <div class="group-by-dropdown current__dropdown" :class="{'active' : clientWidth <= 767 && currentActive == 'subtask' }">
-                                    <strong :style="{color: (clientWidth <= 767 ? '#535358' : '#000')}" :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.subtask') }}: </strong>
-                                    <span :style="{color: (clientWidth <= 767 ? '#535358' : '#818181')}" :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}"> {{collapsed ? $t('Projects.collapsed') : $t('Projects.expanded')}}</span>
+                                    <strong :class="{'font-size-12 font-weight-500' : clientWidth > 767 , 'font-size-14 font-weight-400' : clientWidth <=767}">{{ $t('Projects.subtask') }}: </strong>
+                                    <span :class="{'font-size-12' : clientWidth > 767 , 'font-size-14' : clientWidth <=767}"> {{collapsed ? $t('Projects.collapsed') : $t('Projects.expanded')}}</span>
                                 </div>
                             </button>
                         </template>
@@ -199,7 +202,7 @@
                         </div>
                     </div>
                 </template>
-                <button class="archived-btn font-weight-400 d-flex align-items-center justify-content-between" :style="{color: (clientWidth <= 767 ? '#535358' : '')}" :class="{'outline-primary show-archived-active': showArchived, 'outline-secondary': !showArchived, 'border-radius-6-px font-size-14' : clientWidth <=767 , 'border-0 font-size-13' : clientWidth > 767 }">
+                <button class="archived-btn font-weight-400 d-flex align-items-center justify-content-between" :class="{'outline-primary show-archived-active': showArchived, 'outline-secondary': !showArchived, 'border-radius-6-px font-size-14' : clientWidth <=767 , 'border-0 font-size-13' : clientWidth > 767 }">
                     <template v-if="showArchived">
                         <span class="font-weight-bold font-size-16 dark-gray">{{ $t('ProjectSlider.archived_list') }}</span>
                         <span v-if="!showArchivedProjects" @click="$emit('update:showArchived', false)">{{ $t('ProjectSlider.hide_archive') }}</span>
@@ -258,6 +261,7 @@
 
 <script setup>
 import { ref, computed, defineProps, defineEmits } from 'vue';
+import ShellIcon from '@/components/organisms/Shell/ShellIcon.vue';
 import { useRoute } from 'vue-router';
 import DropDown from '@/components/molecules/DropDown/DropDown.vue';
 import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue';
@@ -324,6 +328,7 @@ const props = defineProps({
 });
 
 const route = useRoute();
+const searchOpen = ref(false);
 // The wizard files rows into one sprint: the one in the route, else the project's first.
 // 22b's "into Mobile App v2" headline reads from this.
 const importSprint = computed(() => {
@@ -373,6 +378,9 @@ const activeGroupIcon = require('@/assets/images/peopleBlue.png');
 const groupIcon = require('@/assets/images/peopleGray.png');
 </script>
 
+<style>
+@import "./project-filters.css";
+</style>
 <style scoped>
 /* Tighten the gaps between the desktop action buttons so the row is less
    crowded — the global .mr-1 gap is 16px (1rem); 8px reads better. This is

--- a/frontend/src/views/Projects/components/project-filters.css
+++ b/frontend/src/views/Projects/components/project-filters.css
@@ -1,0 +1,109 @@
+/* Project filters row (handoff 14a / 10b second row). Re-skins the legacy toolbar
+   onto the tokens without touching its controls, refs, ids or emits. */
+.pft {
+    background: var(--surface);
+    border-bottom: 1px solid var(--hairline);
+    padding: 6px 20px;
+    font: var(--text-small);
+    color: var(--ink);
+}
+.pft.overflow-auto { overflow: visible; }
+.pft .task-filtersearchassignee-wrapper { gap: 8px 10px; }
+/* Legacy CSS gives both groups fixed widths; on the tokens they size to content and the
+   controls take whatever is left, wrapping inside their own group when they must. */
+.pft .task-filtersearch { width: auto !important; flex: 0 0 auto; }
+.pft .task-filter-assignee { width: auto !important; flex: 1 1 auto; min-width: 0; justify-content: flex-end; flex-wrap: wrap; overflow: visible; }
+@media (min-width: 1024px) {
+    .pft .task-filtersearchassignee-wrapper { flex-wrap: nowrap; }
+}
+/* The legacy inner box drew its own frame inside the pill. */
+.pft .group-by-dropdown { border: 0 !important; padding: 0 !important; background: transparent !important; }
+.pft .task-filtersearchassignee-wrapper.w-545 { width: auto; }
+.pft .task-filtersearch { gap: 8px; min-width: 0; }
+.pft .task-filtersearch.mb-10px { margin-bottom: 0 !important; }
+.pft .task-filter-assignee { gap: 6px; flex-wrap: wrap; row-gap: 6px; }
+
+/* search */
+.pft__search-toggle { display: none; }
+.pft__search { display: flex; align-items: center; width: 260px; max-width: 100%; }
+.pft__search-icon { position: absolute; left: 10px; color: var(--ink-3); pointer-events: none; }
+.pft .pft__input.form-control {
+    height: 32px; width: 100%; padding: 0 30px 0 30px;
+    border: 1px solid var(--hairline); border-radius: 8px;
+    background: var(--surface); color: var(--ink); font: var(--text-small);
+    box-shadow: none;
+}
+.pft .pft__input.form-control:focus { border-color: var(--brand); box-shadow: 0 0 0 3px var(--brand-ring); outline: 0; }
+.pft .pft__input.form-control::placeholder { color: var(--ink-3); }
+.pft .task-fitler-search .dropdown-image-horizontal { right: 6px; }
+
+/* pill buttons: group by, subtask, more, calendar */
+.pft .border-groupBy,
+.pft .assignee-filter.manage__filter-users {
+    height: 32px; border: 1px solid var(--hairline) !important; border-radius: 8px !important;
+    background: var(--surface); color: var(--ink);
+}
+.pft .border-groupBy.btn-white { padding: 0 10px; font: var(--text-small); }
+.pft .border-groupBy.btn-white:hover, .pft .assignee-filter.manage__filter-users:hover { background: var(--surface-hover); }
+.pft .group-by-dropdown strong { color: var(--ink); font-weight: 600; font-size: 12.5px; }
+.pft .group-by-dropdown span { color: var(--ink-2); font-size: 12.5px; }
+.pft .group-by-dropdown.active { background: transparent; }
+.pft .assignee-filter .assignee-user, .pft .assignee-filter .assignee-status {
+    height: 30px; display: inline-flex; align-items: center; padding: 0 10px; color: var(--ink-2); font-size: 12.5px;
+}
+.pft .assignee-filter .assignee-user.bg-white, .pft .assignee-filter .assignee-status.bg-white { background: var(--brand-tint) !important; color: var(--brand); }
+.pft .assignee-filter .assignee-user { border-right: 1px solid var(--hairline); }
+
+/* AI + archive */
+.pft .ai_button {
+    height: 32px; padding: 0 12px; border-radius: 8px;
+    border: 1px solid rgba(47, 57, 144, .35); background: var(--surface); color: var(--brand);
+    font: 600 12.5px/1 var(--font-ui);
+}
+.pft .ai_button:hover { background: var(--brand-tint); }
+.pft .ai_button img { filter: none; width: 14px; }
+.pft .archived-btn { height: 32px; padding: 0 10px; border: 0; border-radius: 8px; background: transparent; color: var(--ink-2); font: var(--text-small); }
+.pft .archived-btn:hover { background: var(--surface-hover); color: var(--ink); }
+.pft .archived-btn .dark-gray { color: var(--ink) !important; font-size: 13px !important; }
+
+/* calendar controls */
+.pft .calendar-button {
+    height: 32px; min-width: 32px; padding: 0 10px; border: 1px solid var(--hairline); border-radius: 8px;
+    background: var(--surface); color: var(--ink); font: var(--text-small);
+}
+.pft .calendar-button:hover { background: var(--surface-hover); }
+.pft .monthly-calendar-view { font: 600 12.5px/32px var(--font-ui); color: var(--ink); width: auto !important; padding: 0 6px; }
+
+@media (max-width: 1279px) {
+    .pft .task-filtersearch { flex: 1 1 auto; min-width: 0; }
+    .pft__search { width: auto; flex: 1 1 160px; min-width: 160px; max-width: 220px; }
+    .pft .task-filter-assignee { gap: 4px; flex: 0 0 auto; }
+    .pft .border-groupBy.btn-white { padding: 0 8px; }
+}
+
+/* narrow: search collapses to an icon and expands inline; nothing overflows */
+@media (max-width: 800px) {
+    .pft { padding: 6px 14px; }
+    .pft__search-toggle {
+        display: inline-flex; align-items: center; justify-content: center;
+        width: 32px; height: 32px; border: 1px solid var(--hairline); border-radius: 8px;
+        background: var(--surface); color: var(--ink-2); cursor: pointer; flex: none;
+    }
+    .pft__search { display: none; }
+    .pft--search-open .pft__search { display: flex; width: 100%; flex: 1 1 100%; order: 9; }
+    .pft--search-open .pft__search-toggle { color: var(--brand); border-color: var(--brand); }
+    .pft .task-filtersearch { flex-wrap: wrap; }
+}
+@media (max-width: 767px) {
+    /* Left-aligned rows of equal-height pills; the search group takes its own row. */
+    /* !important on purpose: legacy utility classes (w-545, justify-content-between, btn-white)
+       sit on the same elements with the same specificity. */
+    .pft .task-filtersearchassignee-wrapper { flex-wrap: wrap !important; justify-content: flex-start !important; width: 100% !important; }
+    .pft .task-filtersearch { flex: 0 0 100% !important; width: 100% !important; justify-content: flex-start !important; }
+    .pft .task-filter-assignee { flex: 0 0 100% !important; width: 100% !important; justify-content: flex-start !important; gap: 6px; }
+    .pft .border-groupBy, .pft .ai_button, .pft .archived-btn, .pft .calendar-button, .pft__search-toggle,
+    .pft .assignee-filter.manage__filter-users, .pft .pft__input.form-control { min-height: 40px !important; height: 40px !important; line-height: 38px; }
+    .pft .assignee-filter .assignee-user, .pft .assignee-filter .assignee-status { height: 38px !important; }
+    .pft .border-groupBy.mr-1, .pft .ai_button.mr-1, .pft .assignee-filter.mr-1 { margin-right: 0 !important; }
+    .pft .archived-btn .text-nowrap { white-space: normal; }
+}


### PR DESCRIPTION
## Summary
The last legacy surface in the project views: the search/filter row under the project header. Re-skinned on the ah-* tokens with every control, ref, tour anchor and emit unchanged. One row from 1024px; search collapses to an icon under 800px; phone rows of 40px pills with no overflow. Also restores the List's name column at phone width (tablet rule had won over the phone rule). Board: AR-41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)