### PR TITLE
fix(agents): ground the digest and review skills in the data they were given

### DIFF
--- a/Modules/Agents/engine/orchestrator.js
+++ b/Modules/Agents/engine/orchestrator.js
@@ -115,8 +115,10 @@ async function runGeneric(skill, { task, companyId, budget = {} }) {
     if (!raw && !context.fallback) {
         return { status: 'failed', reason: degraded || 'the model returned nothing usable', skill: skill.slug, usage, model: modelUsed, durationMs: Date.now() - started };
     }
+    let dropped = [];
+    if (raw && typeof skill.verify === 'function') ({ raw, dropped } = skill.verify({ raw, context }));
     const { summary, changes } = skill.toChanges({ task, raw, context });
-    return { status: 'success', skill: skill.slug, model: modelUsed, degraded, summary, changes, findings: [], usage, durationMs: Date.now() - started };
+    return { status: 'success', skill: skill.slug, model: modelUsed, degraded, summary, changes, dropped, findings: [], usage, durationMs: Date.now() - started };
 }
 
 async function run({ skillSlug = 'qa-review', task, companyId, budget = {} }) {

--- a/Modules/Agents/runs.js
+++ b/Modules/Agents/runs.js
@@ -172,7 +172,10 @@ const executeSkill = async (companyId, run, agent, task, { proposals, actions, a
         } else {
             const proposal = await proposals.create(companyId, {
                 agent, runId: String(run._id), taskId: String(task._id), projectId: String(task.ProjectID),
-                what: Array.isArray(result.changes) ? `${run.skill}: ${changes.length} change(s) on ${task.TaskKey || task.TaskName}` : `File ${result.findings.length} QA finding(s) on ${task.TaskKey || task.TaskName}`, why: result.summary, changes,
+                what: Array.isArray(result.changes) ? `${run.skill}: ${changes.length} change(s) on ${task.TaskKey || task.TaskName}` : `File ${result.findings.length} QA finding(s) on ${task.TaskKey || task.TaskName}`,
+                // What the grounding check removed is part of the record a person reviews.
+                why: [result.summary, Array.isArray(result.dropped) && result.dropped.length ? `Dropped as unsupported by the data: ${result.dropped.map((d) => `"${String(d.text).slice(0, 80)}" (${d.reason})`).join('; ')}` : ''].filter(Boolean).join('\n\n'),
+                changes,
                 cost: { tokens: result.usage && result.usage.totalTokens, model: result.model, usd: spent && spent.usd },
             });
             await patch(companyId, run._id, { status: STATUS.WAITING }, { $push: { proposals: String(proposal._id) } });

--- a/Modules/Agents/skills/digest.js
+++ b/Modules/Agents/skills/digest.js
@@ -76,6 +76,37 @@ Return ONLY JSON:
                 list('Overdue', b.overdue), list('Due in 48h', b.dueSoon), list('Blocked', b.blocked), list('In review', b.inReview), list('Unassigned', b.unassigned)].join('\n\n');
     },
 
+    /* Ground truth check. The model is asked not to invent; asking is not a boundary.
+     * A sentence that names a task key not in the lists, or a number that is not one of
+     * the counts, is dropped rather than posted. */
+    verify({ raw, context }) {
+        if (!raw) return { raw, dropped: [] };
+        const b = context.buckets;
+        const known = new Set([].concat(b.overdue, b.dueSoon, b.blocked, b.inReview, b.unassigned, b.movedToday).map((t) => String(t.TaskKey || '').toUpperCase()).filter(Boolean));
+        const counts = new Set([b.total, b.done, b.overdue.length, b.dueSoon.length, b.blocked.length, b.inReview.length, b.unassigned.length, b.movedToday.length].map(String));
+        const dropped = [];
+        // "last 24 hours" / "next 48h" are the windows the data was cut on; any other number is a claim.
+        const claims = (text) => String(text).replace(/\b(24|48)\s*(h|hrs?|hours?)\b/gi, '').replace(/\b[A-Z][A-Z0-9]+-\d+\b/g, '');
+        const okSentence = (sentence) => {
+            const keys = sentence.match(/\b[A-Z][A-Z0-9]+-\d+\b/g) || [];
+            const nums = claims(sentence).match(/\b\d+\b/g) || [];
+            const badKey = keys.find((k) => !known.has(k.toUpperCase()));
+            const badNum = nums.find((n) => !counts.has(n));
+            if (badKey) dropped.push({ reason: `mentions ${badKey}, which is not in the data`, text: sentence.trim() });
+            else if (badNum) dropped.push({ reason: `mentions ${badNum}, which is not one of the counts`, text: sentence.trim() });
+            return !badKey && !badNum;
+        };
+        const digest = String(raw.digest || '').split(/(?<=[.!?])\s+/).filter((x) => x.trim()).filter(okSentence).join(' ');
+        const lookFirst = (Array.isArray(raw.lookFirst) ? raw.lookFirst : []).filter((item) => {
+            const key = (String(item).match(/\b[A-Z][A-Z0-9]+-\d+\b/) || [])[0];
+            if (!(key && known.has(key.toUpperCase()))) { dropped.push({ reason: 'look-first item names a task not in the data', text: String(item) }); return false; }
+            const badNum = (claims(item).match(/\b\d+\b/g) || []).find((n) => !counts.has(n));
+            if (badNum) { dropped.push({ reason: `look-first item claims "${badNum}", which is not in the data`, text: String(item) }); return false; }
+            return true;
+        });
+        return { raw: { ...raw, digest: digest || null, lookFirst }, dropped };
+    },
+
     toChanges({ task, raw, context }) {
         const digest = raw && raw.digest ? String(raw.digest).slice(0, 1500) : context.fallback;
         const look = Array.isArray(raw && raw.lookFirst) ? raw.lookFirst.filter(Boolean).slice(0, 3) : [];

--- a/Modules/Agents/skills/prReview.js
+++ b/Modules/Agents/skills/prReview.js
@@ -55,6 +55,23 @@ Return ONLY JSON:
         return `TASK: ${task.TaskName || ''}\nLINK: ${context.url}${context.truncated ? ' (diff truncated)' : ''}\n\nCHANGE TEXT:\n${context.diff}`;
     },
 
+    /* A risk must point at something in the change text; "where" that does not appear
+     * in the diff is dropped, so the review cannot cite files the PR never touched. */
+    verify({ raw, context }) {
+        if (!raw || !Array.isArray(raw.risks)) return { raw, dropped: [] };
+        const hay = String(context.diff || '').toLowerCase();
+        const dropped = [];
+        const risks = raw.risks.filter((r) => {
+            const where = String((r && r.where) || '').trim();
+            if (!where) return true;
+            const needle = where.toLowerCase().split(/[\s,;:()]+/).filter((w) => w.length > 3);
+            const ok = needle.length === 0 || needle.some((w) => hay.includes(w));
+            if (!ok) dropped.push({ reason: `"${where}" does not appear in the change`, text: String(r.title || '') });
+            return ok;
+        });
+        return { raw: { ...raw, risks }, dropped };
+    },
+
     toChanges({ task, raw, context }) {
         const risks = Array.isArray(raw && raw.risks) ? raw.risks.filter((r) => r && r.title).slice(0, 6) : [];
         const summary = String((raw && raw.summary) || `Reviewed ${context.url}.`).slice(0, 2000);

--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -165,3 +165,10 @@ proposals are now a source of the main Inbox (Primary, owners/admins), counted i
 Approve / Decline / Open in AI Inbox on the row; deciding goes through the agent API so audit,
 undo window and run closure are identical whichever Inbox was used. Also carried usd onto
 proposals so the Inbox stops showing $0.00 for priced runs.
+
+### 2026-09-04 (AR-51: grounding)
+The Reporter kept inventing "in review for 24 days" for a real task key. Prompts are not a
+boundary, so the digest and PR skills verify like the QA skill: a sentence naming a key not in the
+data or a number that is not one of the counts is dropped (24/48 pass only as hours); a PR risk whose
+"where" is not in the diff is dropped. What was dropped is written into the proposal's reasoning so
+the reviewer sees it. Live: the claim came back, was dropped, and the record says so.

--- a/tests/agent-skills.test.js
+++ b/tests/agent-skills.test.js
@@ -77,3 +77,32 @@ describe('digest.ceo (Reporter)', () => {
         expect(out.degraded).toBe('no LLM provider configured');
     });
 });
