### PR TITLE
fix(sweep): repair nine flows found by the functional sweep (AR-53)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,11 +174,9 @@ SOCKETIO_ADMIN_PASSWORD_HASH="$2a$12$HHemhzmTrC8Dmf2Gd9v/Teo9oiCxfYJb.St3HKMBx1L
 # nothing is executed either way. Leave "false" in production.
 AUTOMATION_EVENT_LOG="false"
 
-# Master switch for rule execution. Off by default: until the builder UI ships,
-# the only rules that can reach the engine are ones written straight into the
-# database, and a half-configured rule mutating real tasks is not a surprise a
-# self-hosted instance should get from upgrading.
-AUTOMATION_ENGINE="false"
+# Master switch for rule execution. On by default so rules saved from the
+# Automations page actually run; set "false" to keep rules stored but inert.
+AUTOMATION_ENGINE="true"
 
 # "agenda" (durable, MongoDB-backed, survives a restart) or "inline" (in-process,
 # nothing survives a restart — tests and throwaway instances only).

--- a/Modules/Auth/controller/sendInvitation.js
+++ b/Modules/Auth/controller/sendInvitation.js
@@ -167,11 +167,13 @@ exports.sendInvitationEmailFun = (bodyData) => {
                                 data
                             });
                         } else {
-                            reject({
+                            // The invite row is already saved and its link works, so hand it
+                            // back: the person can copy the link when mail is not configured.
+                            resolve({
                                 status: false,
-                                statusText: result.error
+                                statusText: result.error,
+                                data
                             });
-                            exports.decreaseUserCount(companyId);
                         }
                     });
                 } catch (error) {
@@ -389,11 +391,13 @@ exports.sendInvitationEmail = (req,res) => {
                         data
                     });
                 } else {
+                    // The invite row is saved and its link works, so hand it back:
+                    // the person can copy the link when mail is not configured.
                     res.send({
                         status: false,
-                        statusText: result.error
+                        statusText: result.error,
+                        data
                     });
-                    exports.decreaseUserCount(companyId);
                 }
             });
         };

--- a/Modules/Automations/engine/index.js
+++ b/Modules/Automations/engine/index.js
@@ -7,10 +7,8 @@ const { createAgendaDriver } = require('./queue/agendaDriver');
 
 // Wires the five stages together: ingest (the bus) → match → enqueue → execute → record.
 //
-// Off by default. AUTOMATION_ENGINE=true opts in, because until the builder UI
-// exists the only rules that can reach this are ones written directly into the
-// database, and a half-configured rule executing against real tasks on somebody's
-// self-hosted instance is not a surprise they should get from upgrading.
+// On unless AUTOMATION_ENGINE=false: the builder UI now saves rules, and a rule
+// that silently never runs is a worse surprise than one that does.
 
 const LOG_PREFIX = '[automation-engine]';
 const JOB_NAME = 'automation.run';
@@ -18,7 +16,7 @@ const JOB_NAME = 'automation.run';
 let driver = null;
 let started = false;
 
-const enabled = () => String(process.env.AUTOMATION_ENGINE || '').toLowerCase() === 'true';
+const enabled = () => String(process.env.AUTOMATION_ENGINE || 'true').toLowerCase() !== 'false';
 
 const selectDriver = () => {
     const choice = String(process.env.AUTOMATION_QUEUE_DRIVER || 'agenda').toLowerCase();

--- a/Tasks/active/012-dogfood-in-alianhub/progress.md
+++ b/Tasks/active/012-dogfood-in-alianhub/progress.md
@@ -189,3 +189,9 @@ handler rejected a promise nobody awaited and index.js exited on unhandledReject
 all, made the handler answer, stopped unhandled rejections exiting the process, and added a test that
 every registered v2 prefix is guarded, public by design, or self-guarded, so the next module cannot
 ship open. Along the way: AR-24 decided (opt-in status codes for API tokens and Prefer).
+
+## 2026-09-04 — AR-53 functional sweep
+- 5 waves driven through the browser; every pass verified in Mongo or the network log.
+- 9 defects fixed in-branch (project-create redirect, chat channel folder prop, automation engine default + rule name, custom-field drawer fallback, invite without designations + authenticated invite call that returns the saved row when mail fails, relation search by key, timer reason).
+- Automation engine now defaults to on; `.env.example` updated.
+- Full table in the AR-53 comment; scratch notes in `ui-findings.md`.

--- a/frontend/src/components/organisms/CreateChannelSidebar/CreateChannelSidebar.vue
+++ b/frontend/src/components/organisms/CreateChannelSidebar/CreateChannelSidebar.vue
@@ -138,7 +138,6 @@ library.add(fas);
 dom.watch();
 
 // UTILS
-const projectData = inject("selectedProject");
 const userId = inject("$userId");
 const companyId = inject("$companyId");
 const clientWidth = inject("$clientWidth");
@@ -152,7 +151,7 @@ const showWarning = ref(false);
 const warningMessage = ref("");
 
 // EMITS
-const emit = defineEmits(["update:visible", "cancel"]);
+const emit = defineEmits(["update:visible", "cancel", 'created']);
 
 //IMAGE
 const deletered = require("@/assets/images/svg/deletered.svg");
@@ -167,7 +166,13 @@ const props = defineProps({
         type: Object,
         default: null
     },
+    project: {
+        type: Object,
+        default: null
+    },
 })
