### PR TITLE
docs(tasks): mark the UI sweep findings fixed by PR #549

### DIFF
--- a/Tasks/active/015-guided-project-brief/progress.md
+++ b/Tasks/active/015-guided-project-brief/progress.md
@@ -52,7 +52,7 @@ Same two-line gym brief through the "Create from a description" tile.
 | Plan | "3 sprints · 4 tasks · $0.09"; summary line "3 tasks an agent can start · 4 need a person · 1 need a person first"; assumptions carried; badge "⏳ Agent after: a public URL in the task title or description (QA review)" on a task row; guide preview with 6 stages from this brief, essentials, escalations |
 | Create everything | "All done!" — Project Done, Sprints 3/3, "⚡ 3 agent runs queued", "Open the Guide agent →"; the link opens the Guide agent's settings page at L1 with task.get / task.comment / subtask.create scoped to the project |
 
-Findings
+Findings (1 and 2 fixed in PR #549)
 1. **Source not validated on step 1.** Continue is enabled without a Source; execute then fails with "Select where this project came from." and the wizard drops back to step 1. State survives the round trip (brief, plan and guide are kept, no new model call), but the check belongs on step 1.
 2. **Done-screen counter reads "Tasks 8 / 4"**: created subtasks are counted against the planned task total.
 3. As in the API sweep: implementation tasks labelled `agent` because a planning skill fits them; consider a distinct label when the only matching skill plans rather than does.

--- a/Tasks/active/016-agent-trust-layer/progress.md
+++ b/Tasks/active/016-agent-trust-layer/progress.md
@@ -32,7 +32,7 @@ Notes for review
 - **Revert in the UI:** "Revert this run" → toast "Reverted 1 action(s).", row shows "Reverted 05/09/2026 15:02:44", button gone. (The schema fix in PR #547 is what makes the reverted state stick.)
 - **Instance console → Settings → AI:** "AI agents" section with undo window 24 h, monthly budget 0, "This month 2026-09 $0.14 · no cap", "80% alert not reached / 100% alert not reached" chips, provider openai · Region: any · "Key set".
 
-Finding (pre-existing, task 013 area): loading `/settings/instance/settings` directly bounces to My Profile because the shell checks instance access after mounting; navigating from inside the settings shell works. Worth a guard that waits for the access answer.
+Finding (pre-existing, task 013 area; fixed in PR #549): loading `/settings/instance/settings` directly bounces to My Profile because the shell checks instance access after mounting; navigating from inside the settings shell works. Worth a guard that waits for the access answer.
 
 Open
 - Member-role pass — needs a member account.


### PR DESCRIPTION
Docs only: the three findings recorded in the 015 and 016 progress files now reference the PR that fixed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)