### PR TITLE
fix(ui): enforce the project source on step 1, count subtasks in the total, hold instance routes

### DIFF
--- a/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
+++ b/frontend/src/components/organisms/AiProjectCreator/AiProjectCreator.vue
@@ -110,6 +110,7 @@
                         <div class="aipg-skills-select">
                             <ProjectSourceSelect v-model="source"/>
                         </div>
+                        <p v-if="!hasSource" class="aipg-helper" data-test="source-required">{{ $t('AiProject.source_required') }}</p>
 
                         <label class="aipg-field-label aipg-field-label-stacked">
                             {{ $t('ProjectDetails.proposal_id') }}
@@ -171,14 +172,14 @@
                     <div v-if="hasGeneratedPlan" class="aipg-actions aipg-actions-split">
                         <button
                             class="aipg-btn aipg-btn-ghost"
-                            :disabled="!canGenerate || loading || briefUploading || clarifyLoading"
+                            :disabled="!canGenerate || !hasSource || loading || briefUploading || clarifyLoading"
                             @click="onGeneratePlan">
                             <span v-if="loading || clarifyLoading" class="aipg-spinner aipg-spinner-sm" aria-hidden="true"></span>
                             {{ clarifyLoading ? $t('AiProject.analyzing') : (loading ? $t('AiProject.generating_plan') : 'Re-Generate Plan') }}
                         </button>
                         <button
                             class="aipg-btn aipg-btn-primary"
-                            :disabled="loading || briefUploading || clarifyLoading"
+                            :disabled="!hasSource || loading || briefUploading || clarifyLoading"
                             @click="onNextWithExistingPlan">
                             Next →
                         </button>
@@ -186,14 +187,14 @@
                     <div v-else-if="hasGeneratedQuestions" class="aipg-actions aipg-actions-split">
                         <button
                             class="aipg-btn aipg-btn-ghost"
-                            :disabled="!canGenerate || loading || briefUploading || clarifyLoading"
+                            :disabled="!canGenerate || !hasSource || loading || briefUploading || clarifyLoading"
                             @click="onRegenerateQuestions">
                             <span v-if="clarifyLoading || loading" class="aipg-spinner aipg-spinner-sm" aria-hidden="true"></span>
                             {{ clarifyLoading ? $t('AiProject.analyzing') : (loading ? $t('AiProject.generating_plan') : 'Re-Generate Questions') }}
                         </button>
                         <button
                             class="aipg-btn aipg-btn-primary"
-                            :disabled="loading || briefUploading || clarifyLoading"
+                            :disabled="!hasSource || loading || briefUploading || clarifyLoading"
                             @click="onNextWithExistingQuestions">
                             Next →
                         </button>
@@ -202,7 +203,7 @@
                         <button
                             class="aipg-btn aipg-btn-primary"
                             data-test="start"
-                            :disabled="!canGenerate || loading || briefUploading || clarifyLoading"
+                            :disabled="!canGenerate || !hasSource || loading || briefUploading || clarifyLoading"
                             @click="onGeneratePlan">
                             <span v-if="loading || clarifyLoading" class="aipg-spinner aipg-spinner-sm" aria-hidden="true"></span>
                             {{ clarifyLoading ? $t('AiProject.analyzing') : (loading ? $t('AiProject.generating_plan') : (error ? $t('AiProject.try_again') : $t('AiProject.continue'))) }}
@@ -399,7 +400,7 @@
                         <div class="aipg-progress-row" :class="rowClass('tasks')">
                             <span class="aipg-progress-icon"><span v-html="stepIcon('tasks')" /></span>
                             <span class="aipg-progress-label">Tasks</span>
-                            <span class="aipg-progress-status">{{ progress.tasksDone }} / {{ progress.totalTasks || '…' }}</span>
+                            <span class="aipg-progress-status" data-test="progress-tasks">{{ progress.tasksDone }} / {{ progress.totalTasks || '…' }}</span>
                         </div>
                     </div>
 