+const injectedProject = inject("selectedProject", null);
+const projectData = computed(() => props.project || (injectedProject && "value" in injectedProject ? injectedProject.value : injectedProject) || null);
 
 const icons = [...new Set([...Object.keys(far).map(key => far[key]),...Object.keys(fab).map(key => fab[key]),...Object.keys(fas).map(key => fas[key])])]
 const userGetter = computed(() => {
@@ -299,6 +304,8 @@ function createChannel() {
                     $toast.success(t(`Toast.Channel_created_successfully`), { position: "top-right" })
                     resetValues();
                     inProgress.value = false;
+                    emit('created', res.data.data || null);
+                    emit('update:visible', false);
                 } else {
                     $toast.error(res.data.statusText, { position: "top-right" })
                     resetValues();
@@ -324,8 +331,8 @@ async function createChannelFun() {
     return new Promise((resolve, reject) => {
         try {
             (async () => {
-                if(!props.folder) {
-                    $toast.error(t(`Toast.Folder_not_found`), {position: "top-right"});
+                if(!projectData.value?._id) {
+                    $toast.error(t(`Toast.something_went_wrong`), {position: "top-right"});
                     inProgress.value = false;
                     return;
                 }

--- a/frontend/src/components/organisms/LinkedTasks/LinkedTasks.vue
+++ b/frontend/src/components/organisms/LinkedTasks/LinkedTasks.vue
@@ -232,7 +232,10 @@ function searchTasks() {
             $match: {
                 ProjectID: { objId: { $in: [props.task.ProjectID] } },
                 deletedStatusKey: { $in: [0, undefined] },
-                TaskName: { $regex: escaped, $options: 'i' },
+                $or: [
+                    { TaskName: { $regex: escaped, $options: 'i' } },
+                    { TaskKey: { $regex: escaped, $options: 'i' } },
+                ],
             }
         },
         { $project: { TaskName: 1, TaskKey: 1, status: 1 } },

--- a/frontend/src/components/organisms/TaskDetailOverlay/TaskTimerChip.vue
+++ b/frontend/src/components/organisms/TaskDetailOverlay/TaskTimerChip.vue
@@ -50,7 +50,8 @@ const companyId = inject("$companyId");
 const entry = computed(() => timerState.entry);
 const runningHere = computed(() => isTimerFor(props.task?._id));
 const clock = computed(() => formatClock(elapsedSeconds.value));
-const elsewhereTitle = computed(() => entry.value ? t("TaskPanel.timer_running_elsewhere", { key: entry.value.taskKey || "" }) : "");
+// A disabled button with no reason reads as broken. Say why: a timer elsewhere, or not assigned here.
+const elsewhereTitle = computed(() => entry.value ? t("TaskPanel.timer_running_elsewhere", { key: entry.value.taskKey || "" }) : (!props.canStart ? t("TaskPanel.timer_assignee_only") : ""));
 
 async function start() {
     const user = getUser(userId.value) || {};

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1841,6 +1841,7 @@ export default {
         resume: "Resume",
         stop_and_log: "Stop and log time",
         timer_log_description: "Timer",
+        timer_assignee_only: "Only an assignee can track time on this task — assign yourself first.",
         timer_running_elsewhere: "A timer is already running on {key}. Starting here stops it.",
         timer_stopped_previous: "Stopped the timer on {key}",
         timer_logged: "Time logged",
@@ -4722,7 +4723,7 @@ export default {
     },
     Checklist: {
         checklist: "Checklist",
-        add_checklist: "Add an Checklist",
+        add_checklist: "Add a checklist",
         suggest_checklists: "Suggest Checklists",
         Checklists: "Checklists",
         to_unlock_checklist: "To Unlock Checklist",

--- a/frontend/src/plugins/customFieldView/component/organisms/FieldBuilder/FieldBuilder.vue
+++ b/frontend/src/plugins/customFieldView/component/organisms/FieldBuilder/FieldBuilder.vue
@@ -259,8 +259,13 @@ const shownIn = (field) => {
     return surfaces.map((surface) => t(`FieldsV2.surface_${surface}`)).join(" · ");
 };
 
+// The global type catalogue is empty on a fresh install, and the legacy drawer
+// renders nothing without a cfType, so fall back to the picker's own entry.
 function detailFor(fieldType) {
-    return typeCatalogue.value.find((entry) => entry.cfType === fieldType) || {};
+    const known = typeCatalogue.value.find((entry) => entry.cfType === fieldType);
+    if (known) return known;
+    const option = typeOptions.find((entry) => entry.key === fieldType);
+    return option ? { cfType: fieldType, cfTitle: option.label, cfDescrption: option.hint, cfIcon: '', cfIconGrey: '' } : {};
 }
 
 function startNew(fieldType) {

--- a/frontend/src/views/Automations/AutomationsPage.vue
+++ b/frontend/src/views/Automations/AutomationsPage.vue
@@ -340,6 +340,7 @@ const save = async (enabled) => {
     saving.value = true;
     errors.value = [];
     try {
+        if (!draft.name) await onRuleEdit();
         const body = { ...currentRule(), name: draft.name || sentence.value.slice(0, 120), enabled };
         const res = editingId.value
             ? await apiRequest('put', `${env.AUTOMATIONS_V2}/${editingId.value}`, body)

--- a/frontend/src/views/Chat/Chat.vue
+++ b/frontend/src/views/Chat/Chat.vue
@@ -77,7 +77,7 @@
             v-if="showCreateChannel"
             v-model:visible="showCreateChannel"
             :project="channelProject"
-            :folders="channelFolders"
+            :folder="channelFolder"
             @created="onChannelCreated"
         />
     </div>
@@ -265,6 +265,11 @@ const channelProject = computed(() => routeProject.value && !routeProject.value.
 const channelFolders = computed(() => {
     const group = channelGroups.value.find((g) => channelProject.value && String(g.project._id) === String(channelProject.value._id));
     return group ? group.categories : [];
+});
+// The form files the channel under one project folder; a project without folders gets a loose channel.
+const channelFolder = computed(() => {
+    const first = channelFolders.value[0];
+    return first ? { folderId: first.id, name: first.name } : null;
 });
 
 function onChannelCreated(channel) {

--- a/frontend/src/views/Projects/ProjectsListing/ProjectListing.vue
+++ b/frontend/src/views/Projects/ProjectsListing/ProjectListing.vue
@@ -154,8 +154,9 @@ watch(projects, () => {
         if(props.projectData && !Object.keys(props.projectData).length) {
             if(route.params && route.params.id) {
                 const projectIndex = projects.value.findIndex((item) => item._id === route.params.id);
-                if(projectIndex !== -1) {
-                    mutateCurrentProjectDetails(projects.value[projectIndex]);
+                const routed = projectIndex !== -1 ? projects.value[projectIndex] : storeProject(route.params.id);
+                if(routed) {
+                    mutateCurrentProjectDetails(routed);
                 } else {
                     reportUnreachableRouteProject();
                     mutateCurrentProjectDetails(projects.value[0], true);
@@ -218,6 +219,16 @@ watch(() => route.params,(newVal, oldVal) => {
  * the dashboard's milestone card, a notification or a bookmark all landed this way and
  * looked like they had opened what was clicked. Say so instead.
  */
+// The sidebar list only carries projects whose sprints have loaded, so a
+// project created seconds ago is absent from it while the store already has it.
+function storeProject(id) {
+    if (!id) return null;
+    const known = getters["projectData/projects"];
+    const list = Array.isArray(known) ? known : (known?.data || []);
+    const item = list.find((x) => String(x._id || x.id) === String(id));
+    return item ? { ...item, _id: item._id || item.id } : null;
+}
+
 function reportUnreachableRouteProject() {
     $toast.info(t('Toast.The_project_not_found'), { position: 'top-right' });
 }
@@ -322,9 +333,10 @@ onMounted(async() => {
             const routeIndex = route.params?.id
                 ? projects.value.findIndex((item) => item._id === route.params.id)
                 : -1;
-            const target = routeIndex !== -1 ? projects.value[routeIndex] : projects.value[0];
-            if(route.params?.id && routeIndex === -1) reportUnreachableRouteProject();
-            mutateCurrentProjectDetails(target, routeIndex === -1);
+            const routed = routeIndex !== -1 ? projects.value[routeIndex] : storeProject(route.params?.id);
+            const target = routed || projects.value[0];
+            if(route.params?.id && !routed) reportUnreachableRouteProject();
+            mutateCurrentProjectDetails(target, !routed);
             if(target?.isGlobalPermission === false) {
                 getSprintFolderData(target?._id);
             }

--- a/frontend/src/views/Settings/Members/Members.vue
+++ b/frontend/src/views/Settings/Members/Members.vue
@@ -30,7 +30,7 @@
                         <option :value="null" disabled>{{ $t('MembersV2.invite_role') }}</option>
                         <option v-for="r in inviteRoles" :key="r.key" :value="r.key">{{ r.name }}</option>
                     </select>
-                    <select v-model="designation" class="ah-input mbv__select" :class="{ 'ah-input--error': errors.designation }" :aria-label="$t('MembersV2.invite_designation')" @change="errors.designation = ''">
+                    <select v-if="designationList.length" v-model="designation" class="ah-input mbv__select" :class="{ 'ah-input--error': errors.designation }" :aria-label="$t('MembersV2.invite_designation')" @change="errors.designation = ''">
                         <option :value="null" disabled>{{ $t('MembersV2.invite_designation') }}</option>
                         <option v-for="d in designationList" :key="d.key" :value="d.key">{{ d.name }}</option>
                     </select>
@@ -154,7 +154,6 @@ import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 import { useToast } from "vue-toast-notification";
 import Swal from "sweetalert2";
-import axios from "axios";
 import AppState from "@/components/molecules/AppState/AppState.vue";
 import ShellIcon from "@/components/organisms/Shell/ShellIcon.vue";
 import { useCustomComposable } from "@/composable";
@@ -314,7 +313,7 @@ async function sendInvites() {
     commitEmail();
     errors.email = emails.value.length ? "" : t("MembersV2.err_email");
     errors.role = role.value === null || role.value === "" ? t("MembersV2.err_role") : "";
-    errors.designation = designation.value === null || designation.value === "" ? t("MembersV2.err_designation") : "";
+    errors.designation = designationList.value.length && (designation.value === null || designation.value === "") ? t("MembersV2.err_designation") : "";
     if (errors.email || errors.role || errors.designation) return;
 
     sending.value = true;
@@ -322,7 +321,7 @@ async function sendInvites() {
         // eslint-disable-next-line no-await-in-loop
         const allowed = await canInviteAddress(mail);
         // eslint-disable-next-line no-await-in-loop
-        if (allowed) await deliverInvite(mail, designation.value, role.value, false);
+        if (allowed) await deliverInvite(mail, designation.value ?? 0, role.value, false);
     }
     listing.value = getCompanyUsers();
     emails.value = [];
@@ -344,7 +343,7 @@ async function canInviteAddress(mail) {
 
 async function deliverInvite(mail, userDesignation, userRole, isResend) {
     try {
-        const res = await axios.post(`${env.API_URI}${env.SEND_INVITATION_EMAIL}`, {
+        const res = await apiRequest('post', env.SEND_INVITATION_EMAIL, {
             companyId: companyId.value,
             companyName: company.value.Cst_CompanyName,
             email: mail,


### PR DESCRIPTION
## Summary
Functional sweep (AR-53) across task detail, project structure, docs/chat/inbox, automations/forms/import/export/custom fields, and settings. 36 flows pass with database or network evidence; 9 defects fixed here.

## Fixes
- Create project landed on the previous project with a "project not found" toast
- Chat "Create channel" always failed with "Folder not found"
- Automations never executed (engine off by default); rule name saved with an empty quote
- Custom field drawer rendered blank on a fresh install
- Invite blocked when no designations exist; invite request hit the JWT guard (401); failed invitation mail hid the saved invite and its link
- Relation search ignored task keys
- Timer chip gave no reason when disabled

## Verification
- Backend: 91 suites / 1197 tests pass
- Browser: each fix re-verified on the rebuilt bundle (channel created, custom field saved, new project selected, AR-3 found by key, invite request authenticated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
