### PR TITLE
fix(agents): declare the revert fields on the run schema so a revert sticks

### DIFF
--- a/Tasks/active/015-guided-project-brief/progress.md
+++ b/Tasks/active/015-guided-project-brief/progress.md
@@ -24,5 +24,21 @@ Notes for review
 - `Modules/Agents/agentRecord.js` duplicates `controller.createAgent` defaults; one-line dedupe once 016 lands (016 sets the default to L1 there).
 - Agents schema gained `trigger`; projects gained `aiGuide`, `aiAssumptions`.
 
+## 2026-09-05 — API sweep on beta (owner token, real model)
+Two-line brief: "A mobile app for a small gym so members can book classes and see their schedule. Needs to work on both phones."
+
+| Step | Result |
+|---|---|
+| `/clarify` | coverage: what_for_whom met, four missing; 3 questions, each on a missing point, each `allowUnknown` |
+| `/brief` (all three answered unknown) | five headed sections; 4 assumptions (one per unknown + the never-asked `team`), e.g. "No launch date or budget given; planning for a six-week first release on both iOS and Android" |
+| `/plan` with the approved brief | 10 tasks over 5 sprints; `splitSummary` agent 5 · agent-after 2 · person 3; assumptions echoed; `person` reasons include "It asks for a decision…" and "no agent here has a skill for this kind of work" |
+| `/guide` | 5 stages derived from the brief (Project Initialization → … → Testing and Launch Preparation), 4 essentials, 3 escalations; no fixed list |
+| `/execute` | project created with `aiGuide` (5 stages) and 4 `aiAssumptions`; "Gym Class Booking App Guide" at L1, actions task.get/task.comment/subtask.create, scoped to the project, trigger mention; `runsQueued` 5, `runsRefused` 0 |
+| the 5 runs | all ended `waiting_approval` as L1 requires; proposals carry a `rating` per change; spend $0.002–0.004 each, budget ledger $0.12 for the month |
+
+Finding for review: "Implement user login flow" and similar implementation tasks are labelled `agent` because Daily PM's planning skill fits the work kind and the task carries a brief. The reason text says "Daily PM can run project.plan on it", which is accurate, but the badge alone reads as "an agent will implement this". Consider a distinct label (or wording) when the only matching skill plans rather than does.
+
+Note: `/execute` requires the existing `source` field (upwork / fiverr / other); the UI already sends it. The sweep project "(sweep 015)" is left in the workspace for the browser look; trash it afterwards.
+
 Open
-- Browser sweep of the whole flow on the three domain briefs (owner), then member.
+- Browser sweep of the UI flow (owner), then member — needs a signed-in Browser pane.

--- a/Tasks/active/016-agent-trust-layer/progress.md
+++ b/Tasks/active/016-agent-trust-layer/progress.md
@@ -18,6 +18,14 @@ Notes for review
 - The 80/100 alert stamp is read-then-write; two runs finishing in the same instant could notify twice.
 - Stored proposals now keep each change's `rating`.
 
+## 2026-09-05 — API sweep on beta (owner token)
+- `GET /agents/registry`: 18 actions, 18 rated.
+- `GET /agents/settings`: undoHours 24, budget 0, provider openai with key, no region; `PUT {undoHours: 999}` → "undoHours must be a whole number between 1 and 168."
+- `GET /agents/budget`: month 2026-09, used $0.12, no alerts.
+- Throwaway L2 agent (brief.parse, task.get/comment/subtask.create) on a task with a 347-char brief: 8 changes, every one decided `act` with the reason "reversible task-scoped write with no money in it", run `done`, `decisions[]` has 8 entries, `windowEndsAt` = finishedAt + 24 h.
+- `POST /runs/:id/revert`: 8 reverted, 0 failed. **Defect found:** `revertedAt` / `revertedBy` / `revert` were not stored because the strict `agentRuns` schema lacked them, so a second revert was accepted. Fixed by declaring the fields (this PR); after the fix a second revert answers 409 "Run was already reverted at …".
+- A mixed batch (safe + risky) was not exercised on beta because the seeded agents' skills only emit task-scoped writes; covered by `agent-run-policy` tests.
+
 Open
-- Browser sweep as owner and member of: L2 run with a mixed batch, revert, budget alert, settings panel.
+- Browser sweep as owner and member of the L2 preview panel, run detail with Revert, and the instance console budget section — needs a signed-in Browser pane.
 - 019 evals should start from the `decisions[]` data this produces.

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -822,6 +822,10 @@ const schema = {
         refusals: { type: Number, default: 0, required: false },
         // [{ action, decision: act | propose | refuse, reason, rating, at }] — one per change the policy reviewed
         decisions: { type: Array, default: [], required: false },
+        revertedAt: { type: Date, required: false },
+        revertedBy: { type: String, required: false },
+        // { reverted, failed: [{ action, auditId, reason }] }
+        revert: { type: Object, required: false },
         spendCapUsd: { type: Number, required: false },
         notifyMe: { type: Boolean, default: false, required: false },
         outcome: { type: String, required: false },


### PR DESCRIPTION
Found in the beta API sweep: `revertedAt`, `revertedBy` and the revert summary written by `revert.js` were silently dropped by the strict `agentRuns` schema, so a run never showed as reverted and a second revert was accepted. Declares the three fields; verified live that a second revert now returns 409. Also records the 015 and 016 API sweep results in the progress files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)