### PR TITLE
docs(tasks): file the ai-layer sprint programme as tasks 023-032

### DIFF
--- a/Tasks/ROADMAP-agents.md
+++ b/Tasks/ROADMAP-agents.md
@@ -1,5 +1,7 @@
 # Agents roadmap — from the 2026-09-05 research
 
+> The table below was delivered through task 017 (PR #552). The programme that follows it is the sprint plan filed on 2026-09-10; see "Sprint programme" at the end.
+
 Source: `Tasks/active/015-guided-project-brief/research.md` (74 sources). Principle: every slice merges to `beta` behind the existing agents flag with the three gates (static review, API sweep, browser sweep) inside the task. One release from beta to main at the end of the programme (owner decision, 2026-09-05).
 
 | Order | Task | Slice delivers | Size | Bet from the research |
@@ -27,3 +29,24 @@ Why this order: 015 and 016 run in parallel (owner decision, 2026-09-05) — 015
 | Shared, integrator merges | `Modules/Agents/routes.js` (each adds its own lines), `frontend/src/locales/en.js` (separate namespaces), `frontend/src/views/Ai/agentFit.js` (015 only reads it; 016 does not touch it) |
 
 015's execute hook into `runs.create` uses the public functions of runs.js as they are on beta today; if 016 changes their signatures, 016 updates the call site at merge.
+
+## Sprint programme (owner decision 2026-09-10)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`. One task per sprint, one pull request per step, everything on `beta` behind flags, one release to `main` at the end. Sprints 7 and 8 can run on a parallel track.
+
+| Sprint | Task | Delivers | Size | Needs | Status |
+|---|---|---|---|---|---|
+| 0 | 023 | stop the bleeding: exploitable findings and cost correctness | one week | — | active |
+| 1 | 024 | shared AI core and run correctness | two weeks | 023 | backlog |
+| 2 | 025 | agent revisions and the skill record | two weeks | 024 | backlog |
+| 3 | 026 | observability foundation | two weeks | 024 | backlog |
+| 4 | 027 | the model router | two weeks | 024, 026 | backlog |
+| 5 | 028 | the workflow engine | three weeks | 024, 027 | backlog |
+| 6 | 029 | skill authoring and migration | two weeks | 025, 028 | backlog |
+| 7 | 030 | knowledge and retrieval | three weeks | 024 | backlog |
+| 8 | 031 | security hardening | three weeks | 024 | backlog |
+| 9 | 019 | evals and routing measurement | two weeks | 026, 027, 030 | backlog |
+| 10 | 018 | external agents: OAuth, scopes, delegation | three weeks | 028, 031 | backlog |
+| 11 | 032 | data skills reach outside (ADR 003 phase 4) | two weeks | 029, 031 | backlog |
+
+Totals: 12 tasks, 55 steps, about 27 weeks of engineering; Sprint 0 is active, the rest backlog. Existing 018 and 019 were rewritten as Sprints 10 and 9; Sprint 11 (ADR 003 phase 4) was added because the document's plan had no home for it.

--- a/Tasks/active/016-agent-trust-layer/task.md
+++ b/Tasks/active/016-agent-trust-layer/task.md
@@ -1,6 +1,6 @@
 # 016 — Agent trust layer: risk-rated actions, policy-reviewed L2, whole-run revert, budgets
 
-Status: planned · runs in parallel with 015 · branch `feat/agent-trust-layer` (from `beta`)
+Status: merged 2026-09-05 (PR #545), member-role sweep open · ran in parallel with 015 · branch `feat/agent-trust-layer` (from `beta`)
 
 ## Goal
 An owner can leave an agent at L2 and trust it: every action is rated for risk, a policy decides per action whether to act or to propose, any run can be reverted as a whole inside a window the owner sets, and spend is capped and alerted per company.

--- a/Tasks/active/023-sprint-0-stop-the-bleeding/progress.md
+++ b/Tasks/active/023-sprint-0-stop-the-bleeding/progress.md
@@ -1,0 +1,22 @@
+# Progress: Sprint 0 — stop the bleeding: exploitable findings and cost correctness
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: Merge the two open pull requests, housekeeping
+- [ ] Step 2: Outbound fetches resolve before they validate, check every resolved address against private ranges, revalidate
+- [ ] Step 3: Retrieval applies the page visibility rule the other read paths already use
+- [ ] Step 4: Performing an agent action evaluates the holder's permission catalogue entry, not only the registry
+- [ ] Step 5: Pricing fails closed: an unpriced model refuses to start a billed run with a reason that names the missing pri
+- [ ] Step 6: A test asserts the never-list and the action table can never overlap
+- [ ] Interface: Run detail and audit → undo (extend)
+- [ ] Defects closed: #1, #3, #4, #5, #6, #7, #8, #10, #11, #19
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 0) |
+
+## Last step
+Not started.

--- a/Tasks/active/023-sprint-0-stop-the-bleeding/task.md
+++ b/Tasks/active/023-sprint-0-stop-the-bleeding/task.md
@@ -1,0 +1,46 @@
+---
+id: 023
+title: Sprint 0 — stop the bleeding: exploitable findings and cost correctness
+status: active
+priority: high
+depends_on: []
+created: 2026-09-10
+---
+
+# 023 — Sprint 0 — stop the bleeding: exploitable findings and cost correctness
+
+Status: active · sprint 0 · one week · branch `feat/sprint-0-stop-the-bleeding` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 0. Filed 2026-09-10.
+
+## Goal
+No exploitable finding survives, and spend accounting is correct everywhere.
+
+## Scope
+1. Merge the two open pull requests, housekeeping (#551) first and then task 017 (#552), so every later branch starts from the checkpointed engine.
+2. Outbound fetches resolve before they validate, check every resolved address against private ranges, revalidate on each redirect, and cap size and time (`Modules/Agents/engine/pageAudit.js`).
+3. Retrieval applies the page visibility rule the other read paths already use (`Modules/AI/ask.js`); the MCP document-read tool applies the token's project scope and visibility (`Modules/Mcp/tools.js`); the MCP path re-checks company membership like the REST path does (`Modules/Mcp/server.js`).
+4. Performing an agent action evaluates the holder's permission catalogue entry, not only the registry (`Modules/Agents/actions.js`).
+5. Pricing fails closed: an unpriced model refuses to start a billed run with a reason that names the missing price, and defaults ship for every configured vendor (`usage.js`, `runs.recordSpend`).
+6. A test asserts the never-list and the action table can never overlap. A failed audit write fails the action. The undo path enforces the undo window and the caller's project visibility. Integration secrets are encrypted with the existing cloud-storage idiom, with a migration.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| G Undo | Run detail and audit → undo | extend | The undo window shown as a deadline and enforced, with the reason when it has passed; undo hidden outside the caller's visible projects |
+
+## Defects closed
+#1, #3, #4, #5, #6, #7, #8, #10, #11, #19 from the document's defect table.
+
+## Out of scope
+- Defect 2 (permission guards skipped for browser sessions) waits for Sprint 8, because it needs backend and frontend catalogue parity and a report-only stage first. Deliberate, not a miss.
+
+## Acceptance
+- [ ] The two data-access findings reproduce on the previous commit and fail to reproduce after; the in-process sweep books a non-zero cost on every configured provider.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- Six small pull requests, each with a test that reproduces the defect first. The only schema change is the secrets migration, run by the migrations runner. No flags.
+- Overlaps 016 (undo window, budgets, never-list): 016 shipped 2026-09-05; this sprint fixes what the review found in it.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/018-agent-interop/progress.md
+++ b/Tasks/backlog/018-agent-interop/progress.md
@@ -1,0 +1,19 @@
+# Progress: Sprint 10 — external agents: OAuth, scopes, delegation
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: OAuth 2.1 on the MCP server per the 2025-11-25 authorization spec: protected-resource metadata, PKCE, resource
+- [ ] Step 2: Inbound external agent sessions as workflow step executors: an OAuth client with `actor=agent`, delegation on 
+- [ ] Step 3: (added, carried from the original 018) Governance: an admin approves external agent clients per company; audit
+- [ ] Step 4: (added, carried from the original 018) MCP conformance test against the spec's authorization flow, and the sec
+- [ ] Interface: Task panel → agent strip (extend)
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 10) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/018-agent-interop/task.md
+++ b/Tasks/backlog/018-agent-interop/task.md
@@ -1,21 +1,44 @@
-# 018 — MCP in both directions: OAuth, scopes, external agents as teammates
+---
+id: 018
+title: Sprint 10 — external agents: OAuth, scopes, delegation
+status: backlog
+priority: medium
+depends_on: [028, 031]
+created: 2026-09-10
+---
 
-Status: backlog · depends on 016 · branch `feat/agent-interop` (from `beta`)
+# 018 — Sprint 10 — external agents: OAuth, scopes, delegation
+
+Status: backlog · depends on 028, 031 · sprint 10 · three weeks · branch `feat/agent-interop` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 10. Filed 2026-09-10.
 
 ## Goal
-AlianHub speaks the standard both ways: an external agent (Claude Code first) connects with OAuth and least-privilege scopes, and can be delegated a task inside AlianHub where it shows up as a teammate with typed activity, a human still assigned.
+An outside agent is a teammate with typed activities and a human still assigned, not a token with a bearer header.
 
-## Scope (from research [18][19][20][62][63][64][66])
-- **Outbound:** MCP server moves from bearer tokens to OAuth 2.1 per the 2025-11-25 authorization spec: protected-resource metadata, PKCE, resource indicators, audience-bound tokens, scopes `tasks:read`, `tasks:write`, `projects:read`, `docs:read`, `time:write`, challenged incrementally. Destructive tools flagged so clients prompt. Results carry names, not ids; pagination by default.
-- **Data model coverage:** projects, sprints, statuses, comments, pages, timesheets, in addition to the 11 tools today.
-- **Inbound:** external agent identity (OAuth client with `actor=agent`), delegation on a task (human assignee stays, agent delegated), agent session with typed activities `thought | action | elicitation | response | error`, a 10-second first-activity rule, and a session state shown in the task panel agent strip.
-- **Governance:** admin approves external agent clients per company; audit rows attribute to the agent and the delegating human.
+## Scope
+1. OAuth 2.1 on the MCP server per the 2025-11-25 authorization spec: protected-resource metadata, PKCE, resource indicators, audience-bound tokens; scopes `tasks:read`, `tasks:write`, `projects:read`, `docs:read`, `time:write` challenged incrementally; destructive tools flagged; results carry names not ids; pagination by default. More of the data model exposed with the same registry and rating discipline: projects, sprints, statuses, comments, pages, timesheets.
+2. Inbound external agent sessions as workflow step executors: an OAuth client with `actor=agent`, delegation on a task with the human assignee kept, typed activities `thought | action | elicitation | response | error`, a ten-second first-activity rule, session state in the task-panel agent strip.
+3. (added, carried from the original 018) Governance: an admin approves external agent clients per company; audit rows attribute to the agent and the delegating human; a revoked grant stops a session mid-step.
+4. (added, carried from the original 018) MCP conformance test against the spec's authorization flow, and the security checklist: no token pass-through, a session is never used as auth.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| B Communication | Task panel → agent strip | extend | Session state and typed activities of a delegated external agent, within ten seconds of the first activity |
+
+## Defects closed
+None directly.
 
 ## Out of scope
-- A2A. Watch the protocol; adopt when a second partner needs agent-to-agent hand-off.
+- A2A: watch the protocol; adopt when a second partner needs agent-to-agent hand-off.
 - Marketplace of agents.
 
 ## Acceptance
-- [ ] Claude Code connects via OAuth with `tasks:read` only and is refused a write with a scope challenge; after step-up it writes and the audit row names it.
-- [ ] Delegating a task to Claude Code produces a session, activities appear in the task panel within 10 s, the human assignee is unchanged, and the result lands as a proposal or a linked PR.
-- [ ] MCP conformance test against the spec's authorization flow; security best practices checklist (no token pass-through, session not used as auth).
+- [ ] An external coding agent completes a step in a workflow, its actions appear in the audit with the right attribution, a revoked grant stops it mid-step; Claude Code with `tasks:read` only is refused a write with a scope challenge and writes after step-up.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- Rewritten 2026-09-10 from the original 018 as Sprint 10 of the architecture document; steps 3 and 4 are the original's governance and conformance items, which the document's sprint plan omitted.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/019-agent-evals-observability/progress.md
+++ b/Tasks/backlog/019-agent-evals-observability/progress.md
@@ -1,0 +1,19 @@
+# Progress: Sprint 9 — evals and routing measurement
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: A golden set of fifty to two hundred real tasks per task class
+- [ ] Step 2: Online outcome metrics per model and class from what the trust layer already records: approval rate, decline r
+- [ ] Step 3: Dashboards and the rate alerts from Sprint 3 wired to these metrics; the regression rule that a change to any 
+- [ ] Step 4: (carried) 006's prompt-injection regression test on the run path is the injection slice of the golden set; 006
+- [ ] Interface: AI hub → routing outcomes (new)
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 9) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/019-agent-evals-observability/task.md
+++ b/Tasks/backlog/019-agent-evals-observability/task.md
@@ -1,17 +1,43 @@
-# 019 — Evals and observability for agent runs
+---
+id: 019
+title: Sprint 9 — evals and routing measurement
+status: backlog
+priority: medium
+depends_on: [026, 027, 030]
+created: 2026-09-10
+---
 
