### PR TITLE
fix(023): evaluate the holder permission catalogue when performing an agent action

### DIFF
--- a/Config/permissionGuard.js
+++ b/Config/permissionGuard.js
@@ -287,4 +287,6 @@ module.exports = {
     evaluateMany,
     MCP_PERMISSION_KEYS,
     invalidateRoleCache,
+    isWritable,
+    isReadable,
 };

--- a/Modules/Agents/actions.js
+++ b/Modules/Agents/actions.js
@@ -5,6 +5,7 @@ const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries'
 const socketEmitter = require('../../event/socketEventEmitter');
 const tools = require('../Automations/engine/tools');
 const registry = require('./registry');
+const permissions = require('./permissions');
 const audit = require('./agentAudit');
 const { attribution, isAgent } = require('./actor');
 const completionStore = require('../Tasks/helpers/completionStore');
@@ -250,6 +251,8 @@ const perform = async ({ companyId, actor, action, params = {}, reason = '', cos
     if (decision && decision.decision === 'refuse') throw await refusal(companyId, actor, { action, params, reason: decision.reason, ip });
     const check = registry.evaluate(action, params, { allowedActions });
     if (!check.allowed) throw await refusal(companyId, actor, { action, params, reason: check.reason, ip });
+    const holder = await permissions.holderMay(companyId, actor, action, params);
+    if (!holder.allowed) throw await refusal(companyId, actor, { action, params, reason: holder.reason, ip });
     if (!check.action.write) return { result: null, auditId: null, undo: null };
     const exec = executors[action];
     if (!exec) throw new tools.DeterministicError(`${action} has no executor`);
@@ -272,8 +275,10 @@ const perform = async ({ companyId, actor, action, params = {}, reason = '', cos
 /* Reads still go through the registry so a refusal is logged the same way. */
 const authorizeRead = async ({ companyId, actor, action, params = {}, ip = '', allowedActions }) => {
     const check = registry.evaluate(action, params, { allowedActions });
-    if (check.allowed) return true;
-    throw await refusal(companyId, actor, { action, params, reason: check.reason, ip });
+    if (!check.allowed) throw await refusal(companyId, actor, { action, params, reason: check.reason, ip });
+    const holder = await permissions.holderMay(companyId, actor, action, params);
+    if (!holder.allowed) throw await refusal(companyId, actor, { action, params, reason: holder.reason, ip });
+    return true;
 };
 
 module.exports = { perform, authorizeRead, RefusedError, executors, workEntry, SCOPE, RATING_KEYS, RATINGS, rating, ratings, unrated, isCompleteRating, manifest };

--- a/Modules/Agents/permissions.js
+++ b/Modules/Agents/permissions.js
@@ -1,0 +1,89 @@
+const mongoose = require('mongoose');
+const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const { myCache } = require('../../Config/config');
+const { getRoleType, isPrivileged, arrangeRules, isWritable, isReadable } = require('../../Config/permissionGuard');
+const { fetchRules } = require('../settings/securityPermissions/controller');
+const registry = require('./registry');
+
+// The person behind an agent decides what the agent may do: the token holder,
+// the person who started the run, or the approver of a proposal. Their
+// Security & Permissions catalogue is evaluated for the action's project the
+// same way the web app evaluates it for them — global rules, or the project's
+// own rules when the project opted out of the global ones. Anything that
+// cannot be resolved (no person, not a member, rules unreadable) is refused.
+
+const OBJECT_ID = /^[0-9a-fA-F]{24}$/;
+const PROJECT_RULES_TTL_SECONDS = 604800;
+const REASON = 'permission_denied';
+
+const oid = (v) => (OBJECT_ID.test(String(v || '')) ? new mongoose.Types.ObjectId(String(v)) : null);
+
+const lookup = (arranged, path) => {
+    let rule = null;
+    for (const segment of String(path).split('.')) {
+        rule = rule ? rule[segment] : arranged[segment];
+        if (rule === undefined || rule === null) return null;
+    }
+    return rule && Array.isArray(rule.roles) ? rule : null;
+};
+
+/* Same cache key as Modules/projectRules, so an edit there invalidates this too. */
+const projectRules = async (companyId, projectId) => {
+    const key = `projectRules:${projectId}`;
+    const cached = myCache.get(key);
+    if (Array.isArray(cached) && cached.length) return cached;
+    const rules = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.PROJECT_RULES, data: [{ projectId: String(projectId) }] }, 'find');
+    myCache.set(key, rules || [], PROJECT_RULES_TTL_SECONDS);
+    return rules || [];
+};
+
+const rulesFor = async (companyId, projectId) => {
+    const project = projectId && oid(projectId)
+        ? await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.PROJECTS, data: [{ _id: oid(projectId) }, { isGlobalPermission: 1 }] }, 'findOne')
+        : null;
+    if (project && project.isGlobalPermission === false) return arrangeRules(await projectRules(companyId, projectId));
+    return arrangeRules(await fetchRules(companyId));
+};
+
+const projectOf = async (companyId, params = {}) => {
+    if (params.projectId) return String(params.projectId);
+    const taskId = oid(params.taskId);
+    if (!taskId) return null;
+    const task = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [{ _id: taskId }, { ProjectID: 1 }] }, 'findOne');
+    return task && task.ProjectID ? String(task.ProjectID) : null;
+};
+
+/* null | false | true (or 1 | 2 for scoped keys), exactly as the catalogue stores it. */
+const evaluate = async (companyId, uid, key, { projectId } = {}) => {
+    const roleType = await getRoleType(companyId, uid);
+    if (roleType === null) return null;
+    if (isPrivileged(roleType)) return true;
+    const rule = lookup(await rulesFor(companyId, projectId), key);
+    if (!rule) return null;
+    const match = rule.roles.find((r) => r.key === roleType);
+    return match ? match.permission : null;
+};
+
+const denied = (key, why) => ({ allowed: false, reason: `${REASON}: ${key} ${why}`, permission: key });
+
+/* Does the person behind `actor` hold every catalogue entry `action` needs? */
+const holderMay = async (companyId, actor, action, params = {}) => {
+    const required = registry.permissionsFor(action, params);
+    if (!required.length) return { allowed: true, reason: '', permission: null };
+    const uid = String((actor && actor.userId) || '');
+    if (!OBJECT_ID.test(uid)) return denied(required[0].key, 'cannot be checked — no person is behind this agent');
+    let projectId;
+    try {
+        projectId = await projectOf(companyId, params);
+        for (const { key, write } of required) {
+            const value = await evaluate(companyId, uid, key, { projectId });
+            if (!(write ? isWritable(value) : isReadable(value))) return denied(key, 'is not granted to the person behind this agent');
+        }
+    } catch (e) {
+        return denied(required[0].key, `could not be evaluated (${e.message})`);
+    }
+    return { allowed: true, reason: '', permission: null };
+};
+
+module.exports = { holderMay, evaluate, REASON };