+
+describe('grounding — what the model was not given is dropped', () => {
+    const digest = getSkill('digest.ceo');
+    const rows = [
+        { TaskKey: 'AR-1', TaskName: 'Late', statusType: 'active', status: { text: 'In Progress' }, DueDate: '2026-09-01', AssigneeUserId: [] },
+        { TaskKey: 'AR-2', TaskName: 'Stuck', statusType: 'active', status: { text: 'On Hold' }, AssigneeUserId: ['u'] },
+    ];
+    it('drops a digest sentence that invents a number or a task key, keeps the rest', () => {
+        const context = { buckets: digest.buckets(rows, Date.parse('2026-09-04T12:00:00Z')) };
+        const raw = { digest: 'There are 2 open tasks moved in the last 24 hours. AR-1 is overdue. AR-17 has been in review for 24 days. Nothing else moved.', lookFirst: ['AR-1 — overdue', 'AR-99 — invented', 'AR-2 — blocked for 24 days'] };
+        const { raw: cleaned, dropped } = digest.verify({ raw, context });
+        expect(cleaned.digest).toBe('There are 2 open tasks moved in the last 24 hours. AR-1 is overdue. Nothing else moved.');
+        expect(cleaned.lookFirst).toEqual(['AR-1 — overdue']);
+        expect(dropped.map((d) => d.reason)).toEqual(['mentions AR-17, which is not in the data', 'look-first item names a task not in the data', 'look-first item claims "24", which is not in the data']);
+    });
+    it('drops a PR risk that cites a file the diff never touched', () => {
+        const pr = getSkill('pr.summary');
+        const context = { diff: 'diff --git a/Modules/Agents/runs.js b/Modules/Agents/runs.js\n+const x = 1;', url: 'u' };
+        const raw = { summary: 's', risks: [{ title: 'Real', where: 'Modules/Agents/runs.js' }, { title: 'Invented', where: 'frontend/src/App.vue' }, { title: 'Unlocated' }] };
+        const { raw: cleaned, dropped } = pr.verify({ raw, context });
+        expect(cleaned.risks.map((r) => r.title)).toEqual(['Real', 'Unlocated']);
+        expect(dropped[0].text).toBe('Invented');
+    });
+    it('is applied by the orchestrator, which reports what it dropped', async () => {
+        MongoDbCrudOpration.mockResolvedValueOnce(rows);
+        const out = await orchestrator.run({ skillSlug: 'digest.ceo', task, companyId: 'c1', budget: { allowModel: false } });
+        expect(out.dropped).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
The Reporter invented "in review for 24 days" despite the prompt. Digest and PR-review skills now verify against their input like the QA skill: unsupported keys, numbers and file paths are dropped, and the proposal records what was removed. Verified live. Board: AR-51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)