-Status: backlog · starts with 016, ongoing · branch per change
+# 019 — Sprint 9 — evals and routing measurement
+
+Status: backlog · depends on 026, 027, 030 · sprint 9 · two weeks · branch `feat/agent-evals` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 9. Filed 2026-09-10.
 
 ## Goal
-A prompt or harness change cannot silently degrade the agents, and every run can be explained after the fact from one record.
+A routing or prompt change is a measured business decision, and every run can be explained after the fact from one record.
 
-## Scope (from research [40][56][67][74])
-- **Eval set:** 20–50 real tasks from this workspace (brief → plan, qa-review, pr.summary, routing), each with an outcome check on resulting state (rows exist, no collateral changes) and a rubric; graded by code first, model-rubric second. Replayed by `npm run evals` with a fake model for structure and a real model gated behind a flag.
-- **Trace per run:** one record linking plan, every tool call, policy decisions, approvals, cost and resulting domain events; OpenTelemetry GenAI attribute names for tokens and cost so it can be exported.
-- **Dashboard in /ai:** escalation rate, approve/decline rate, skips by reason, cost per skill, revert count.
-- **Regression rule:** a change to any prompt under `Modules/Agents/skills` or `Modules/AIProjectGenerator/prompts` must run the eval set in CI.
+## Scope
+1. A golden set of fifty to two hundred real tasks per task class (brief → plan, qa-review, pr.summary, routing, retrieval), each with an outcome check on the resulting state and a rubric, graded by code first and a model rubric second; injection cases per class; replayed by `npm run evals` with a fake model for structure and a real model behind a flag.
+2. Online outcome metrics per model and class from what the trust layer already records: approval rate, decline reasons, revert rate, edit distance, repair rate; cost per approved change as the summary number; a held-out slice; canary comparison per agent revision.
+3. Dashboards and the rate alerts from Sprint 3 wired to these metrics; the regression rule that a change to any prompt under `Modules/Agents/skills` or `Modules/AIProjectGenerator/prompts` runs the eval set in CI.
+4. (carried) 006's prompt-injection regression test on the run path is the injection slice of the golden set; 006's two-week acceptance trial is the first held-out comparison.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| F Evaluation | AI hub → routing outcomes | new | Approval rate, decline reasons, revert rate, edit distance and cost per approved change, per model and per task class, with the held-out comparison |
+
+## Defects closed
+None directly.
+
+## Out of scope
+- Anything in another sprint's scope.
 
 ## Acceptance
