### PR TITLE
docs(tasks): record the owner UI sweeps of 015 and 016 on beta

### DIFF
--- a/Tasks/active/015-guided-project-brief/progress.md
+++ b/Tasks/active/015-guided-project-brief/progress.md
@@ -40,5 +40,24 @@ Finding for review: "Implement user login flow" and similar implementation tasks
 
 Note: `/execute` requires the existing `source` field (upwork / fiverr / other); the UI already sends it. The sweep project "(sweep 015)" is left in the workspace for the browser look; trash it afterwards.
 
+## 2026-09-05 — UI sweep on beta (owner, Browser pane, real model)
+Same two-line gym brief through the "Create from a description" tile.
+
+| Step | Result |
+|---|---|
+| Describe | textarea + Continue; the Source field is not enforced here (see finding) |
+| Clarify, round 1 | coverage chips: What and for whom met, four missing; "Round 1 of 2 · only the missing points are asked"; question 1/3 with option cards and "I don't know yet"; all three answered unknown |
+| Clarify, round 2 | exactly one question, the never-asked Team point; answered "External developer or agency" |
+| Brief | chips now show Team met; original beside the drafted brief; three assumptions listed for the unknowns; **Generate plan disabled until Approve brief** (verified before/after) |
+| Plan | "3 sprints · 4 tasks · $0.09"; summary line "3 tasks an agent can start · 4 need a person · 1 need a person first"; assumptions carried; badge "⏳ Agent after: a public URL in the task title or description (QA review)" on a task row; guide preview with 6 stages from this brief, essentials, escalations |
+| Create everything | "All done!" — Project Done, Sprints 3/3, "⚡ 3 agent runs queued", "Open the Guide agent →"; the link opens the Guide agent's settings page at L1 with task.get / task.comment / subtask.create scoped to the project |
+
+Findings
+1. **Source not validated on step 1.** Continue is enabled without a Source; execute then fails with "Select where this project came from." and the wizard drops back to step 1. State survives the round trip (brief, plan and guide are kept, no new model call), but the check belongs on step 1.
+2. **Done-screen counter reads "Tasks 8 / 4"**: created subtasks are counted against the planned task total.
+3. As in the API sweep: implementation tasks labelled `agent` because a planning skill fits them; consider a distinct label when the only matching skill plans rather than does.
+
+Cleanup: two sweep projects exist now ("Gym Class Booking App (sweep 015)" from the API run and "Gym Class Booking App" from the UI run) with their Guide agents; trash both when done.
+
 Open
-- Browser sweep of the UI flow (owner), then member — needs a signed-in Browser pane.
+- Member-role pass — needs a member account.

--- a/Tasks/active/016-agent-trust-layer/progress.md
+++ b/Tasks/active/016-agent-trust-layer/progress.md
@@ -26,6 +26,14 @@ Notes for review
 - `POST /runs/:id/revert`: 8 reverted, 0 failed. **Defect found:** `revertedAt` / `revertedBy` / `revert` were not stored because the strict `agentRuns` schema lacked them, so a second revert was accepted. Fixed by declaring the fields (this PR); after the fix a second revert answers 409 "Run was already reverted at …".
 - A mixed batch (safe + risky) was not exercised on beta because the seeded agents' skills only emit task-scoped writes; covered by `agent-run-policy` tests.
 
+## 2026-09-05 — UI sweep on beta (owner, Browser pane)
+- **Agent settings, L1 default:** the Guide agent created by 015 opens at "L1 · Suggest"; the "What L2 will do without asking" panel lists task.get (read only), task.comment and subtask.create ("reversible, one task, no money") under "Acts without asking" and "Nothing" under "Proposes first".
+- **Policy on a real L2 run:** Run now on "Sweep Intake" (L2, actions task.get / task.comment / tasks.search) against GCBA2-3 → run `done`, "6 refused"; Details shows DECISIONS: six `subtask.create` refused ("outside this agent's allowed actions"), one `task.comment` acted ("reversible task-scoped write with no money in it"), "Can be reverted until 06/09/2026 15:01".
+- **Revert in the UI:** "Revert this run" → toast "Reverted 1 action(s).", row shows "Reverted 05/09/2026 15:02:44", button gone. (The schema fix in PR #547 is what makes the reverted state stick.)
+- **Instance console → Settings → AI:** "AI agents" section with undo window 24 h, monthly budget 0, "This month 2026-09 $0.14 · no cap", "80% alert not reached / 100% alert not reached" chips, provider openai · Region: any · "Key set".
+
+Finding (pre-existing, task 013 area): loading `/settings/instance/settings` directly bounces to My Profile because the shell checks instance access after mounting; navigating from inside the settings shell works. Worth a guard that waits for the access answer.
+
 Open
-- Browser sweep as owner and member of the L2 preview panel, run detail with Revert, and the instance console budget section — needs a signed-in Browser pane.
+- Member-role pass — needs a member account.
 - 019 evals should start from the `decisions[]` data this produces.


### PR DESCRIPTION
Owner walk-through of the guided project flow and the trust-layer screens on beta, with three UI findings (Source not validated on step 1, done-screen task counter, direct-URL bounce on the instance console). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)