--- a/Modules/Agents/registry.js
+++ b/Modules/Agents/registry.js
@@ -7,7 +7,12 @@
 // has nothing to switch on. The guard, the MCP server and the proposal approver
 // all resolve actions through this one file.
 
+// `permission` names the Security & Permissions catalogue entry
+// (Config/permissionGuard) that governs the same operation for a person.
+// perform() evaluates it for the person behind the agent, so a token never
+// exceeds its holder's role. An action without one cannot be registered.
 const RISK = Object.freeze({ LOW: 'low', MEDIUM: 'medium', HIGH: 'high' });
+const PERMISSION_KEY = /^[a-z_]+\.[a-z_]+$/;
 const DONE_STATUS_TYPE = 'close';
 const DONE_STATUS_TYPES = Object.freeze(['close', 'done', 'default_close']);
 
@@ -17,29 +22,71 @@ const AGENT_STATUS_NAMES = Object.freeze(['in progress', 'in review']);
 const AGENT_STATUS_NAME_PATTERN = /progress|review|doing|testing|qa/;
 
 const ACTIONS = Object.freeze([
-    { key: 'tasks.next', label: 'Next assigned task', risk: RISK.LOW, undoable: false, write: false, cost: 'read' },
-    { key: 'tasks.search', label: 'Search own tasks', risk: RISK.LOW, undoable: false, write: false, cost: 'read' },
-    { key: 'task.get', label: 'Read a task brief', risk: RISK.LOW, undoable: false, write: false, cost: 'read+summary' },
-    { key: 'task.comment', label: 'Comment on a task', risk: RISK.LOW, undoable: true, write: true, cost: 'write' },
+    { key: 'tasks.next', label: 'Next assigned task', risk: RISK.LOW, undoable: false, write: false, cost: 'read', permission: 'task.task_list' },
+    { key: 'tasks.search', label: 'Search own tasks', risk: RISK.LOW, undoable: false, write: false, cost: 'read', permission: 'task.task_list' },
+    { key: 'task.get', label: 'Read a task brief', risk: RISK.LOW, undoable: false, write: false, cost: 'read+summary', permission: 'task.task_list' },
+    { key: 'task.comment', label: 'Comment on a task', risk: RISK.LOW, undoable: true, write: true, cost: 'write', permission: 'task.task_comment' },
     { key: 'task.status.set', label: 'Set status (In progress / In review only)', risk: RISK.LOW, undoable: true, write: true, cost: 'write',
-      constraint: 'statusType must not be "close"; status name must be In progress or In review' },
-    { key: 'task.link', label: 'Attach a PR, branch or doc', risk: RISK.LOW, undoable: true, write: true, cost: 'write' },
-    { key: 'task.assign', label: 'Assign a task', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write' },
+      constraint: 'statusType must not be "close"; status name must be In progress or In review', permission: 'task.task_status' },
+    { key: 'task.link', label: 'Attach a PR, branch or doc', risk: RISK.LOW, undoable: true, write: true, cost: 'write', permission: 'task.task_attachments' },
+    { key: 'task.assign', label: 'Assign a task', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write', permission: 'task.task_assignee' },
     { key: 'task.update', label: 'Update task fields', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write',
-      fields: ['TaskName', 'description', 'rawDescription', 'Task_Priority', 'DueDate', 'startDate', 'tagsArray', 'checklistArray', 'points', 'totalEstimatedTime'] },
-    { key: 'task.sprint.move', label: 'Move a task between sprints', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write' },
-    { key: 'subtask.create', label: 'Create a subtask', risk: RISK.LOW, undoable: true, write: true, cost: 'write' },
+      fields: ['TaskName', 'description', 'rawDescription', 'Task_Priority', 'DueDate', 'startDate', 'tagsArray', 'checklistArray', 'points', 'totalEstimatedTime'],
+      permission: { byField: {
+          TaskName: 'task.task_name_edit', description: 'task.task_description', rawDescription: 'task.task_description',
+          Task_Priority: 'task.task_priority', DueDate: 'task.task_due_date', startDate: 'task.task_start_date',
+          tagsArray: 'task.task_tag', checklistArray: 'task.task_checklist', points: 'task.task_estimated_hours', totalEstimatedTime: 'task.task_estimated_hours',
+      } } },
+    { key: 'task.sprint.move', label: 'Move a task between sprints', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write', permission: 'task.task_move' },
+    { key: 'subtask.create', label: 'Create a subtask', risk: RISK.LOW, undoable: true, write: true, cost: 'write', permission: 'task.sub_task_create' },
     { key: 'task.create', label: 'File a task (opening status, unassigned)', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write',
-      constraint: 'always the project\'s opening status; never assigned; only in a project the token can see' },
-    { key: 'timelog.start', label: 'Start a timer', risk: RISK.LOW, undoable: true, write: true, cost: 'write' },
-    { key: 'timelog.stop', label: 'Stop a timer', risk: RISK.LOW, undoable: true, write: true, cost: 'write' },
-    { key: 'docs.read', label: 'Read a linked doc', risk: RISK.LOW, undoable: false, write: false, cost: 'read' },
-    { key: 'page.draft', label: 'Draft a page (stays a draft until approved)', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write' },
-    { key: 'chat.post', label: 'Post in a channel', risk: RISK.LOW, undoable: false, write: true, cost: 'write' },
-    { key: 'reminder.create', label: 'Create a reminder', risk: RISK.LOW, undoable: false, write: true, cost: 'write' },
+      constraint: 'always the project\'s opening status; never assigned; only in a project the token can see', permission: 'task.task_create' },
+    { key: 'timelog.start', label: 'Start a timer', risk: RISK.LOW, undoable: true, write: true, cost: 'write', permission: 'sheet_settings.user_timesheet' },
+    { key: 'timelog.stop', label: 'Stop a timer', risk: RISK.LOW, undoable: true, write: true, cost: 'write', permission: 'sheet_settings.user_timesheet' },
+    { key: 'docs.read', label: 'Read a linked doc', risk: RISK.LOW, undoable: false, write: false, cost: 'read', permission: 'project.project_details' },
+    { key: 'page.draft', label: 'Draft a page (stays a draft until approved)', risk: RISK.MEDIUM, undoable: true, write: true, cost: 'write', permission: 'project.project_details' },
+    { key: 'chat.post', label: 'Post in a channel', risk: RISK.LOW, undoable: false, write: true, cost: 'write', permission: 'task.task_comment' },
+    { key: 'reminder.create', label: 'Create a reminder', risk: RISK.LOW, undoable: false, write: true, cost: 'write', permission: { key: 'task.task_list', write: false } },
     { key: 'deploy.staging', label: 'Propose a staging deploy', risk: RISK.HIGH, undoable: false, write: true, cost: 'write',
-      gate: 'owner_admin', proposeOnly: true },
+      gate: 'owner_admin', proposeOnly: true, permission: 'settings.settings_edit_company' },
 ]);
+
+/* A string maps the whole action at its own level (write for writes, read for
+ * reads); { key, write } pins the level; { byField } holds each task.update
+ * field to the entry a person editing that field is held to. */
+const permissionsFor = (key, params = {}) => {
+    const action = BY_KEY.get(String(key || ''));
+    if (!action) return [];
+    const p = action.permission;
+    if (typeof p === 'string') return [{ key: p, write: Boolean(action.write) }];
+    if (p && p.byField) {
+        const fields = Object.keys(params.fields || {});
+        const keys = [...new Set((fields.length ? fields : action.fields || []).map((f) => p.byField[f]).filter(Boolean))];
+        return keys.map((k) => ({ key: k, write: true }));
+    }
+    if (p && p.key) return [{ key: p.key, write: typeof p.write === 'boolean' ? p.write : Boolean(action.write) }];
+    return [];
+};
+
+const validate = (entries) => {
+    const bad = (a, why) => new Error(`agent registry: ${a.key || '(no key)'} ${why}`);
+    entries.forEach((a) => {
+        const p = a.permission;
+        if (typeof p === 'string') {
+            if (!PERMISSION_KEY.test(p)) throw bad(a, `has an invalid permission mapping "${p}"`);
+            return;
+        }
+        if (p && p.byField && typeof p.byField === 'object') {
+            const unmapped = (a.fields || []).filter((f) => !PERMISSION_KEY.test(String(p.byField[f] || '')));
+            if (!a.fields || !a.fields.length || unmapped.length) throw bad(a, `leaves fields without a permission mapping: ${unmapped.join(', ') || '(no fields)'}`);
+            return;
+        }
+        if (p && typeof p.key === 'string' && PERMISSION_KEY.test(p.key)) return;
+        throw bad(a, 'has no permission mapping; every action must name the catalogue entry that governs it for a person');
+    });
+    return entries;
+};
+
 
 // Named so a reviewer can confirm they are not reachable. A trailing `.*` covers
 // every key under that prefix.
@@ -59,7 +106,7 @@ const indexActions = (actions) => {
     return new Map(actions.map((a) => [a.key, a]));
 };
 
-const BY_KEY = indexActions(ACTIONS);
+const BY_KEY = indexActions(validate(ACTIONS));
 
 const get = (key) => BY_KEY.get(String(key || '')) || null;
 const has = (key) => BY_KEY.has(String(key || ''));
@@ -134,5 +181,5 @@ const manifest = () => ({
 
 module.exports = {
     ACTIONS, NEVER, RISK, AUTONOMY, DONE_STATUS_TYPE, DONE_STATUS_TYPES, AGENT_STATUS_NAMES,
-    get, has, keys, isNever, indexActions, evaluate, isAgentSettableStatus, mayActDirectly, manifest,
+    get, has, keys, isNever, indexActions, evaluate, isAgentSettableStatus, mayActDirectly, manifest, permissionsFor, validate,
 };

--- a/tests/agent-audit-ordering.test.js
+++ b/tests/agent-audit-ordering.test.js
@@ -6,6 +6,7 @@ jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), 
 jest.mock('../Config/permissionGuard', () => ({ ROLE_OWNER: 1, ROLE_ADMIN: 2, getRoleType: jest.fn(async () => 1), isPrivileged: (r) => r === 1 || r === 2 }));
 jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
 jest.mock('../Modules/Tasks/helpers/completionStore', () => ({ forStatusChange: jest.fn(async () => null), recordWork: jest.fn(async () => null) }));
+jest.mock('../Modules/Agents/permissions', () => ({ holderMay: jest.fn(async () => ({ allowed: true, reason: '' })) }));
 jest.mock('../Modules/Agents/engine/orchestrator', () => ({ gather: jest.fn(async () => ({ status: 'gathered', context: {} })), analyse: jest.fn() }));
 jest.mock('../Modules/Agents/engine/findingMemory', () => ({ load: jest.fn(async () => new Map()), decide: jest.fn(), record: jest.fn(), touch: jest.fn() }));
 jest.mock('../Modules/Agents/memory', () => ({

--- a/tests/agent-audit-single-row.test.js
+++ b/tests/agent-audit-single-row.test.js
@@ -7,6 +7,7 @@ jest.mock('../Modules/Tasks/helpers/completionStore', () => ({
     forStatusChange: jest.fn(async () => null),
     recordWork: jest.fn(async () => null),
 }));
+jest.mock('../Modules/Agents/permissions', () => ({ holderMay: jest.fn(async () => ({ allowed: true, reason: '' })) }));
 
 const { SCHEMA_TYPE } = require('../Config/schemaType');
 const actions = require('../Modules/Agents/actions');

--- a/tests/agent-permission-catalogue.test.js
+++ b/tests/agent-permission-catalogue.test.js
@@ -1,0 +1,143 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../Config/config', () => ({ myCache: { get: () => undefined, set: () => {}, del: () => {}, getTtl: () => 0 } }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+jest.mock('../Modules/Tasks/helpers/completionStore', () => ({
+    forStatusChange: jest.fn(async () => null),
+    recordWork: jest.fn(async () => null),
+}));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const registry = require('../Modules/Agents/registry');
+const actions = require('../Modules/Agents/actions');
+
+const CID = '6a8ee973d625fca52e519a12';
+const PROJECT_ID = '6a9954186dd786246031e47b';
+const TASK_ID = '6f0000000000000000000701';
+const AGENT_ID = '6f0000000000000000000a01';
+const OWNER = '6f0000000000000000000001';
+const MEMBER = '6f0000000000000000000002';
+const MEMBER_ROLE = 3;
+
+const actorFor = (userId) => ({ kind: 'agent', userId, agentId: AGENT_ID, agentName: 'Reviewer', runId: null, viaAccount: 'workspace' });
+
+const seedRules = (type, grants, { projectId } = {}) => {
+    const parent = mockDb.seed(type, { key: 'task', name: 'Task', isParent: true, ...(projectId ? { projectId } : {}) });
+    Object.entries(grants).forEach(([key, permission]) => mockDb.seed(type, {
+        key, name: key, isParent: false, parentId: parent._id, roles: [{ key: MEMBER_ROLE, permission }], ...(projectId ? { projectId } : {}),
+    }));
+};
+
+const auditRows = () => mockDb.store[SCHEMA_TYPE.AUDIT_LOGS] || [];
+const priorityUpdate = (userId) => actions.perform({ companyId: CID, actor: actorFor(userId), action: 'task.update', params: { taskId: TASK_ID, fields: { Task_Priority: 'HIGH' } } });
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    jest.clearAllMocks();
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: OWNER, roleType: 1 });
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: MEMBER, roleType: MEMBER_ROLE });
+    mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: PROJECT_ID, CompanyId: CID, isGlobalPermission: true });
+    mockDb.seed(SCHEMA_TYPE.TASKS, { _id: TASK_ID, CompanyId: CID, ProjectID: PROJECT_ID, TaskName: 'Fix the thing', TaskKey: 'AR-1', Task_Priority: 'LOW' });
+});
+
+describe('perform() evaluates the permission catalogue of the person behind the agent', () => {
+    it('refuses a member whose role holds the permission read-only, audits it, and writes nothing', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_priority: false, task_comment: true });
+
+        await expect(priorityUpdate(MEMBER)).rejects.toMatchObject({ name: 'RefusedError', status: 403, message: expect.stringMatching(/permission_denied.*task\.task_priority/) });
+
+        expect(mockDb.store[SCHEMA_TYPE.TASKS][0].Task_Priority).toBe('LOW');
+        expect(auditRows()).toHaveLength(1);
+        expect(auditRows()[0]).toMatchObject({ action: 'agent.action_refused', meta: { action: 'task.update', reason: expect.stringMatching(/task\.task_priority/), ran: false } });
+    });
+
+    it('lets the same action through for a member whose role grants it', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_priority: true });
+
+        const out = await priorityUpdate(MEMBER);
+
+        expect(out.auditId).toBeTruthy();
+        expect(mockDb.store[SCHEMA_TYPE.TASKS][0].Task_Priority).toBe('HIGH');
+        expect(auditRows().map((r) => r.action)).toEqual(['agent.action']);
+    });
+
+    it('lets an owner through without a catalogue row', async () => {
+        const out = await priorityUpdate(OWNER);
+        expect(out.auditId).toBeTruthy();
+        expect(mockDb.store[SCHEMA_TYPE.TASKS][0].Task_Priority).toBe('HIGH');
+    });
+
+    it('refuses when no permission is granted at all (missing row), naming the permission', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_comment: true });
+        await expect(priorityUpdate(MEMBER)).rejects.toMatchObject({ name: 'RefusedError', message: expect.stringMatching(/permission_denied: task\.task_priority/) });
+    });
+
+    it('checks every field of a task.update against its own catalogue entry', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_priority: true, task_due_date: false });
+        await expect(actions.perform({ companyId: CID, actor: actorFor(MEMBER), action: 'task.update', params: { taskId: TASK_ID, fields: { Task_Priority: 'HIGH', DueDate: '2026-10-01' } } }))
+            .rejects.toMatchObject({ name: 'RefusedError', message: expect.stringMatching(/permission_denied: task\.task_due_date/) });
+        expect(mockDb.store[SCHEMA_TYPE.TASKS][0].Task_Priority).toBe('LOW');
+    });
+
+    it('uses the project\'s own rules when the project opted out of the global ones', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_priority: true });
+        mockDb.store[SCHEMA_TYPE.PROJECTS][0].isGlobalPermission = false;
+        seedRules(SCHEMA_TYPE.PROJECT_RULES, { task_priority: false }, { projectId: PROJECT_ID });
+
+        await expect(priorityUpdate(MEMBER)).rejects.toMatchObject({ name: 'RefusedError', message: expect.stringMatching(/permission_denied: task\.task_priority/) });
+        expect(mockDb.store[SCHEMA_TYPE.TASKS][0].Task_Priority).toBe('LOW');
+    });
+
+    it('refuses an agent with no person behind it', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_priority: true });
+        await expect(priorityUpdate('')).rejects.toMatchObject({ name: 'RefusedError', message: expect.stringMatching(/permission_denied/) });
+        expect(mockDb.store[SCHEMA_TYPE.TASKS][0].Task_Priority).toBe('LOW');
+    });
+
+    it('refuses someone who is not a member of the company', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_priority: true });
+        await expect(priorityUpdate('6f00000000000000000000ff')).rejects.toMatchObject({ name: 'RefusedError', message: expect.stringMatching(/permission_denied/) });
+    });
+
+    it('applies the same check to a comment, the lowest-risk write', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_comment: false });
+        await expect(actions.perform({ companyId: CID, actor: actorFor(MEMBER), action: 'task.comment', params: { taskId: TASK_ID, body: 'hi' } }))
+            .rejects.toMatchObject({ name: 'RefusedError', message: expect.stringMatching(/permission_denied: task\.task_comment/) });
+        expect(mockDb.store[SCHEMA_TYPE.COMMENTS] || []).toHaveLength(0);
+    });
+
+    it('gates reads too: tasks.search needs the task list', async () => {
+        seedRules(SCHEMA_TYPE.RULES, { task_list: null });
+        await expect(actions.authorizeRead({ companyId: CID, actor: actorFor(MEMBER), action: 'tasks.search', params: {} }))
+            .rejects.toMatchObject({ name: 'RefusedError', message: expect.stringMatching(/permission_denied: task\.task_list/) });
+        mockDb.store[SCHEMA_TYPE.RULES].find((r) => r.key === 'task_list').roles[0].permission = false;
+        await expect(actions.authorizeRead({ companyId: CID, actor: actorFor(MEMBER), action: 'tasks.search', params: {} })).resolves.toBe(true);
+    });
+});
+
+describe('the registry refuses an action without a permission mapping', () => {
+    const entry = (over = {}) => ({ key: 'sprint.close', label: 'Close a sprint', risk: 'low', undoable: true, write: true, cost: 'write', ...over });
+
+    it('every registered action maps to a catalogue entry', () => {
+        registry.ACTIONS.forEach((a) => {
+            const required = registry.permissionsFor(a.key, a.fields ? { fields: Object.fromEntries(a.fields.map((f) => [f, 1])) } : {});
+            expect({ key: a.key, n: required.length > 0 }).toEqual({ key: a.key, n: true });
+            required.forEach((p) => expect(p).toMatchObject({ key: expect.stringMatching(/^[a-z_]+\.[a-z_]+$/), write: expect.any(Boolean) }));
+        });
+    });
+
+    it('throws at load for an entry with no mapping, an empty one, or a field left unmapped', () => {
+        expect(() => registry.validate([entry()])).toThrow(/sprint\.close.*permission/);
+        expect(() => registry.validate([entry({ permission: '' })])).toThrow(/sprint\.close.*permission/);
+        expect(() => registry.validate([entry({ permission: 'not-a-catalogue-key' })])).toThrow(/sprint\.close.*permission/);
+        expect(() => registry.validate([entry({ fields: ['a', 'b'], permission: { byField: { a: 'task.task_tag' } } })])).toThrow(/sprint\.close.*\bb\b/);
+        expect(() => registry.validate([entry({ permission: 'project.project_sprint_create' })])).not.toThrow();
+        expect(() => registry.validate([entry({ fields: ['a'], permission: { byField: { a: 'task.task_tag' } } })])).not.toThrow();
+    });
+
+    it('validates the shipped registry', () => {
+        expect(() => registry.validate(registry.ACTIONS)).not.toThrow();
+    });
+});