-- [ ] Eval suite runs in CI on prompt changes and fails on a seeded regression.
-- [ ] `GET /agents/runs/:id` returns the trace; the run page shows it.
-- [ ] Dashboard numbers match the audit rows for a seeded week.
+- [ ] The cheaper-model scenario is answered from data for at least three task classes; the eval suite fails on a seeded regression in CI.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- Rewritten 2026-09-10 from the original 019: the eval set grew from 20–50 to 50–200 per class per the architecture document; the trace-per-run and health-dashboard items moved to 026, where the replay record lives.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/024-sprint-1-shared-core-run-correctness/progress.md
+++ b/Tasks/backlog/024-sprint-1-shared-core-run-correctness/progress.md
@@ -1,0 +1,23 @@
+# Progress: Sprint 1 — shared AI core and run correctness
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: Move the provider factory, usage and pricing, the instruction guard, the single model call and the persistence
+- [ ] Step 2: Agent runs gain an idempotency key and an in-flight claim: a partial unique index on agent, task and open stat
+- [ ] Step 3: Align the job lock with the model timeout per job, and set the server-level timeouts that are missing today.
+- [ ] Step 4: Thread loop depth from the originating envelope through agent actions instead of resetting it to zero
+- [ ] Step 5: Record spend at the core boundary so every AI feature, not only agent runs, reaches the budget.
+- [ ] Step 6: Check the run spend cap before the model call from a token estimate, and reconcile after.
+- [ ] Step 7: (added) The run collection's expiry is keyed to terminal status only, so a run waiting on a person is never de
+- [ ] Interface: Instance console → AI agents (extend)
+- [ ] Defects closed: #12, #13, #14, #15, #16, #18
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 1) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/024-sprint-1-shared-core-run-correctness/task.md
+++ b/Tasks/backlog/024-sprint-1-shared-core-run-correctness/task.md
@@ -1,0 +1,47 @@
+---
+id: 024
+title: Sprint 1 — shared AI core and run correctness
+status: backlog
+priority: high
+depends_on: [023]
+created: 2026-09-10
+---
+
+# 024 — Sprint 1 — shared AI core and run correctness
+
+Status: backlog · depends on 023 · sprint 1 · two weeks · branch `feat/sprint-1-shared-core-run-correctness` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 1. Filed 2026-09-10.
+
+## Goal
+One AI core, and an agent run that cannot execute twice.
+
+## Scope
+1. Move the provider factory, usage and pricing, the instruction guard, the single model call and the persistence factory into `Modules/AICore/`, leaving re-export shims at every old path so the thirteen consumers and their test mocks keep working. Move the one direct-to-vendor call (`Modules/ProjectTemplates/controller.js`) onto the factory. (ADR 003 phase 0)
+2. Agent runs gain an idempotency key and an in-flight claim: a partial unique index on agent, task and open status, checked with a duplicate-key catch rather than find-then-insert, and a reaper for proposals stuck in the applying state.
+3. Align the job lock with the model timeout per job, and set the server-level timeouts that are missing today.
+4. Thread loop depth from the originating envelope through agent actions instead of resetting it to zero (`Modules/Agents/actions.js` context).
+5. Record spend at the core boundary so every AI feature, not only agent runs, reaches the budget.
+6. Check the run spend cap before the model call from a token estimate, and reconcile after.
+7. (added) The run collection's expiry is keyed to terminal status only, so a run waiting on a person is never deleted under its proposal.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| H Cost | Instance console → AI agents | extend | Spend from every AI feature, not only agent runs, against the budget, with the alert thresholds already shown |
+
+## Defects closed
+#12, #13, #14, #15, #16, #18 from the document's defect table.
+
+## Out of scope
+- Anything in another sprint's scope.
+
+## Acceptance
+- [ ] Full backend and frontend suites green; a double-submitted run start yields one run; a rule-triggered run under a slow model produces one execution.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- The shims make this a pure move; tests move with the code in the same commit. Consumers are repointed one module per pull request after the core lands, then the shims are deleted.
+- Closes 006's remaining item "spend cap evaluated after the model call".
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/025-sprint-2-revisions-and-skill-record/progress.md
+++ b/Tasks/backlog/025-sprint-2-revisions-and-skill-record/progress.md
@@ -1,0 +1,20 @@
+# Progress: Sprint 2 — agent revisions and the skill record
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: Agent revisions and skill revisions as immutable documents; a run pins both at start; promote and roll back ar
+- [ ] Step 2: The skill record, its validator returning field-level errors like the automation rule validator, the frozen ca
+- [ ] Step 3: Save-time validation of emitted actions, and the effective-actions intersection with the agent's allowed actio
+- [ ] Step 4: The intake skill
+- [ ] Interface: Agent settings → revision history (new)
+- [ ] Interface: Run detail → pinned revision (extend)
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 2) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/025-sprint-2-revisions-and-skill-record/task.md
+++ b/Tasks/backlog/025-sprint-2-revisions-and-skill-record/task.md
@@ -1,0 +1,44 @@
+---
+id: 025
+title: Sprint 2 — agent revisions and the skill record
+status: backlog
+priority: high
+depends_on: [024]
+created: 2026-09-10
+---
+
+# 025 — Sprint 2 — agent revisions and the skill record
+
+Status: backlog · depends on 024 · sprint 2 · two weeks · branch `feat/sprint-2-revisions-and-skill-record` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 2. Filed 2026-09-10.
+
+## Goal
+Every run is reproducible, and a skill is data.
+
+## Scope
+1. Agent revisions and skill revisions as immutable documents; a run pins both at start; promote and roll back are pointer moves with an audit row. A revision carries a state (draft, candidate, live, superseded) and declares what it serves.
+2. The skill record, its validator returning field-level errors like the automation rule validator, the frozen catalogues for inputs, readers, prompt partials and emitted actions, the manifest endpoint (`GET /api/v2/agents/skills`), and the hybrid resolver that reads a company's data skills first and the built-in code skills second. (ADR 003 phase 1)
+3. Save-time validation of emitted actions, and the effective-actions intersection with the agent's allowed actions and the registry; the agent manifest endpoint so workflows and rules bind agents by id and optional revision.
+4. The intake skill (`brief.parse`) re-expressed as a data skill. If it does not fit, the vocabulary is wrong and this sprint is where that is learned.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| A Lifecycle | Agent settings → revision history | new | Numbered revisions with who changed what and when, a diff between any two, promote and roll back as one click each, the revision badge on every run |
+| A Lifecycle | Run detail → pinned revision | extend | Which agent revision and skill revision produced this run, linked |
+
+## Defects closed
+None directly.
+
+## Out of scope
+- Canary traffic shares and automatic demotion are designed in the document (section A) and land with the routing outcomes in Sprint 9.
+
+## Acceptance
+- [ ] A run six weeks old can name the exact skill, prompt hash and model that produced it.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- A seed migration writes the built-in skills as revision one in every company database. Runs created before the change resolve to a synthetic revision zero so nothing old breaks. Every new field is declared in the strict schema before the first write.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/026-sprint-3-observability-foundation/progress.md
+++ b/Tasks/backlog/026-sprint-3-observability-foundation/progress.md
@@ -1,0 +1,25 @@
+# Progress: Sprint 3 — observability foundation
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: OpenTelemetry with the trace identifier on the run row, every step row, every audit row and every log line; lo
+- [ ] Step 2: The replay record per model call: prompt hash and reference, retrieved chunk identifiers, raw response, model 
+- [ ] Step 3: A metrics endpoint behind admin auth: rate, errors and duration per workflow, step, agent and model; token and
+- [ ] Step 4: Provider error codes preserved end to end and grouped, so an error tracker has something to group.
+- [ ] Step 5: Alerts on rates: error rate per agent, approval rate falling, cost against forecast, queue age.
+- [ ] Step 6: (added) The two competing uncaught-exception handlers collapse into one path that reports, flushes and exits.
+- [ ] Interface: Run detail → trace (extend)
+- [ ] Interface: Run detail → replay (new)
+- [ ] Interface: AI hub → health (new)
+- [ ] Interface: Notification settings (extend)
+- [ ] Defects closed: #21
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 3) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/026-sprint-3-observability-foundation/task.md
+++ b/Tasks/backlog/026-sprint-3-observability-foundation/task.md
@@ -1,0 +1,49 @@
+---
+id: 026
+title: Sprint 3 — observability foundation
+status: backlog
+priority: high
+depends_on: [024]
+created: 2026-09-10
+---
+
+# 026 — Sprint 3 — observability foundation
+
+Status: backlog · depends on 024 · sprint 3 · two weeks · branch `feat/sprint-3-observability-foundation` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 3. Filed 2026-09-10.
+
+## Goal
+The eight questions in section H of the document have a lookup, not an inference. Lands before routing because routing cannot be evaluated without it.
+
+## Scope
+1. OpenTelemetry with the trace identifier on the run row, every step row, every audit row and every log line; logs move to structured records; the exporter is off unless an endpoint is configured.
+2. The replay record per model call: prompt hash and reference, retrieved chunk identifiers, raw response, model and parameters, agent and skill revisions, with a retention and redaction policy. (absorbs 019 "trace per run")
+3. A metrics endpoint behind admin auth: rate, errors and duration per workflow, step, agent and model; token and cost counters; approval, decline and revert rates. (absorbs 019 "dashboard in /ai", the health half)
+4. Provider error codes preserved end to end and grouped, so an error tracker has something to group.
+5. Alerts on rates: error rate per agent, approval rate falling, cost against forecast, queue age.
+6. (added) The two competing uncaught-exception handlers collapse into one path that reports, flushes and exits.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| H Observability | Run detail → trace | extend | A timeline of steps, the model call and every tool call with durations, tokens, cost and the decision on each; link to the replay record |
+| H Observability | Run detail → replay | new | The prompt sent, the retrieved passages and the raw response, redacted per policy, for owners and admins |
+| H Observability | AI hub → health | new | Error rate, approval rate and cost per agent and per workflow over time, sortable |
+| H Alerts | Notification settings | extend | Owners and admins choose which rate alerts reach them |
+
+## Defects closed
+#21 from the document's defect table.
+
+## Out of scope
+- Anything in another sprint's scope.
+
+## Acceptance
+- [ ] From a run identifier, the prompt, the retrieved context, the raw response and every tool call are reachable in under a minute.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- The replay record is written from the core's single model call, which is why Sprint 1 comes first.
+- Task 019 kept its eval scope and hands its trace and health-dashboard items to this task.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/027-sprint-4-model-router/progress.md
+++ b/Tasks/backlog/027-sprint-4-model-router/progress.md
@@ -1,0 +1,21 @@
+# Progress: Sprint 4 — the model router
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: Model and provider on the chat options; a provider registry that includes a Google adapter alongside OpenAI, A
+- [ ] Step 2: Task classes with a quality floor, latency target and input budget each; a per-tenant policy table; per-agent 
+- [ ] Step 3: Health tracking per provider and model with a circuit breaker, half-open probes, failover to the next candidat
+- [ ] Step 4: Pre-flight token estimate, reservation against the tenant budget, reconciliation after; the routing decision a
+- [ ] Interface: Instance console → providers (new)
+- [ ] Interface: Workspace settings → routing policy (new)
+- [ ] Interface: Agent and skill settings → model pin (extend)
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 4) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/027-sprint-4-model-router/task.md
+++ b/Tasks/backlog/027-sprint-4-model-router/task.md
@@ -1,0 +1,45 @@
+---
+id: 027
+title: Sprint 4 — the model router
+status: backlog
+priority: high
+depends_on: [024, 026]
+created: 2026-09-10
+---
+
+# 027 — Sprint 4 — the model router
+
+Status: backlog · depends on 024, 026 · sprint 4 · two weeks · branch `feat/sprint-4-model-router` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 4. Filed 2026-09-10.
+
+## Goal
+Any task can run on any configured provider, and the platform survives one being down.
+
+## Scope
+1. Model and provider on the chat options; a provider registry that includes a Google adapter alongside OpenAI, Anthropic and DeepSeek; per-provider normalisation of output ceilings, structured-output mode, reasoning-model parameters and error codes.
+2. Task classes with a quality floor, latency target and input budget each; a per-tenant policy table; per-agent and per-skill model pins validated against a priced allowlist. (ADR 003 phase 3, cost half)
+3. Health tracking per provider and model with a circuit breaker, half-open probes, failover to the next candidate, and per-provider rate-limit budgets as token buckets; retry with backoff on transient provider errors.
+4. Pre-flight token estimate, reservation against the tenant budget, reconciliation after; the routing decision and its reasons written to the model-call span and the replay record.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| F Routing | Instance console → providers | new | Each provider and model with health, breaker state, rate-limit budget and whether it is priced; a loud warning when a pinned model has no price |
+| F Routing | Workspace settings → routing policy | new | Task class to model preferences with quality floor and latency target, per workspace |
+| F Routing | Agent and skill settings → model pin | extend | Pin a model per agent or per skill from the priced allowlist (shared with Sprint 6) |
+
+## Defects closed
+None directly.
+
+## Out of scope
+- Anything in another sprint's scope.
+
+## Acceptance
+- [ ] With one provider blackholed in a test environment, agent runs continue on the fallback and the breaker state is visible.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- Behind a router flag whose default policy reproduces today's single-provider behaviour, so flipping it is a no-op until a policy is set. The Google adapter ships with the same contract tests the other three pass.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/028-sprint-5-workflow-engine/progress.md
+++ b/Tasks/backlog/028-sprint-5-workflow-engine/progress.md
@@ -1,0 +1,26 @@
+# Progress: Sprint 5 — the workflow engine
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: Workflow runs and step runs as the unit of everything, generalised from the automation runner: dependencies, r
+- [ ] Step 2: Step types: agent run, tool call, human approval with owner, deadline and escalation, fan-out and fan-in, cond
+- [ ] Step 3: Agent runs become step executors; user-started runs go through the queue like rule-started ones already do; th
+- [ ] Step 4: Dispatch rides the durable queue with typed results validated at each edge; deadline and budget shrink per hop
+- [ ] Step 5: (added) The hourly run limit that is stored and never enforced becomes the loop's admission control, so the sc
+- [ ] Interface: Workflow run → lineage (new)
+- [ ] Interface: Workflow builder (new)
+- [ ] Interface: Workflow run view (new)
+- [ ] Interface: AI Inbox → approval steps (extend)
+- [ ] Interface: Workflow run → iteration counter (new)
+- [ ] Interface: Workflow run → failed step (new)
+- [ ] Defects closed: #17
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 5) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/028-sprint-5-workflow-engine/task.md
+++ b/Tasks/backlog/028-sprint-5-workflow-engine/task.md
@@ -1,0 +1,49 @@
+---
+id: 028
+title: Sprint 5 — the workflow engine
+status: backlog
+priority: high
+depends_on: [024, 027]
+created: 2026-09-10
+---
+
+# 028 — Sprint 5 — the workflow engine
+
+Status: backlog · depends on 024, 027 · sprint 5 · three weeks · branch `feat/sprint-5-workflow-engine` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 5. Filed 2026-09-10.
+
+## Goal
+Multi-step, multi-agent work is durable, parallel where safe, and resumable at any step.
+
+## Scope
+1. Workflow runs and step runs as the unit of everything, generalised from the automation runner: dependencies, ready-set scheduling, per-tenant concurrency as a distributed claim count, a unique index on run and step, a heartbeat lease with fencing, deterministic-versus-transient retries, action-level idempotency keys on audit rows.
+2. Step types: agent run, tool call, human approval with owner, deadline and escalation, fan-out and fan-in, condition, wait and timer. A loop is a bounded re-entry with an iteration cap and a budget, which is how a monitoring and optimisation cycle is expressed; a time-based trigger joins the trigger catalogue.
+3. Agent runs become step executors; user-started runs go through the queue like rule-started ones already do; the workflow API under `/api/v2/workflows` with an idempotency key on run start and per-step retry, skip, resume and compensate.
+4. Dispatch rides the durable queue with typed results validated at each edge; deadline and budget shrink per hop; the depth guard applies to agent hops and workflow re-entry.
+5. (added) The hourly run limit that is stored and never enforced becomes the loop's admission control, so the schema field finally means something.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| B Communication | Workflow run → lineage | new | Who handed off to whom, the typed result at each edge, the accountable person on each step |
+| C Orchestration | Workflow builder | new | Compose steps from the manifest like the automation sentence builder; dependencies, budget, deadline; save disabled by default; dry-run against a real input |
+| C Orchestration | Workflow run view | new | The step graph with status, duration and cost per step; retry, skip, resume and compensate on a failed step; a blocked workflow with its reason |
+| C Approval | AI Inbox → approval steps | extend | Owner, deadline, escalation path and reassign on workflow approvals |
+| C Loops | Workflow run → iteration counter | new | Iterations used of the maximum, budget used of the cap, and a stop control |
+| I Recovery | Workflow run → failed step | new | The error, whether deterministic, attempts and backoff, and the one control that applies |
+
+## Defects closed
+#17 from the document's defect table.
+
+## Out of scope
+- Temporal. The queue and the engine stay behind adapter interfaces; the trigger to switch is in the document's trade-off 2.
+
+## Acceptance
+- [ ] A fifteen-step workflow killed at step eleven resumes at eleven with no duplicate writes; an approval step reassigns and escalates on deadline.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- An existing automation rule is a one-node workflow, so rules run unchanged. The old direct execution path stays as a thin compatibility wrapper for one release, then goes.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/029-sprint-6-skill-authoring-migration/progress.md
+++ b/Tasks/backlog/029-sprint-6-skill-authoring-migration/progress.md
@@ -1,0 +1,19 @@
+# Progress: Sprint 6 — skill authoring and migration
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: The Skill Library becomes a library: create, edit, dry-run against a chosen task, risk preview from the union 
+- [ ] Step 2: The reporter
+- [ ] Interface: Skill Library (extend)
+- [ ] Interface: Agent settings → skills (extend)
+- [ ] Interface: Agent and skill settings → model pin (extend)
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 6) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/029-sprint-6-skill-authoring-migration/task.md
+++ b/Tasks/backlog/029-sprint-6-skill-authoring-migration/task.md
@@ -1,0 +1,44 @@
+---
+id: 029
+title: Sprint 6 — skill authoring and migration
+status: backlog
+priority: medium
+depends_on: [025, 028]
+created: 2026-09-10
+---
+
+# 029 — Sprint 6 — skill authoring and migration
+
+Status: backlog · depends on 025, 028 · sprint 6 · two weeks · branch `feat/sprint-6-skill-authoring-migration` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 6. Filed 2026-09-10.
+
+## Goal
+A workspace admin composes an agent from skills they wrote, in the product.
+
+## Scope
+1. The Skill Library becomes a library: create, edit, dry-run against a chosen task, risk preview from the union of emitted actions, retire. Agent settings pick skills from the manifest; the three duplicated input tables in the frontend (`agentFit.js`, `skillInputs.js`, `taskSplit.js`) are deleted with their parity test. (ADR 003 phase 2)
+2. The reporter (`digest.ceo`) and project-guide skills re-expressed as data; per-skill model pin exposed in the editor. (ADR 003 phase 3, migration half)
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| Skills | Skill Library | extend | A real library: create, edit, dry-run, risk preview, retire; today it lists the action registry |
+| Skills | Agent settings → skills | extend | Pick skills from the manifest; effective actions shown as the intersection with the agent's allowed actions |
+| F Routing | Agent and skill settings → model pin | extend | Per-skill pin in the editor (shared with Sprint 4) |
+
+## Defects closed
+None directly.
+
+## Out of scope
+- External reads for data skills: Sprint 11.
+
+## Acceptance
+- [ ] An admin creates a new skill, assigns it to an agent, runs it on a task and sees its outcome, with no deploy.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- The authoring surface ships in the same sprint as the last runtime piece it needs, and the owner sweeps it before merge.
+- The dry-run-against-a-task control is the same pattern 021 item 12 asks for on automation rules; build it once.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/030-sprint-7-knowledge-and-retrieval/progress.md
+++ b/Tasks/backlog/030-sprint-7-knowledge-and-retrieval/progress.md
@@ -1,0 +1,21 @@
+# Progress: Sprint 7 — knowledge and retrieval
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: One retrieval interface with hybrid lexical and vector search; the lexical implementation ships first on the f
+- [ ] Step 2: Ingestion off the event bus, extended to page, comment, attachment and memory events: extract, chunk on struct
+- [ ] Step 3: Sources brought in order of value: page bodies, comments, meeting transcripts, uploaded files through text ext
+- [ ] Step 4: The vector adapter for hosted deployments behind the interface; agent-scoped memory as a distinct scope in the
+- [ ] Step 5: The regular-expression path in Ask is retired.
+- [ ] Interface: Instance console → knowledge sources (new)
+- [ ] Interface: Ask → citations (extend)
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 7) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/030-sprint-7-knowledge-and-retrieval/task.md
+++ b/Tasks/backlog/030-sprint-7-knowledge-and-retrieval/task.md
@@ -1,0 +1,45 @@
+---
+id: 030
+title: Sprint 7 — knowledge and retrieval
+status: backlog
+priority: medium
+depends_on: [024]
+created: 2026-09-10
+---
+
+# 030 — Sprint 7 — knowledge and retrieval
+
+Status: backlog · depends on 024 · sprint 7 · three weeks · branch `feat/sprint-7-knowledge-and-retrieval` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 7. Filed 2026-09-10.
+
+## Goal
+Agents and Ask can reach what the workspace actually knows, and only what the caller may see.
+
+## Scope
+1. One retrieval interface with hybrid lexical and vector search; the lexical implementation ships first on the full-text indexes that already exist, with access control applied at query time from the caller's visible set.
+2. Ingestion off the event bus, extended to page, comment, attachment and memory events: extract, chunk on structure, embed, upsert against a content hash; tombstone on delete; cascade on project and user deletion; embedding model version on every chunk; an erasure path.
+3. Sources brought in order of value: page bodies, comments, meeting transcripts, uploaded files through text extraction, project guides, and workspace-level pages that have no project. Structured performance data is reached through a registry read action, not embedded.
+4. The vector adapter for hosted deployments behind the interface; agent-scoped memory as a distinct scope in the store.
+5. The regular-expression path in Ask is retired.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| E Knowledge | Instance console → knowledge sources | new | Sources indexed per workspace, freshness and size, embedding model, re-index and erasure controls |
+| E Knowledge | Ask → citations | extend | Citations reflect the caller's visibility; a "why this answer" panel lists the retrieved passages with source and permission |
+
+## Defects closed
+None directly.
+
+## Out of scope
+- Anything in another sprint's scope.
+
+## Acceptance
+- [ ] A question about a private page is answered for its owner and not for a colleague; a deleted page disappears from answers within a minute.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- The index is built per tenant by a background migration; retrieval is flagged per tenant; answer quality is compared on a held-out set of real questions before the flag defaults on.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/031-sprint-8-security-hardening/progress.md
+++ b/Tasks/backlog/031-sprint-8-security-hardening/progress.md
@@ -1,0 +1,24 @@
+# Progress: Sprint 8 — security hardening
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: Server-side permission enforcement for browser sessions, after bringing the backend catalogue to parity with t
+- [ ] Step 2: Service identities for the engine, workers, indexer and router; step-scoped short-lived credentials minted per
+- [ ] Step 3: Agent egress through an allow-listing proxy per tenant.
+- [ ] Step 4: Audit as append-only with a per-tenant hash chain; audit retention at least as long as run retention; tainted-
+- [ ] Step 5: Http-only session cookies and a content security policy, which is frontend work with the socket and refresh fl
+- [ ] Interface: Accounts → tokens (extend)
+- [ ] Interface: Instance console → egress allowlist (new)
+- [ ] Interface: Instance console → enforcement (new)
+- [ ] Interface: Audit log (extend)
+- [ ] Defects closed: #2, #9, #20
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 8) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/031-sprint-8-security-hardening/task.md
+++ b/Tasks/backlog/031-sprint-8-security-hardening/task.md
@@ -1,0 +1,47 @@
+---
+id: 031
+title: Sprint 8 — security hardening
+status: backlog
+priority: high
+depends_on: [024]
+created: 2026-09-10
+---
+
+# 031 — Sprint 8 — security hardening
+
+Status: backlog · depends on 024 · sprint 8 · three weeks · branch `feat/sprint-8-security-hardening` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 8. Filed 2026-09-10.
+
+## Goal
+Authorization is enforced where the data is, and a leaked credential buys minutes.
+
+## Scope
+1. Server-side permission enforcement for browser sessions, after bringing the backend catalogue to parity with the frontend on per-project overrides (013's G10 is the same surface); staged as report-only for two weeks, logging would-be denials, then enforced.
+2. Service identities for the engine, workers, indexer and router; step-scoped short-lived credentials minted per step and verified against the live step; provider keys and integration secrets in a secrets store referenced by handle, with rotation and revocation; per-tenant provider keys.
+3. Agent egress through an allow-listing proxy per tenant.
+4. Audit as append-only with a per-tenant hash chain; audit retention at least as long as run retention; tainted-context marking so a run that read external content routes its risky actions to approval.
+5. Http-only session cookies and a content security policy, which is frontend work with the socket and refresh flows adjusted.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| G Security | Accounts → tokens | extend | Expiry mandatory, scopes never empty, last use, step-scoped credentials shown as such |
+| G Security | Instance console → egress allowlist | new | The hosts agents may fetch, per workspace |
+| G Security | Instance console → enforcement | new | Report-only or enforce, with the would-be denial log |
+| G Security | Audit log | extend | An integrity indicator per row and a filter for refusals |
+
+## Defects closed
+#2, #9, #20 from the document's defect table.
+
+## Out of scope
+- Anything in another sprint's scope.
+
+## Acceptance
+- [ ] The three critical findings from the defect list are closed by design, not by patch; a would-be denial report over two weeks shows no legitimate traffic blocked.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- Report-only mode is the safety net for the enforcement change, since the last attempt caused false denials in production.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/backlog/032-sprint-11-data-skills-reach/progress.md
+++ b/Tasks/backlog/032-sprint-11-data-skills-reach/progress.md
@@ -1,0 +1,18 @@
+# Progress: Sprint 11 — data skills reach outside (ADR 003 phase 4)
+
+## Checklist
+One pull request per step; tick with the merge commit.
+
+- [ ] Step 1: Declared external reads join the skill vocabulary: URL and API readers with a declared host, capped size and t
+- [ ] Step 2: The PR-review skill
+- [ ] Step 3: The Skill Library editor exposes declared reads with the allowlist check, and the replay record captures what 
+- [ ] Interface: Skill Library → declared reads (extend)
+- [ ] Exit gate met and gates green
+
+## Log
+| Date | Entry |
+|---|---|
+| 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 11) |
+
+## Last step
+Not started.