@@ -572,6 +573,7 @@ export default defineComponent({
         const placeholderText = 'e.g. "A 3-month SaaS launch for a 5-person team building an invoicing tool with Stripe billing. Kanban workflow. GitHub + Slack integrations. MVP in 6 weeks; full launch in 12."';
 
         const canGenerate = computed(() => description.value.trim().length >= 20);
+        const hasSource = computed(() => PROJECT_SOURCES.includes(source.value));
 
         // True once a plan has been produced and is still held in memory.
         // Drives the dual-button layout on Step 1 (Next + Re-Generate)
@@ -627,10 +629,16 @@ export default defineComponent({
         }
 
         const totals = computed(() => {
-            if (!plan.value || !Array.isArray(plan.value.sprints)) return { sprints: 0, tasks: 0 };
-            let t = 0;
-            for (const sp of plan.value.sprints) t += (sp.tasks || []).length;
-            return { sprints: plan.value.sprints.length, tasks: t };
+            if (!plan.value || !Array.isArray(plan.value.sprints)) return { sprints: 0, tasks: 0, taskDocs: 0 };
+            let tasks = 0;
+            let taskDocs = 0;
+            for (const sp of plan.value.sprints) {
+                for (const task of sp.tasks || []) {
+                    tasks += 1;
+                    taskDocs += 1 + (Array.isArray(task.subtasks) ? task.subtasks.length : 0);
+                }
+            }
+            return { sprints: plan.value.sprints.length, tasks, taskDocs };
         });
 
         const briefAssumptions = computed(() => {
@@ -850,7 +858,7 @@ export default defineComponent({
         // Entry point from Step 1. Questions come back only for points the brief
         // misses; none at all (or a failed call) goes straight to the brief draft.
         async function onGeneratePlan() {
-            if (!canGenerate.value) return;
+            if (!canGenerate.value || !hasSource.value) return;
             error.value = '';
             clarifyError.value = '';
             resetBriefFlow();
@@ -1108,9 +1116,7 @@ export default defineComponent({
 
         async function onApprovePlan() {
             if (!plan.value) return;
-            // Enforced here rather than before plan generation: the AI doesn't
-            // need either value, so blocking step 1 would be friction for nothing.
-            if (!PROJECT_SOURCES.includes(source.value)) {
+            if (!hasSource.value) {
                 error.value = t('Projects.source_required');
                 step.value = 'input';
                 return;
@@ -1143,7 +1149,7 @@ export default defineComponent({
                 jobId.value = result.jobId;
                 step.value = 'executing';
                 progress.totalSprints = totals.value.sprints;
-                progress.totalTasks = totals.value.tasks;
+                progress.totalTasks = totals.value.taskDocs;
                 subscribe();
             } catch (e) {
                 error.value = friendlyErr(e);
@@ -1171,8 +1177,9 @@ export default defineComponent({
                     } else if (payload.step === 'tasks') {
                         progress.sprintState = 'done';
                         progress.tasksState = payload.status === 'done' ? 'done' : 'active';
+                        // The server's `total` counts parent tasks only while `completed`
+                        // includes subtasks; the plan-derived taskDocs total is the one that matches.
                         if (typeof payload.completed === 'number') progress.tasksDone = payload.completed;
-                        if (typeof payload.total === 'number') progress.totalTasks = payload.total;
                     }
                 } else if (payload.event === 'complete') {
                     progress.project = 'done';
@@ -1287,7 +1294,7 @@ export default defineComponent({
             plan, planId, editableProjectName,
             jobId, progress, createdProjectId,
             placeholderText,
-            canGenerate, hasGeneratedPlan, hasGeneratedQuestions, totals, isBusy,
+            canGenerate, hasSource, hasGeneratedPlan, hasGeneratedQuestions, totals, isBusy,
             runUsage, usageTooltip, formatTokens, formatCost, formatHours,
             renderTaskDescription, isStepDone, stepClass, stepDoneDot, rowClass, stepIcon, stepStatusLabel,
             onFileChosen, clearBrief,

--- a/frontend/src/locales/ar.js
+++ b/frontend/src/locales/ar.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/ar.pending.json
+++ b/frontend/src/locales/ar.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ar",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.212Z",
+  "updatedAt": "2026-09-05T09:43:53.225Z",
   "keys": {
     "Scrum.stranded_head": "These {count} will stay in this sprint",
     "Scrum.stranded_hint": "They are unfinished, but their parent task is done — and a subtask moves with its parent. Finish them, or reopen the parent task, before completing the sprint.",
@@ -7239,6 +7239,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/ch.js
+++ b/frontend/src/locales/ch.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/ch.pending.json
+++ b/frontend/src/locales/ch.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ch",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.237Z",
+  "updatedAt": "2026-09-05T09:43:53.264Z",
   "keys": {
     "errorPage.card_name": "card name",
     "Auth.welcome_back": "Welcome back",
@@ -5097,6 +5097,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1619,6 +1619,7 @@ export default {
         step_create: "Create",
         describe_label: "What is the project about?",
         min_chars: "{count} / {min} minimum characters",
+        source_required: "Choose a source to continue — every project records where it came from.",
         continue: "Continue →",
         analyzing: "Analyzing your brief…",
         analyzing_sub: "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/fr.pending.json
+++ b/frontend/src/locales/fr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "fr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.260Z",
+  "updatedAt": "2026-09-05T09:43:53.292Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5106,6 +5106,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/ge.js
+++ b/frontend/src/locales/ge.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/ge.pending.json
+++ b/frontend/src/locales/ge.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ge",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.284Z",
+  "updatedAt": "2026-09-05T09:43:53.325Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5178,6 +5178,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/gr.js
+++ b/frontend/src/locales/gr.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/gr.pending.json
+++ b/frontend/src/locales/gr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.311Z",
+  "updatedAt": "2026-09-05T09:43:53.360Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5099,6 +5099,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/gu.js
+++ b/frontend/src/locales/gu.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/gu.pending.json
+++ b/frontend/src/locales/gu.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gu",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.335Z",
+  "updatedAt": "2026-09-05T09:43:53.394Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5097,6 +5097,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/hi.pending.json
+++ b/frontend/src/locales/hi.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "hi",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.362Z",
+  "updatedAt": "2026-09-05T09:43:53.424Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5098,6 +5098,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/it.pending.json
+++ b/frontend/src/locales/it.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "it",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.385Z",
+  "updatedAt": "2026-09-05T09:43:53.447Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5097,6 +5097,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/ru.pending.json
+++ b/frontend/src/locales/ru.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ru",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.411Z",
+  "updatedAt": "2026-09-05T09:43:53.472Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5096,6 +5096,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/locales/spa.js
+++ b/frontend/src/locales/spa.js
@@ -1596,6 +1596,7 @@ export default {
         "step_create": "Create",
         "describe_label": "What is the project about?",
         "min_chars": "{count} / {min} minimum characters",
+        "source_required": "Choose a source to continue — every project records where it came from.",
         "continue": "Continue →",
         "analyzing": "Analyzing your brief…",
         "analyzing_sub": "Checking which of the five points your description already covers.",

--- a/frontend/src/locales/spa.pending.json
+++ b/frontend/src/locales/spa.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "spa",
   "machineTranslated": false,
-  "updatedAt": "2026-09-05T06:58:38.432Z",
+  "updatedAt": "2026-09-05T09:43:53.496Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5096,6 +5096,7 @@
     "AiProject.all_done": "All done!",
     "AiProject.building": "Building your project…",
     "AiProject.starting": "Starting…",
-    "AiProject.create_everything": "✓ Create everything"
+    "AiProject.create_everything": "✓ Create everything",
+    "AiProject.source_required": "Choose a source to continue — every project records where it came from."
   }
 }

--- a/frontend/src/views/Settings/SettingsShell.vue
+++ b/frontend/src/views/Settings/SettingsShell.vue
@@ -61,7 +61,7 @@
                 </button>
             </header>
             <div class="st__content ah-scroll">
-                <router-view />
+                <router-view v-if="!accessPending" />
             </div>
         </div>
 
@@ -122,8 +122,8 @@ const membersVisible = () => checkPermission("settings.settings_role_management"
 const hasBilling = computed(() => !!(chargebeeRouter.upgradeTab || paddleRouter.upgradeTab) && isOwner.value && router.hasRoute("Upgrade"));
 
 // The Instance group belongs to the account that set the instance up (users.isProductOwner),
-// which the server decides; a member never sees it.
-const instanceAdmin = ref(false);
+// which the server decides; a member never sees it. null = answer not in yet.
+const instanceAdmin = ref(null);
 onMounted(() => {
     apiRequestWithoutCompnay("get", env.INSTANCE_ACCESS)
         .then((res) => { instanceAdmin.value = res?.data?.data?.allowed === true; })
@@ -168,12 +168,12 @@ const rawGroups = computed(() => [
         key: "instance",
         label: "Instance.group",
         items: [
-            { key: "instance-health", text: t("Instance.nav_health"), icon: "monitor", to: to("InstanceHealth"), names: ["InstanceHealth"], show: instanceAdmin.value },
-            { key: "instance-settings", text: t("Instance.nav_settings"), icon: "settings", to: to("InstanceSettings"), names: ["InstanceSettings"], show: instanceAdmin.value },
-            { key: "instance-backups", text: t("Instance.nav_backups"), icon: "download", to: to("InstanceBackups"), names: ["InstanceBackups"], show: instanceAdmin.value },
-            { key: "instance-upgrade", text: t("Instance.nav_upgrade"), icon: "refresh", to: to("InstanceUpgrade"), names: ["InstanceUpgrade"], show: instanceAdmin.value },
-            { key: "instance-logs", text: t("Instance.nav_logs"), icon: "file", to: to("InstanceLogs"), names: ["InstanceLogs"], show: instanceAdmin.value },
-            { key: "instance-stats", text: t("Instance.nav_stats"), icon: "reports", to: to("InstanceStats"), names: ["InstanceStats"], show: instanceAdmin.value }
+            { key: "instance-health", text: t("Instance.nav_health"), icon: "monitor", to: to("InstanceHealth"), names: ["InstanceHealth"], show: instanceAdmin.value === true },
+            { key: "instance-settings", text: t("Instance.nav_settings"), icon: "settings", to: to("InstanceSettings"), names: ["InstanceSettings"], show: instanceAdmin.value === true },
+            { key: "instance-backups", text: t("Instance.nav_backups"), icon: "download", to: to("InstanceBackups"), names: ["InstanceBackups"], show: instanceAdmin.value === true },
+            { key: "instance-upgrade", text: t("Instance.nav_upgrade"), icon: "refresh", to: to("InstanceUpgrade"), names: ["InstanceUpgrade"], show: instanceAdmin.value === true },
+            { key: "instance-logs", text: t("Instance.nav_logs"), icon: "file", to: to("InstanceLogs"), names: ["InstanceLogs"], show: instanceAdmin.value === true },
+            { key: "instance-stats", text: t("Instance.nav_stats"), icon: "reports", to: to("InstanceStats"), names: ["InstanceStats"], show: instanceAdmin.value === true }
         ]
     }
 ]);
@@ -182,21 +182,25 @@ const groups = computed(() => rawGroups.value
     .map((g) => ({ ...g, items: g.items.filter((i) => i.show && router.hasRoute(i.to.name)).map((i) => ({ ...i, active: i.names.includes(route.name) })) }))
     .filter((g) => g.items.length));
 
+const currentItem = computed(() => rawGroups.value
+    .flatMap((g) => g.items.map((i) => ({ ...i, group: g.key })))
+    .find((i) => i.names.includes(route.name)));
+const accessPending = computed(() => currentItem.value?.group === "instance" && instanceAdmin.value === null);
+
 const pageTitle = computed(() => {
-    const hit = rawGroups.value.flatMap((g) => g.items).find((i) => i.names.includes(route.name));
     if (route.name === "changePassword") return label("settingslider.Change Password");
-    if (hit) return hit.text;
+    if (currentItem.value) return currentItem.value.text;
     const title = route.meta?.title || "";
     return te(`settingslider.${title}`) ? t(`settingslider.${title}`) : title;
 });
 
 function guardRoute() {
-    const hit = rawGroups.value.flatMap((g) => g.items).find((i) => i.names.includes(route.name));
-    if (hit && !hit.show) router.replace(to("My Profile"));
+    if (accessPending.value) return;
+    if (currentItem.value && !currentItem.value.show) router.replace(to("My Profile"));
 }
 
 onMounted(guardRoute);
-watch(() => route.name, guardRoute);
+watch([() => route.name, instanceAdmin], guardRoute);
 watch(narrow, (v) => { if (!v) drawer.value = false; });
 </script>
 

--- a/frontend/tests/unit/aiProjectCreator.spec.js
+++ b/frontend/tests/unit/aiProjectCreator.spec.js
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createStore } from 'vuex';
-import { h } from 'vue';
+import { h, nextTick } from 'vue';
 
 const { apiRequest, push, stub } = vi.hoisted(() => ({
     apiRequest: vi.fn(),
@@ -89,9 +89,20 @@ function mountCreator() {
     return mount(AiProjectCreator, { props: { visible: true }, global: { plugins: [store] } });
 }
 
+const describeProject = (wrapper) => wrapper.find('textarea.aipg-textarea').setValue('An online shop for makers selling handmade goods to hobbyists.');
+
 async function describeAndStart(wrapper) {
-    await wrapper.find('textarea.aipg-textarea').setValue('An online shop for makers selling handmade goods to hobbyists.');
+    await describeProject(wrapper);
+    wrapper.vm.source = 'other';
+    await nextTick();
     await wrapper.find('[data-test="start"]').trigger('click');
+    await flushPromises();
+}
+
+async function reachPreview(wrapper) {
+    await describeAndStart(wrapper);
+    await wrapper.find('[data-test="approve-brief"]').trigger('click');
+    await wrapper.find('[data-test="generate-plan"]').trigger('click');
     await flushPromises();
 }
 
@@ -229,7 +240,6 @@ describe('AiProjectCreator guided flow', () => {
         await wrapper.find('[data-test="generate-plan"]').trigger('click');
         await flushPromises();
 
-        wrapper.vm.source = 'other';
         await wrapper.find('[data-test="create-everything"]').trigger('click');
         await flushPromises();
 
@@ -240,7 +250,7 @@ describe('AiProjectCreator guided flow', () => {
         expect(wrapper.vm.step).toBe('executing');
 
         FakeEventSource.last.emit({
-            event: 'complete', projectId: 'proj-1', totals: { sprints: 1, tasks: 3 },
+            event: 'complete', projectId: 'proj-1', totals: { sprints: 1, tasks: 4 },
             guideAgentId: 'agent-9', runsQueued: 1,
             runsRefused: [{ taskId: 't2', taskName: 'Summarise the theme PR', reason: 'needs a person — a pull-request or branch link on the task' }]
         });
@@ -262,14 +272,74 @@ describe('AiProjectCreator guided flow', () => {
         await wrapper.find('[data-test="approve-brief"]').trigger('click');
         await wrapper.find('[data-test="generate-plan"]').trigger('click');
         await flushPromises();
-        wrapper.vm.source = 'other';
         await wrapper.find('[data-test="create-everything"]').trigger('click');
         await flushPromises();
-        FakeEventSource.last.emit({ event: 'complete', projectId: 'proj-1', totals: { sprints: 1, tasks: 3 } });
+        FakeEventSource.last.emit({ event: 'complete', projectId: 'proj-1', totals: { sprints: 1, tasks: 4 } });
         await flushPromises();
 
         await wrapper.find('[data-test="open-project"]').trigger('click');
         expect(wrapper.emitted('created')[0]).toEqual([{ projectId: 'proj-1' }]);
+    });
+
+    it('keeps Continue disabled and explains why until a source is chosen', async () => {
+        routes({ clarify: () => ({ coverage: allMet, round: 1, maxRounds: 2, questions: [] }) });
+        const wrapper = mountCreator();
+        await describeProject(wrapper);
+
+        const start = wrapper.find('[data-test="start"]');
+        expect(start.attributes('disabled')).toBeDefined();
+        expect(wrapper.find('[data-test="source-required"]').text()).toBe('AiProject.source_required');
+        await start.trigger('click');
+        await flushPromises();
+        expect(callsTo(env.AI_PROJECT_CLARIFY)).toHaveLength(0);
+        expect(wrapper.vm.step).toBe('input');
+
+        wrapper.vm.source = 'upwork';
+        await nextTick();
+        expect(wrapper.find('[data-test="start"]').attributes('disabled')).toBeUndefined();
+        expect(wrapper.find('[data-test="source-required"]').exists()).toBe(false);
+    });
+
+    it('never calls execute without a source and keeps the plan for the way back', async () => {
+        routes({ clarify: () => ({ coverage: allMet, round: 1, maxRounds: 2, questions: [] }) });
+        const wrapper = mountCreator();
+        await reachPreview(wrapper);
+
+        wrapper.vm.source = '';
+        await wrapper.find('[data-test="create-everything"]').trigger('click');
+        await flushPromises();
+
+        expect(callsTo(env.AI_PROJECT_EXECUTE)).toHaveLength(0);
+        expect(wrapper.vm.step).toBe('input');
+        expect(wrapper.text()).toContain('Projects.source_required');
+        expect(buttonByText(wrapper, 'Next →').attributes('disabled')).toBeDefined();
+
+        wrapper.vm.source = 'other';
+        await nextTick();
+        await buttonByText(wrapper, 'Next →').trigger('click');
+        expect(wrapper.vm.step).toBe('preview');
+        expect(callsTo(env.AI_PROJECT_PLAN)).toHaveLength(1);
+    });
+
+    it('counts subtasks in the task total so the done screen reads N / N', async () => {
+        routes({ clarify: () => ({ coverage: allMet, round: 1, maxRounds: 2, questions: [] }) });
+        const wrapper = mountCreator();
+        await reachPreview(wrapper);
+        await wrapper.find('[data-test="create-everything"]').trigger('click');
+        await flushPromises();
+
+        const counter = () => wrapper.find('[data-test="progress-tasks"]').text();
+        expect(counter()).toBe('0 / 4');
+
+        FakeEventSource.last.emit({ event: 'progress', step: 'tasks', status: 'started', total: 3 });
+        FakeEventSource.last.emit({ event: 'progress', step: 'tasks', status: 'progress', completed: 4, total: 3 });
+        await nextTick();
+        expect(counter()).toBe('4 / 4');
+
+        FakeEventSource.last.emit({ event: 'complete', projectId: 'proj-1', totals: { sprints: 1, tasks: 4 } });
+        await flushPromises();
+        expect(wrapper.vm.step).toBe('done');
+        expect(counter()).toBe('4 / 4');
     });
 
     it('falls back to the old plan path when the brief endpoint fails', async () => {

--- a/frontend/tests/unit/settingsShell.spec.js
+++ b/frontend/tests/unit/settingsShell.spec.js
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import { createStore } from 'vuex';
+import { h } from 'vue';
+
+const { apiRequestWithoutCompnay } = vi.hoisted(() => ({ apiRequestWithoutCompnay: vi.fn() }));
+
+vi.mock('@/services', () => ({ apiRequestWithoutCompnay }));
+vi.mock('@/composable', () => ({ useCustomComposable: () => ({ checkPermission: () => true }) }));
+vi.mock('@/plugins/customFieldView/helper.js', () => ({ customField: () => ({ tabRouteHelper: () => [] }) }));
+vi.mock('@/plugins/chargebee/router', () => ({ default: {} }));
+vi.mock('@/plugins/paddle/router.js', () => ({ default: {} }));
+vi.mock('@/components/organisms/Shell/ShellIcon.vue', () => ({ default: { name: 'ShellIcon', render: () => null } }));
+vi.mock('@/components/molecules/AddTeamSidebar/AddTeamSidebar.vue', () => ({ default: { name: 'AddTeamSidebar', render: () => null } }));
+vi.mock('@/components/organisms/CreateProject/CreateProjectSidebar.vue', () => ({ default: { name: 'CreateProjectSidebar', render: () => null } }));
+
+import SettingsShell from '@/views/Settings/SettingsShell.vue';
+
+const page = (name) => ({ render: () => h('div', { 'data-test': `page-${name}` }) });
+const routes = [
+    { path: '/:cid/settings/my-profile', name: 'My Profile', component: page('profile') },
+    { path: '/:cid/settings/setting', name: 'Setting', component: page('setting') },
+    { path: '/:cid/settings/instance/health', name: 'InstanceHealth', component: page('health') },
+    { path: '/:cid/settings/instance/settings', name: 'InstanceSettings', component: page('instance-settings') }
+];
+
+const store = createStore({
+    modules: { settings: { namespaced: true, getters: { companies: () => [], selectedCompany: () => ({}), companyUserDetail: () => ({ roleType: 1 }) } } }
+});
+
+const access = (allowed) => Promise.resolve({ data: { status: true, data: { allowed } } });
+const pending = () => new Promise(() => {});
+
+const open = async (path, answer) => {
+    apiRequestWithoutCompnay.mockImplementation(answer);
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    router.push(path);
+    await router.isReady();
+    const wrapper = mount(SettingsShell, { global: { plugins: [router, store] } });
+    await flushPromises();
+    return { wrapper, router };
+};
+
+describe('SettingsShell instance route guard', () => {
+    beforeEach(() => { apiRequestWithoutCompnay.mockReset(); });
+
+    it('holds an instance route without rendering it while the access check is pending', async () => {
+        const { wrapper, router } = await open('/company-1/settings/instance/settings', pending);
+        expect(router.currentRoute.value.name).toBe('InstanceSettings');
+        expect(wrapper.find('[data-test="page-instance-settings"]').exists()).toBe(false);
+        expect(wrapper.find('.st__nav').text()).not.toContain('Instance.nav_settings');
+    });
+
+    it('stays on the instance route and renders it once access is allowed', async () => {
+        const { wrapper, router } = await open('/company-1/settings/instance/settings', () => access(true));
+        expect(router.currentRoute.value.name).toBe('InstanceSettings');
+        expect(wrapper.find('[data-test="page-instance-settings"]').exists()).toBe(true);
+        expect(wrapper.find('.st__nav').text()).toContain('Instance.nav_settings');
+    });
+
+    it('redirects a member to My Profile once access is denied', async () => {
+        const { wrapper, router } = await open('/company-1/settings/instance/settings', () => access(false));
+        expect(router.currentRoute.value.name).toBe('My Profile');
+        expect(wrapper.find('[data-test="page-profile"]').exists()).toBe(true);
+        expect(wrapper.find('.st__nav').text()).not.toContain('Instance.nav_settings');
+    });
+
+    it('treats a failed access check as denied', async () => {
+        const { router } = await open('/company-1/settings/instance/settings', () => Promise.reject(new Error('boom')));
+        expect(router.currentRoute.value.name).toBe('My Profile');
+    });
+
+    it('keeps in-shell navigation between instance routes for an owner', async () => {
+        const { wrapper, router } = await open('/company-1/settings/setting', () => access(true));
+        await router.push({ name: 'InstanceHealth', params: { cid: 'company-1' } });
+        await flushPromises();
+        expect(router.currentRoute.value.name).toBe('InstanceHealth');
+        expect(wrapper.find('[data-test="page-health"]').exists()).toBe(true);
+    });
+
+    it('redirects a member who navigates to an instance route from inside the shell', async () => {
+        const { router } = await open('/company-1/settings/setting', () => access(false));
+        await router.push({ name: 'InstanceHealth', params: { cid: 'company-1' } });
+        await flushPromises();
+        expect(router.currentRoute.value.name).toBe('My Profile');
+    });
+
+    it('leaves non-instance routes alone while the check is pending', async () => {
+        const { wrapper, router } = await open('/company-1/settings/setting', pending);
+        expect(router.currentRoute.value.name).toBe('Setting');
+        expect(wrapper.find('[data-test="page-setting"]').exists()).toBe(true);
+    });
+});


### PR DESCRIPTION
The three findings from the owner UI sweep on beta (Tasks 015/016 progress files):

- AI project creator: step 1 cannot continue without a Source; the execute-time bounce stays as a last line of defence. The done-screen tasks counter uses the same denominator as its numerator (tasks + subtasks).
- Settings shell: Instance routes wait for the instance-access answer instead of redirecting to My Profile on a direct load; members are still redirected once the answer is a definite no.

Tests: aiProjectCreator.spec (12), new settingsShell.spec (7); vitest, eslint, i18n check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)