### PR DESCRIPTION
Closes defect 3 of the Sprint 0 verification (task 023). Stacked on #552 (`feat/agent-memory`).

## The defect

`actions.perform()` consulted the action registry and the agent's `allowedActions`, but never the Security & Permissions catalogue of the person behind the token or run. A member whose role holds task priority (or status, assignee, …) read-only could still have an agent write it, so a machine token exceeded its holder's role.

## The fix

- **Registry** (`Modules/Agents/registry.js`): every action carries a `permission` naming the catalogue entry that governs the same operation for a person; `task.update` maps per field. `validate()` runs at module load and throws for an action with no mapping, an invalid key, or an unmapped field — a future action cannot skip the check.
- **Holder evaluation** (`Modules/Agents/permissions.js`, new): resolves the person behind the actor (`actor.userId` — token holder, run starter, or proposal approver) and evaluates the mapped entries through `Config/permissionGuard` (`getRoleType`, `arrangeRules`, `isWritable`/`isReadable`) for the action's project: global rules, or the project's own `PROJECT_RULES` when the project has `isGlobalPermission === false`, exactly as the web app's `checkPermission` does. Owner/admin pass; no person, non-member, missing rule or an unreadable rule set refuse.
- **perform / authorizeRead** (`Modules/Agents/actions.js`): after the registry check and before any executor, a failed holder check is refused with `permission_denied: <catalogue key> …` and recorded as an `agent.action_refused` audit row, the same way registry and policy refusals are.