--- a/Tasks/backlog/032-sprint-11-data-skills-reach/task.md
+++ b/Tasks/backlog/032-sprint-11-data-skills-reach/task.md
@@ -1,0 +1,42 @@
+---
+id: 032
+title: Sprint 11 — data skills reach outside (ADR 003 phase 4)
+status: backlog
+priority: medium
+depends_on: [029, 031]
+created: 2026-09-10
+---
+
+# 032 — Sprint 11 — data skills reach outside (ADR 003 phase 4)
+
+Status: backlog · depends on 029, 031 · sprint 11 · two weeks · branch `feat/sprint-11-data-skills-reach` (from `beta`)
+
+Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 11. Filed 2026-09-10.
+
+## Goal
+A data skill can read declared external sources through the tenant's egress allowlist, so the PR-review skill stops being the last code skill that does not need an evidence layer.
+
+## Scope
+1. Declared external reads join the skill vocabulary: URL and API readers with a declared host, capped size and time, resolved through the per-tenant egress proxy from Sprint 8, and validated against the allowlist at save.
+2. The PR-review skill (`pr.summary`) re-expressed as a data skill; `qa-review` stays code by design because it measures page facts.
+3. The Skill Library editor exposes declared reads with the allowlist check, and the replay record captures what was fetched.
+
+## Interface
+| Area | Surface | State | Delivers |
+|---|---|---|---|
+| Skills | Skill Library → declared reads | extend | A skill declares the hosts it reads, checked against the workspace allowlist at save |
+
+## Defects closed
+None directly.
+
+## Out of scope
+- Custom code in a sandboxed runtime (ADR 003 phase 5) stays deferred.
+
+## Acceptance
+- [ ] An admin authors a skill that reads a declared external endpoint, a non-allow-listed host is refused at save, and a fetched body appears in the replay record.
+- [ ] Every interface row above swept by the owner and by a member.
+- [ ] Gates: `npm test`, vitest, `npm run i18n:check` after backfill, lint 0 errors, frontend build, the in-process sweep against the real database and model, and the owner's API and browser sweeps recorded in progress.md before merge.
+
+## Decisions
+- Added 2026-09-10: ADR 003 phase 4 had no sprint in the architecture document's plan; the document gains this sprint in the same change.
+- Branch from `beta`, one slice per pull request, checks green before merge. New behaviour behind a flag whose default reproduces today. Schema fields declared before the first write; any shape change ships its migration in the same pull request. Deviations from the plan and their reasons recorded here.

