### PR TITLE
fix(023): consult the never-list in registry evaluation and test it cannot overlap the action table

### DIFF
--- a/Modules/Agents/policy.js
+++ b/Modules/Agents/policy.js
@@ -9,7 +9,7 @@ const DECISION = Object.freeze({ ACT: 'act', PROPOSE: 'propose', REFUSE: 'refuse
 const SCOPES = Object.freeze(['task', 'project', 'workspace']);
 const REVIEW_LEVEL = 2;
 
-const isNever = (key) => registry.NEVER.some((n) => n === key || (n.endsWith('.*') && key.startsWith(n.slice(0, -1))));
+const { isNever } = registry;
 
 const isComplete = (r) => Boolean(r) && typeof r.write === 'boolean' && typeof r.reversible === 'boolean'
     && SCOPES.includes(r.scope) && typeof r.money === 'boolean';

--- a/Modules/Agents/registry.js
+++ b/Modules/Agents/registry.js
@@ -41,13 +41,25 @@ const ACTIONS = Object.freeze([
       gate: 'owner_admin', proposeOnly: true },
 ]);
 
-const BY_KEY = new Map(ACTIONS.map((a) => [a.key, a]));
-
-// Named so a reviewer can confirm they are not reachable. Never added to ACTIONS.
+// Named so a reviewer can confirm they are not reachable. A trailing `.*` covers
+// every key under that prefix.
 const NEVER = Object.freeze([
     'project.delete', 'task.delete', 'billing.*', 'deploy.production', 'git.merge',
     'member.remove', 'permissions.edit', 'status.set("Done")',
 ]);
+
+const isNever = (key) => {
+    const k = String(key || '');
+    return NEVER.some((n) => n === k || (n.endsWith('.*') && k.startsWith(n.slice(0, -1))));
+};
+
+const indexActions = (actions) => {
+    const overlap = actions.map((a) => a.key).filter(isNever);
+    if (overlap.length) throw new Error(`never-listed action(s) cannot be registered: ${overlap.join(', ')}`);
+    return new Map(actions.map((a) => [a.key, a]));
+};
+
+const BY_KEY = indexActions(ACTIONS);
 
 const get = (key) => BY_KEY.get(String(key || '')) || null;
 const has = (key) => BY_KEY.has(String(key || ''));
@@ -70,6 +82,7 @@ const isAgentSettableStatus = ({ statusType, name } = {}) => {
 
 /* The one decision every agent call goes through. Returns { allowed, reason, action }. */
 const evaluate = (key, params = {}, { allowedActions } = {}) => {
+    if (isNever(key)) return { allowed: false, code: 'never_listed', reason: `Agents cannot perform ${key} (never_listed)`, action: null };
     const action = get(key);
     if (!action) return { allowed: false, reason: `Agents cannot perform ${key || '(unknown action)'}`, action: null };
     if (Array.isArray(allowedActions) && allowedActions.length && !allowedActions.includes(action.key)) {
@@ -121,5 +134,5 @@ const manifest = () => ({
 
 module.exports = {
     ACTIONS, NEVER, RISK, AUTONOMY, DONE_STATUS_TYPE, DONE_STATUS_TYPES, AGENT_STATUS_NAMES,
-    get, has, keys, evaluate, isAgentSettableStatus, mayActDirectly, manifest,
+    get, has, keys, isNever, indexActions, evaluate, isAgentSettableStatus, mayActDirectly, manifest,
 };

--- a/tests/agent-actions-rated.test.js
+++ b/tests/agent-actions-rated.test.js
@@ -124,6 +124,6 @@ describe('perform() honours a policy refusal', () => {
         await expect(actions.perform({ companyId: 'c1', actor, action: 'task.comment', params: { taskId: 't1' }, allowedActions: ['task.get'], decision: { decision: 'act', reason: 'x' } }))
             .rejects.toMatchObject({ name: 'RefusedError', message: 'Agents cannot perform task.comment (not in this agent\'s skills)' });
         await expect(actions.perform({ companyId: 'c1', actor, action: 'project.delete', params: {}, decision: { decision: 'act', reason: 'x' } }))
-            .rejects.toMatchObject({ name: 'RefusedError', message: 'Agents cannot perform project.delete' });
+            .rejects.toMatchObject({ name: 'RefusedError', message: 'Agents cannot perform project.delete (never_listed)' });
     });
 });

--- a/tests/agent-never-list.test.js
+++ b/tests/agent-never-list.test.js
@@ -1,0 +1,51 @@
+const registry = require('../Modules/Agents/registry');
+const policy = require('../Modules/Agents/policy');
+
+const neverMatches = (key) => registry.NEVER.some((n) => n === key || (n.endsWith('.*') && key.startsWith(n.slice(0, -1))));
+
+describe('never-list vs action table', () => {
+    it('no registered action key is on the never-list, exactly or under a wildcard', () => {
+        const overlap = registry.ACTIONS.map((a) => a.key).filter(neverMatches);
+        expect(overlap).toEqual([]);
+    });
+
+    it('every never-list entry has no counterpart in the action table', () => {
+        const keys = registry.keys();
+        const reachable = registry.NEVER.filter((n) => (n.endsWith('.*')
+            ? keys.some((k) => k.startsWith(n.slice(0, -1)))
+            : keys.includes(n)));
+        expect(reachable).toEqual([]);
+    });
+
+    it('isNever matches exact keys and wildcard prefixes only', () => {
+        expect(registry.isNever('project.delete')).toBe(true);
+        expect(registry.isNever('billing.refund')).toBe(true);
+        expect(registry.isNever('billing')).toBe(false);
+        expect(registry.isNever('task.comment')).toBe(false);
+        expect(registry.isNever('')).toBe(false);
+        expect(policy.isNever).toBe(registry.isNever);
+    });
+});
+
+describe('registering a never-listed key', () => {
+    it.each(['project.delete', 'billing.charge', 'task.delete'])('throws at load for %s', (key) => {
+        const actions = [...registry.ACTIONS, { key, label: 'x', risk: registry.RISK.LOW, undoable: false, write: true, cost: 'write' }];
+        expect(() => registry.indexActions(actions)).toThrow(`never-listed action(s) cannot be registered: ${key}`);
+    });
+
+    it('indexes the real table without throwing', () => {
+        expect(registry.indexActions(registry.ACTIONS).size).toBe(registry.ACTIONS.length);
+    });
+});
+
+describe('evaluate refuses never-listed keys before consulting the table', () => {
+    it.each(['project.delete', 'billing.charge', 'deploy.production', 'status.set("Done")'])('%s is refused with never_listed', (key) => {
+        expect(registry.evaluate(key, {}, { allowedActions: [key] })).toEqual({
+            allowed: false, code: 'never_listed', reason: `Agents cannot perform ${key} (never_listed)`, action: null,
+        });
+    });
+
+    it('mayActDirectly is false for a never-listed key at every level', () => {
+        [0, 1, 2, 3].forEach((l) => expect(registry.mayActDirectly(l, 'task.delete')).toBe(false));
+    });
+});


### PR DESCRIPTION
Closes defect 10 (Sprint 0, step 6a). Stacked on #552 (`feat/agent-memory`).

## Defect

`NEVER` in `Modules/Agents/registry.js` was documentation only. `registry.evaluate` never consulted it, so adding a matching key to `ACTIONS` would have made a forbidden action live despite its never-list entry. Only `policy.decide` checked it, and `actions.perform` / the guard / proposals call `registry.evaluate` directly.

## Fix

- `isNever` moves into the registry (exact key, or `prefix.*` wildcard); `policy.js` re-exports the same function.
- `ACTIONS` is indexed through `indexActions`, which throws at module load when any key is never-listed.
- `evaluate` refuses a never-listed key first, with `code: 'never_listed'` and reason `Agents cannot perform <key> (never_listed)`, even if `allowedActions` names it.
- No other behaviour change; one existing assertion in `tests/agent-actions-rated.test.js` updated for the new reason text.

## Test reproduces first

`tests/agent-never-list.test.js` iterates the real `ACTIONS` against the real `NEVER` (exact and wildcard). Checked out on the base commit with two overlapping entries temporarily added to `ACTIONS`:

```
FAIL tests/agent-never-list.test.js
  ● never-list vs action table › no registered action key is on the never-list, exactly or under a wildcard
    - Array []
    + Array [ "project.delete", "billing.charge" ]
  ● never-list vs action table › every never-list entry has no counterpart in the action table
    - Array []
    + Array [ "project.delete", "billing.*" ]
```

With this commit the same edit also throws at load: `never-listed action(s) cannot be registered: project.delete, billing.charge`.

## Results

- `npx jest tests/agent- tests/ai-project tests/conventions`: 42 suites, 555 tests, all passing on Node 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
