### PR TITLE
fix(agents): require the notification module by its tracked lowercase path

### DIFF
--- a/Modules/Agents/runs.js
+++ b/Modules/Agents/runs.js
@@ -234,7 +234,7 @@ const changesFor = async (companyId, task, result) => {
 const notifyStarter = async (companyId, run, task, { status, outcome, error }) => {
     if (!run.notifyMe || !run.startedBy) return;
     try {
-        const { handleNotificationtFun } = require('../Notification/prepare-notification-data/controllerV2');
+        const { handleNotificationtFun } = require('../notification/prepare-notification-data/controllerV2');
         const { Notification_key } = require('../../Config/notificationKey');
         const detail = outcome || error || '';
         const what = status === STATUS.WAITING ? 'needs your approval' : `is ${status}${detail ? ` — ${detail}` : ''}`;

--- a/tests/agent-run-options.test.js
+++ b/tests/agent-run-options.test.js
@@ -8,14 +8,14 @@ jest.mock('../Modules/Automations/engine/tools', () => ({ getTask: jest.fn() }))
 jest.mock('../Modules/Agents/engine/orchestrator', () => ({ run: jest.fn() }));
 jest.mock('../Modules/Agents/engine/findingMemory', () => ({ load: jest.fn(async () => new Map()), decide: jest.fn(), record: jest.fn(), touch: jest.fn() }));
 jest.mock('../Modules/AIProjectGenerator/usage', () => ({ summarize: jest.fn(() => ({ costUsd: 0, totalTokens: 0, model: 'm' })) }));
-jest.mock('../Modules/Notification/prepare-notification-data/controllerV2', () => ({ handleNotificationtFun: jest.fn(async () => ({ status: true })) }));
+jest.mock('../Modules/notification/prepare-notification-data/controllerV2', () => ({ handleNotificationtFun: jest.fn(async () => ({ status: true })) }));
 
 const { SCHEMA_TYPE } = require('../Config/schemaType');
 const tools = require('../Modules/Automations/engine/tools');
 const orchestrator = require('../Modules/Agents/engine/orchestrator');
 const memory = require('../Modules/Agents/engine/findingMemory');
 const { summarize } = require('../Modules/AIProjectGenerator/usage');
-const { handleNotificationtFun } = require('../Modules/Notification/prepare-notification-data/controllerV2');
+const { handleNotificationtFun } = require('../Modules/notification/prepare-notification-data/controllerV2');
 const runs = require('../Modules/Agents/runs');
 const ctrl = require('../Modules/Agents/controller');
 


### PR DESCRIPTION
The run engine and its test required `../Notification/...` while git tracks `Modules/notification`. macOS resolved it case-insensitively; the Linux backend CI job on PR #543 could not (`tests/agent-run-options.test.js` failed to run). One-line path fix in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)