--- a/Tasks/index.md
+++ b/Tasks/index.md
@@ -23,8 +23,18 @@ Auto-maintained registry of all tasks. Reflects YAML frontmatter from each `task
 | 015 | Guided project start — complete brief, agent/human split | active | high | 014 | active/015-guided-project-brief |
 | 016 | Agent trust layer — risk-rated actions, policy L2, whole-run revert, budgets | active | high | 014 | active/016-agent-trust-layer |
 | 017 | Agent memory the product owns | active | high | 015, 016 | active/017-agent-memory |
-| 018 | MCP both ways — OAuth, scopes, external agents as teammates | backlog | medium | 016 | backlog/018-agent-interop |
-| 019 | Evals and observability for agent runs | backlog | high | 016 | backlog/019-agent-evals-observability |
+| 018 | Sprint 10 — external agents: OAuth, scopes, delegation | backlog | medium | 028, 031 | backlog/018-agent-interop |
+| 019 | Sprint 9 — evals and routing measurement | backlog | medium | 026, 027, 030 | backlog/019-agent-evals-observability |
 | 020 | Automation comments show as Ghost User | backlog | medium | — | backlog/020-automation-comment-author |
 | 021 | Maintainability leftovers verified 2026-09-10 | backlog | medium | — | backlog/021-maintainability-leftovers |
 | 022 | Pieces worth porting from the closed pre-redesign PRs | backlog | low | — | backlog/022-salvage-from-closed-prs |
+| 023 | Sprint 0 — stop the bleeding: exploitable findings and cost correctness | active | high | — | active/023-sprint-0-stop-the-bleeding |
+| 024 | Sprint 1 — shared AI core and run correctness | backlog | high | 023 | backlog/024-sprint-1-shared-core-run-correctness |
+| 025 | Sprint 2 — agent revisions and the skill record | backlog | high | 024 | backlog/025-sprint-2-revisions-and-skill-record |
+| 026 | Sprint 3 — observability foundation | backlog | high | 024 | backlog/026-sprint-3-observability-foundation |
+| 027 | Sprint 4 — the model router | backlog | high | 024, 026 | backlog/027-sprint-4-model-router |
+| 028 | Sprint 5 — the workflow engine | backlog | high | 024, 027 | backlog/028-sprint-5-workflow-engine |
+| 029 | Sprint 6 — skill authoring and migration | backlog | medium | 025, 028 | backlog/029-sprint-6-skill-authoring-migration |
+| 030 | Sprint 7 — knowledge and retrieval | backlog | medium | 024 | backlog/030-sprint-7-knowledge-and-retrieval |
+| 031 | Sprint 8 — security hardening | backlog | high | 024 | backlog/031-sprint-8-security-hardening |
+| 032 | Sprint 11 — data skills reach outside (ADR 003 phase 4) | backlog | medium | 029, 031 | backlog/032-sprint-11-data-skills-reach |


### PR DESCRIPTION
Files the sprint plan from `docs/AI-PLATFORM-ARCHITECTURE.md` as task folders so the remaining work is countable and can be picked up with the task-manager skill. Stacked on #551 (housekeeping); retarget to `beta` once that merges.

## What remains

| | Count |
|---|---|
| Sprints | 12 (Sprint 0 active, 11 backlog) |
| Tasks | 12: ten new (023–032), two rewritten in place (018 → Sprint 10, 019 → Sprint 9) |
| Steps | 55, one pull request each |
| Interface rows | 29 |
| Defects closed by a step | 18 of 21 (2, 9, 20 in Sprint 8; 16, 17, 21 given explicit steps) |
| Engineering time | about 27 weeks; Sprints 7 and 8 can run in parallel |

## Deviations from the document, recorded in the tasks
- Sprint 11 added: ADR 003 phase 4 (external reads for data skills) had no sprint. The document gains the same sprint on `docs/adr-ai-layer`.
- 018's governance item and MCP conformance test, which the sprint plan omitted, are steps 3 and 4 of Sprint 10.
- 019's trace-per-run and health dashboard moved to Sprint 3 (026), where the replay record lives.
- 016's status line corrected: it merged on 2026-09-05.

Each task.md carries frontmatter plus the house heading and status line, the sprint's steps as scope, its interface rows, the defects it closes, the exit gate and the standing gates; each progress.md is the checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
