### PR TITLE
fix(agents): what running a real agent team on our own board exposed

### DIFF
--- a/Modules/Agents/actions.js
+++ b/Modules/Agents/actions.js
@@ -35,9 +35,13 @@ const workEntry = (actor, hours = 0) => {
     return { actorId: a.actorId, actorType: a.actorType, agentId: a.agentId, viaAccount: a.viaAccount || 'workspace', hours };
 };
 
-const context = (actor, action) => ({
-    ruleId: null, ruleName: attribution(actor).label, runId: actor.runId || null, action: `agent.${action}`, depth: 0,
-});
+const context = (actor, action) => {
+    const a = attribution(actor);
+    return {
+        ruleId: null, ruleName: a.label, runId: actor.runId || null, action: `agent.${action}`, depth: 0,
+        userId: String(actor.userId || a.actorId || ''), actorType: a.actorType, agentId: a.agentId || null, viaAccount: a.viaAccount || null,
+    };
+};
 
 const findRunningTimer = (companyId, taskId, userId) => MongoDbCrudOpration(companyId, {
     type: SCHEMA_TYPE.TIMESHEET,

--- a/Modules/Agents/controller.js
+++ b/Modules/Agents/controller.js
@@ -29,11 +29,26 @@ const humanActor = async (req) => {
 
 const privileged = async (companyId, uid) => isPrivileged(await getRoleType(companyId, uid));
 
+/* The wizard sends skills as objects; map(String) used to store "[object Object]"
+ * and every run of that agent then asked for a skill by that name. */
+const normaliseSkill = (skill) => {
+    if (!skill) return null;
+    if (typeof skill === 'string') return { key: skill.slice(0, 80), name: skill.slice(0, 80), enabled: true };
+    const key = String(skill.key || skill.slug || skill.name || '').slice(0, 80);
+    if (!key) return null;
+    return {
+        key,
+        name: String(skill.name || key).slice(0, 80),
+        enabled: skill.enabled !== false,
+        ...(Array.isArray(skill.actions) ? { actions: skill.actions.map(String).slice(0, 40) } : {}),
+    };
+};
+
 const agentPatchFields = (body) => {
     const set = {};
     if (body.name !== undefined) set.name = String(body.name).trim().slice(0, 80);
     if (body.description !== undefined) set.description = String(body.description).slice(0, 1000);
-    if (body.skills !== undefined && Array.isArray(body.skills)) set.skills = body.skills.map(String).slice(0, 20);
+    if (body.skills !== undefined && Array.isArray(body.skills)) set.skills = body.skills.slice(0, 20).map(normaliseSkill).filter(Boolean);
     if (body.allowedActions !== undefined && Array.isArray(body.allowedActions)) set.allowedActions = body.allowedActions.filter((a) => registry.has(a));
     if (body.projectIds !== undefined && Array.isArray(body.projectIds)) set.projectIds = body.projectIds.filter((id) => OBJECT_ID.test(String(id))).map(String);
     if (body.autonomy !== undefined) set.autonomy = Math.min(3, Math.max(0, Number(body.autonomy) || 0));
@@ -197,7 +212,12 @@ exports.startRun = async (req, res) => {
             if (!task) return fail(res, 'Task not found.', 404);
             if (agent.projectIds && agent.projectIds.length && !agent.projectIds.includes(String(task.ProjectID))) return fail(res, 'This agent is not scoped to that project.', 403);
         }
-        const run = await runs.create(companyId, { agent, taskId, projectId: task && task.ProjectID, skill: skill || (agent.skills && agent.skills[0]) || 'qa-review', trigger: TRIGGERS.includes(trigger) ? trigger : 'manual', startedBy: actor.userId, viaAccount: isAgent(actor) ? actor.viaAccount : agent.account, note });
+        if (!task) {
+            // Every executable skill works on a task. Without one the run used to be created,
+            // never executed and never finished — "running" forever in every counter.
+            return fail(res, 'This agent needs a task to run on. Start the run from a task, or mention the agent in a comment.');
+        }
+        const run = await runs.create(companyId, { agent, taskId, projectId: task && task.ProjectID, skill: runs.skillSlugOf(agent, skill), trigger: TRIGGERS.includes(trigger) ? trigger : 'manual', startedBy: actor.userId, viaAccount: isAgent(actor) ? actor.viaAccount : agent.account, note });
         if (task && registry.has('subtask.create')) {
             const runActor = { kind: 'agent', userId: actor.userId, agentId: String(agent._id), agentName: agent.name, runId: String(run._id), viaAccount: run.viaAccount, tokenId: null };
             setImmediate(() => runs.executeSkill(companyId, run, agent, task, { proposals, actions, actor: runActor }));
@@ -367,3 +387,5 @@ exports.releaseCandidate = async (req, res) => {
         return res.send({ status: true, data });
     } catch (e) { logger.error(`releaseCandidate: ${e.message}`); return fail(res, e.message); }
 };
+
+exports.normaliseSkill = normaliseSkill;

--- a/Modules/Agents/engine/orchestrator.js
+++ b/Modules/Agents/engine/orchestrator.js
@@ -90,7 +90,12 @@ async function run({ skillSlug = 'qa-review', task, budget = {} }) {
     // ── 1. gather ────────────────────────────────────────────────────────────
     const url = extractUrl(task?.TaskName) || extractUrl(task?.description) || extractUrl(task?.rawDescription);
     if (!url) {
-        return { status: 'skipped', reason: 'no reviewable URL found in the task title or description',
+        const text = [task?.TaskName, task?.description, task?.rawDescription].join(' ');
+        const privateUrl = /https?:\/\/(localhost|127\.|10\.|192\.168\.|0\.0\.0\.0|\[?::1)/i.test(text);
+        return { status: 'skipped',
+                 reason: privateUrl
+                     ? 'the URL points at a private or local host, which agents do not fetch — use a public address'
+                     : 'no reviewable URL found in the task title or description',
                  skill: skill.slug, findings: [], usage, durationMs: Date.now() - started };
     }
 

--- a/Modules/Agents/proposals.js
+++ b/Modules/Agents/proposals.js
@@ -125,6 +125,13 @@ const approve = async (companyId, id, { decider, isPrivileged, changes: edited, 
     const undoUntil = new Date(Date.now() + UNDO_WINDOW_MS);
     const updated = await setStatus(companyId, id, { status, changes, decidedBy: decider.userId, decidedAt: new Date(), undoUntil, auditIds });
     await audit.recordProposalDecision(companyId, decider, { proposalId: id, decision: status, agentName: p.agentName, runId: p.runId, changes: applied, ip });
+    // The run was waiting on this decision; without closing it here it sat in
+    // "waiting_approval" — and in every running count — after the work was done.
+    if (p.runId) {
+        const runs = require('./runs');
+        const okCount = applied.filter((a) => a.ok).length;
+        await runs.finish(companyId, p.runId, { status: runs.STATUS.DONE, outcome: `${status} by a person — ${okCount} of ${applied.length} change(s) applied` }).catch(() => {});
+    }
     return { proposal: updated, applied, undoToken: String(id), undoUntil };
 };
 
@@ -133,6 +140,7 @@ const decline = async (companyId, id, { decider, ip, reason }) => {
     if (!p) return { error: 'Proposal not found.', status: 404 };
     if (p.status !== STATUS.PENDING) return { error: `Proposal is already ${p.status}.`, status: 409 };
     const updated = await setStatus(companyId, id, { status: STATUS.DECLINED, decidedBy: decider.userId, decidedAt: new Date() });
+    if (p.runId) { const runs = require('./runs'); await runs.finish(companyId, p.runId, { status: runs.STATUS.DONE, outcome: 'declined by a person' }).catch(() => {}); }
     await audit.recordProposalDecision(companyId, decider, { proposalId: id, decision: `declined${reason ? `: ${String(reason).slice(0, 200)}` : ''}`, agentName: p.agentName, runId: p.runId, ip });
     return { proposal: updated };
 };

--- a/Modules/Agents/registry.js
+++ b/Modules/Agents/registry.js
@@ -94,11 +94,14 @@ const evaluate = (key, params = {}, { allowedActions } = {}) => {
 };
 
 /* Autonomy levels (9c). Anything at or under the level runs; the rest is proposed. */
+/* Matches the ladder the product shows (L0 Assist · L1 Suggest · L2 Act in bounds ·
+ * L3 Scheduled). L1 used to act on low-risk actions, so an agent labelled
+ * "Suggest" filed subtasks on the board without anyone approving them. */
 const AUTONOMY = Object.freeze({
-    0: { label: 'Suggest everything', actsOn: [] },
-    1: { label: 'Act on low-risk, propose the rest', actsOn: [RISK.LOW] },
-    2: { label: 'Act on low and medium risk, propose the rest', actsOn: [RISK.LOW, RISK.MEDIUM] },
-    3: { label: 'Also run on a schedule', actsOn: [RISK.LOW, RISK.MEDIUM] },
+    0: { label: 'Assist — answers only, proposes nothing on its own', actsOn: [] },
+    1: { label: 'Suggest — proposes everything, a person approves', actsOn: [] },
+    2: { label: 'Act in bounds — low and medium risk directly, proposes the rest', actsOn: [RISK.LOW, RISK.MEDIUM] },
+    3: { label: 'Scheduled — as L2, and may run unattended', actsOn: [RISK.LOW, RISK.MEDIUM] },
 });
 
 const mayActDirectly = (autonomy, key) => {

--- a/Modules/Agents/runs.js
+++ b/Modules/Agents/runs.js
@@ -182,4 +182,15 @@ const executeSkill = async (companyId, run, agent, task, { proposals, actions, a
     }
 };
 
-module.exports = { STATUS, OPEN, canStart, create, patch, appendAction, finish, stop, recordSpend, list, summary, pauseAll, getAgent, executeSkill, monthKey };
+
+/* Which skill a run executes. Agents store skills as objects ({ key, name, … });
+ * an explicit slug wins, then the agent's first skill key, then the QA review. */
+const skillSlugOf = (agent, explicit) => {
+    if (explicit && typeof explicit === 'string') return explicit;
+    const first = agent && Array.isArray(agent.skills) ? agent.skills[0] : null;
+    if (!first) return 'qa-review';
+    if (typeof first === 'string') return first;
+    return first.key || first.slug || first.name || 'qa-review';
+};
+
+module.exports = { STATUS, OPEN, canStart, skillSlugOf, create, patch, appendAction, finish, stop, recordSpend, list, summary, pauseAll, getAgent, executeSkill, monthKey };

--- a/Modules/Automations/engine/tools.js
+++ b/Modules/Automations/engine/tools.js
@@ -105,10 +105,13 @@ const addComment = async (companyId, taskId, body, context = {}) => {
             projectId,
             taskId: oid(taskId),
             sprintId: task.sprintId || undefined,
-            userId: context.ruleId ? `automation:${context.ruleId}` : 'automation',
+            userId: context.userId || (context.ruleId ? `automation:${context.ruleId}` : 'automation'),
             type: 'text',
             message: text,
             isDeleted: false,
+            // Attribution written with the row: the post-insert update the agent path
+            // used to rely on never applied, so agent comments read as "automation".
+            ...(context.actorType ? { actorType: context.actorType, agentId: context.agentId || null, viaAccount: context.viaAccount || null, runId: context.runId || null } : {}),
         },
     }, 'save');
 

--- a/Modules/Mcp/brief.js
+++ b/Modules/Mcp/brief.js
@@ -78,7 +78,8 @@ const buildBrief = async (ctx, taskId) => {
     const [comments, project, sprint, relatedRows, pages] = await Promise.all([
         MongoDbCrudOpration(ctx.companyId, {
             type: SCHEMA_TYPE.COMMENTS,
-            data: [{ taskId: String(task._id), deletedStatusKey: { $ne: 1 } }, null, { sort: { createdAt: 1 }, limit: 60 }],
+            // Comments store taskId as an ObjectId (Comments/controller.js); older rows may hold a string.
+            data: [{ taskId: { $in: [task._id, String(task._id)] }, isDeleted: { $ne: true }, deletedStatusKey: { $ne: 1 } }, null, { sort: { createdAt: 1 }, limit: 60 }],
         }, 'find').catch(() => []),
         MongoDbCrudOpration(ctx.companyId, { type: SCHEMA_TYPE.PROJECTS, data: [{ _id: oid(task.ProjectID) }] }, 'findOne').catch(() => null),
         task.sprintId

--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -135,3 +135,16 @@ is a light lavender and every primary button kept white text (2.55:1) — dark i
 white wrappers in dark; darkened only when a redesigned page is inside so legacy views keep their
 light panels and dark ink. Settings › General is still legacy-light in dark by design of the compat
 rule; its own white-on-white "Task Priority" label is a legacy defect, not filed.
+
+### 2026-09-04 (AR-44: an agent team on our own project)
+Built four agents through the wizard (Daily PM, Code Reviewer, Reporter, QA Reviewer), ran them, and
+followed one real QA run end to end (public help site → gpt-4o → 4 findings → Inbox proposal →
+approved → subtasks + summary → undo). What using it surfaced, all fixed unless noted:
+- "Run now" with no task created a run that never executed and never finished — stuck running forever.
+- Skills saved as "[object Object]" (map(String) on objects); a template agent then ran a skill by that name.
+- The ladder said L1 = Suggest; the registry let L1 act on low-risk actions, so a "Suggest" agent wrote to the board unasked.
+- Agent comments had no attribution: the comments schema had no actorType/agentId, so the fields were stripped and the approver was credited. The MCP brief queried taskId as a string while comments store an ObjectId, so agents could never read a thread.
+- gpt-4o priced at $0 (OpenAI prices are not built in by design); LLM_PRICING set and documented.
+- A run whose proposal was decided stayed "waiting_approval" forever.
+- localhost URLs are refused (SSRF guard, correct) but the skip said "no reviewable URL".
+Left as friction, not fixed: templates are only offered on the empty state; no Stop control on a Hub card; only one skill (qa-review) actually executes — the other template skills are labels.

--- a/tests/agent-autonomy.test.js
+++ b/tests/agent-autonomy.test.js
@@ -1,0 +1,16 @@
+const registry = require('../Modules/Agents/registry');
+
+describe('autonomy ladder — the registry matches what the product says', () => {
+    it('L1 "Suggest" proposes everything, even low-risk actions', () => {
+        expect(registry.mayActDirectly(1, 'subtask.create')).toBe(false);
+        expect(registry.mayActDirectly(1, 'task.comment')).toBe(false);
+    });
+    it('L2 "Act in bounds" acts on low and medium risk, never on gated or propose-only actions', () => {
+        expect(registry.mayActDirectly(2, 'subtask.create')).toBe(true);
+        expect(registry.mayActDirectly(2, 'task.update')).toBe(true);
+        expect(registry.mayActDirectly(2, 'deploy.staging')).toBe(false);
+    });
+    it('L0 acts on nothing', () => {
+        expect(registry.mayActDirectly(0, 'task.comment')).toBe(false);
+    });
+});

--- a/tests/agent-run-skill.test.js
+++ b/tests/agent-run-skill.test.js
@@ -1,0 +1,32 @@
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+const { skillSlugOf } = require('../Modules/Agents/runs');
+
+describe('which skill a run executes', () => {
+    it('takes the explicit slug first', () => {
+        expect(skillSlugOf({ skills: [{ key: 'brief.parse' }] }, 'qa-review')).toBe('qa-review');
+    });
+    it('reads the key off a stored skill object instead of stringifying it', () => {
+        expect(skillSlugOf({ skills: [{ key: 'brief.parse', name: 'brief.parse' }] })).toBe('brief.parse');
+        expect(skillSlugOf({ skills: [{ key: 'x' }] })).not.toBe('[object Object]');
+    });
+    it('accepts legacy string skills and falls back to the QA review', () => {
+        expect(skillSlugOf({ skills: ['pr.summary'] })).toBe('pr.summary');
+        expect(skillSlugOf({ skills: [] })).toBe('qa-review');
+        expect(skillSlugOf(null)).toBe('qa-review');
+    });
+});
+
+describe('skills as stored by the API', () => {
+    jest.mock('../Modules/Agents/runs', () => ({ getAgent: jest.fn(), canStart: jest.fn(), create: jest.fn(), skillSlugOf: jest.fn() }));
+    const { normaliseSkill } = require('../Modules/Agents/controller');
+    it('keeps the key and name of a skill object instead of stringifying it', () => {
+        expect(normaliseSkill({ key: 'brief.parse', name: 'brief.parse', actions: ['task.comment'], enabled: true }))
+            .toEqual({ key: 'brief.parse', name: 'brief.parse', enabled: true, actions: ['task.comment'] });
+    });
+    it('accepts a bare string and drops junk', () => {
+        expect(normaliseSkill('pr.summary')).toEqual({ key: 'pr.summary', name: 'pr.summary', enabled: true });
+        expect(normaliseSkill({})).toBeNull();
+        expect(normaliseSkill(null)).toBeNull();
+    });
+});

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -2798,7 +2798,7 @@ const schema = {
             type: Boolean,
             required: false,
             default: false
-        }
+        },
     },
     comments: {
         "legacyId": {
@@ -2915,7 +2915,13 @@ const schema = {
         },
         transcript: { type: String, required: false },
         isAgent: { type: Boolean, required: false },
-        agentName: { type: String, required: false }
+        agentName: { type: String, required: false },
+        // 27c attribution. Without these the fields were stripped on save and every
+        // agent comment read as posted by the person who approved it.
+        actorType: { type: String, default: "" },
+        agentId: { type: String, default: "" },
+        viaAccount: { type: String, default: "" },
+        runId: { type: String, default: "" }
     },
     mainChat: {
         ProjectCode: {


### PR DESCRIPTION
## Summary
Built a four-agent team through the wizard and followed one QA run end to end. Seven engine defects fixed: no-task runs stuck forever, skills saved as `[object Object]`, L1 "Suggest" acting without approval, agent comments unattributed (schema) and invisible to the MCP brief (ObjectId vs string), runs stuck after a decision, misleading skip reason for localhost URLs, undocumented pricing override. Board: AR-44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)