## Mapping

| Action | Catalogue entry |
|---|---|
| tasks.next, tasks.search, task.get | task.task_list (read) |
| task.comment, chat.post | task.task_comment |
| task.status.set | task.task_status |
| task.link | task.task_attachments |
| task.assign | task.task_assignee |
| task.update | per field: TaskName→task_name_edit, description/rawDescription→task_description, Task_Priority→task_priority, DueDate→task_due_date, startDate→task_start_date, tagsArray→task_tag, checklistArray→task_checklist, points/totalEstimatedTime→task_estimated_hours |
| task.sprint.move | task.task_move |
| subtask.create | task.sub_task_create |
| task.create | task.task_create |
| timelog.start, timelog.stop | sheet_settings.user_timesheet |
| docs.read | project.project_details (read) |
| page.draft | project.project_details |
| reminder.create | task.task_list (read; no catalogue entry governs reminders) |
| deploy.staging | settings.settings_edit_company (owner/admin gate) |

## Tests

Test reproduces first: `tests/agent-permission-catalogue.test.js` was committed on its own (45ef81c8) and fails on the previous commit — 11 of 13 fail, the two that pass are the "allowed" cases. It passes after the fix.

- a member holding the permission read-only is refused on `perform`, the task is untouched, one `agent.action_refused` row names the permission
- the same action succeeds for a member whose role grants it, and for an owner
- every `task.update` field is checked against its own entry
- a project that opted out of global rules is judged by its own rules
- no person behind the agent / not a member of the company → refused
- reads are gated too (`tasks.search` needs `task.task_list`)
- the registry rejects an entry with no mapping, an empty or malformed one, or an unmapped field, and accepts the shipped registry

`tests/agent-audit-single-row.test.js` mocks the holder check (its actor has no person by design).

Ran: `npx jest tests/agent- tests/mcp- tests/ai-project- tests/automation- tests/conventions` — 50 suites, 663 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
