### PR TITLE
fix(timesheet): keep the empty-week message in view on phones

### DIFF
--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -120,3 +120,10 @@ row from 1024px (search shrinks first), icon-collapse search under 800px, phone 
 Found on the way: the tablet List column rule (mine, yesterday) was declared after the phone rule and
 won, so at 375px the name column was 0px wide — restored. Left cosmetic: the Group-by pill's legacy
 inner box adds 2px at phone width.
+
+### 2026-09-04 (AR-42: mobile pass 2)
+Task detail, Chat, AI Inbox, Approvals and Log time measured at 375×812. All clean except the
+timesheet, whose week grid scrolls sideways inside its card and took the empty-state message with
+it. Pinned with sticky — which needed the grid wrapper's overflow:hidden lifted on phones, or the
+grid, not the scroller, owns the sticky element. Task detail is full-width with the composer above
+the tab bar; only nits left (a legacy "Scroll to bottom" link, 26px tab chips on AI Inbox).

--- a/frontend/src/views/Timesheet/UserTimeSheet/UserTimesheet.vue
+++ b/frontend/src/views/Timesheet/UserTimeSheet/UserTimesheet.vue
@@ -406,5 +406,9 @@ onMounted(() => {
 @media (max-width: 767px) {
     .ut2-panel { width: 100%; }
     .ut2-row { grid-template-columns: minmax(160px, 1fr) repeat(var(--days), 56px) 64px; }
+    /* The week grid scrolls sideways inside its card; the empty-state text must not
+       scroll away with it. Sticky to the scroller's left edge, sized to the viewport. */
+    .ut2-grid { overflow: visible; } /* otherwise the grid, not the scroller, is the sticky container */
+    .ut2-empty { position: sticky; left: 0; max-width: calc(100vw - 92px); }
 }
 </style>


### PR DESCRIPTION
## Summary
Second 375px pass (task detail, Chat, AI Inbox, Approvals, Log time). One defect: the timesheet's week grid scrolls inside its card and clipped the empty-state message. Pinned sticky to the scroller. Board: AR-42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)