### PR TITLE
fix(api): recognise an API token by its bearer prefix for status mapping

### DIFF
--- a/Config/strictStatus.js
+++ b/Config/strictStatus.js
@@ -8,7 +8,12 @@
  * `Prefer: status-codes`. The body is never changed, only the status line, and the
  * mapping is announced in X-Status-Mapped so it is visible in any client log. */
 
-const wantsStatusCodes = (req) => Boolean(req.apiToken) || /\bstatus-codes\b/i.test(String(req.get && req.get('Prefer') || ''));
+// An API token is recognised by its bearer prefix, not by whether some later
+// middleware resolved it: on routes outside the JWT guard req.apiToken is never set.
+const API_TOKEN_PREFIX = /^Bearer\s+ahp_/i;
+const wantsStatusCodes = (req) => Boolean(req.apiToken)
+    || API_TOKEN_PREFIX.test(String((req.get && req.get('Authorization')) || (req.headers && req.headers.authorization) || ''))
+    || /\bstatus-codes\b/i.test(String((req.get && req.get('Prefer')) || ''));
 
 const inferStatus = (body) => {
     const explicit = Number(body.statusCode || body.code);

--- a/tests/strict-status.test.js
+++ b/tests/strict-status.test.js
@@ -31,5 +31,7 @@ describe('HTTP 200-on-failure, opt-in status codes', () => {
         expect(inferStatus({ statusText: 'Proposal is already approved.' })).toBe(409);
         expect(inferStatus({ statusText: 'Invalid token' })).toBe(401);
         expect(wantsStatusCodes({ get: () => 'return=minimal, status-codes' })).toBe(true);
+        expect(wantsStatusCodes({ get: (h) => (h === 'Authorization' ? 'Bearer ahp_abc' : '') })).toBe(true);
+        expect(wantsStatusCodes({ get: (h) => (h === 'Authorization' ? 'Bearer eyJhbGciOi' : '') })).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
Correction to #537: a token only got real 4xx where the JWT guard resolved it into `req.apiToken`; routes outside that guard still answered 200. The bearer prefix (`ahp_`) now counts as opt-in. Verified live on the endpoint that previously returned 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)