### PR TITLE
fix(023): fail the agent action when its audit row cannot be written

### DIFF
--- a/Modules/Agents/actions.js
+++ b/Modules/Agents/actions.js
@@ -10,9 +10,10 @@ const { attribution, isAgent } = require('./actor');
 const completionStore = require('../Tasks/helpers/completionStore');
 
 // The single place an agent's action is executed. MCP tools, approved proposals
-// and workspace-agent runs all call perform(): registry check → tool layer →
-// provenance → audit row with an undo descriptor. A human calling the same REST
-// routes never passes through here; the guard only watches them.
+// and workspace-agent runs all call perform(): registry check → pending audit
+// row → tool layer → provenance → row marked applied with its undo descriptor.
+// A human calling the same REST routes never passes through here; the guard
+// only watches them.
 
 class RefusedError extends Error {
     constructor(message, auditId) { super(message); this.name = 'RefusedError'; this.status = 403; this.auditId = auditId || null; }
@@ -253,14 +254,18 @@ const perform = async ({ companyId, actor, action, params = {}, reason = '', cos
     const exec = executors[action];
     if (!exec) throw new tools.DeterministicError(`${action} has no executor`);
 
-    const out = await exec({ companyId, actor, params });
+    const auditId = await audit.openAction(companyId, actor, { action, reason, params, cost, ip, entityId: params.taskId });
+    let out;
+    try {
+        out = await exec({ companyId, actor, params });
+    } catch (e) {
+        await audit.failAction(companyId, auditId, e.message);
+        throw e;
+    }
     if (isAgent(actor) && params.taskId && action !== 'timelog.stop' && action !== 'task.status.set') {
         await completionStore.recordWork(companyId, params.taskId, workEntry(actor, 0));
     }
-    const auditId = await audit.recordAction(companyId, actor, {
-        action, reason, params, cost, undo: out.undo, ip,
-        entityType: out.entityType || 'task', entityId: out.entityId, entityName: out.entityName,
-    });
+    await audit.applyAction(companyId, auditId, { undo: out.undo, entityType: out.entityType || 'task', entityId: out.entityId, entityName: out.entityName });
     return { result: out.result, auditId, undo: out.undo, task: out.task || null };
 };
 

--- a/Modules/Agents/agentAudit.js
+++ b/Modules/Agents/agentAudit.js
@@ -9,6 +9,10 @@ const { isAgent, attribution } = require('./actor');
 // { actorType, agentId, runId, action, reason, params, cost, undo, viaAccount }
 // in meta, and the row id is what an undo token points at — so unlike
 // recordAudit this one waits for the write and returns the id.
+//
+// An action row is opened `pending` before the mutation and marked `applied`
+// (with its undo descriptor) after it, so an action can never happen without
+// a row: a failed open aborts the action, a failed mark fails its result.
 
 const ACTION_DONE = 'agent.action';
 const ACTION_REFUSED = 'agent.action_refused';
@@ -27,16 +31,47 @@ const safeParams = (params) => {
     return clip(p);
 };
 
+const STATE = Object.freeze({ PENDING: 'pending', APPLIED: 'applied', FAILED: 'failed' });
+const AUDIT_UNAVAILABLE = 'audit_unavailable';
+const AUDIT_UNMARKED = 'audit_unmarked';
+
+class AuditUnavailableError extends Error {
+    constructor(detail) {
+        super(`${AUDIT_UNAVAILABLE}: the action was not performed because its audit row could not be written (${detail})`);
+        this.name = 'AuditUnavailableError'; this.reason = AUDIT_UNAVAILABLE; this.status = 503;
+    }
+}
+
+class AuditUnmarkedError extends Error {
+    constructor(auditId, detail) {
+        super(`${AUDIT_UNMARKED}: the action ran but its audit row ${auditId} could not be marked applied (${detail})`);
+        this.name = 'AuditUnmarkedError'; this.reason = AUDIT_UNMARKED; this.status = 500; this.auditId = auditId;
+    }
+}
+
 const write = async (companyId, entry) => {
     const n = normalizeAuditEntry(entry);
-    if (!n.valid || !companyId) return null;
-    try {
-        const saved = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AUDIT_LOGS, data: n.entry }, 'save');
-        return saved && saved._id ? String(saved._id) : null;
-    } catch (e) {
+    if (!n.valid) throw new Error(n.reason || 'invalid audit entry');
+    if (!companyId) throw new Error('companyId is required');
+    const saved = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AUDIT_LOGS, data: n.entry }, 'save');
+    if (!saved || !saved._id) throw new Error('no row id returned');
+    return String(saved._id);
+};
+
+const writeQuietly = async (companyId, entry) => {
+    try { return await write(companyId, entry); } catch (e) {
         logger.error(`agent audit write failed: ${e.message}`);
         return null;
     }
+};
+
+const rowFilter = (auditId) => (/^[0-9a-fA-F]{24}$/.test(String(auditId)) ? { _id: new mongoose.Types.ObjectId(String(auditId)) } : null);
+
+const setRow = async (companyId, auditId, $set) => {
+    const filter = rowFilter(auditId);
+    if (!filter) throw new Error(`invalid audit id ${auditId}`);
+    const r = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AUDIT_LOGS, data: [filter, { $set }] }, 'updateOne');
+    if (!r || !(r.matchedCount > 0 || r.modifiedCount > 0)) throw new Error(`audit row ${auditId} not found`);
 };
 
 const baseMeta = (actor) => {
@@ -52,22 +87,54 @@ const baseMeta = (actor) => {
     };
 };
 
