### PR TITLE
fix(023): resolve and revalidate outbound fetches before following them

### DIFF
--- a/Modules/Agents/engine/orchestrator.js
+++ b/Modules/Agents/engine/orchestrator.js
@@ -2,6 +2,7 @@ const logger = require('../../../Config/loggerConfig');
 const { getProvider, isAnyProviderConfigured } = require('../../AIProjectGenerator/llmProvider');
 const { emptyUsage, usageFromResult, addUsage } = require('../../AIProjectGenerator/usage');
 const { audit, extractUrl } = require('./pageAudit');
+const { isBlockedHostname } = require('./safeFetch');
 const skillIndex = require('../skills');
 
 // A deterministic pipeline, not a free-roaming agent loop:
@@ -133,7 +134,7 @@ async function gather({ skillSlug = 'qa-review', task, companyId, memory }) {
     const url = extractUrl(task?.TaskName) || extractUrl(task?.description) || extractUrl(task?.rawDescription);
     if (url) return { status: GATHERED, skill: skill.slug, context: { url } };
     const text = [task?.TaskName, task?.description, task?.rawDescription].join(' ');
-    const privateUrl = /https?:\/\/(localhost|127\.|10\.|192\.168\.|0\.0\.0\.0|\[?::1)/i.test(text);
+    const privateUrl = (text.match(/https?:\/\/[^\s<>"')]+/gi) || []).some((u) => { try { return isBlockedHostname(new URL(u).hostname); } catch (e) { return false; } });
     return skipped(skill, privateUrl
         ? 'the URL points at a private or local host, which agents do not fetch — use a public address'
         : 'no reviewable URL found in the task title or description', started);

--- a/Modules/Agents/engine/pageAudit.js
+++ b/Modules/Agents/engine/pageAudit.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+const { safeFetch, isBlockedHostname } = require('./safeFetch');
 
 // Deterministic static-HTML audit — the EVIDENCE layer.
 //
@@ -16,11 +16,6 @@ const TIMEOUT_MS = 15000;
 const MAX_BYTES = 3 * 1024 * 1024;
 const UA = 'AlianHub-QA-Agent/1.0 (+https://alianhub.com)';
 
-/* Block anything that is not a public http(s) host. An agent that follows a URL
- * out of a task description is a request forgery primitive if it can be pointed
- * at localhost or a metadata endpoint. */
-const PRIVATE_HOST = /^(localhost$|127\.|10\.|192\.168\.|169\.254\.|0\.0\.0\.0|\[?::1\]?$|172\.(1[6-9]|2\d|3[01])\.)/i;
-
 const extractUrl = (text) => {
     if (!text) return null;
     const m = String(text).match(/https?:\/\/[^\s<>"')]+/i)
@@ -30,7 +25,7 @@ const extractUrl = (text) => {
     try {
         const u = new URL(raw);
         if (!/^https?:$/.test(u.protocol)) return null;
-        if (PRIVATE_HOST.test(u.hostname)) return null;
+        if (isBlockedHostname(u.hostname)) return null;
         return u.toString();
     } catch { return null; }
 };
@@ -45,15 +40,13 @@ const attrs = (tag) => {
 const tagsOf = (html, name) => html.match(new RegExp(`<${name}\\b[^>]*>`, 'gi')) || [];
 
 async function fetchPage(url) {
-    const res = await axios.get(url, {
-        timeout: TIMEOUT_MS,
-        maxContentLength: MAX_BYTES,
+    const res = await safeFetch(url, {
+        timeoutMs: TIMEOUT_MS,
+        maxBytes: MAX_BYTES,
         maxRedirects: 5,
         headers: { 'User-Agent': UA, Accept: 'text/html,application/xhtml+xml' },
-        validateStatus: () => true,
-        responseType: 'text',
     });
-    return { status: res.status, html: typeof res.data === 'string' ? res.data : '', bytes: Buffer.byteLength(String(res.data || '')) };
+    return { status: res.status, html: res.body, bytes: res.bytes };
 }
 
 /* Each check returns a fact: { id, ok, detail, evidence }. `evidence` is what the
@@ -158,4 +151,4 @@ async function audit(url) {
              facts: auditHtml(page.html, url), blindSpots: BLIND_SPOTS };
 }
 
-module.exports = { audit, auditHtml, extractUrl, fetchPage, BLIND_SPOTS, PRIVATE_HOST };
+module.exports = { audit, auditHtml, extractUrl, fetchPage, BLIND_SPOTS };

--- a/Modules/Agents/engine/safeFetch.js
+++ b/Modules/Agents/engine/safeFetch.js
@@ -1,0 +1,171 @@
+const dns = require('dns');
+const net = require('net');
+const axios = require('axios');
+
+/* Outbound fetches driven by task text. The URL is untrusted, so the rule is
+ * applied to the RESOLVED address (which defeats numeric and alternate hostname
+ * encodings), re-applied to every redirect hop, and the socket is pinned to the
+ * address that passed so a DNS answer cannot change between check and connect. */
+
+const DEFAULTS = Object.freeze({ timeoutMs: 10000, maxBytes: 1024 * 1024, maxRedirects: 5 });
+
+const BLOCKED_SUFFIXES = ['.local', '.internal'];
+
+const V4_RESERVED = [
+    ['0.0.0.0', 8], ['10.0.0.0', 8], ['100.64.0.0', 10], ['127.0.0.0', 8], ['169.254.0.0', 16],
+    ['172.16.0.0', 12], ['192.168.0.0', 16], ['224.0.0.0', 4], ['240.0.0.0', 4],
+];
+
+const v4ToInt = (ip) => ip.split('.').reduce((n, o) => (n * 256) + Number(o), 0);
+const inV4Block = (ip, [base, bits]) => (v4ToInt(ip) >>> (32 - bits)) === (v4ToInt(base) >>> (32 - bits));
+
+const isPrivateV4 = (ip) => ip === '255.255.255.255' || V4_RESERVED.some((block) => inV4Block(ip, block));
+
+const expandV6 = (ip) => {
+    const [head, tail = ''] = ip.split('::');
+    const left = head ? head.split(':') : [];
+    const right = tail ? tail.split(':') : [];
+    const fill = Array(8 - left.length - right.length).fill('0');
+    return [...left, ...fill, ...right].map((h) => parseInt(h || '0', 16));
+};
+
+const mappedV4 = (ip) => {
+    const m = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+    if (m) return m[1];
+    const words = expandV6(ip);
+    if (words.slice(0, 5).every((w) => w === 0) && words[5] === 0xffff) {
+        return [words[6] >> 8, words[6] & 0xff, words[7] >> 8, words[7] & 0xff].join('.');
+    }
+    return null;
+};
+
+const isPrivateV6 = (ip) => {
+    const bare = ip.replace(/%.*$/, '');
+    const mapped = mappedV4(bare);
+    if (mapped) return isPrivateV4(mapped);
+    const words = expandV6(bare);
+    if (words.every((w) => w === 0)) return true;
+    if (words.slice(0, 7).every((w) => w === 0) && words[7] === 1) return true;
+    const top = words[0];
+    if ((top & 0xfe00) === 0xfc00) return true;
+    if ((top & 0xffc0) === 0xfe80) return true;
+    if ((top & 0xff00) === 0xff00) return true;
+    return false;
+};
+
+const isPrivateAddress = (ip) => {
+    const kind = net.isIP(ip);
+    if (kind === 4) return isPrivateV4(ip);
+    if (kind === 6) return isPrivateV6(ip);
+    return true;
+};
+
+const stripBrackets = (host) => String(host || '').trim().toLowerCase().replace(/^\[|\]$/g, '');
+
+/* Hostnames that never deserve a DNS round trip. Non-dotted-quad numeric forms
+ * (`127.1`, `0x7f000001`, `2130706433`) are treated as literals too: the URL
+ * parser normalises them, but a stray string reaching here should not pass. */
+const isBlockedHostname = (hostname) => {
+    const host = stripBrackets(hostname);
+    if (!host) return true;
+    if (host === 'localhost' || host.endsWith('.localhost')) return true;
+    if (BLOCKED_SUFFIXES.some((s) => host.endsWith(s))) return true;
+    if (net.isIP(host)) return isPrivateAddress(host);
+    if (/^(0x[0-9a-f]+|\d+)(\.(0x[0-9a-f]+|\d+)){0,3}$/i.test(host)) {
+        try { return isBlockedHostname(new URL(`http://${host}/`).hostname); } catch (e) { return true; }
+    }
+    return false;
+};
+
+const parseHttpUrl = (url) => {
+    let u;
+    try { u = new URL(String(url)); } catch (e) { throw new Error(`not a valid URL: ${url}`); }
+    if (!/^https?:$/.test(u.protocol)) throw new Error(`only http and https URLs can be fetched (got ${u.protocol.replace(/:$/, '')})`);
+    return u;
+};
+
+async function resolvePublic(url) {
+    const u = parseHttpUrl(url);
+    const host = stripBrackets(u.hostname);
+    if (isBlockedHostname(host)) throw new Error(`${u.hostname} is a private, local or internal host — agents do not fetch it`);
+    let answers;
+    try {
+        answers = await dns.promises.lookup(host, { all: true, verbatim: true });
+    } catch (e) {
+        throw new Error(`could not resolve ${u.hostname}: ${e.code || e.message}`);
+    }
+    if (!answers || !answers.length) throw new Error(`could not resolve ${u.hostname}`);
+    const bad = answers.find((a) => isPrivateAddress(a.address));
+    if (bad) throw new Error(`${u.hostname} resolves to a private or reserved address (${bad.address}) — agents do not fetch it`);
+    return { url: u, address: answers[0].address, family: answers[0].family || net.isIP(answers[0].address) };
+}
+
+const pinnedLookup = ({ address, family }) => (hostname, options, cb) => cb(null, address, family);
+
+async function readCapped(stream, { maxBytes, remainingMs }) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        let size = 0;
+        let settled = false;
+        const finish = (fn, value) => { if (settled) return; settled = true; clearTimeout(timer); fn(value); };
+        const timer = setTimeout(() => { stream.destroy(); finish(reject, new Error('fetch exceeded its time budget')); }, remainingMs);
+        stream.on('data', (chunk) => {
+            size += chunk.length;
+            if (size > maxBytes) { stream.destroy(); return finish(reject, new Error(`response is larger than the ${maxBytes} byte size cap`)); }
+            chunks.push(chunk);
+        });
+        stream.on('end', () => finish(resolve, Buffer.concat(chunks)));
+        stream.on('error', (e) => finish(reject, e));
+    });
+}
+
+/* Follows redirects by hand so every hop is validated and pinned. `opts.resolve`
+ * exists for tests that need a "public" name to land on a local server. */
+async function safeFetch(url, opts = {}) {
+    const { timeoutMs, maxBytes, maxRedirects } = { ...DEFAULTS, ...opts };
+    const resolve = opts.resolve || resolvePublic;
+    const deadline = Date.now() + timeoutMs;
+    const remaining = () => {
+        const left = deadline - Date.now();
+        if (left <= 0) throw new Error('fetch exceeded its time budget');
+        return left;
+    };
+
+    let current = String(url);
+    for (let hop = 0; ; hop += 1) {
+        const target = await resolve(current);
+        const controller = new AbortController();
+        const abortTimer = setTimeout(() => controller.abort(), remaining());
+        let res;
+        try {
+            res = await axios.get(target.url.toString(), {
+                headers: opts.headers,
+                timeout: remaining(),
+                signal: controller.signal,
+                maxRedirects: 0,
+                maxContentLength: maxBytes,
+                lookup: pinnedLookup(target),
+                validateStatus: () => true,
+                responseType: 'stream',
+            });
+        } catch (e) {
+            clearTimeout(abortTimer);
+            if (controller.signal.aborted || e.code === 'ECONNABORTED' || e.code === 'ERR_CANCELED') throw new Error('fetch exceeded its time budget');
+            throw e;
+        }
+        clearTimeout(abortTimer);
+
+        const location = res.headers && res.headers.location;
+        if (res.status >= 300 && res.status < 400 && location) {
+            res.data.destroy();
+            if (hop >= maxRedirects) throw new Error(`too many redirects (more than ${maxRedirects})`);
+            current = new URL(String(location), target.url).toString();
+            continue;
+        }
+
+        const body = await readCapped(res.data, { maxBytes, remainingMs: remaining() });
+        return { status: res.status, headers: res.headers, body: body.toString('utf8'), bytes: body.length, url: target.url.toString() };
+    }
+}
+
+module.exports = { safeFetch, resolvePublic, isBlockedHostname, isPrivateAddress, DEFAULTS };

--- a/Modules/Agents/skills/prReview.js
+++ b/Modules/Agents/skills/prReview.js
@@ -1,6 +1,7 @@
 // Reviewer: summarise a linked pull request and flag risk.
 
-const { PRIVATE_HOST, fetchPage } = require('../engine/pageAudit');
+const { fetchPage } = require('../engine/pageAudit');
+const { isBlockedHostname } = require('../engine/safeFetch');
 
 const MAX_DIFF_CHARS = 30000;
 const PR_URL = /https?:\/\/[^\s<>"')]+/g;
@@ -29,7 +30,7 @@ module.exports = {
         if (!url) return { skip: 'no pull request or branch link on this task — attach one with task.link or paste the PR URL in the description' };
         let host;
         try { host = new URL(url).hostname; } catch (e) { return { skip: `the link is not a valid URL: ${url}` }; }
-        if (PRIVATE_HOST.test(host)) return { skip: 'the link points at a private or local host, which agents do not fetch' };
+        if (isBlockedHostname(host)) return { skip: 'the link points at a private or local host, which agents do not fetch' };
         const target = /github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(url) ? `${url.replace(/\/files.*$/, '')}.diff` : url;
         const page = await fetchPage(target);
         if (page.status >= 400 || !page.html) return { skip: `could not fetch ${target} (HTTP ${page.status})` };

--- a/Modules/Agents/taskInputs.js
+++ b/Modules/Agents/taskInputs.js
@@ -2,15 +2,16 @@
 // brief. The router refuses an agent whose skills need an input the task lacks,
 // instead of starting a run that skips.
 
+const { isBlockedHostname } = require('./engine/safeFetch');
+
 const URL_RE = /https?:\/\/[^\s<>"')]+/gi;
 const PR_RE = /\/pull\/\d+|\/merge_requests\/\d+|\/compare\//;
-const PRIVATE_HOST = /^(localhost|127\.|10\.|192\.168\.|0\.0\.0\.0|\[?::1)/i;
 const MIN_BRIEF_CHARS = 40;
 
 const plain = (html) => String(html || '').replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
 
 const hostOf = (url) => { try { return new URL(url).hostname; } catch (e) { return ''; } };
-const isPublic = (url) => { const h = hostOf(url); return Boolean(h) && !PRIVATE_HOST.test(h); };
+const isPublic = (url) => { const h = hostOf(url); return Boolean(h) && !isBlockedHostname(h); };
 
 const urlsIn = (task) => [task.TaskName, task.description, task.rawDescription].map((v) => String(v || '')).join(' ').match(URL_RE) || [];
 

--- a/tests/agent-egress.test.js
+++ b/tests/agent-egress.test.js
@@ -1,0 +1,147 @@
+const http = require('http');
+const dns = require('dns');
+const { safeFetch, resolvePublic, isBlockedHostname, isPrivateAddress } = require('../Modules/Agents/engine/safeFetch');
+const { fetchPage, extractUrl } = require('../Modules/Agents/engine/pageAudit');
+const { inputsOf } = require('../Modules/Agents/taskInputs');
+
+const SECRET = 'IMDS-TOKEN-DO-NOT-LEAK';
+
+const listen = (handler) => new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+});
+
+describe('agent egress — private-host rule', () => {
+    it('classifies every reserved range by the resolved address, not the string', () => {
+        ['0.0.0.0', '0.1.2.3', '10.1.2.3', '127.0.0.1', '127.9.9.9', '169.254.169.254', '172.16.0.1', '172.31.255.255',
+         '192.168.1.1', '100.64.0.1', '100.127.255.254', '224.0.0.1', '239.255.255.250', '255.255.255.255',
+         '::', '::1', 'fc00::1', 'fd12::1', 'fe80::1', 'febf::1', 'ff02::1',
+         '::ffff:127.0.0.1', '::ffff:169.254.169.254', '::ffff:10.0.0.1', '::ffff:7f00:1'].forEach((ip) => {
+            expect([ip, isPrivateAddress(ip)]).toEqual([ip, true]);
+        });
+        ['8.8.8.8', '203.0.113.10', '172.32.0.1', '100.128.0.1', '2606:4700::1111', '::ffff:8.8.8.8'].forEach((ip) => {
+            expect([ip, isPrivateAddress(ip)]).toEqual([ip, false]);
+        });
+    });
+
+    it('refuses localhost and internal-only suffixes before resolving', () => {
+        ['localhost', 'LOCALHOST', 'printer.local', 'db.internal', 'a.b.internal', '[::1]', '127.1', '0x7f000001', '2130706433'].forEach((h) => {
+            expect([h, isBlockedHostname(h)]).toEqual([h, true]);
+        });
+        expect(isBlockedHostname('example.com')).toBe(false);
+        expect(isBlockedHostname('internal.example.com')).toBe(false);
+    });
+
+    describe('resolution', () => {
+        let lookup;
+        beforeEach(() => { lookup = jest.spyOn(dns.promises, 'lookup'); });
+        afterEach(() => lookup.mockRestore());
+
+        it('rejects a public-looking hostname that resolves to a private address', async () => {
+            lookup.mockResolvedValue([{ address: '10.0.0.7', family: 4 }]);
+            await expect(resolvePublic('https://internal-service.example.com/')).rejects.toThrow(/private|reserved/i);
+            expect(lookup).toHaveBeenCalledWith('internal-service.example.com', expect.objectContaining({ all: true }));
+        });
+
+        it('rejects when ANY resolved address is private', async () => {
+            lookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }, { address: '169.254.169.254', family: 4 }]);
+            await expect(resolvePublic('http://split-horizon.example.com/')).rejects.toThrow(/private|reserved/i);
+            lookup.mockResolvedValue([{ address: '2606:4700::1111', family: 6 }, { address: '::ffff:127.0.0.1', family: 6 }]);
+            await expect(resolvePublic('http://mapped.example.com/')).rejects.toThrow(/private|reserved/i);
+        });
+
+        it('returns the validated address so the connection can be pinned to it', async () => {
+            lookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+            await expect(resolvePublic('https://example.com/x')).resolves.toMatchObject({ address: '203.0.113.10', family: 4 });
+        });
+
+        it('only allows http and https', async () => {
+            await expect(resolvePublic('file:///etc/passwd')).rejects.toThrow(/http/);
+            await expect(resolvePublic('ftp://example.com/')).rejects.toThrow(/http/);
+            await expect(resolvePublic('not a url')).rejects.toThrow();
+            expect(lookup).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('fetching', () => {
+        let server; let port; let hits;
+        beforeAll(async () => {
+            hits = [];
+            ({ server, port } = await listen((req, res) => {
+                hits.push(req.url);
+                if (req.url === '/secret') return res.end(SECRET);
+                if (req.url === '/to-loopback') { res.writeHead(302, { Location: `http://127.0.0.1:${port}/secret` }); return res.end(); }
+                if (req.url === '/to-metadata') { res.writeHead(302, { Location: 'http://169.254.169.254/latest/meta-data/' }); return res.end(); }
+                if (req.url === '/to-internal-name') { res.writeHead(302, { Location: 'http://db.internal/' }); return res.end(); }
+                if (req.url === '/relative') { res.writeHead(301, { Location: '/landed' }); return res.end(); }
+                if (req.url === '/landed') return res.end('<html><title>landed</title></html>');
+                if (/^\/loop\/\d+$/.test(req.url)) { const n = Number(req.url.split('/')[2]); res.writeHead(302, { Location: `/loop/${n + 1}` }); return res.end(); }
+                if (req.url === '/big') { res.writeHead(200, { 'Content-Type': 'text/html' }); const chunk = Buffer.alloc(64 * 1024, 'a'); const tick = () => { if (!res.write(chunk)) return res.once('drain', tick); setImmediate(tick); }; return tick(); }
+                if (req.url === '/slow') return;
+                res.writeHead(404); res.end();
+            }));
+        });
+        afterAll(() => new Promise((r) => { server.closeAllConnections?.(); server.close(r); }));
+        beforeEach(() => { hits.length = 0; });
+
+        /* Every address on this test server is loopback, so a fake resolver stands in
+         * for DNS on the FIRST hop only: `public.test` is "public" and pinned to the
+         * server. Every other target — including redirect targets — goes through the
+         * real rule, which is exactly what the old code skipped. */
+        const resolve = (url) => {
+            const u = new URL(url);
+            if (u.hostname === 'public.test') return Promise.resolve({ url: u, address: '127.0.0.1', family: 4 });
+            return resolvePublic(url);
+        };
+        const opts = () => ({ resolve, timeoutMs: 3000, maxRedirects: 5, maxBytes: 1024 * 1024 });
+
+        it('fetchPage refuses a loopback literal outright', async () => {
+            await expect(fetchPage(`http://127.0.0.1:${port}/secret`)).rejects.toThrow(/private|reserved/i);
+            expect(hits).toEqual([]);
+        });
+
+        it('does not follow a redirect from a public host to loopback', async () => {
+            await expect(safeFetch(`http://public.test:${port}/to-loopback`, opts())).rejects.toThrow(/private|reserved/i);
+            expect(hits).toEqual(['/to-loopback']);
+        });
+
+        it('does not follow a redirect to the cloud metadata endpoint or an internal name', async () => {
+            await expect(safeFetch(`http://public.test:${port}/to-metadata`, opts())).rejects.toThrow(/private|reserved/i);
+            await expect(safeFetch(`http://public.test:${port}/to-internal-name`, opts())).rejects.toThrow(/private|reserved|internal/i);
+            expect(hits).toEqual(['/to-metadata', '/to-internal-name']);
+        });
+
+        it('follows a relative redirect on the same validated host', async () => {
+            const page = await safeFetch(`http://public.test:${port}/relative`, opts());
+            expect(page.status).toBe(200);
+            expect(page.body).toContain('landed');
+            expect(page.url).toBe(`http://public.test:${port}/landed`);
+            expect(hits).toEqual(['/relative', '/landed']);
+        });
+
+        it('stops after the redirect cap', async () => {
+            await expect(safeFetch(`http://public.test:${port}/loop/0`, opts())).rejects.toThrow(/redirect/i);
+            expect(hits.length).toBeLessThanOrEqual(6);
+        });
+
+        it('aborts the stream once the body exceeds the size cap', async () => {
+            await expect(safeFetch(`http://public.test:${port}/big`, { ...opts(), maxBytes: 200 * 1024 })).rejects.toThrow(/size|large|bytes/i);
+        });
+
+        it('gives up when the total time budget is spent', async () => {
+            const started = Date.now();
+            await expect(safeFetch(`http://public.test:${port}/slow`, { ...opts(), timeoutMs: 300 })).rejects.toThrow(/time/i);
+            expect(Date.now() - started).toBeLessThan(2500);
+        });
+    });
+
+    it('the task-input and URL-extraction rules share the same list', () => {
+        ['http://169.254.169.254/latest/meta-data/', 'http://172.20.0.1/', 'http://100.64.1.1/', 'http://[::1]:4000/', 'http://[fe80::1]/',
+         'http://0.0.0.0:4000/', 'http://printer.local/', 'http://vault.internal/', 'http://127.1/', 'http://2130706433/'].forEach((url) => {
+            expect([url, inputsOf({ TaskName: `Review ${url}` }).publicUrl]).toEqual([url, null]);
+            expect([url, extractUrl(`Review ${url}`)]).toEqual([url, null]);
+        });
+        expect(inputsOf({ TaskName: 'Review https://example.com/pricing' }).publicUrl).toBe('https://example.com/pricing');
+        expect(extractUrl('Review https://example.com/pricing')).toBe('https://example.com/pricing');
+    });
+});

--- a/tests/agent-qa.test.js
+++ b/tests/agent-qa.test.js
@@ -1,4 +1,4 @@
-const { auditHtml, extractUrl, PRIVATE_HOST } = require('../Modules/Agents/engine/pageAudit');
+const { auditHtml, extractUrl } = require('../Modules/Agents/engine/pageAudit');
 const { verify, parseModelJson, findingsWithoutModel, getSkill } = require('../Modules/Agents/engine/orchestrator');
 
 const skill = getSkill('qa-review');

--- a/tests/agent-skills.test.js
+++ b/tests/agent-skills.test.js
@@ -1,6 +1,6 @@
 jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
 jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
-jest.mock('../Modules/Agents/engine/pageAudit', () => ({ PRIVATE_HOST: /^(localhost$|127\.)/i, fetchPage: jest.fn() }));
+jest.mock('../Modules/Agents/engine/pageAudit', () => ({ fetchPage: jest.fn() }));
 
 const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
 const { fetchPage } = require('../Modules/Agents/engine/pageAudit');


### PR DESCRIPTION
Sprint 0, step 2 of the AI-layer programme (task 023). Stacked on #552.

## What it closes

**Defect 1** — `Modules/Agents/engine/pageAudit.js` `fetchPage` and the rule behind `Modules/Agents/taskInputs.js` let a task description drive a server-side fetch into loopback, the cloud metadata endpoint or an internal service name:

- `fetchPage` had no host check at all and let axios auto-follow up to five redirects, so `https://attacker.example/x` → `302 http://169.254.169.254/latest/meta-data/` was fetched and its body handed to the model.
- The only check lived in the URL extractors, and it was a hostname prefix regex. `taskInputs.js` did not even list `169.254/16` or `172.16/12`; neither copy covered `100.64/10`, multicast, `::`/`fe80::`/`fc00::`, IPv4-mapped IPv6, `.local`/`.internal`, or a public-looking name that resolves to a private address.

**ADR 003 "private-host pattern differs"** — there were three divergent regexes (`pageAudit.js`, `taskInputs.js`, `orchestrator.js`). All of them, plus `skills/prReview.js`, now go through one module.

## The fix

New `Modules/Agents/engine/safeFetch.js`:

- `isBlockedHostname(host)` — the synchronous half of the rule (localhost, `*.local`, `*.internal`, and IP literals in any reserved range, including `127.1` / `0x7f000001` / `2130706433` forms). Used by `extractUrl`, `taskInputs.isPublic`, `prReview.gather` and the orchestrator's skip message.
- `resolvePublic(url)` — parse, http(s) only, `dns.promises.lookup(host, { all: true })`, reject if **any** answer is private/reserved: `0/8`, `10/8`, `100.64/10`, `127/8`, `169.254/16`, `172.16/12`, `192.168/16`, `224/4`, `240/4`, broadcast, `::`, `::1`, `fc00::/7`, `fe80::/10`, `ff00::/8`, and `::ffff:a.b.c.d` unwrapped and checked as IPv4. Returns the validated address.
- `safeFetch(url, opts)` — axios with `maxRedirects: 0`; redirects followed by hand, at most 5 hops, `resolvePublic` re-run on every `Location` (relative ones resolved against the validated hop). The socket is pinned with axios's `lookup` option returning the address that passed, so a DNS answer cannot change between check and connect. Response is streamed; a 10 s total budget and a 1 MB default cap (`pageAudit` keeps its 15 s / 3 MB) abort the stream rather than read-then-truncate.

`fetchPage` is now a thin wrapper over `safeFetch`; the `PRIVATE_HOST` export is gone.

## How the test reproduces it first

`tests/agent-egress.test.js`, written before the fix. Against the pre-fix code:

```
$ node -e '…fetchPage("http://127.0.0.1:PORT/r")…'   # /r is 302 → http://127.0.0.1:PORT/secret
OLD CODE returned: 200 IMDS-SECRET
$ inputsOf({TaskName:"Review http://169.254.169.254/latest/"}).publicUrl
http://169.254.169.254/latest/
```

The suite uses a local `http` server for redirects (public → loopback, public → `169.254.169.254`, public → `db.internal`, relative, a redirect loop, an oversized body, a hanging response) and `jest.spyOn(dns.promises, 'lookup')` for resolution (name → `10.0.0.7`; split answer `203.0.113.10` + `169.254.169.254`; `2606:4700::1111` + `::ffff:127.0.0.1`). The first hop to the local server goes through an injected `resolve` that maps `public.test` to the server; every redirect target goes through the real rule.

- `fetchPage('http://127.0.0.1:…/secret')` rejects, server never hit
- redirect to loopback / metadata / `.internal` rejects; server sees only the first request
- relative redirect on the same validated host is followed
- 6th hop rejects with a redirect error
- body over the cap rejects with a size error mid-stream
- hanging server rejects within the budget

## Test results

- `npx jest tests/agent-egress.test.js` — 14 passed
- `npx jest --selectProjects unit` — 134 suites, 1682 passed
- `npx jest tests/conventions` — 7 suites, 88 passed

## Limitations

- Pinning relies on axios's `lookup` option, which the http adapter passes straight to `http.request`; if an `HTTP(S)_PROXY` env var is set, the proxy resolves the hostname and the pin does not apply to that hop. No proxy is configured in this codebase.
- `frontend/src/views/Ai/agentFit.js` carries a UI-only copy of the task-input rule for the picker; the server is authoritative and it was left untouched to keep this PR to the egress path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
