### PR TITLE
fix(023): apply page visibility and token scope on retrieval and mcp reads

### DIFF
--- a/Modules/AI/ask.js
+++ b/Modules/AI/ask.js
@@ -6,6 +6,7 @@ const { getRoleType, isPrivileged } = require('../../Config/permissionGuard');
 const logger = require('../../Config/loggerConfig');
 const { getProvider, isAnyProviderConfigured } = require('../AIProjectGenerator/llmProvider');
 const { visibleProjects } = require('../Agents/scope');
+const { pageVisibilityFilter } = require('../Pages/helpers/pageRules');
 
 // Ask (handoff 13i) — a question box over the workspace.
 //
@@ -53,9 +54,9 @@ const gather = async (companyId, uid, { question, projectId, limit = MAX_PER_TYP
     const textMatch = orRegex(terms, ['TaskName', 'TaskKey', 'rawDescription']);
     if (textMatch) Object.assign(taskMatch, textMatch);
 
-    const pageMatch = { deletedStatusKey: { $ne: 1 }, ProjectID: { $in: ids } };
+    const pageMatch = { deletedStatusKey: { $ne: 1 }, ProjectID: { $in: ids }, $and: [pageVisibilityFilter(uid)] };
     const pageText = orRegex(terms, ['title']);
-    if (pageText) Object.assign(pageMatch, pageText);
+    if (pageText) pageMatch.$and.push(pageText);
 
     const [tasks, pages] = await Promise.all([
         MongoDbCrudOpration(companyId, {

--- a/Modules/Mcp/server.js
+++ b/Modules/Mcp/server.js
@@ -1,5 +1,6 @@
 const apiTokens = require('../ApiTokens/controller');
 const { hasScope } = require('../ApiTokens/helpers/apiTokenRules');
+const { verifyCompanyMembership } = require('../../Config/jwt');
 const { resolveActor } = require('../Agents/actor');
 const { RefusedError } = require('../Agents/actions');
 const registry = require('../Agents/registry');
@@ -18,8 +19,21 @@ const contentResult = (payload) => ({ content: [{ type: 'text', text: JSON.strin
 
 const ipOf = (req) => String(req.headers['x-forwarded-for'] || req.ip || '').split(',')[0].trim();
 
+const NOT_A_MEMBER = 'You are no longer a member of this company';
+
+const unauthorized = (res) => {
+    res.set('WWW-Authenticate', 'Bearer realm="alianhub-mcp"');
+    return res.status(401).json(rpcError(null, -32001, 'A valid bearer token and companyId are required.'));
+};
+
+const forbidden = (res) => res.status(403).json({
+    ...rpcError(null, -32003, NOT_A_MEMBER), status: false, error: NOT_A_MEMBER, statusText: 'Forbidden',
+});
+
 /* Authenticate the bearer PAT and build the calling context. The token narrows
- * the user's own permissions — it never widens them. */
+ * the user's own permissions — it never widens them. Returns null for a bad
+ * token and { forbidden: true } when the holder has left the company, so a
+ * removed member is cut off on the next request, not when the token expires. */
 const authenticate = async (req) => {
     const header = String(req.headers.authorization || '');
     const raw = header.startsWith('Bearer ') ? header.slice(7).trim() : '';
@@ -28,6 +42,7 @@ const authenticate = async (req) => {
 
     const token = await apiTokens.verifyToken(companyId, raw);
     if (!token) return null;
+    if (!(await verifyCompanyMembership(String(token.userId || ''), companyId))) return { forbidden: true };
 
     req.apiToken = token;
     req.uid = String(token.userId || '');
@@ -111,10 +126,8 @@ const handleRpc = async (ctx, message) => {
 const post = async (req, res) => {
     try {
         const ctx = await authenticate(req);
-        if (!ctx) {
-            res.set('WWW-Authenticate', 'Bearer realm="alianhub-mcp"');
-            return res.status(401).json(rpcError(null, -32001, 'A valid bearer token and companyId are required.'));
-        }
+        if (!ctx) return unauthorized(res);
+        if (ctx.forbidden) return forbidden(res);
 
         const body = req.body;
         const batch = Array.isArray(body);
@@ -141,10 +154,8 @@ const post = async (req, res) => {
  * every request in the POST response, so there is no stream to open. */
 const get = async (req, res) => {
     const ctx = await authenticate(req);
-    if (!ctx) {
-        res.set('WWW-Authenticate', 'Bearer realm="alianhub-mcp"');
-        return res.status(401).json(rpcError(null, -32001, 'A valid bearer token and companyId are required.'));
-    }
+    if (!ctx) return unauthorized(res);
+    if (ctx.forbidden) return forbidden(res);
     return res.status(405).json(rpcError(null, -32000, 'This server replies on POST; no SSE stream is offered.'));
 };
 

--- a/Modules/Mcp/tools.js
+++ b/Modules/Mcp/tools.js
@@ -4,7 +4,7 @@ const registry = require('../Agents/registry');
 const actions = require('../Agents/actions');
 const { oid } = require('../Automations/engine/tools');
 const { buildBrief } = require('./brief');
-const { htmlToRawText } = require('../Pages/helpers/pageRules');
+const { htmlToRawText, pageVisibleTo } = require('../Pages/helpers/pageRules');
 const { blocksToRawText, contentToEditorData } = require('../Pages/helpers/pageContent');
 
 const PAGE_TEXT_MAX = 40000;
@@ -12,11 +12,12 @@ const PAGE_TEXT_MAX = 40000;
 const str = (v, max = 500) => String(v === undefined || v === null ? '' : v).slice(0, max);
 const clampLimit = (v, def = 10, max = 50) => Math.min(Math.max(parseInt(v, 10) || def, 1), max);
 
-const scopeFilter = (ctx, extra = {}) => {
-    const filter = { CompanyId: String(ctx.companyId), deletedStatusKey: { $ne: 1 }, ...extra };
+const projectScope = (ctx, filter) => {
     if (ctx.projectIds && ctx.projectIds.length) filter.ProjectID = { $in: ctx.projectIds };
     return filter;
 };
+
+const scopeFilter = (ctx, extra = {}) => projectScope(ctx, { CompanyId: String(ctx.companyId), deletedStatusKey: { $ne: 1 }, ...extra });
 
 /* Stored rawText is a 5000-char search excerpt, so the full body comes from the html. */
 const pageText = (page) => {
@@ -152,9 +153,9 @@ const TOOLS = [
             const _id = oid(str(args.pageId, 40));
             if (!_id) return { error: 'invalid pageId' };
             const page = await MongoDbCrudOpration(ctx.companyId, {
-                type: SCHEMA_TYPE.PAGES, data: [{ _id, deletedStatusKey: { $ne: 1 } }],
+                type: SCHEMA_TYPE.PAGES, data: [projectScope(ctx, { _id, deletedStatusKey: { $ne: 1 } })],
             }, 'findOne');
-            if (!page) return { error: 'page not found' };
+            if (!pageVisibleTo(page, ctx.userId)) return { error: 'page not found' };
             return {
                 pageId: String(page._id),
                 title: page.title || '',

--- a/Modules/Pages/controller.js
+++ b/Modules/Pages/controller.js
@@ -13,6 +13,8 @@ const {
     parseDate,
     nextReviewDate,
     reviewState,
+    pageVisibleTo,
+    pageVisibilityFilter,
 } = require('./helpers/pageRules');
 const {
     emptyEditorData,
@@ -190,8 +192,7 @@ exports.listPages = async (req, res) => {
 
         // A private doc belongs to its author alone, so it never appears in anyone else's
         // list — including a task's linked docs, where it would otherwise leak by title.
-        const uid = callerId(req);
-        filter.$or = [{ visibility: { $ne: 'private' } }, { createdBy: uid }];
+        Object.assign(filter, pageVisibilityFilter(callerId(req)));
 
         const pages = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.PAGES,
@@ -221,7 +222,7 @@ exports.getPage = async (req, res) => {
         }
         // Same answer for "not yours" as for "does not exist": otherwise the difference
         // tells a caller that a private doc with this id is there.
-        if (String(page.visibility || '') === 'private' && String(page.createdBy || '') !== callerId(req)) {
+        if (!pageVisibleTo(page, callerId(req))) {
             return res.send({ status: false, statusText: 'Page not found.' });
         }
         const data = typeof page.toObject === 'function' ? page.toObject() : page;
@@ -279,7 +280,7 @@ exports.updatePage = async (req, res) => {
         }
 
         const userId = callerId(req);
-        if (String(existing.visibility || '') === 'private' && String(existing.createdBy || '') !== userId) {
+        if (!pageVisibleTo(existing, userId)) {
             return res.send({ status: false, statusText: 'Page not found.' });
         }
 
@@ -323,8 +324,7 @@ const findVisiblePage = async (companyId, id, uid, deletedStatusKey = 0) => {
         data: [{ _id: new mongoose.Types.ObjectId(id), deletedStatusKey }],
     }, 'findOne');
     if (!page) return null;
-    if (String(page.visibility || '') === 'private' && String(page.createdBy || '') !== uid) return null;
-    return page;
+    return pageVisibleTo(page, uid) ? page : null;
 };
 
 const patchPage = async (companyId, id, update) => MongoDbCrudOpration(companyId, {
@@ -493,7 +493,7 @@ exports.composeWithAi = async (req, res) => {
                 data: [{ _id: new mongoose.Types.ObjectId(pageId), deletedStatusKey: 0 }],
             }, 'findOne');
             if (page) {
-                if (String(page.visibility || '') === 'private' && String(page.createdBy || '') !== callerId(req)) {
+                if (!pageVisibleTo(page, callerId(req))) {
                     return res.send({ status: false, statusText: 'Page not found.' });
                 }
                 if (!pageTitle) pageTitle = page.title || '';

--- a/Modules/Pages/helpers/pageRules.js
+++ b/Modules/Pages/helpers/pageRules.js
@@ -35,6 +35,14 @@ const htmlToRawText = (html, max = 5000) => String(html || '')
     .trim()
     .slice(0, max);
 
+/* A private page belongs to its author alone. Every read path — list, get,
+ * Ask retrieval, MCP — applies this one rule so a private doc never leaks by
+ * title or body to anyone else in the project. */
+const pageVisibleTo = (page, uid) => Boolean(page)
+    && (String(page.visibility || '') !== 'private' || String(page.createdBy || '') === String(uid || ''));
+
+const pageVisibilityFilter = (uid) => ({ $or: [{ visibility: { $ne: 'private' } }, { createdBy: String(uid || '') }] });
+
 const REVIEW_INTERVAL_MONTHS = 3;
 const STALE_AFTER_MONTHS = 6;
 const REVIEW_STATES = ['none', 'verified', 'due', 'stale'];
@@ -74,6 +82,8 @@ module.exports = {
     validatePageInput,
     contentTooLarge,
     htmlToRawText,
+    pageVisibleTo,
+    pageVisibilityFilter,
     parseDate,
     nextReviewDate,
     reviewState,

--- a/tests/agent-mcp-actor.test.js
+++ b/tests/agent-mcp-actor.test.js
@@ -21,7 +21,7 @@ const req = (over = {}) => ({ headers: {}, query: {}, body: {}, uid: USER_ID, ..
 beforeEach(() => {
     Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
     jest.clearAllMocks();
-    mockDb.seed(dbCollections.USERS, { _id: USER_ID, Employee_Name: 'Mevil' });
+    mockDb.seed(dbCollections.USERS, { _id: USER_ID, Employee_Name: 'Mevil', AssignCompany: C });
 });
 
 describe('F2 — a plain personal token is an agent when it arrives over MCP', () => {

--- a/tests/ai-ask-visibility.test.js
+++ b/tests/ai-ask-visibility.test.js
@@ -1,0 +1,51 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../Modules/Agents/scope', () => ({ visibleProjects: jest.fn() }));
+jest.mock('../Modules/AIProjectGenerator/llmProvider', () => ({ getProvider: jest.fn(), isAnyProviderConfigured: () => false }));
+jest.mock('../Config/permissionGuard', () => ({ getRoleType: jest.fn(async () => 3), isPrivileged: () => false }));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn() }));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { visibleProjects } = require('../Modules/Agents/scope');
+const { gather } = require('../Modules/AI/ask');
+
+const C = '6f0000000000000000000c01';
+const PROJECT = '6f0000000000000000000a01';
+const ME = '6f0000000000000000000001';
+const OTHER = '6f0000000000000000000002';
+
+const page = (over) => mockDb.seed(SCHEMA_TYPE.PAGES, { ProjectID: PROJECT, deletedStatusKey: 0, visibility: 'project', updatedAt: new Date(), ...over });
+const titles = (out) => out.sources.filter((s) => s.kind === 'page').map((s) => s.title).sort();
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    jest.clearAllMocks();
+    visibleProjects.mockResolvedValue([{ _id: PROJECT, ProjectName: 'Ops' }]);
+});
+
+describe('defect 4 — Ask retrieval applies page visibility', () => {
+    it('leaves another member\'s private page out of the sources, even in a project the asker can open', async () => {
+        page({ title: 'Salary review notes', visibility: 'private', createdBy: OTHER });
+        page({ title: 'Salary bands (public)', createdBy: OTHER });
+        page({ title: 'Salary plan draft', visibility: 'private', createdBy: ME });
+
+        const out = await gather(C, ME, { question: 'salary' });
+        expect(titles(out)).toEqual(['Salary bands (public)', 'Salary plan draft']);
+    });
+
+    it('still narrows by the question\'s terms alongside the visibility rule', async () => {
+        page({ title: 'Release checklist', createdBy: OTHER });
+        page({ title: 'Lunch menu', createdBy: OTHER });
+        page({ title: 'Release secrets', visibility: 'private', createdBy: OTHER });
+
+        const out = await gather(C, ME, { question: 'release' });
+        expect(titles(out)).toEqual(['Release checklist']);
+    });
+
+    it('applies the rule when the question has no usable search terms', async () => {
+        page({ title: 'Private only', visibility: 'private', createdBy: OTHER });
+        const out = await gather(C, ME, { question: 'the' });
+        expect(titles(out)).toEqual([]);
+    });
+});

--- a/tests/fixtures/fakeMongo.js
+++ b/tests/fixtures/fakeMongo.js
@@ -9,6 +9,7 @@ const read = (doc, key) => key.split('.').reduce((v, k) => (v == null ? undefine
 
 const matches = (doc, filter = {}) => Object.entries(filter).every(([key, cond]) => {
     if (key === '$or') return cond.some((f) => matches(doc, f));
+    if (key === '$and') return cond.every((f) => matches(doc, f));
     const raw = read(doc, key);
     const value = raw === undefined ? undefined : (raw instanceof Date ? raw.getTime() : (key === '_id' ? String(raw) : raw));
     if (cond instanceof RegExp) return cond.test(String(value));
@@ -20,6 +21,8 @@ const matches = (doc, filter = {}) => Object.entries(filter).every(([key, cond])
             if (op === '$ne') return value !== want;
             if (op === '$gte') return value >= want;
             if (op === '$exists') return (value !== undefined) === arg;
+            if (op === '$regex') return new RegExp(arg, cond.$options || '').test(String(value));
+            if (op === '$options') return true;
             throw new Error(`fakeMongo: unsupported operator ${op}`);
         });
     }

--- a/tests/mcp-docs-read.test.js
+++ b/tests/mcp-docs-read.test.js
@@ -59,3 +59,28 @@ describe('F3 — docs.read returns the stored page body', () => {
         expect(await read('not-an-id')).toEqual({ error: 'invalid pageId' });
     });
 });
+
+describe('defect 5 — docs.read honours the token\'s project scope and page visibility', () => {
+    const P1 = '6f0000000000000000000a01';
+    const P2 = '6f0000000000000000000a02';
+    const scoped = (pageId) => tools.call({ ...ctx, projectIds: [P1] }, 'docs.read', { pageId });
+
+    it('refuses a page outside the projects the token is scoped to', async () => {
+        const inside = mockDb.seed(SCHEMA_TYPE.PAGES, { title: 'In scope', ProjectID: P1, content: { html: '<p>ok</p>' } });
+        const outside = mockDb.seed(SCHEMA_TYPE.PAGES, { title: 'Out of scope', ProjectID: P2, content: { html: '<p>secret</p>' } });
+        const companyWide = mockDb.seed(SCHEMA_TYPE.PAGES, { title: 'Company wide', content: { html: '<p>handbook</p>' } });
+
+        expect((await scoped(inside._id)).text).toBe('ok');
+        expect(await scoped(outside._id)).toEqual({ error: 'page not found' });
+        expect(await scoped(companyWide._id)).toEqual({ error: 'page not found' });
+        expect((await read(companyWide._id)).text).toBe('handbook');
+    });
+
+    it('refuses another member\'s private page and reads the holder\'s own', async () => {
+        const theirs = mockDb.seed(SCHEMA_TYPE.PAGES, { title: 'Theirs', visibility: 'private', createdBy: 'u2', content: { html: '<p>private</p>' } });
+        const mine = mockDb.seed(SCHEMA_TYPE.PAGES, { title: 'Mine', visibility: 'private', createdBy: 'u1', content: { html: '<p>own notes</p>' } });
+
+        expect(await read(theirs._id)).toEqual({ error: 'page not found' });
+        expect((await read(mine._id)).text).toBe('own notes');
+    });
+});

--- a/tests/mcp-membership.test.js
+++ b/tests/mcp-membership.test.js
@@ -1,0 +1,68 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn() }));
+jest.mock('../Config/jwt', () => ({ verifyCompanyMembership: jest.fn() }));
+jest.mock('../Modules/ApiTokens/controller', () => ({ verifyToken: jest.fn(), logTokenActivity: jest.fn() }));
+jest.mock('../Modules/Agents/actor', () => ({ resolveActor: jest.fn(async () => ({ kind: 'agent', userId: '6f0000000000000000000001' })) }));
+jest.mock('../Modules/Agents/actions', () => ({ RefusedError: class RefusedError extends Error {} }));
+jest.mock('../Modules/Agents/registry', () => ({ NEVER: [] }));
+jest.mock('../Modules/Mcp/tools', () => ({ manifest: () => [], call: jest.fn() }));
+
+const { verifyCompanyMembership } = require('../Config/jwt');
+const apiTokens = require('../Modules/ApiTokens/controller');
+const server = require('../Modules/Mcp/server');
+
+const USER_ID = '6f0000000000000000000001';
+const C = '6f0000000000000000000c01';
+const token = { _id: '6f0000000000000000000101', name: 'Laptop', userId: USER_ID, scopes: ['read'], active: true };
+
+const request = (body = { jsonrpc: '2.0', id: 1, method: 'ping' }) => ({
+    headers: { authorization: 'Bearer ah_abc' }, query: { companyId: C }, body, ip: '1.1.1.1',
+});
+const response = () => {
+    const res = { statusCode: 200, headers: {}, body: undefined };
+    res.set = jest.fn((k, v) => { res.headers[k] = v; return res; });
+    res.status = jest.fn((code) => { res.statusCode = code; return res; });
+    res.json = jest.fn((body) => { res.body = body; return res; });
+    res.end = jest.fn(() => res);
+    return res;
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    apiTokens.verifyToken.mockResolvedValue(token);
+});
+
+describe('defect 8 — the MCP server re-checks company membership on every request', () => {
+    it('rejects a removed member with the 403 the REST token path returns, before any RPC runs', async () => {
+        verifyCompanyMembership.mockResolvedValue(false);
+        const res = response();
+        await server.post(request(), res);
+        expect(verifyCompanyMembership).toHaveBeenCalledWith(USER_ID, C);
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toMatchObject({ status: false, error: 'You are no longer a member of this company', statusText: 'Forbidden' });
+        expect(apiTokens.logTokenActivity).not.toHaveBeenCalled();
+    });
+
+    it('rejects the GET probe the same way', async () => {
+        verifyCompanyMembership.mockResolvedValue(false);
+        const res = response();
+        await server.get(request(), res);
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toMatchObject({ status: false, statusText: 'Forbidden' });
+    });
+
+    it('answers a current member as before', async () => {
+        verifyCompanyMembership.mockResolvedValue(true);
+        const res = response();
+        await server.post(request(), res);
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ jsonrpc: '2.0', id: 1, result: {} });
+    });
+
+    it('still answers 401 for a bad token without consulting membership', async () => {
+        apiTokens.verifyToken.mockResolvedValue(null);
+        const res = response();
+        await server.post(request(), res);
+        expect(res.statusCode).toBe(401);
+        expect(verifyCompanyMembership).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Sprint 0, step 3 of task 023. Stacked on #552 (`feat/agent-memory`).

## Defects closed

**Defect 4 — Ask retrieval ignored page visibility.** `Modules/AI/ask.js` matched pages by project only, so another member's private page came back as a source (title, and through it the body) to anyone who could open the project. The private-page rule the pages controller already applied on list/get/update is now one helper, `pageVisibleTo` / `pageVisibilityFilter` in `Modules/Pages/helpers/pageRules.js`, and `gather()` applies the filter alongside the title match.

**Defect 5 — MCP `docs.read` ignored the token's project scope and page visibility.** A project-scoped token could read any page body in the company. `docs.read` now applies the same `ProjectID` scope the task reads use and the same visibility rule for the token's holder; both answer `page not found`, the same reply as for a missing page, so a refusal does not confirm the page exists.

**Defect 8 — the MCP server never re-checked membership.** A removed member kept MCP access until the token was deactivated. `authenticate()` now calls the same `verifyCompanyMembership` the REST token path uses on every request and answers 403 with the REST shape (`{ status: false, error: 'You are no longer a member of this company', statusText: 'Forbidden' }`, plus the JSON-RPC error fields) before any RPC runs or activity is logged.

## How each test reproduces the defect first

- `tests/ai-ask-visibility.test.js` — seeds a public page, another member's private page and the asker's own private page in one visible project, then calls `gather()`. On the previous commit the other member's private title is in the sources (3 of 3 cases fail); after, only the public and own pages are.
- `tests/mcp-docs-read.test.js` (new `defect 5` block) — calls `docs.read` with `projectIds: [P1]` for pages in P1, P2 and company-wide, and with an unscoped token for another member's private page. On the previous commit every read returns the body (2 of 2 cases fail); after, only the in-scope and own pages do.
- `tests/mcp-membership.test.js` — mocks `verifyCompanyMembership` to `false` and posts a `ping`. On the previous commit the server never consults it and answers 200 (2 of 2 cases fail); after, POST and GET answer 403 in the REST shape and no activity is logged. The current-member and bad-token cases guard the existing 200/401 paths.

`tests/fixtures/fakeMongo.js` learns `$and` and `$regex` so the retrieval filter can run; `tests/agent-mcp-actor.test.js` seeds the user's `AssignCompany` since membership is now live in `authenticate()`.

## Verification

- `npx jest --selectProjects unit` — 135 suites, 1677 tests green
- `npx jest tests/conventions` — 7 suites, 88 tests green
- With `Modules/` stashed, the three suites fail on exactly the 7 new cases and pass the 7 pre-existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)