-/* An allowed agent call. `undo` is the inverse-action descriptor executed by undo.js. */
-const recordAction = async (companyId, actor, { action, reason, params, cost, undo, entityType, entityId, entityName, ip }) => {
+/* Opens the row for an allowed agent call before anything is mutated. Throws
+ * AuditUnavailableError, and the caller must not act. */
+const openAction = async (companyId, actor, { action, reason, params, cost, entityType, entityId, entityName, ip }) => {
     const a = attribution(actor);
-    return write(companyId, {
-        actorId: a.actorId, actorName: a.label, ip,
-        action: ACTION_DONE,
-        entityType: entityType || 'task', entityId: entityId ? String(entityId) : '', entityName: entityName || '',
-        meta: { ...baseMeta(actor), action, reason: reason || '', params: safeParams(params), cost: cost || null,
-                undo: undo || null, undoable: Boolean(undo), undoneAt: null, undoneBy: null },
-    });
+    try {
+        return await write(companyId, {
+            actorId: a.actorId, actorName: a.label, ip,
+            action: ACTION_DONE,
+            entityType: entityType || 'task', entityId: entityId ? String(entityId) : '', entityName: entityName || '',
+            meta: { ...baseMeta(actor), action, reason: reason || '', params: safeParams(params), cost: cost || null,
+                    state: STATE.PENDING, undo: null, undoable: false, undoneAt: null, undoneBy: null },
+        });
+    } catch (e) {
+        logger.error(`agent audit: ${AUDIT_UNAVAILABLE} for ${action}: ${e.message}`);
+        throw new AuditUnavailableError(e.message);
+    }
+};
+
+/* `undo` is the inverse-action descriptor executed by undo.js. Throws
+ * AuditUnmarkedError after logging: the mutation happened and the row needs reconciling. */
+const applyAction = async (companyId, auditId, { undo, entityType, entityId, entityName } = {}) => {
+    const $set = { 'meta.state': STATE.APPLIED, 'meta.undo': undo || null, 'meta.undoable': Boolean(undo) };
+    if (entityType) $set.entityType = entityType;
+    if (entityId) $set.entityId = String(entityId);
+    if (entityName) $set.entityName = entityName;
+    try { await setRow(companyId, auditId, $set); } catch (e) {
+        logger.error(`agent audit: ${AUDIT_UNMARKED} — row ${auditId} is still pending after the action ran, reconcile it: ${e.message}`);
+        throw new AuditUnmarkedError(auditId, e.message);
+    }
+};
+
+/* The action threw before changing anything; the row records that and stays out of undo. */
+const failAction = async (companyId, auditId, detail) => {
+    try { await setRow(companyId, auditId, { 'meta.state': STATE.FAILED, 'meta.failed': String(detail || '').slice(0, 500), 'meta.undoable': false }); } catch (e) {
+        logger.error(`agent audit: row ${auditId} could not be marked failed: ${e.message}`);
+    }
+};
+
+const recordAction = async (companyId, actor, entry) => {
+    const auditId = await openAction(companyId, actor, entry);
+    await applyAction(companyId, auditId, entry);
+    return auditId;
 };
 
 /* A refused call — logged with what was attempted and why, and nothing ran. */
 const recordRefusal = async (companyId, actor, { action, reason, params, entityType, entityId, path, ip }) => {
     const a = attribution(actor);
-    return write(companyId, {
+    return writeQuietly(companyId, {
         actorId: a.actorId, actorName: a.label, ip,
         action: ACTION_REFUSED,
         entityType: entityType || 'task', entityId: entityId ? String(entityId) : '',
@@ -77,7 +144,7 @@ const recordRefusal = async (companyId, actor, { action, reason, params, entityT
 
 const recordUndo = async (companyId, actor, { originalId, action, entityType, entityId, ip }) => {
     const a = attribution(actor);
-    return write(companyId, {
+    return writeQuietly(companyId, {
         actorId: a.actorId, actorName: a.label, ip,
         action: ACTION_UNDONE,
         entityType: entityType || 'task', entityId: entityId ? String(entityId) : '',
@@ -87,7 +154,7 @@ const recordUndo = async (companyId, actor, { originalId, action, entityType, en
 
 const recordProposalDecision = async (companyId, actor, { proposalId, decision, agentName, runId, changes, ip }) => {
     const a = attribution(actor);
-    return write(companyId, {
+    return writeQuietly(companyId, {
         actorId: a.actorId, actorName: a.label, ip,
         action: PROPOSAL_DECIDED,
         entityType: 'agent_proposal', entityId: String(proposalId),
@@ -97,7 +164,7 @@ const recordProposalDecision = async (companyId, actor, { proposalId, decision, 
 
 const recordAgentDeleted = async (companyId, actor, { agentId, agentName, ip }) => {
     const a = attribution(actor);
-    return write(companyId, {
+    return writeQuietly(companyId, {
         actorId: a.actorId, actorName: a.label, ip,
         action: AGENT_DELETED,
         entityType: 'agent', entityId: String(agentId), entityName: agentName || '',
@@ -107,7 +174,7 @@ const recordAgentDeleted = async (companyId, actor, { agentId, agentName, ip }) 
 
 const recordRunReverted = async (companyId, actor, { runId, agentId, agentName, reverted, failed, ip }) => {
     const a = attribution(actor);
-    return write(companyId, {
+    return writeQuietly(companyId, {
         actorId: a.actorId, actorName: a.label, ip,
         action: RUN_REVERTED,
         entityType: 'agent_run', entityId: String(runId), entityName: agentName || '',
@@ -116,21 +183,22 @@ const recordRunReverted = async (companyId, actor, { runId, agentId, agentName, 
 };
 
 const markUndone = async (companyId, auditId, byActorId) => {
-    if (!/^[0-9a-fA-F]{24}$/.test(String(auditId))) return;
+    const filter = rowFilter(auditId);
+    if (!filter) return;
     await MongoDbCrudOpration(companyId, {
         type: SCHEMA_TYPE.AUDIT_LOGS,
-        data: [{ _id: new mongoose.Types.ObjectId(String(auditId)) }, { $set: { 'meta.undoneAt': new Date(), 'meta.undoneBy': String(byActorId || '') } }],
+        data: [filter, { $set: { 'meta.undoneAt': new Date(), 'meta.undoneBy': String(byActorId || '') } }],
     }, 'updateOne').catch((e) => logger.error(`markUndone: ${e.message}`));
 };
 
 const findById = async (companyId, auditId) => {
-    if (!/^[0-9a-fA-F]{24}$/.test(String(auditId))) return null;
-    return MongoDbCrudOpration(companyId, {
-        type: SCHEMA_TYPE.AUDIT_LOGS, data: [{ _id: new mongoose.Types.ObjectId(String(auditId)) }],
-    }, 'findOne');
+    const filter = rowFilter(auditId);
+    if (!filter) return null;
+    return MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AUDIT_LOGS, data: [filter] }, 'findOne');
 };
 
 module.exports = {
-    ACTION_DONE, ACTION_REFUSED, ACTION_UNDONE, PROPOSAL_DECIDED, AGENT_DELETED, RUN_REVERTED,
-    recordAction, recordRefusal, recordUndo, recordProposalDecision, recordAgentDeleted, recordRunReverted, markUndone, findById,
+    ACTION_DONE, ACTION_REFUSED, ACTION_UNDONE, PROPOSAL_DECIDED, AGENT_DELETED, RUN_REVERTED, STATE, AUDIT_UNAVAILABLE, AUDIT_UNMARKED,
+    AuditUnavailableError, AuditUnmarkedError,
+    openAction, applyAction, failAction, recordAction, recordRefusal, recordUndo, recordProposalDecision, recordAgentDeleted, recordRunReverted, markUndone, findById,
 };

--- a/Modules/Agents/engine/graph.js
+++ b/Modules/Agents/engine/graph.js
@@ -128,7 +128,11 @@ async function act(state, config) {
             // eslint-disable-next-line no-await-in-loop
             if (change.remember) await findingMemory.record(companyId, { ...change.remember, subtaskId: out.result && out.result.subtaskId });
         } catch (e) {
-            if (e.name !== 'RefusedError') throw e;
+            if (e.name !== 'RefusedError') {
+                // eslint-disable-next-line no-await-in-loop
+                await runs.patch(companyId, run._id, {}, { $push: { actions: { action: change.action, auditId: e.auditId || null, ok: false, error: e.message, at: new Date() } } });
+                throw e;
+            }
             refusals += 1;
             // eslint-disable-next-line no-await-in-loop
             await runs.patch(companyId, run._id, {}, { $inc: { refusals: 1 }, $push: { actions: { action: change.action, auditId: e.auditId || null, ok: false, refused: e.message, at: new Date() } } });

--- a/Modules/Agents/guard.js
+++ b/Modules/Agents/guard.js
@@ -72,11 +72,18 @@ const taskPatchGuard = withActor(async (req, res, next, actor) => {
     const check = registry.evaluate(action, params);
     if (!check.allowed) return refuse(req, res, actor, { action, reason: check.reason, params, entityId: params.taskId });
     req.agentAction = { action, params };
+    const companyId = req.headers['companyid'] || '';
+    let auditId;
+    try {
+        auditId = await audit.openAction(companyId, actor, { action, reason: 'via REST', params, entityId: params.taskId, ip: req.ip || '' });
+    } catch (e) {
+        return res.status(503).json({ status: false, message: e.message, statusText: audit.AUDIT_UNAVAILABLE });
+    }
     res.on('finish', () => {
-        if (res.statusCode >= 400) return;
-        audit.recordAction(req.headers['companyid'] || '', actor, {
-            action, reason: 'via REST', params, entityId: params.taskId, ip: req.ip || '', undo: null,
-        }).catch(() => {});
+        const settle = res.statusCode >= 400
+            ? audit.failAction(companyId, auditId, `HTTP ${res.statusCode}`)
+            : audit.applyAction(companyId, auditId, { undo: null });
+        settle.catch((e) => logger.error(`agent guard: ${e.message}`));
     });
     return next();
 });

--- a/Modules/Agents/revert.js
+++ b/Modules/Agents/revert.js
@@ -34,7 +34,7 @@ const revertRun = async (companyId, runId, { actor, isPrivileged, ip }) => {
         return { error: `The revert window closed at ${windowEndsAt.toISOString()} (${undoHours} h after the run finished).`, status: 409 };
     }
 
-    const rows = (await actionRows(companyId, run._id)) || [];
+    const rows = ((await actionRows(companyId, run._id)) || []).filter((r) => !(r.meta && r.meta.state === audit.STATE.FAILED));
     const pending = rows.filter((r) => !(r.meta && r.meta.undoneAt));
     if (!rows.length) return { error: 'This run made no reversible changes.', status: 409 };
 

--- a/Modules/Agents/undo.js
+++ b/Modules/Agents/undo.js
@@ -79,6 +79,8 @@ const isUndoable = (row) => Boolean(row && row.meta && row.meta.undo && inverses
 const undoAuditRow = async (companyId, row, actor, ip) => {
     if (!row || row.action !== audit.ACTION_DONE) return { ok: false, reason: 'Only agent actions can be undone.' };
     if (row.meta && row.meta.undoneAt) return { ok: false, reason: 'Already undone.' };
+    if (row.meta && row.meta.state === audit.STATE.PENDING) return { ok: false, reason: 'The action was never confirmed in the audit log; reconcile it by hand before undoing.' };
+    if (row.meta && row.meta.state === audit.STATE.FAILED) return { ok: false, reason: 'The action failed and changed nothing.' };
     const u = row.meta && row.meta.undo;
     if (!u || !inverses[u.kind]) return { ok: false, reason: 'not undoable' };
     const result = await inverses[u.kind](companyId, u);

--- a/tests/agent-audit-ordering.test.js
+++ b/tests/agent-audit-ordering.test.js
@@ -1,0 +1,158 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../Config/permissionGuard', () => ({ ROLE_OWNER: 1, ROLE_ADMIN: 2, getRoleType: jest.fn(async () => 1), isPrivileged: (r) => r === 1 || r === 2 }));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+jest.mock('../Modules/Tasks/helpers/completionStore', () => ({ forStatusChange: jest.fn(async () => null), recordWork: jest.fn(async () => null) }));
+jest.mock('../Modules/Agents/engine/orchestrator', () => ({ gather: jest.fn(async () => ({ status: 'gathered', context: {} })), analyse: jest.fn() }));
+jest.mock('../Modules/Agents/engine/findingMemory', () => ({ load: jest.fn(async () => new Map()), decide: jest.fn(), record: jest.fn(), touch: jest.fn() }));
+jest.mock('../Modules/Agents/memory', () => ({
+    DECLINE_REASON_TEXT: {},
+    contextFor: jest.fn(async () => ''),
+    recordEpisode: jest.fn(async () => null),
+    preferenceCandidate: jest.fn(async () => null),
+    rememberApprovedChanges: jest.fn(async () => null),
+}));
+jest.mock('../Modules/AIProjectGenerator/usage', () => ({ summarize: jest.fn(() => ({ costUsd: 0.01, totalTokens: 100, model: 'm' })) }));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const logger = require('../Config/loggerConfig');
+const persistence = require('../Modules/Agents/engine/persistence');
+const orchestrator = require('../Modules/Agents/engine/orchestrator');
+const findingMemory = require('../Modules/Agents/engine/findingMemory');
+const actions = require('../Modules/Agents/actions');
+const proposals = require('../Modules/Agents/proposals');
+const runs = require('../Modules/Agents/runs');
+const revert = require('../Modules/Agents/revert');
+const undo = require('../Modules/Agents/undo');
+
+const CID = '6a8ee973d625fca52e519a12';
+const TASK_ID = '6f0000000000000000000701';
+const AGENT_ID = '6f0000000000000000000a01';
+const RUN_ID = '6f0000000000000000000c01';
+const PROJECT_ID = '6a9954186dd786246031e47b';
+
+const agentActor = { kind: 'agent', userId: 'u1', agentId: AGENT_ID, agentName: 'Code Reviewer', runId: RUN_ID, viaAccount: 'workspace', tokenId: null };
+const task = () => ({ _id: TASK_ID, CompanyId: CID, ProjectID: PROJECT_ID, TaskName: 'Fix the thing', TaskKey: 'AR-1', Task_Priority: 'LOW' });
+const agent = (over = {}) => ({ _id: AGENT_ID, name: 'Code Reviewer', autonomy: 2, allowedActions: [], projectIds: [], account: 'workspace', spendCapUsd: 10, ...over });
+
+const rows = (type) => mockDb.store[type] || [];
+const auditRows = () => rows(SCHEMA_TYPE.AUDIT_LOGS);
+const comments = () => rows(SCHEMA_TYPE.COMMENTS);
+const runRow = (id) => rows(SCHEMA_TYPE.AGENT_RUNS).find((r) => String(r._id) === String(id));
+
+const auditSaves = [];
+const snapshotting = (real) => async (companyId, q, m) => {
+    if (q.type === SCHEMA_TYPE.AUDIT_LOGS && m === 'save') auditSaves.push({ at: mockDb.calls.length, data: JSON.parse(JSON.stringify(q.data)) });
+    return real(companyId, q, m);
+};
+const failAudit = (method) => {
+    const real = mockDb.crud.getMockImplementation();
+    mockDb.crud.mockImplementation(async (companyId, q, m) => {
+        if (q.type === SCHEMA_TYPE.AUDIT_LOGS && m === method) throw new Error('audit store down');
+        return real(companyId, q, m);
+    });
+};
+
+let realCrud;
+let mem;
+beforeAll(() => { realCrud = snapshotting(mockDb.crud.getMockImplementation()); });
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    mockDb.calls.length = 0;
+    auditSaves.length = 0;
+    jest.clearAllMocks();
+    mockDb.crud.mockImplementation(realCrud);
+    mem = persistence.useInMemory();
+    mockDb.seed(SCHEMA_TYPE.TASKS, task());
+    mockDb.seed(SCHEMA_TYPE.AGENTS, agent());
+});
+afterEach(() => { mem.reset(); persistence.useMongo(); });
+
+const comment = () => actions.perform({ companyId: CID, actor: agentActor, action: 'task.comment', params: { taskId: TASK_ID, body: 'Looks good' }, reason: 'qa-review finding' });
+
+describe('the audit row is written before the action and gates it', () => {
+    it('when the audit row cannot be written the action is not performed and the caller gets audit_unavailable', async () => {
+        failAudit('save');
+
+        await expect(comment()).rejects.toMatchObject({ name: 'AuditUnavailableError', reason: 'audit_unavailable', message: expect.stringContaining('audit_unavailable') });
+        expect(comments()).toHaveLength(0);
+        expect(auditRows()).toHaveLength(0);
+    });
+
+    it('a healthy write leaves one row that goes pending before the mutation and applied, with the undo descriptor, after it', async () => {
+        const out = await comment();
+
+        const commentSave = mockDb.calls.findIndex((c) => c.type === SCHEMA_TYPE.COMMENTS && c.method === 'save');
+        expect(auditSaves).toHaveLength(1);
+        expect(auditSaves[0].data.meta).toMatchObject({ state: 'pending', undo: null, undoable: false, action: 'task.comment' });
+        expect(auditSaves[0].at).toBeLessThan(commentSave);
+
+        expect(auditRows()).toHaveLength(1);
+        expect(auditRows()[0]).toMatchObject({
+            _id: out.auditId, action: 'agent.action', entityId: TASK_ID,
+            meta: { state: 'applied', undoable: true, undo: { kind: 'comment', commentId: out.result.commentId, taskId: TASK_ID } },
+        });
+    });
+
+    it('when the row cannot be marked applied the action is reported failed, logged loudly, and the pending row is not undoable', async () => {
+        failAudit('updateOne');
+
+        await expect(comment()).rejects.toMatchObject({ name: 'AuditUnmarkedError', reason: 'audit_unmarked', auditId: expect.any(String) });
+        expect(comments()).toHaveLength(1);
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('audit_unmarked'));
+        expect(auditRows()[0].meta).toMatchObject({ state: 'pending', undoable: false });
+        expect(await undo.undoAuditRow(CID, auditRows()[0], { kind: 'human', userId: 'u1' }, '')).toMatchObject({ ok: false, reason: expect.stringMatching(/never confirmed/) });
+    });
+
+    it('an executor that throws closes its row as failed so a revert does not treat it as a change', async () => {
+        await expect(actions.perform({ companyId: CID, actor: agentActor, action: 'task.comment', params: { taskId: 'missing', body: 'x' } })).rejects.toBeTruthy();
+        expect(auditRows()).toHaveLength(1);
+        expect(auditRows()[0].meta).toMatchObject({ state: 'failed', undoable: false, failed: expect.any(String) });
+    });
+
+    it('an approved proposal reports the step failed with audit_unavailable and applies nothing', async () => {
+        const created = await proposals.create(CID, {
+            agent: agent(), taskId: TASK_ID, projectId: PROJECT_ID, runId: null, what: 'Comment', why: 'because',
+            changes: [{ action: 'task.comment', label: 'Comment', reversible: true, params: { taskId: TASK_ID, body: 'hi' } }],
+        });
+        failAudit('save');
+
+        const out = await proposals.approve(CID, created._id, { decider: { kind: 'human', userId: 'u9' }, isPrivileged: true, ip: '' });
+        expect(out.error).toBeUndefined();
+        expect(comments()).toHaveLength(0);
+        expect(rows(SCHEMA_TYPE.AGENT_PROPOSALS)[0].auditIds).toEqual([]);
+        expect(out.applied).toEqual([{ action: 'task.comment', ok: false, error: expect.stringContaining('audit_unavailable') }]);
+    });
+});
+
+describe('a run whose act phase cannot audit', () => {
+    const subtask = (title) => ({ action: 'subtask.create', label: `Subtask: ${title}`, reversible: true, params: { taskId: TASK_ID, title } });
+
+    beforeEach(() => {
+        findingMemory.load.mockResolvedValue(new Map());
+        findingMemory.decide.mockImplementation(async (companyId, taskId, findings) => findings.map((f) => ({ finding: f, action: 'file', reason: 'new' })));
+        orchestrator.analyse.mockResolvedValue({ status: 'success', skill: 'plan', changes: [subtask('One'), subtask('Two')], summary: 'planned', usage: { totalTokens: 100 }, model: 'm' });
+    });
+
+    it('reports the step failed, fails the run, mutates nothing, and leaves the revert path nothing undocumented', async () => {
+        const a = agent();
+        const run = await runs.create(CID, { agent: a, taskId: TASK_ID, projectId: PROJECT_ID, skill: 'plan', startedBy: 'u1' });
+        failAudit('save');
+
+        const out = await runs.executeSkill(CID, run, a, task(), { proposals, actions, actor: { ...agentActor, runId: String(run._id) } });
+        expect(out).toMatchObject({ status: 'failed', error: expect.stringContaining('audit_unavailable') });
+
+        const row = runRow(run._id);
+        expect(row.status).toBe('failed');
+        expect(row.actions).toHaveLength(1);
+        expect(row.actions[0]).toMatchObject({ action: 'subtask.create', ok: false, auditId: null, error: expect.stringContaining('audit_unavailable') });
+        expect(rows(SCHEMA_TYPE.TASKS).filter((t) => t.ParentTaskID)).toHaveLength(0);
+        expect(auditRows()).toHaveLength(0);
+
+        mockDb.crud.mockImplementation(realCrud);
+        expect(await revert.revertRun(CID, run._id, { actor: { kind: 'human', userId: 'u1' }, isPrivileged: true, ip: '' })).toMatchObject({ status: 409, error: 'This run made no reversible changes.' });
+    });
+});

--- a/tests/agent-graph.test.js
+++ b/tests/agent-graph.test.js
@@ -16,7 +16,7 @@ jest.mock('../Modules/Agents/actions', () => {
     const actual = jest.requireActual('../Modules/Agents/actions');
     return { rating: actual.rating, perform: jest.fn(async () => ({ auditId: 'aud1', result: { subtaskId: 'st1' } })) };
 });
-jest.mock('../Modules/Agents/agentAudit', () => ({ ACTION_DONE: 'agent.action', recordProposalDecision: jest.fn(async () => 'dec1'), recordRunReverted: jest.fn(async () => 'rev1'), findById: jest.fn() }));
+jest.mock('../Modules/Agents/agentAudit', () => ({ ACTION_DONE: 'agent.action', STATE: { PENDING: 'pending', APPLIED: 'applied', FAILED: 'failed' }, recordProposalDecision: jest.fn(async () => 'dec1'), recordRunReverted: jest.fn(async () => 'rev1'), findById: jest.fn() }));
 jest.mock('../Modules/Agents/undo', () => ({ undoAuditRow: jest.fn(async () => ({ ok: true })) }));
 jest.mock('../Modules/AIProjectGenerator/usage', () => ({ summarize: jest.fn(() => ({ costUsd: 0.01, totalTokens: 100, model: 'm' })) }));
 


### PR DESCRIPTION
Closes defect 19 (Sprint 0, step 6b of task 023). Stacked on #552.

## Defect

In the agent action path an audit write that failed was caught and swallowed (`agentAudit.write` returned `null`, `guard.js` had `.catch(() => {})`), so an action could run with no audit row and no undo descriptor.

## Ordering chosen: pending → mutate → applied

`actions.perform` now:

1. `audit.openAction(...)` writes the `agent.action` row with `meta.state: 'pending'`, `undo: null`, `undoable: false` **before** the executor runs. If that write fails the action throws `AuditUnavailableError` (`reason: 'audit_unavailable'`, status 503) and nothing is mutated.
2. Runs the executor. If it throws, the row is closed as `meta.state: 'failed'` (with the reason) and the error propagates; a failed row is ignored by revert and refused by undo.
3. `audit.applyAction(...)` marks the row `applied` and stores the undo descriptor and entity fields. If that mark fails the mutation has already happened, so the action's result is reported failed with `AuditUnmarkedError` (`reason: 'audit_unmarked'`, carries `auditId`) and a loud `logger.error` names the row for reconciliation. Undo on such a pending row refuses with an explicit reason instead of silently doing nothing.

Why pending/applied rather than only "write before mutate": the row id is what an undo token points at and the undo descriptor is only known after the executor runs, so a single pre-write cannot carry it. The two-phase row keeps the id stable, is cheap (one `updateOne`), and makes an unconfirmed action visible in the log rather than absent.

## Swallow sites changed

- `Modules/Agents/agentAudit.js` — `write` no longer swallows; action rows go through `openAction` / `applyAction` / `failAction`. Log-only writers (`recordRefusal`, `recordUndo`, `recordProposalDecision`, `recordAgentDeleted`, `recordRunReverted`) keep swallowing via `writeQuietly` since they record nothing that gates a mutation.
- `Modules/Agents/actions.js` — `perform` uses the pending/applied ordering above.
- `Modules/Agents/guard.js` — `taskPatchGuard` opened its row in `res.on('finish')` with `.catch(() => {})`; it now opens the pending row before `next()`, answers `503 audit_unavailable` if it cannot, and marks the row applied/failed on finish with a logged (not swallowed) error.
- `Modules/Agents/engine/graph.js` — the act node records a non-refusal failure (`ok: false, error`) on the run's `actions` before rethrowing, so the run fails with the step visible.
- `Modules/Agents/undo.js` / `revert.js` — pending rows refuse undo with a reconcile message; failed rows are not treated as changes.

## Tests

`tests/agent-audit-ordering.test.js` (fakeMongo, audit `save` / `updateOne` stubbed to throw):

- audit write fails → action not performed, caller gets `AuditUnavailableError` naming `audit_unavailable` — **fails on the previous commit** (the comment was created and the call resolved), passes now
- healthy path → one row, saved `pending` before the comment save, ends `applied` with the undo descriptor
- mark-applied fails → `AuditUnmarkedError`, loud log, row stays `pending`, undo refuses it
- executor throws → row closed `failed`
- approved proposal step reports `ok: false` with `audit_unavailable`, applies nothing
- run at L2 with audit down → step recorded failed on the run, run `failed`, no subtask created, no audit rows, revert reports no reversible changes (nothing missing a descriptor)

`tests/agent-graph.test.js`: its `agentAudit` mock gained `STATE`.

Results: `npx jest tests/agent- tests/conventions` → 37 suites, 490 tests passing; `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
