### PR TITLE
fix(023): encrypt integration secrets at rest with a migration

### DIFF
--- a/Modules/Integrations/controller.js
+++ b/Modules/Integrations/controller.js
@@ -8,7 +8,7 @@ const S = require('./helpers/slackRules'); // AUTO-06
 
 // AUTO-04 — generic integration connections registry (per-company). Backs the
 // marketplace (AUTO-05), Slack (AUTO-06) and custom iframe apps (AUTO-07).
-// Secrets are stored in config but never returned (redact()).
+// Secrets are stored encrypted in config (R.sealConfig) and never returned (redact()).
 
 const companyOf = (req) => req.headers['companyid'] || (req.body && req.body.companyId) || (req.query && req.query.companyId);
 const oid = (id) => { try { return new mongoose.Types.ObjectId(String(id)); } catch (e) { return null; } };
@@ -39,6 +39,7 @@ exports.connect = async (req, res) => {
         const check = R.validateConnection(req.body || {});
         if (!check.valid) return res.send({ status: false, statusText: check.reason });
         const item = R.byKey(check.value.type);
+        const config = R.sealConfig(check.value.type, check.value.config);
         // Single-instance integrations update in place rather than duplicate.
         if (item && !item.multiple) {
             const existing = await MongoDbCrudOpration(companyId, {
@@ -47,14 +48,14 @@ exports.connect = async (req, res) => {
             if (existing) {
                 const upd = await MongoDbCrudOpration(companyId, {
                     type: SCHEMA_TYPE.INTEGRATION_CONNECTIONS,
-                    data: [{ _id: existing._id }, { $set: { config: check.value.config, name: check.value.name, status: 'connected', enabled: true } }, { returnDocument: 'after' }],
+                    data: [{ _id: existing._id }, { $set: { config, name: check.value.name, status: 'connected', enabled: true, secretsVersion: R.SECRETS_VERSION } }, { returnDocument: 'after' }],
                 }, 'findOneAndUpdate');
                 removeCache(`integration_connections:${companyId}`);
                 return res.send({ status: true, statusText: 'Updated.', data: R.redact(upd) });
             }
         }
         const data = {
-            _id: new mongoose.Types.ObjectId(), type: check.value.type, name: check.value.name, config: check.value.config,
+            _id: new mongoose.Types.ObjectId(), type: check.value.type, name: check.value.name, config, secretsVersion: R.SECRETS_VERSION,
             status: 'connected', enabled: true, createdBy: String(req.uid || ''), connectedAt: new Date(), deletedStatusKey: 0,
         };
         const saved = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.INTEGRATION_CONNECTIONS, data }, 'save');
@@ -103,10 +104,11 @@ exports.slackCommand = async (req, res) => {
         const conn = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.INTEGRATION_CONNECTIONS, data: [{ type: 'slack', deletedStatusKey: { $ne: 1 } }],
         }, 'findOne').catch(() => null);
-        if (!conn || conn.enabled === false || !conn.config || !conn.config.verification_token) {
+        const verificationToken = conn && conn.config ? R.openConfig('slack', conn.config).verification_token : null;
+        if (!conn || conn.enabled === false || !verificationToken) {
             return res.json(S.ephemeral('Slack isn’t connected for this workspace yet — add it in AlianHub → Integrations → Marketplace.'));
         }
-        if (!S.verifyToken(conn.config.verification_token, req.body && req.body.token)) {
+        if (!S.verifyToken(verificationToken, req.body && req.body.token)) {
             return res.status(401).json(S.ephemeral('Verification failed.'));
         }
         const { sub } = S.parseCommand(req.body && req.body.text);

--- a/Modules/Integrations/helpers/integrationsRules.js
+++ b/Modules/Integrations/helpers/integrationsRules.js
@@ -2,6 +2,7 @@
 // generic integration_connections registry backs the marketplace (AUTO-05), the
 // Slack bot (AUTO-06) and custom iframe apps (AUTO-07). Unit-tested in
 // tests/integrations-rules.test.js.
+const secretField = require('../../../utils/secretField');
 
 // Static catalog of connectable integrations. `fields` are the config inputs;
 // `secret:true` fields are never returned to the client. `multiple:true` allows
@@ -42,16 +43,20 @@ const validateConnection = ({ type, config } = {}) => {
     return { valid: true, reason: '', value: { type: item.key, name, config: out } };
 };
 
+const secretKeys = (type) => { const item = byKey(type); return ((item && item.fields) || []).filter((f) => f.secret).map((f) => f.key); };
+
+// Secrets rest encrypted (utils/secretField); sealConfig on every write, openConfig only where the value is used.
+const sealConfig = (type, config) => secretField.sealFields(config, secretKeys(type));
+const openConfig = (type, config) => secretField.openFields(config, secretKeys(type));
+
 // Strip secret values for client display; expose which secrets are set.
 const redact = (conn) => {
     if (!conn) return conn;
     const o = conn.toObject ? conn.toObject() : { ...conn };
-    const item = byKey(o.type);
-    const secretKeys = ((item && item.fields) || []).filter((f) => f.secret).map((f) => f.key);
     const cfg = { ...(o.config || {}) };
     const secrets = {};
-    for (const k of secretKeys) { secrets[k] = !!cfg[k]; delete cfg[k]; }
+    for (const k of secretKeys(o.type)) { secrets[k] = !!cfg[k]; delete cfg[k]; }
     return { ...o, config: cfg, secrets };
 };
 
-module.exports = { CATALOG, byKey, getCatalog, validateConnection, redact, isEmbeddableUrl };
+module.exports = { CATALOG, SECRETS_VERSION: secretField.VERSION, byKey, getCatalog, validateConnection, redact, isEmbeddableUrl, secretKeys, sealConfig, openConfig };

--- a/migrations/007-encrypt-integration-secrets.js
+++ b/migrations/007-encrypt-integration-secrets.js
@@ -1,0 +1,53 @@
+const R = require('../Modules/Integrations/helpers/integrationsRules');
+const { isEncrypted, decrypt } = require('../utils/secretField');
+
+/* Integration credentials (GitHub/GitLab tokens, Slack verification token, OAuth
+ * client secrets, webhook URLs) were saved as plaintext. Seals every secret config
+ * key of every connection, in every company database, and stamps secretsVersion
+ * so a re-run only touches rows written before this. Rows with no secret field
+ * are stamped too, so status reads as fully migrated. */
+
+const REFUSAL = 'Rolling back writes every integration secret back to plaintext. Re-run with --confirm to do it.';
+
+const forEachConnection = (ctx, fn) => ctx.forEachCompany(async (companyId) => {
+    const rows = await ctx.company(companyId, { type: ctx.SCHEMA_TYPE.INTEGRATION_CONNECTIONS, data: [{}] }, 'find') || [];
+    const counts = { encrypted: 0, stamped: 0, skipped: 0, decrypted: 0 };
+    for (const row of rows) counts[await fn(companyId, row)] += 1;
+    ctx.logger.info(`[migrations] 007 ${companyId}: ${JSON.stringify(counts)}`);
+    return counts;
+});
+
+const write = (ctx, companyId, row, set) => ctx.company(companyId, {
+    type: ctx.SCHEMA_TYPE.INTEGRATION_CONNECTIONS, data: [{ _id: row._id }, { $set: set }],
+}, 'updateOne');
+
+module.exports = {
+    id: '007-encrypt-integration-secrets',
+    scope: 'company',
+    async up(ctx) {
+        await forEachConnection(ctx, async (companyId, row) => {
+            if (row.secretsVersion === R.SECRETS_VERSION) return 'skipped';
+            const config = row.config || {};
+            const pending = R.secretKeys(row.type).filter((k) => config[k] && !isEncrypted(config[k]));
+            const set = { secretsVersion: R.SECRETS_VERSION };
+            if (pending.length) set.config = R.sealConfig(row.type, config);
+            await write(ctx, companyId, row, set);
+            return pending.length ? 'encrypted' : 'stamped';
+        });
+    },
+    async down(ctx, { confirmed } = {}) {
+        if (confirmed !== true) throw new Error(REFUSAL);
+        await forEachConnection(ctx, async (companyId, row) => {
+            if (row.secretsVersion !== R.SECRETS_VERSION) return 'skipped';
+            const config = { ...(row.config || {}) };
+            for (const k of R.secretKeys(row.type)) {
+                if (!isEncrypted(config[k])) continue;
+                const plain = decrypt(config[k]);
+                if (plain === null) throw new Error(`${row.type} ${row._id}: secret "${k}" does not decrypt with the current key`);
+                config[k] = plain;
+            }
+            await write(ctx, companyId, row, { config, secretsVersion: 0 });
+            return 'decrypted';
+        });
+    },
+};

--- a/migrations/index.js
+++ b/migrations/index.js
@@ -97,6 +97,28 @@ async function runMigrations({ store, migrations, makeContext, logger = console,
     }
 }
 
+/* Reverts one applied migration that defines down(ctx, options) and forgets its
+ * record so `up` can apply it again. Only the caller's explicit options reach the
+ * migration; a rollback that rewrites data guards itself on them. */
+async function rollbackMigration({ store, migrations, makeContext, logger = console, owner = `${os.hostname()}:${process.pid}` }, id, options = {}) {
+    const migration = migrations.find((m) => m.id === id);
+    if (!migration) throw new Error(`unknown migration "${id}"`);
+    if (typeof migration.down !== 'function') throw new Error(`${id} has no down()`);
+    const record = (await store.all()).find((r) => r._id === id);
+    if (!record || !record.ok) throw new Error(`${id} is not applied`);
+    const locked = await store.tryLock(owner, LOCK_TTL_MS);
+    if (!locked) return { skipped: 'locked' };
+    try {
+        const ctx = makeContext();
+        logger.info(`[migrations] rolling back ${id} (${migration.scope})`);
+        await migration.down(ctx, options);
+        await store.remove(id);
+        return { skipped: false, id, companies: ctx.companies };
+    } finally {
+        await store.unlock(owner);
+    }
+}
+
 async function migrationStatus({ store, migrations }) {
     const { applied, pending, failed } = planRuns(migrations, await store.all());
     return {
@@ -160,4 +182,4 @@ async function runMigrationsAtBoot({ auto = process.env.MIGRATIONS_AUTO !== 'fal
     }
 }
 
-module.exports = { LOCK_ID, LOCK_TTL_MS, listMigrations, validateMigration, planRuns, buildContext, runMigrations, migrationStatus, refreshMigrationState, liveDeps, runMigrationsAtBoot };
+module.exports = { LOCK_ID, LOCK_TTL_MS, listMigrations, validateMigration, planRuns, buildContext, runMigrations, rollbackMigration, migrationStatus, refreshMigrationState, liveDeps, runMigrationsAtBoot };

--- a/migrations/store.js
+++ b/migrations/store.js
@@ -11,6 +11,10 @@ function createMongoStore({ MongoDbCrudOpration, SCHEMA_TYPE, lockId }) {
         async put(doc) {
             await run([{ _id: doc._id }, { $set: doc }, { upsert: true, new: true }], 'findOneAndUpdate');
         },
+        async remove(id) {
+            if (id === lockId) return;
+            await run([{ _id: id }], 'deleteOne');
+        },
         /* One process migrates at a time. A stale lock (a crashed run) is taken over
          * once it expires; a live one makes the upsert collide on _id, which is the
          * "someone else has it" answer. */
@@ -41,6 +45,7 @@ function createMemoryStore({ lockId = '__lock' } = {}) {
         docs,
         async all() { return [...docs.values()].filter((d) => d._id !== lockId).map((d) => ({ ...d })); },
         async put(doc) { docs.set(doc._id, { ...(docs.get(doc._id) || {}), ...doc }); },
+        async remove(id) { if (id !== lockId) docs.delete(id); },
         async tryLock(owner, ttlMs) {
             const lock = docs.get(lockId);
             if (lock && lock.expiresAt > new Date()) return false;

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,19 +1,34 @@
 #!/usr/bin/env node
-/* npm run migrate -- status | up
+/* npm run migrate -- status | up | down <id> [--confirm]
  * The same runner the server uses at boot, for operators who set
- * MIGRATIONS_AUTO=false or want to see what a new version will do first. */
+ * MIGRATIONS_AUTO=false or want to see what a new version will do first.
+ * `down` reverts one migration that defines down(); a migration that rewrites
+ * data (007 decrypts every integration secret) refuses without --confirm. */
 const path = require('path');
 
 require('../Config/applyEnv').loadDotEnv(path.join(__dirname, '..', '.env'));
 if (!process.env.STORAGE_TYPE) process.env.STORAGE_TYPE = 'server';
 
-const command = process.argv[2] || 'status';
+const args = process.argv.slice(2);
+const flags = new Set(args.filter((a) => a.startsWith('--')));
+const positional = args.filter((a) => !a.startsWith('--'));
+const command = positional[0] || 'status';
 
 async function main() {
     if (!process.env.MONGODB_URL) throw new Error('MONGODB_URL is not set.');
-    const { liveDeps, runMigrations, migrationStatus } = require('../migrations');
+    const { liveDeps, runMigrations, rollbackMigration, migrationStatus } = require('../migrations');
     const deps = liveDeps();
     deps.logger = console;
+
+    if (command === 'down') {
+        const id = positional[1];
+        if (!id) throw new Error('Usage: migrate down <migration id> [--confirm]');
+        const result = await rollbackMigration(deps, id, { confirmed: flags.has('--confirm') });
+        if (result.skipped) { console.log(`Skipped: ${result.skipped} (another process is migrating).`); return; }
+        Object.entries(result.companies || {}).forEach(([companyId, outcome]) => console.log(`  ${outcome.ok ? '✓' : '✗'} ${companyId} ${JSON.stringify(outcome)}`));
+        console.log(`Rolled back ${id}.`);
+        return;
+    }
 
     if (command === 'status') {
         const status = await migrationStatus(deps);
@@ -32,7 +47,7 @@ async function main() {
         console.log(result.applied.length ? `Applied ${result.applied.length}; ${result.pending.length} pending.` : 'Nothing to do.');
         return;
     }
-    throw new Error(`Unknown command "${command}". Use: status | up`);
+    throw new Error(`Unknown command "${command}". Use: status | up | down <id> [--confirm]`);
 }
 
 main().then(() => process.exit(0)).catch((error) => {

--- a/tests/integrations-secrets.test.js
+++ b/tests/integrations-secrets.test.js
@@ -1,0 +1,57 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn() }));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const ctrl = require('../Modules/Integrations/controller');
+const { isEncrypted } = require('../utils/secretField');
+
+const PLAIN = 'xoxb-plaintext-verification-token';
+const res = () => { const r = { body: null }; r.send = (b) => { r.body = b; return r; }; r.json = r.send; r.status = () => r; return r; };
+const req = (body, extra = {}) => ({ headers: { companyid: 'c1' }, body, uid: 'u1', params: {}, ...extra });
+
+beforeAll(() => { process.env.JWT_SECRET = 'test-secret'; });
+
+describe('integration secrets at rest', () => {
+    test('a saved connection never stores the secret in plaintext, and the API never returns it', async () => {
+        const r = res();
+        await ctrl.connect(req({ type: 'slack', config: { verification_token: PLAIN, default_channel: '#dev' } }), r);
+        expect(r.body.status).toBe(true);
+        const raw = mockDb.store[SCHEMA_TYPE.INTEGRATION_CONNECTIONS][0];
+        expect(JSON.stringify(raw)).not.toContain(PLAIN);
+        expect(isEncrypted(raw.config.verification_token)).toBe(true);
+        expect(raw.config.default_channel).toBe('#dev');
+        expect(raw.secretsVersion).toBe(1);
+        expect(JSON.stringify(r.body)).not.toContain(PLAIN);
+        expect(r.body.data.secrets).toEqual({ verification_token: true });
+    });
+
+    test('re-connecting a single-instance integration re-encrypts in place', async () => {
+        const r = res();
+        await ctrl.connect(req({ type: 'slack', config: { verification_token: 'second-token' } }), r);
+        const rows = mockDb.store[SCHEMA_TYPE.INTEGRATION_CONNECTIONS];
+        expect(rows).toHaveLength(1);
+        expect(JSON.stringify(rows[0])).not.toContain('second-token');
+        expect(isEncrypted(rows[0].config.verification_token)).toBe(true);
+        expect(rows[0].secretsVersion).toBe(1);
+        expect(JSON.stringify(r.body)).not.toContain('second-token');
+    });
+
+    test('the slack command decrypts at the point of use', async () => {
+        const ok = res();
+        await ctrl.slackCommand({ params: { companyId: 'c1' }, body: { token: 'second-token', text: 'help' } }, ok);
+        expect(ok.body.text).toMatch(/alianhub/i);
+        const bad = res();
+        await ctrl.slackCommand({ params: { companyId: 'c1' }, body: { token: 'wrong', text: 'help' } }, bad);
+        expect(bad.body.text).toMatch(/verification failed/i);
+    });
+
+    test('listConnections never exposes secrets', async () => {
+        const r = res();
+        await ctrl.listConnections(req({}), r);
+        expect(JSON.stringify(r.body)).not.toContain('second-token');
+        expect(r.body.data[0].config).not.toHaveProperty('verification_token');
+    });
+});

--- a/tests/migration-encrypt-secrets.test.js
+++ b/tests/migration-encrypt-secrets.test.js
@@ -1,0 +1,60 @@
+const fakeMongo = require('./fixtures/fakeMongo');
+const { buildContext, validateMigration } = require('../migrations');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { encrypt, decrypt, isEncrypted } = require('../utils/secretField');
+
+const migration = require('../migrations/007-encrypt-integration-secrets');
+const T = SCHEMA_TYPE.INTEGRATION_CONNECTIONS;
+const logger = { info: jest.fn(), error: jest.fn() };
+
+beforeAll(() => { process.env.JWT_SECRET = 'test-secret'; });
+
+const contextFor = (db) => buildContext({ MongoDbCrudOpration: db.crud, SCHEMA_TYPE, logger, listCompanies: async () => [{ _id: 'c1' }] });
+
+describe('007-encrypt-integration-secrets', () => {
+    test('is a valid company-scoped migration', () => {
+        expect(() => validateMigration(migration, '007-encrypt-integration-secrets')).not.toThrow();
+        expect(migration.scope).toBe('company');
+    });
+
+    test('encrypts seeded plaintext secrets, leaves encrypted rows untouched, and is idempotent', async () => {
+        const db = fakeMongo.create();
+        const plain = db.seed(T, { type: 'github', config: { token: 'ghp_plain', repo: 'a/b' }, deletedStatusKey: 0 });
+        const already = encrypt('already-sealed');
+        const sealed = db.seed(T, { type: 'gitlab', config: { token: already, project: 'g/p' }, secretsVersion: 1, deletedStatusKey: 0 });
+        const noSecret = db.seed(T, { type: 'custom_iframe', config: { name: 'Grafana', url: 'https://g.example.com' }, deletedStatusKey: 0 });
+
+        const first = contextFor(db);
+        await migration.up(first);
+        expect(first.companies.c1).toMatchObject({ ok: true, encrypted: 1, stamped: 1, skipped: 1 });
+
+        const rows = db.store[T];
+        const github = rows.find((r) => r._id === plain._id);
+        expect(github.config.token).not.toBe('ghp_plain');
+        expect(isEncrypted(github.config.token)).toBe(true);
+        expect(decrypt(github.config.token)).toBe('ghp_plain');
+        expect(github.config.repo).toBe('a/b');
+        expect(github.secretsVersion).toBe(1);
+        expect(rows.find((r) => r._id === sealed._id).config.token).toBe(already);
+        expect(rows.find((r) => r._id === noSecret._id).secretsVersion).toBe(1);
+
+        const snapshot = JSON.stringify(rows);
+        const again = contextFor(db);
+        await migration.up(again);
+        expect(again.companies.c1).toMatchObject({ encrypted: 0, stamped: 0, skipped: 3 });
+        expect(JSON.stringify(db.store[T])).toBe(snapshot);
+    });
+
+    test('down refuses without the explicit flag and decrypts back with it', async () => {
+        const db = fakeMongo.create();
+        db.seed(T, { type: 'slack', config: { verification_token: 'v-tok' }, deletedStatusKey: 0 });
+        await migration.up(contextFor(db));
+        await expect(migration.down(contextFor(db), {})).rejects.toThrow(/--confirm/);
+        expect(isEncrypted(db.store[T][0].config.verification_token)).toBe(true);
+        const down = contextFor(db);
+        await migration.down(down, { confirmed: true });
+        expect(down.companies.c1).toMatchObject({ ok: true, decrypted: 1 });
+        expect(db.store[T][0].config.verification_token).toBe('v-tok');
+        expect(db.store[T][0].secretsVersion).toBe(0);
+    });
+});

--- a/tests/secret-field.test.js
+++ b/tests/secret-field.test.js
@@ -1,0 +1,40 @@
+const { encrypt, decrypt, isEncrypted, sealFields, openFields } = require('../utils/secretField');
+
+beforeAll(() => { process.env.JWT_SECRET = 'test-secret'; });
+
+describe('secretField', () => {
+    test('round-trips a value and never stores it in plaintext', () => {
+        const sealed = encrypt('ghp_supersecrettoken');
+        expect(sealed).not.toContain('ghp_supersecrettoken');
+        expect(isEncrypted(sealed)).toBe(true);
+        expect(decrypt(sealed)).toBe('ghp_supersecrettoken');
+    });
+
+    test('is idempotent: an already-encrypted value is not encrypted twice', () => {
+        const once = encrypt('abc');
+        expect(encrypt(once)).toBe(once);
+    });
+
+    test('empty values stay empty and plaintext reads through unchanged', () => {
+        expect(encrypt('')).toBe('');
+        expect(encrypt(null)).toBe('');
+        expect(isEncrypted('https://hooks.zapier.com/a:b:c')).toBe(false);
+        expect(decrypt('legacy-plaintext')).toBe('legacy-plaintext');
+    });
+
+    test('tampered ciphertext or a rotated key fails closed', () => {
+        const sealed = encrypt('abc');
+        expect(decrypt(sealed.slice(0, -2) + 'zz')).toBeNull();
+        process.env.JWT_SECRET = 'rotated';
+        expect(decrypt(sealed)).toBeNull();
+        process.env.JWT_SECRET = 'test-secret';
+    });
+
+    test('sealFields / openFields only touch the named keys', () => {
+        const sealed = sealFields({ token: 't0k', repo: 'a/b' }, ['token', 'missing']);
+        expect(sealed.repo).toBe('a/b');
+        expect(isEncrypted(sealed.token)).toBe(true);
+        expect(sealed).not.toHaveProperty('missing');
+        expect(openFields(sealed, ['token'])).toEqual({ token: 't0k', repo: 'a/b' });
+    });
+});

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -874,12 +874,14 @@ const schema = {
         finishedAt: { type: Date, required: false },
     },
     // Integration connections — managed by Modules/Integrations (AUTO-04). Generic
-    // registry backing the marketplace, Slack and iframe apps. Secrets live in
-    // config but are redacted before reaching the client.
+    // registry backing the marketplace, Slack and iframe apps. Secret config keys
+    // are AES-256-GCM ciphertext (utils/secretField); secretsVersion 0 marks a row
+    // migration 007 has not sealed yet.
     integrationConnections: {
         type: { type: String, required: true },
         name: { type: String, required: false },
         config: { type: Object, default: {}, required: false },
+        secretsVersion: { type: Number, default: 0, required: false },
         status: { type: String, default: 'connected', required: false },
         enabled: { type: Boolean, default: true, required: false },
         createdBy: { type: String, required: false },

--- a/utils/secretField.js
+++ b/utils/secretField.js
@@ -1,0 +1,31 @@
+/* Secrets at rest for any per-company integration credential. Same AES-256-GCM
+ * construction and key as the cloud-storage tokens (Modules/CloudStorage/helpers/
+ * cloudCrypto), wrapped in a versioned marker so a stored value can be told apart
+ * from plaintext without guessing: plaintext never starts with "enc:v1:". */
+const { encryptToken, decryptToken } = require('../Modules/CloudStorage/helpers/cloudCrypto');
+
+const VERSION = 1;
+const PREFIX = `enc:v${VERSION}:`;
+
+const isEncrypted = (value) => typeof value === 'string' && value.startsWith(PREFIX);
+
+const encrypt = (value) => {
+    if (value === null || value === undefined || String(value) === '') return '';
+    if (isEncrypted(value)) return value;
+    return PREFIX + encryptToken(String(value));
+};
+
+/* Plaintext reads through so unmigrated rows keep working; a value that carries
+ * the marker but will not decrypt (tampered, or the key rotated) yields null. */
+const decrypt = (value) => (isEncrypted(value) ? decryptToken(value.slice(PREFIX.length)) : value);
+
+const mapFields = (obj, keys, fn) => {
+    const out = { ...(obj || {}) };
+    for (const key of keys || []) if (out[key] !== undefined && out[key] !== null && out[key] !== '') out[key] = fn(out[key]);
+    return out;
+};
+
+const sealFields = (obj, keys) => mapFields(obj, keys, encrypt);
+const openFields = (obj, keys) => mapFields(obj, keys, decrypt);
+
+module.exports = { VERSION, PREFIX, isEncrypted, encrypt, decrypt, sealFields, openFields };


### PR DESCRIPTION
Sprint 0, step 6d — closes defect 6: integration credentials stored in plaintext. Stacked on #552 (`feat/agent-memory`).

## What was plaintext

`integration_connections.config.<secret field>` in every company database — the catalog's `secret: true` keys:

| type | key |
|---|---|
| github / gitlab | `token` (repository write access) |
| slack | `verification_token` |
| google_calendar | `client_secret` |
| microsoft_teams | `webhook_url` |
| zapier | `hook_url` |

The GitHub/GitLab OAuth controllers never persist tokens (they hand `access_token` straight back to the client), and `Modules/Agents/{shipping,accounts}.js` only read `type name status` from connections, so the registry above was the only at-rest store. Cloud-storage tokens were already encrypted and are untouched.

## Fix

- `utils/secretField.js` — wraps the existing cloud-storage AES-256-GCM idiom (`Modules/CloudStorage/helpers/cloudCrypto`, key from `CLOUD_STORAGE_ENC_KEY` with the `JWT_SECRET` fallback); no new scheme, no new env var. Values carry an `enc:v1:` marker so encryption is idempotent and plaintext reads through until migrated; tampered or key-rotated ciphertext fails closed to `null`.
- `Modules/Integrations/helpers/integrationsRules.js` — `secretKeys / sealConfig / openConfig` driven by the catalog, `SECRETS_VERSION`.
- `Modules/Integrations/controller.js` — both write paths in `connect` seal the config and stamp `secretsVersion: 1`; the Slack command handler decrypts at the point of use. List/connect/update responses keep redacting secrets to booleans (existing design), so nothing masked is returned.
- `utils/mongo-handler/schema.js` — `integrationConnections.secretsVersion` declared (strict schema; default 0 = unmigrated).

## Migration

`migrations/007-encrypt-integration-secrets.js` (scope `company`). Runs at boot like the others, or by hand:

```
npm run migrate -- status
npm run migrate -- up
```

Per company it logs `{ encrypted, stamped, skipped }`: rows whose secrets were sealed, rows with no secret value that only got the version stamp, and rows already at version 1 (left byte-for-byte alone). Re-running is a no-op.

**Rollback** decrypts every secret back to plaintext, so it refuses without the explicit flag:

```
npm run migrate -- down 007-encrypt-integration-secrets            # refuses, explains
npm run migrate -- down 007-encrypt-integration-secrets --confirm  # decrypts, resets secretsVersion to 0, forgets the run record
```

`down` is new generic runner support (`rollbackMigration` in `migrations/index.js`, `store.remove`); a migration without `down()` cannot be rolled back. Rollback aborts on the first secret that does not decrypt with the current key rather than writing partial data.

## Tests (written first)

- `tests/integrations-secrets.test.js` — saves a Slack connection through the controller and asserts the raw stored document does not contain the plaintext and the response never returns it; re-connect path; Slack command verifies against the decrypted value; list never leaks. **Fails on the previous commit** (2 of 4 tests, verified by reverting only the controller).
- `tests/secret-field.test.js` — round-trip, idempotence, empty/plaintext passthrough, tamper and key-rotation fail closed, `sealFields/openFields` scope.
- `tests/migration-encrypt-secrets.test.js` — seeds a plaintext row, an already-encrypted row and a no-secret row; `up` encrypts one, leaves the sealed row untouched, stamps the third; second run is a no-op with identical bytes; `down` refuses without `--confirm` and decrypts back with it.

`npx jest --selectProjects unit` 136 suites / 1680 tests green, `npx jest tests/conventions` 7 / 88 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
