### PR TITLE
fix(024): expire agent runs only after they reach a terminal status

### DIFF
--- a/Modules/Agents/proposals.js
+++ b/Modules/Agents/proposals.js
@@ -28,6 +28,7 @@ const GATE_OWNER_ADMIN = 'owner_admin';
 // The canned decline reasons the Inbox offers; only these can grow into a user preference.
 const DECLINE_REASONS = Object.freeze(Object.keys(memory.DECLINE_REASON_TEXT));
 const DECLINE_REASON_MAX = 200;
+const REASON = Object.freeze({ RUN_MISSING: 'run_missing' });
 const oid = (id) => { try { return new mongoose.Types.ObjectId(String(id)); } catch (e) { return null; } };
 
 const quietly = async (what, fn) => {
@@ -185,7 +186,8 @@ const approve = async (companyId, id, { decider, isPrivileged, changes: edited, 
     if (!agent) return { error: 'This agent was deleted — decline the proposal instead.', status: 409 };
     if (p.runId) {
         const run = await runOf(companyId, p.runId);
-        if (run && run.status === runs.STATUS.STOPPED) return { error: 'Run was stopped.', status: 409 };
+        if (!run) return { error: 'The run behind this proposal no longer exists — decline it instead.', status: 409, reason: REASON.RUN_MISSING };
+        if (run.status === runs.STATUS.STOPPED) return { error: 'Run was stopped.', status: 409 };
     }
 
     const claimed = await setStatus(companyId, id, { status: STATUS.APPLYING, decidedBy: decider.userId, decidedAt: new Date() }, { onlyIf: STATUS.PENDING });
@@ -257,4 +259,4 @@ const undoApproval = async (companyId, id, { decider, ip }) => {
     return { proposal: updated, results };
 };
 
-module.exports = { STATUS, UNDO_WINDOW_MS, GATE_OWNER_ADMIN, DECLINE_REASONS, validateChanges, create, list, get, approve, decline, undoApproval, bucketOf };
+module.exports = { STATUS, REASON, UNDO_WINDOW_MS, GATE_OWNER_ADMIN, DECLINE_REASONS, validateChanges, create, list, get, approve, decline, undoApproval, bucketOf };

--- a/Modules/Agents/runs.js
+++ b/Modules/Agents/runs.js
@@ -15,6 +15,9 @@ const OPEN = [STATUS.QUEUED, STATUS.RUNNING, STATUS.WAITING];
 // A skip is the skill declining its input (no URL, no PR link, brief too short):
 // neither a success to count as clean nor a failure to fix, so it is its own status.
 const TERMINAL = [STATUS.DONE, STATUS.SKIPPED, STATUS.FAILED, STATUS.STOPPED];
+// How long a finished run is kept. Open runs never expire: a run waiting on a
+// person must outlive its proposal, however long that person takes.
+const RETENTION_SECONDS = 15552000;
 const oid = (id) => { try { return new mongoose.Types.ObjectId(String(id)); } catch (e) { return null; } };
 const monthKey = (d = new Date()) => d.toISOString().slice(0, 7);
 const startOfDayUtc = (d = new Date()) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
@@ -96,11 +99,17 @@ const appendAction = (companyId, runId, entry) => patch(companyId, runId, {}, { 
 
 const get = (companyId, runId) => MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AGENT_RUNS, data: [{ _id: oid(runId) }] }, 'findOne');
 
+const terminalUpdate = (status, at = new Date()) => {
+    if (!TERMINAL.includes(status)) throw new Error(`${status} is not a terminal run status`);
+    return { status, finishedAt: at, expiresAt: new Date(at.getTime() + RETENTION_SECONDS * 1000) };
+};
+
 const finish = async (companyId, runId, { status = STATUS.DONE, outcome, error, episode, onlyIf } = {}) => {
     const run = await get(companyId, runId);
     if (!run) return null;
-    const startedAt = run.startedAt ? new Date(run.startedAt).getTime() : Date.now();
-    const set = { status, finishedAt: new Date(), elapsedMs: Date.now() - startedAt, outcome: outcome || null, error: error || null, ...(episode ? { episode } : {}) };
+    const now = new Date();
+    const startedAt = run.startedAt ? new Date(run.startedAt).getTime() : now.getTime();
+    const set = { ...terminalUpdate(status, now), elapsedMs: now.getTime() - startedAt, outcome: outcome || null, error: error || null, ...(episode ? { episode } : {}) };
     return patch(companyId, runId, set, {}, { onlyIf });
 };
 
@@ -290,4 +299,4 @@ const skillSlugOf = (agent, explicit) => {
     return first.key || first.slug || first.name || 'qa-review';
 };
 
-module.exports = { STATUS, OPEN, TERMINAL, canStart, runsToday, skillSlugOf, create, get, patch, appendAction, finish, isRunning, reapStale, stop, recordSpend, list, summary, countsByStatus, pauseAll, getAgent, emitAgent, changesFor, executeSkill, monthKey };
+module.exports = { STATUS, OPEN, TERMINAL, RETENTION_SECONDS, terminalUpdate, canStart, runsToday, skillSlugOf, create, get, patch, appendAction, finish, isRunning, reapStale, stop, recordSpend, list, summary, countsByStatus, pauseAll, getAgent, emitAgent, changesFor, executeSkill, monthKey };

--- a/migrations/008-agent-run-expiry.js
+++ b/migrations/008-agent-run-expiry.js
@@ -1,0 +1,31 @@
+const { TERMINAL, RETENTION_SECONDS } = require('../Modules/Agents/runs');
+
+/* agent_runs had a TTL on createdAt, so a run waiting on a person for longer
+ * than the retention period was deleted under its proposal (defect 16). The
+ * schema now carries the TTL on expiresAt, which only a terminal status sets.
+ * syncIndexes drops the createdAt TTL index and builds the expiresAt one from
+ * the schema; the backfill gives every already-finished run its expiry, from
+ * finishedAt (or createdAt for the few rows without one). */
+
+const RUNS = (ctx) => ctx.SCHEMA_TYPE.AGENT_RUNS;
+
+const expiryFrom = (row) => new Date(new Date(row.finishedAt || row.createdAt || Date.now()).getTime() + RETENTION_SECONDS * 1000);
+
+module.exports = {
+    id: '008-agent-run-expiry',
+    scope: 'company',
+    async up(ctx) {
+        await ctx.forEachCompany(async (companyId) => {
+            const droppedIndexes = (await ctx.company(companyId, { type: RUNS(ctx), data: [] }, 'syncIndexes')) || [];
+            const terminal = await ctx.company(companyId, { type: RUNS(ctx), data: [{ status: { $in: TERMINAL } }, '_id status finishedAt createdAt expiresAt'] }, 'find') || [];
+            const counts = { droppedIndexes, backfilled: 0, skipped: 0 };
+            for (const row of terminal) {
+                if (row.expiresAt) { counts.skipped += 1; continue; }
+                await ctx.company(companyId, { type: RUNS(ctx), data: [{ _id: row._id }, { $set: { expiresAt: expiryFrom(row) } }] }, 'updateOne');
+                counts.backfilled += 1;
+            }
+            ctx.logger.info(`[migrations] 008 ${companyId}: ${JSON.stringify(counts)}`);
+            return counts;
+        });
+    },
+};

--- a/tests/agent-proposal-run-missing.test.js
+++ b/tests/agent-proposal-run-missing.test.js
@@ -1,0 +1,57 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+jest.mock('../Modules/Agents/actions', () => ({ perform: jest.fn(async () => ({ auditId: 'aud1', result: {} })) }));
+jest.mock('../Modules/Agents/agentAudit', () => ({ recordProposalDecision: jest.fn(async () => 'dec1'), findById: jest.fn() }));
+jest.mock('../Modules/Agents/engine/graph', () => ({ resumeGraph: jest.fn(async () => ({ resumed: false })) }));
+jest.mock('../Modules/Agents/engine/persistence', () => {
+    const deleteThread = jest.fn(async () => {});
+    return { deleteThread, saverFor: jest.fn(() => ({ deleteThread })), storeFor: jest.fn(() => { throw new Error('no store in this suite'); }), ready: jest.fn(async () => {}) };
+});
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const actions = require('../Modules/Agents/actions');
+const memory = require('../Modules/Agents/memory');
+const proposals = require('../Modules/Agents/proposals');
+
+const C = 'c1';
+const AGENT_ID = '6f0000000000000000000a01';
+const opts = { decider: { kind: 'human', userId: 'u1' }, isPrivileged: true, ip: '' };
+const GONE_RUN = '6f00000000000000000000ff';
+const changes = [{ action: 'task.comment', params: { taskId: 't1', body: 'hi' }, label: 'Comment' }];
+const pendingFor = (runId) => mockDb.seed(SCHEMA_TYPE.AGENT_PROPOSALS, { agentId: AGENT_ID, agentName: 'Reviewer', runId, taskId: 't1', projectId: 'p1', status: 'pending', gate: null, changes });
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    jest.clearAllMocks();
+    jest.spyOn(memory, 'rememberApprovedChanges').mockResolvedValue([]);
+    jest.spyOn(memory, 'preferenceCandidate').mockResolvedValue(null);
+    mockDb.seed(SCHEMA_TYPE.AGENTS, { _id: AGENT_ID, name: 'Reviewer', allowedActions: ['task.get', 'task.comment'], deletedStatusKey: 0 });
+});
+
+describe('#16 a proposal whose run is gone', () => {
+    it('is refused on approve with run_missing and applies nothing', async () => {
+        const p = pendingFor(GONE_RUN);
+        const out = await proposals.approve(C, p._id, opts);
+        expect(out).toMatchObject({ status: 409, reason: proposals.REASON.RUN_MISSING });
+        expect(out.error).toMatch(/no longer exists/);
+        expect(actions.perform).not.toHaveBeenCalled();
+        expect(mockDb.store[SCHEMA_TYPE.AGENT_PROPOSALS][0].status).toBe('pending');
+    });
+
+    it('can still be declined so the Inbox is not stuck with it', async () => {
+        const p = pendingFor(GONE_RUN);
+        const out = await proposals.decline(C, p._id, { ...opts, reason: 'stale' });
+        expect(out.error).toBeUndefined();
+        expect(mockDb.store[SCHEMA_TYPE.AGENT_PROPOSALS][0].status).toBe('declined');
+    });
+
+    it('still approves a proposal with no run behind it at all', async () => {
+        const p = pendingFor(null);
+        const out = await proposals.approve(C, p._id, opts);
+        expect(out.error).toBeUndefined();
+        expect(actions.perform).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/agent-run-expiry.test.js
+++ b/tests/agent-run-expiry.test.js
@@ -1,0 +1,74 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const runs = require('../Modules/Agents/runs');
+const { agentRunsSchema } = require('../utils/mongo-handler/createSchema');
+const { schema } = require('../utils/mongo-handler/schema');
+
+const C = 'c1';
+const AGENT_ID = '6f0000000000000000000a01';
+const agent = { _id: AGENT_ID, name: 'Reviewer', account: 'workspace', deletedStatusKey: 0 };
+const runRow = (id) => mockDb.store[SCHEMA_TYPE.AGENT_RUNS].find((r) => String(r._id) === String(id));
+const retentionMs = runs.RETENTION_SECONDS * 1000;
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    mockDb.calls.length = 0;
+    jest.clearAllMocks();
+    mockDb.seed(SCHEMA_TYPE.AGENTS, agent);
+});
+
+describe('#16 agent runs expire only after a terminal status', () => {
+    it('declares the TTL on expiresAt, not on createdAt', () => {
+        const indexes = agentRunsSchema.indexes();
+        const ttl = indexes.filter(([, options]) => options && options.expireAfterSeconds !== undefined);
+        expect(ttl).toEqual([[{ expiresAt: 1 }, expect.objectContaining({ expireAfterSeconds: 0 })]]);
+        expect(schema.agentRuns.expiresAt).toMatchObject({ type: Date });
+    });
+
+    it('an open run has no expiry, including while it waits on a person', async () => {
+        const run = await runs.create(C, { agent, taskId: 't1', projectId: 'p1', skill: 'qa-review' });
+        expect(runRow(run._id).expiresAt).toBeUndefined();
+        await runs.patch(C, run._id, { status: runs.STATUS.WAITING });
+        expect(runRow(run._id).expiresAt).toBeUndefined();
+        expect(runs.OPEN).toEqual(expect.arrayContaining([runs.STATUS.QUEUED, runs.STATUS.RUNNING, runs.STATUS.WAITING]));
+    });
+
+    it.each(runs.TERMINAL)('finish(%s) sets expiresAt to the finish time plus the retention period', async (status) => {
+        const run = await runs.create(C, { agent, taskId: 't1', projectId: 'p1', skill: 'qa-review' });
+        const saved = await runs.finish(C, run._id, { status });
+        const row = runRow(run._id);
+        expect(row.status).toBe(status);
+        expect(row.expiresAt).toBeInstanceOf(Date);
+        expect(row.expiresAt.getTime()).toBe(new Date(row.finishedAt).getTime() + retentionMs);
+        expect(saved.expiresAt.getTime()).toBe(row.expiresAt.getTime());
+    });
+
+    it('terminalUpdate gives every transition the same fields', () => {
+        const at = new Date('2026-09-01T00:00:00Z');
+        expect(runs.terminalUpdate(runs.STATUS.FAILED, at)).toEqual({ status: 'failed', finishedAt: at, expiresAt: new Date(at.getTime() + retentionMs) });
+        expect(() => runs.terminalUpdate(runs.STATUS.WAITING)).toThrow(/terminal/);
+    });
+
+    it('stop, reapStale and pauseAll all go through the terminal update', async () => {
+        const stopped = await runs.create(C, { agent, taskId: 't1', projectId: 'p1' });
+        await runs.stop(C, stopped._id, 'u1');
+        expect(runRow(stopped._id)).toMatchObject({ status: 'stopped', expiresAt: expect.any(Date) });
+
+        const stale = await runs.create(C, { agent, taskId: 't2', projectId: 'p1' });
+        await runs.reapStale(C);
+        expect(runRow(stale._id)).toMatchObject({ status: 'failed', expiresAt: expect.any(Date) });
+
+        const active = await runs.create(C, { agent, taskId: 't3', projectId: 'p1' });
+        const waiting = await runs.create(C, { agent, taskId: 't4', projectId: 'p1' });
+        await runs.patch(C, waiting._id, { status: runs.STATUS.WAITING });
+        await runs.pauseAll(C, 'pause_all');
+        expect(runRow(active._id)).toMatchObject({ status: 'stopped', expiresAt: expect.any(Date) });
+        expect(runRow(waiting._id).status).toBe('waiting_approval');
+        expect(runRow(waiting._id).expiresAt).toBeUndefined();
+    });
+});

--- a/tests/migration-agent-run-expiry.test.js
+++ b/tests/migration-agent-run-expiry.test.js
@@ -1,0 +1,65 @@
+const fakeMongo = require('./fixtures/fakeMongo');
+const { buildContext, validateMigration, listMigrations } = require('../migrations');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const runs = require('../Modules/Agents/runs');
+
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const migration = require('../migrations/008-agent-run-expiry');
+const T = SCHEMA_TYPE.AGENT_RUNS;
+const logger = { info: jest.fn(), error: jest.fn() };
+const DAY = 24 * 3600 * 1000;
+
+/* fakeMongo has no index methods; the first sync reports the old TTL index dropped, later ones nothing. */
+const dbWithIndexes = () => {
+    const db = fakeMongo.create();
+    const synced = [];
+    const crud = async (companyId, q, method) => {
+        if (method === 'syncIndexes') { synced.push(companyId); return synced.filter((c) => c === companyId).length === 1 ? ['createdAt_1'] : []; }
+        return db.crud(companyId, q, method);
+    };
+    return { ...db, crud, synced };
+};
+
+const contextFor = (db) => buildContext({ MongoDbCrudOpration: db.crud, SCHEMA_TYPE, logger, listCompanies: async () => [{ _id: 'c1' }] });
+
+describe('008-agent-run-expiry', () => {
+    test('is a valid company-scoped migration the runner lists after 007', () => {
+        expect(() => validateMigration(migration, '008-agent-run-expiry')).not.toThrow();
+        expect(migration.scope).toBe('company');
+        const ids = listMigrations().map((m) => m.id);
+        expect(ids.indexOf('008-agent-run-expiry')).toBe(ids.indexOf('007-encrypt-integration-secrets') + 1);
+    });
+
+    test('syncs the indexes, backfills expiresAt for terminal runs only, and is idempotent', async () => {
+        const db = dbWithIndexes();
+        const finishedAt = new Date(Date.now() - 10 * DAY);
+        const createdAt = new Date(Date.now() - 20 * DAY);
+        const done = db.seed(T, { agentId: 'a', status: 'done', finishedAt, createdAt });
+        const failedNoFinish = db.seed(T, { agentId: 'a', status: 'failed', createdAt });
+        const already = db.seed(T, { agentId: 'a', status: 'stopped', finishedAt, expiresAt: new Date(1) });
+        const waiting = db.seed(T, { agentId: 'a', status: 'waiting_approval', createdAt: new Date(Date.now() - 400 * DAY) });
+        const running = db.seed(T, { agentId: 'a', status: 'running', createdAt });
+
+        const first = contextFor(db);
+        await migration.up(first);
+        expect(first.companies.c1).toMatchObject({ ok: true, droppedIndexes: ['createdAt_1'], backfilled: 2, skipped: 1 });
+        expect(db.synced).toEqual(['c1']);
+
+        const rows = db.store[T];
+        const at = (id) => rows.find((r) => r._id === id);
+        expect(at(done._id).expiresAt.getTime()).toBe(finishedAt.getTime() + runs.RETENTION_SECONDS * 1000);
+        expect(at(failedNoFinish._id).expiresAt.getTime()).toBe(createdAt.getTime() + runs.RETENTION_SECONDS * 1000);
+        expect(at(already._id).expiresAt.getTime()).toBe(1);
+        expect(at(waiting._id).expiresAt).toBeUndefined();
+        expect(at(running._id).expiresAt).toBeUndefined();
+
+        const snapshot = JSON.stringify(rows);
+        const again = contextFor(db);
+        await migration.up(again);
+        expect(again.companies.c1).toMatchObject({ ok: true, droppedIndexes: [], backfilled: 0, skipped: 3 });
+        expect(JSON.stringify(db.store[T])).toBe(snapshot);
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('008 c1'));
+    });
+});

--- a/utils/mongo-handler/createSchema.js
+++ b/utils/mongo-handler/createSchema.js
@@ -191,7 +191,7 @@ agentRunsSchema.index({ status: 1, startedAt: -1 });
 agentRunsSchema.index({ taskId: 1, startedAt: -1 });
 agentRunsSchema.index({ projectId: 1, status: 1 });
 agentRunsSchema.index({ projectId: 1, finishedAt: -1 });
-agentRunsSchema.index({ createdAt: 1 }, { expireAfterSeconds: 15552000 });
+agentRunsSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 const agentProposalsSchema = new Schema(schema.agentProposals, {strict: true, timestamps: true});
 agentProposalsSchema.index({ status: 1, createdAt: -1 });

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -814,6 +814,8 @@ const schema = {
         startedBy: { type: String, required: false },
         startedAt: { type: Date, required: false },
         finishedAt: { type: Date, required: false },
+        // set with the terminal status; the TTL index deletes the run once it passes
+        expiresAt: { type: Date, required: false },
         elapsedMs: { type: Number, default: 0, required: false },
         // { tokens, usd, model, billedToWorkspace }
         spend: { type: Object, required: false },


### PR DESCRIPTION
Closes defect 16 of task 024 (Sprint 1, step 7).

## Defect
`agent_runs` had an unconditional TTL index on `createdAt` (180 days). A run waiting on a person for longer than that was deleted under its proposal, leaving an orphaned proposal that could still be approved against a run that no longer existed.

## Reproduction
1. Start a run that files a proposal, so the run sits in `waiting_approval`.
2. Leave the proposal undecided past the TTL (or age the run's `createdAt` past it): Mongo deletes the run row.
3. Approve the proposal: the changes are applied, `settleRun` finds no run, and the audit trail points at a run that is gone.

On this branch step 2 no longer deletes the run (open runs have no `expiresAt`), and step 3 is refused with `run_missing` even if the run was removed by other means.

## Change
- TTL moved to `expiresAt` with `expireAfterSeconds: 0`; `expiresAt` declared on the `agentRuns` schema.
- `runs.terminalUpdate(status, at)` returns `{ status, finishedAt, expiresAt }` (finish time + the unchanged 180-day retention) and throws for a non-terminal status. `runs.finish` spreads it, so every terminal transition (graph remember/fail paths, proposal settle, `stop`, `reapStale`, `pauseAll`) sets `expiresAt` in the same update. Open runs (`queued`, `running`, `waiting_approval`) never get one. `revert.js` only adds `revertedAt` to an already-terminal run, so it is unaffected.
- `proposals.approve` refuses a proposal whose `runId` no longer resolves: `{ status: 409, reason: 'run_missing' }`. Decline still works so the Inbox is not stuck with it.
- The LangGraph checkpoint TTL in `engine/persistence.js` is unchanged.

## Migration
`migrations/008-agent-run-expiry.js` (company scope, idempotent): `syncIndexes` on `agent_runs` drops the `createdAt_1` TTL index and builds `expiresAt_1` from the schema; then backfills `expiresAt` for runs already in a terminal status (`finishedAt`, or `createdAt` for rows without one, plus retention). Logs `{ droppedIndexes, backfilled, skipped }` per company.

## Tests
- `tests/agent-run-expiry.test.js`: index definition, open/waiting runs have no expiry, every terminal status sets it, stop/reap/pauseAll go through the same update.
- `tests/migration-agent-run-expiry.test.js`: index sync, backfill, idempotence, ordering after 007.
- `tests/agent-proposal-run-missing.test.js`: approve refused with `run_missing`, decline allowed, run-less proposals still approve.

The index-definition and terminal-transition assertions fail on `origin/beta`. `npx jest --selectProjects unit`: 147 suites / 1779 tests green; `tests/conventions`: 88 green; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
