### PR TITLE
feat(api): real status codes for callers who opt in

### DIFF
--- a/Config/strictStatus.js
+++ b/Config/strictStatus.js
@@ -1,0 +1,40 @@
+/* HTTP 200-on-failure, decided (AR-24).
+ *
+ * Every handler answers failures with HTTP 200 and { status: false } in the body,
+ * and every frontend caller reads that field. Changing the code for everyone is a
+ * migration of hundreds of callers. So the convention is kept for the app, and a
+ * caller that cares about status codes opts in: an API token or MCP token (agents,
+ * integrations, webhooks) gets real 4xx automatically; anything else can ask with
+ * `Prefer: status-codes`. The body is never changed, only the status line, and the
+ * mapping is announced in X-Status-Mapped so it is visible in any client log. */
+
+const wantsStatusCodes = (req) => Boolean(req.apiToken) || /\bstatus-codes\b/i.test(String(req.get && req.get('Prefer') || ''));
+
+const inferStatus = (body) => {
+    const explicit = Number(body.statusCode || body.code);
+    if (explicit >= 400 && explicit <= 599) return explicit;
+    const text = String(body.statusText || body.message || '');
+    if (/not found|no such|does not exist/i.test(text)) return 404;
+    if (/permission|not allowed|forbidden|cannot (perform|create|edit|delete)|only (an )?(owner|admin)|read-only/i.test(text)) return 403;
+    if (/already|conflict|duplicate/i.test(text)) return 409;
+    if (/token|unauthori[sz]ed|log ?in|session/i.test(text)) return 401;
+    return 400;
+};
+
+const isFailureBody = (body) => body && typeof body === 'object' && !Array.isArray(body) && body.status === false;
+
+const strictStatus = () => (req, res, next) => {
+    const send = res.send.bind(res);
+    res.send = (body) => {
+        let parsed = body;
+        if (typeof body === 'string' && body[0] === '{') { try { parsed = JSON.parse(body); } catch (e) { parsed = null; } }
+        if (res.statusCode === 200 && isFailureBody(parsed) && wantsStatusCodes(req)) {
+            res.status(inferStatus(parsed));
+            res.set('X-Status-Mapped', '1');
+        }
+        return send(body);
+    };
+    next();
+};
+
+module.exports = { strictStatus, wantsStatusCodes, inferStatus, isFailureBody };

--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -172,3 +172,10 @@ boundary, so the digest and PR skills verify like the QA skill: a sentence namin
 data or a number that is not one of the counts is dropped (24/48 pass only as hours); a PR risk whose
 "where" is not in the diff is dropped. What was dropped is written into the proposal's reasoning so
 the reviewer sees it. Live: the claim came back, was dropped, and the record says so.
+
+### 2026-09-04 (AR-24: the 200-on-failure convention, decided)
+Kept for the app, real codes for those who care. A middleware maps 200 + {status:false} to 4xx only
+when the caller opts in: an API/MCP token gets it automatically, anyone else can send
+Prefer: status-codes. The body is never changed; X-Status-Mapped announces it. Inference from the
+wording the codebase uses (not found → 404, permission → 403, already → 409, token → 401, else 400),
+or an explicit statusCode in the body. Verified: app JWT 200, Prefer 400, API token 400.

--- a/index.js
+++ b/index.js
@@ -127,6 +127,8 @@ app.use((req, res, next) => {
     res.set('Cache-Control', 'no-store');
     next();
 });
+// Real 4xx for API/MCP tokens and anyone sending Prefer: status-codes; the app keeps its 200 + {status:false}.
+app.use(require('./Config/strictStatus').strictStatus());
 
 function initializeControllers() {
     const envFile = fs.readFileSync(__dirname + "/.env");

--- a/tests/strict-status.test.js
+++ b/tests/strict-status.test.js
@@ -1,0 +1,35 @@
+const { strictStatus, inferStatus, wantsStatusCodes } = require('../Config/strictStatus');
+
+const fakeRes = () => { const r = { statusCode: 200, headers: {}, sent: null }; r.status = (c) => { r.statusCode = c; return r; }; r.set = (k, v) => { r.headers[k] = v; return r; }; r.send = (b) => { r.sent = b; return r; }; return r; };
+const run = (req, body, presetStatus) => { const res = fakeRes(); if (presetStatus) res.statusCode = presetStatus; strictStatus()(req, res, () => {}); res.send(body); return res; };
+
+describe('HTTP 200-on-failure, opt-in status codes', () => {
+    it('leaves the app alone: no token, no Prefer header → 200 and the same body', () => {
+        const res = run({ get: () => '' }, { status: false, statusText: 'Task not found.' });
+        expect(res.statusCode).toBe(200);
+        expect(res.headers['X-Status-Mapped']).toBeUndefined();
+        expect(res.sent).toEqual({ status: false, statusText: 'Task not found.' });
+    });
+    it('gives an API token caller a real status, body unchanged, and says so in a header', () => {
+        const res = run({ apiToken: { _id: 't' }, get: () => '' }, { status: false, statusText: 'Task not found.' });
+        expect(res.statusCode).toBe(404);
+        expect(res.headers['X-Status-Mapped']).toBe('1');
+        expect(res.sent.status).toBe(false);
+    });
+    it('honours Prefer: status-codes and an explicit statusCode in the body', () => {
+        expect(run({ get: (h) => (h === 'Prefer' ? 'status-codes' : '') }, { status: false, statusText: 'Agents cannot create agents.' }).statusCode).toBe(403);
+        expect(run({ apiToken: {} , get: () => '' }, { status: false, statusText: 'x', statusCode: 422 }).statusCode).toBe(422);
+    });
+    it('never touches successes, arrays, or responses that already carry a status', () => {
+        expect(run({ apiToken: {}, get: () => '' }, { status: true, data: [] }).statusCode).toBe(200);
+        expect(run({ apiToken: {}, get: () => '' }, [{ status: false }]).statusCode).toBe(200);
+        expect(run({ apiToken: {}, get: () => '' }, { status: false, statusText: 'nope' }, 500).statusCode).toBe(500);
+    });
+    it('maps the wording the codebase actually uses', () => {
+        expect(inferStatus({ statusText: 'companyId is required.' })).toBe(400);
+        expect(inferStatus({ statusText: 'This token is read-only.' })).toBe(403);
+        expect(inferStatus({ statusText: 'Proposal is already approved.' })).toBe(409);
+        expect(inferStatus({ statusText: 'Invalid token' })).toBe(401);
+        expect(wantsStatusCodes({ get: () => 'return=minimal, status-codes' })).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
AR-24 decided without a migration: the app keeps 200 + `{status:false}`; API/MCP tokens get real 4xx automatically and anyone can opt in with `Prefer: status-codes`. Body unchanged, mapping announced in `X-Status-Mapped`. Verified live: app JWT 200, Prefer 400, token 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)