### PR TITLE
fix(024): thread loop depth from the originating envelope through agent actions

### DIFF
--- a/Modules/Agents/actions.js
+++ b/Modules/Agents/actions.js
@@ -65,11 +65,13 @@ const manifest = () => {
     return { ...m, actions: m.actions.map((a) => ({ ...a, rating: rating(a.key) })), ratingKeys: [...RATING_KEYS], scopes: Object.values(SCOPE) };
 };
 
-const emitTask = (doc, updatedFields, actor) => {
+const clampDepth = (depth) => Math.max(0, Number(depth) || 0);
+
+const emitTask = (doc, updatedFields, actor, depth) => {
     socketEmitter.emit('update', {
         type: 'update', module: 'task', data: doc, updatedFields,
         actor: { kind: 'agent', userId: actor.userId || null, agentId: actor.agentId || null },
-        depth: 1,
+        depth: clampDepth(depth) + 1,
     });
 };
 
@@ -79,11 +81,13 @@ const workEntry = (actor, hours = 0) => {
 };
 
 // perform() writes the agent.action row (undo descriptor, attribution), so the
-// tool layer must not add its automation.task.* row for the same change.
-const context = (actor, action) => {
+// tool layer must not add its automation.task.* row for the same change. `depth`
+// is the originating event's; the tool layer emits at depth + 1 so the bus's
+// loop guard keeps counting through an agent hop.
+const context = (actor, action, depth) => {
     const a = attribution(actor);
     return {
-        ruleId: null, ruleName: a.label, runId: actor.runId || null, action: `agent.${action}`, depth: 0,
+        ruleId: null, ruleName: a.label, runId: actor.runId || null, action: `agent.${action}`, depth: clampDepth(depth),
         userId: String(actor.userId || a.actorId || ''), actorType: a.actorType, agentId: a.agentId || null, viaAccount: a.viaAccount || null,
         auditedByCaller: true,
     };
@@ -97,8 +101,8 @@ const findRunningTimer = (companyId, taskId, userId) => MongoDbCrudOpration(comp
 /* ── the executors ─────────────────────────────────────────────────────────── */
 
 const executors = {
-    async 'task.comment'({ companyId, actor, params }) {
-        const r = await tools.addComment(companyId, params.taskId, params.body, context(actor, 'task.comment'));
+    async 'task.comment'({ companyId, actor, params, depth }) {
+        const r = await tools.addComment(companyId, params.taskId, params.body, context(actor, 'task.comment', depth));
         const a = attribution(actor);
         await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.COMMENTS,
@@ -107,7 +111,7 @@ const executors = {
         return { result: { commentId: r.commentId }, undo: { kind: 'comment', commentId: r.commentId, taskId: String(params.taskId) }, entityId: params.taskId };
     },
 
-    async 'task.status.set'({ companyId, actor, params }) {
+    async 'task.status.set'({ companyId, actor, params, depth }) {
         const task = await tools.getTask(companyId, params.taskId);
         const patch = await tools.resolveStatus(companyId, task.ProjectID, params.status.name || params.status.text);
         const check = registry.evaluate('task.status.set', { status: { statusType: patch.statusType, name: patch.status.text } });
@@ -117,11 +121,11 @@ const executors = {
             toStatus: { statusType: patch.statusType, name: patch.status.text }, actor: workEntry(actor),
         });
         const set = completion && !completion.error ? { ...patch, completion: completion.completion } : patch;
-        const r = await tools.updateTask(companyId, task._id, set, context(actor, 'task.status.set'));
+        const r = await tools.updateTask(companyId, task._id, set, context(actor, 'task.status.set', depth));
         return { result: { status: patch.status.text, statusType: patch.statusType }, undo: { kind: 'status', taskId: String(task._id), previous }, entityId: task._id, entityName: task.TaskName, task: r.task };
     },
 
-    async 'task.link'({ companyId, actor, params }) {
+    async 'task.link'({ companyId, actor, params, depth }) {
         const task = await tools.getTask(companyId, params.taskId);
         const url = String(params.url || '').trim();
         if (!/^https?:\/\//i.test(url) || url.length > 2000) throw new tools.DeterministicError('a valid http(s) url is required');
@@ -134,50 +138,50 @@ const executors = {
         const updated = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.TASKS, data: [{ _id: task._id }, { $push: { links: link } }, { returnDocument: 'after' }],
         }, 'findOneAndUpdate');
-        emitTask(updated, { links: updated.links }, actor);
+        emitTask(updated, { links: updated.links }, actor, depth);
         return { result: { linkId: String(link._id), kind: link.kind }, undo: { kind: 'link', taskId: String(task._id), linkId: String(link._id) }, entityId: task._id, entityName: task.TaskName };
     },
 
-    async 'task.assign'({ companyId, actor, params }) {
+    async 'task.assign'({ companyId, actor, params, depth }) {
         const task = await tools.getTask(companyId, params.taskId);
         const ids = (Array.isArray(params.assigneeIds) ? params.assigneeIds : [params.assigneeId]).filter((v) => OBJECT_ID.test(String(v || ''))).map(String);
         if (!ids.length) throw new tools.DeterministicError('assigneeIds is required');
         const previous = (task.AssigneeUserId || []).map(String);
         const next = params.replace ? ids : [...new Set([...previous, ...ids])];
-        const r = await tools.updateTask(companyId, task._id, { AssigneeUserId: next }, context(actor, 'task.assign'));
+        const r = await tools.updateTask(companyId, task._id, { AssigneeUserId: next }, context(actor, 'task.assign', depth));
         return { result: { assignees: next }, undo: { kind: 'assign', taskId: String(task._id), previous }, entityId: task._id, entityName: task.TaskName, task: r.task };
     },
 
-    async 'task.update'({ companyId, actor, params }) {
+    async 'task.update'({ companyId, actor, params, depth }) {
         const task = await tools.getTask(companyId, params.taskId);
         const fields = params.fields || {};
         const previous = {};
         Object.keys(fields).forEach((k) => { previous[k] = task[k] === undefined ? null : task[k]; });
-        const r = await tools.updateTask(companyId, task._id, fields, context(actor, 'task.update'));
+        const r = await tools.updateTask(companyId, task._id, fields, context(actor, 'task.update', depth));
         return { result: { fields: Object.keys(fields) }, undo: { kind: 'update', taskId: String(task._id), previous }, entityId: task._id, entityName: task.TaskName, task: r.task };
     },
 
-    async 'task.sprint.move'({ companyId, actor, params }) {
+    async 'task.sprint.move'({ companyId, actor, params, depth }) {
         const task = await tools.getTask(companyId, params.taskId);
         const target = oid(params.sprintId);
         if (!target) throw new tools.DeterministicError('a valid sprintId is required');
         const sprint = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.SPRINTS, data: [{ _id: target, projectId: task.ProjectID }] }, 'findOne');
         if (!sprint) throw new tools.DeterministicError('sprint not found in this project');
         const previous = { sprintId: task.sprintId, sprintArray: task.sprintArray };
-        const r = await tools.updateTask(companyId, task._id, { sprintId: target, sprintArray: { _id: target, name: sprint.name } }, context(actor, 'task.sprint.move'));
+        const r = await tools.updateTask(companyId, task._id, { sprintId: target, sprintArray: { _id: target, name: sprint.name } }, context(actor, 'task.sprint.move', depth));
         return { result: { sprintId: String(target), name: sprint.name }, undo: { kind: 'sprint', taskId: String(task._id), previous }, entityId: task._id, entityName: task.TaskName, task: r.task };
     },
 
-    async 'subtask.create'({ companyId, actor, params }) {
-        const r = await tools.createSubtask(companyId, params.taskId, { title: params.title, description: params.description || '' }, context(actor, 'subtask.create'));
+    async 'subtask.create'({ companyId, actor, params, depth }) {
+        const r = await tools.createSubtask(companyId, params.taskId, { title: params.title, description: params.description || '' }, context(actor, 'subtask.create', depth));
         return { result: { subtaskId: r.subtaskId, title: r.title }, undo: { kind: 'subtask', subtaskId: r.subtaskId, parentTaskId: String(params.taskId) }, entityId: params.taskId };
     },
 
-    async 'task.create'({ companyId, actor, params }) {
+    async 'task.create'({ companyId, actor, params, depth }) {
         const r = await tools.createTask(companyId, params.projectId, {
             title: params.title, description: params.description || '', sprintId: params.sprintId || '', priority: params.priority || 'MEDIUM',
             leaderId: actor.userId || '',
-        }, context(actor, 'task.create'));
+        }, context(actor, 'task.create', depth));
         return { result: { taskId: r.taskId, key: r.key, title: r.title }, undo: { kind: 'task', taskId: r.taskId, projectId: String(params.projectId) }, entityId: r.taskId, entityName: r.title };
     },
 
@@ -233,8 +237,8 @@ const executors = {
         return { result: { pageId: String(saved._id) }, undo: { kind: 'page', pageId: String(saved._id) }, entityType: 'page', entityId: saved._id, entityName: title };
     },
 
-    async 'chat.post'({ companyId, actor, params }) {
-        const r = await tools.addComment(companyId, params.taskId, params.body, context(actor, 'chat.post'));
+    async 'chat.post'({ companyId, actor, params, depth }) {
+        const r = await tools.addComment(companyId, params.taskId, params.body, context(actor, 'chat.post', depth));
         return { result: { commentId: r.commentId }, undo: { kind: 'comment', commentId: r.commentId, taskId: String(params.taskId) }, entityId: params.taskId };
     },
 };
@@ -247,7 +251,7 @@ const refusal = async (companyId, actor, { action, params, reason, ip }) => {
 /* Run one action for an actor. Refusals are audited and thrown as RefusedError.
  * A policy `decision` of refuse is honoured before the registry check, so a
  * policy refusal leaves the same audit row as a registry one. */
-const perform = async ({ companyId, actor, action, params = {}, reason = '', cost = null, ip = '', allowedActions, decision = null }) => {
+const perform = async ({ companyId, actor, action, params = {}, reason = '', cost = null, ip = '', allowedActions, decision = null, depth = 0 }) => {
     if (decision && decision.decision === 'refuse') throw await refusal(companyId, actor, { action, params, reason: decision.reason, ip });
     const check = registry.evaluate(action, params, { allowedActions });
     if (!check.allowed) throw await refusal(companyId, actor, { action, params, reason: check.reason, ip });
@@ -260,7 +264,7 @@ const perform = async ({ companyId, actor, action, params = {}, reason = '', cos
     const auditId = await audit.openAction(companyId, actor, { action, reason, params, cost, ip, entityId: params.taskId });
     let out;
     try {
-        out = await exec({ companyId, actor, params });
+        out = await exec({ companyId, actor, params, depth: clampDepth(depth) });
     } catch (e) {
         await audit.failAction(companyId, auditId, e.message);
         throw e;

--- a/Modules/Agents/engine/graph.js
+++ b/Modules/Agents/engine/graph.js
@@ -121,7 +121,7 @@ async function act(state, config) {
         if (!(await runs.isRunning(companyId, run._id))) return { applied, refusals, abandoned: true };
         try {
             // eslint-disable-next-line no-await-in-loop
-            const out = await deps.actions.perform({ companyId, actor: deps.actor, action: change.action, params: change.params, reason: `${run.skill} finding`, allowedActions: agent.allowedActions, decision: verdict });
+            const out = await deps.actions.perform({ companyId, actor: deps.actor, action: change.action, params: change.params, reason: `${run.skill} finding`, allowedActions: agent.allowedActions, decision: verdict, depth: runs.originDepth(run) });
             // eslint-disable-next-line no-await-in-loop
             await runs.patch(companyId, run._id, {}, { $push: { actions: { action: change.action, auditId: out.auditId, ok: true, at: new Date() } } });
             applied += 1;

--- a/Modules/Agents/proposals.js
+++ b/Modules/Agents/proposals.js
@@ -184,11 +184,10 @@ const approve = async (companyId, id, { decider, isPrivileged, changes: edited, 
     const runs = require('./runs');
     const agent = await runs.getAgent(companyId, p.agentId);
     if (!agent) return { error: 'This agent was deleted — decline the proposal instead.', status: 409 };
-    if (p.runId) {
-        const run = await runOf(companyId, p.runId);
-        if (!run) return { error: 'The run behind this proposal no longer exists — decline it instead.', status: 409, reason: REASON.RUN_MISSING };
-        if (run.status === runs.STATUS.STOPPED) return { error: 'Run was stopped.', status: 409 };
-    }
+    const run = p.runId ? await runOf(companyId, p.runId) : null;
+    if (p.runId && !run) return { error: 'The run behind this proposal no longer exists — decline it instead.', status: 409, reason: REASON.RUN_MISSING };
+    if (run && run.status === runs.STATUS.STOPPED) return { error: 'Run was stopped.', status: 409 };
+    const depth = runs.originDepth(run);
 
     const claimed = await setStatus(companyId, id, { status: STATUS.APPLYING, decidedBy: decider.userId, decidedAt: new Date() }, { onlyIf: STATUS.PENDING });
     if (!claimed) return alreadyDecided(companyId, id);
@@ -199,7 +198,7 @@ const approve = async (companyId, id, { decider, isPrivileged, changes: edited, 
     for (const c of changes) {
         try {
             // eslint-disable-next-line no-await-in-loop
-            const out = await actions.perform({ companyId, actor: agentActor, action: c.action, params: { ...c.params, __proposal: true }, reason: `approved proposal ${id} by ${decider.userId}`, ip, allowedActions: agent.allowedActions });
+            const out = await actions.perform({ companyId, actor: agentActor, action: c.action, params: { ...c.params, __proposal: true }, reason: `approved proposal ${id} by ${decider.userId}`, ip, allowedActions: agent.allowedActions, depth });
             if (out.auditId) auditIds.push(out.auditId);
             applied.push({ action: c.action, ok: true, result: out.result });
         } catch (e) {

--- a/Modules/Agents/runs.js
+++ b/Modules/Agents/runs.js
@@ -4,6 +4,7 @@ const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries'
 const socketEmitter = require('../../event/socketEventEmitter');
 const logger = require('../../Config/loggerConfig');
 const usage = require('../AIProjectGenerator/usage');
+const { MAX_DEPTH } = require('../../event/domainEventBus');
 
 // Agent runs and spend. A run is the unit the rail footer counts ("2 running"),
 // the project header chip sums (elapsed, spend) and the audit log links to
@@ -20,6 +21,8 @@ const TERMINAL = [STATUS.DONE, STATUS.SKIPPED, STATUS.FAILED, STATUS.STOPPED];
 const RETENTION_SECONDS = 15552000;
 const oid = (id) => { try { return new mongoose.Types.ObjectId(String(id)); } catch (e) { return null; } };
 const monthKey = (d = new Date()) => d.toISOString().slice(0, 7);
+const clampDepth = (depth) => Math.max(0, Number(depth) || 0);
+const originDepth = (run) => clampDepth(run && run.triggerDepth);
 const startOfDayUtc = (d = new Date()) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
 
 const emit = (companyId, type, data) => {
@@ -36,9 +39,14 @@ const runsToday = (companyId, agentId) => MongoDbCrudOpration(companyId, {
     type: SCHEMA_TYPE.AGENT_RUNS, data: [{ agentId: String(agentId), startedAt: { $gte: startOfDayUtc() } }],
 }, 'countDocuments');
 
+// The bus drops any envelope deeper than MAX_DEPTH, so a run whose actions would
+// emit past it is refused up front instead of running and losing its events.
+const LOOP_DEPTH_EXCEEDED = 'loop_depth_exceeded';
+
 /* Can this agent start a run right now? Returns { ok, reason }. */
-const canStart = async (agent, { trigger, viaAccount, companyId } = {}) => {
+const canStart = async (agent, { trigger, viaAccount, companyId, depth } = {}) => {
     if (!agent) return { ok: false, reason: 'Agent not found.' };
+    if (clampDepth(depth) >= MAX_DEPTH) return { ok: false, reason: LOOP_DEPTH_EXCEEDED, code: LOOP_DEPTH_EXCEEDED, depth: clampDepth(depth), maxDepth: MAX_DEPTH };
     if (agent.paused) return { ok: false, reason: `Agent is paused${agent.pausedReason ? ` (${agent.pausedReason})` : ''}.` };
     const via = viaAccount || agent.account || 'workspace';
     if (via !== 'local') {
@@ -66,12 +74,13 @@ const canStart = async (agent, { trigger, viaAccount, companyId } = {}) => {
     return { ok: true, reason: '' };
 };
 
-const create = async (companyId, { agent, taskId, projectId, skill, trigger, startedBy, viaAccount, note, spendCapUsd, notifyMe }) => {
+const create = async (companyId, { agent, taskId, projectId, skill, trigger, startedBy, viaAccount, note, spendCapUsd, notifyMe, triggerDepth, triggerEventId }) => {
     const run = await MongoDbCrudOpration(companyId, {
         type: SCHEMA_TYPE.AGENT_RUNS,
         data: {
             agentId: String(agent._id), agentName: agent.name, taskId: taskId ? String(taskId) : null, projectId: projectId ? String(projectId) : null,
             skill: skill || null, trigger: trigger || 'manual', status: STATUS.RUNNING, viaAccount: viaAccount || agent.account || 'workspace',
+            triggerDepth: clampDepth(triggerDepth), triggerEventId: triggerEventId ? String(triggerEventId) : null,
             startedBy: startedBy ? String(startedBy) : null, startedAt: new Date(), elapsedMs: 0,
             spend: { tokens: 0, usd: 0, model: null, billedToWorkspace: (viaAccount || agent.account || 'workspace') === 'workspace' },
             actions: note ? [{ action: 'mention', note: String(note).slice(0, 2000), at: new Date() }] : [],
@@ -299,4 +308,4 @@ const skillSlugOf = (agent, explicit) => {
     return first.key || first.slug || first.name || 'qa-review';
 };
 
-module.exports = { STATUS, OPEN, TERMINAL, RETENTION_SECONDS, terminalUpdate, canStart, runsToday, skillSlugOf, create, get, patch, appendAction, finish, isRunning, reapStale, stop, recordSpend, list, summary, countsByStatus, pauseAll, getAgent, emitAgent, changesFor, executeSkill, monthKey };
+module.exports = { STATUS, OPEN, TERMINAL, RETENTION_SECONDS, LOOP_DEPTH_EXCEEDED, originDepth, terminalUpdate, canStart, runsToday, skillSlugOf, create, get, patch, appendAction, finish, isRunning, reapStale, stop, recordSpend, list, summary, countsByStatus, pauseAll, getAgent, emitAgent, changesFor, executeSkill, monthKey };

--- a/Modules/Automations/engine/actions/runAgent.js
+++ b/Modules/Automations/engine/actions/runAgent.js
@@ -32,6 +32,10 @@ const ruleOwner = async (companyId, ruleId) => {
     return rule && rule.createdBy ? String(rule.createdBy) : null;
 };
 
+const recordLoopRefusal = (companyId, agent, { taskId, context, check }) => require('../../../Agents/agentAudit').recordRefusal(companyId,
+    { kind: 'agent', userId: null, agentId: String(agent._id), agentName: agent.name, runId: null, viaAccount: agent.account, tokenId: null },
+    { action: 'run.start', reason: check.reason, entityId: taskId, params: { ruleId: context.ruleId, ruleName: context.ruleName, eventId: context.eventId || null, depth: check.depth, maxDepth: check.maxDepth } });
+
 module.exports = {
     key: 'run_agent',
     label: 'Run an AI agent',
@@ -50,8 +54,11 @@ module.exports = {
         if (!String(config.agent || '').trim()) throw refuse('This rule does not name an agent — pick one so its pause switch, spend cap and allowed actions apply.');
         const agent = await findAgent(companyId, config.agent);
         if (!agent) throw refuse(`No agent named "${config.agent}" in this workspace.`);
-        const check = await runs.canStart(agent, { trigger: 'rule', companyId });
-        if (!check.ok) throw refuse(`${agent.name} cannot run: ${check.reason}`);
+        const check = await runs.canStart(agent, { trigger: 'rule', companyId, depth: context.depth });
+        if (!check.ok) {
+            if (check.code === runs.LOOP_DEPTH_EXCEEDED) await recordLoopRefusal(companyId, agent, { taskId: entity.id, context, check });
+            throw refuse(`${agent.name} cannot run: ${check.reason}`);
+        }
         if (agent.projectIds && agent.projectIds.length && !agent.projectIds.map(String).includes(String(task.ProjectID))) {
             throw refuse(`${agent.name} is not scoped to this project.`);
         }
@@ -60,6 +67,7 @@ module.exports = {
         const run = await runs.create(companyId, {
             agent, taskId: entity.id, projectId: task.ProjectID, skill: runs.skillSlugOf(agent, config.skill), trigger: 'rule',
             startedBy, viaAccount: agent.account, note: context.ruleName ? `rule "${context.ruleName}"` : null,
+            triggerDepth: context.depth, triggerEventId: context.eventId,
         });
         const actor = { kind: 'agent', userId: startedBy, agentId: String(agent._id), agentName: agent.name, runId: String(run._id), viaAccount: run.viaAccount, tokenId: null };
         const out = await runs.executeSkill(companyId, run, agent, task, { proposals, actions, actor });

--- a/Modules/Automations/engine/runner.js
+++ b/Modules/Automations/engine/runner.js
@@ -96,7 +96,7 @@ async function runOnce(companyId, run, rule, envelope) {
     const steps = Array.isArray(rule.steps) ? rule.steps.slice(0, MAX_STEPS) : [];
     const outputs = { ...(run.outputs || {}) };
     const recorded = Array.isArray(run.steps) ? run.steps.slice() : [];
-    const context = { runId: String(run._id), ruleId: String(rule._id), ruleName: rule.name, depth: envelope.depth };
+    const context = { runId: String(run._id), ruleId: String(rule._id), ruleName: rule.name, depth: envelope.depth, eventId: envelope.id };
 
     // Resume point. Everything before the cursor already ran and already mutated.
     for (let i = Number(run.cursor) || 0; i < steps.length; i++) {

--- a/tests/agent-automation-run.test.js
+++ b/tests/agent-automation-run.test.js
@@ -46,7 +46,7 @@ describe('#1 rule-triggered agent runs go through the run engine', () => {
     it('refuses with canStart\'s reason — paused, pause-all, spend cap and the daily limit all apply', async () => {
         runs.canStart.mockResolvedValueOnce({ ok: false, reason: 'Agent is paused (pause_all).' });
         await expect(runAgent.run(args({ skill: 'qa-review', agent: 'code reviewer' }))).rejects.toMatchObject({ deterministic: true, message: 'Code Reviewer cannot run: Agent is paused (pause_all).' });
-        expect(runs.canStart).toHaveBeenCalledWith(expect.objectContaining({ name: 'Code Reviewer' }), { trigger: 'rule', companyId: C });
+        expect(runs.canStart).toHaveBeenCalledWith(expect.objectContaining({ name: 'Code Reviewer' }), { trigger: 'rule', companyId: C, depth: 0 });
         expect(runs.create).not.toHaveBeenCalled();
     });
 
@@ -57,7 +57,7 @@ describe('#1 rule-triggered agent runs go through the run engine', () => {
 
     it('creates a rule-triggered run for the named agent and executes it as that agent, on behalf of the rule\'s author', async () => {
         const out = await runAgent.run(args({ skill: 'pr.summary', agent: 'Code Reviewer' }));
-        expect(runs.create).toHaveBeenCalledWith(C, expect.objectContaining({ taskId: TASK_ID, projectId: 'p1', skill: 'pr.summary', trigger: 'rule', startedBy: 'u1', note: 'rule "QA on done"' }));
+        expect(runs.create).toHaveBeenCalledWith(C, expect.objectContaining({ taskId: TASK_ID, projectId: 'p1', skill: 'pr.summary', trigger: 'rule', startedBy: 'u1', note: 'rule "QA on done"', triggerDepth: 0 }));
         const [, run, agent, t, deps] = runs.executeSkill.mock.calls[0];
         expect(run._id).toBe('run1');
         expect(agent.name).toBe('Code Reviewer');

--- a/tests/agent-graph.test.js
+++ b/tests/agent-graph.test.js
@@ -160,6 +160,17 @@ describe('a run is a LangGraph thread', () => {
         expect(await checkpointOf(C, run)).toBeUndefined();
     });
 
+    it('act hands perform the depth the run was triggered at, so its events land one deeper', async () => {
+        planned([subtask('One')]);
+        const a = agent({ autonomy: 2 });
+        const run = await start(a, { trigger: 'rule', triggerDepth: 2, triggerEventId: 'evt_1' });
+        await execute(run, a);
+        expect(actions.perform).toHaveBeenCalledWith(expect.objectContaining({ action: 'subtask.create', depth: 2 }));
+        const manual = await start(a);
+        await execute(manual, a);
+        expect(actions.perform).toHaveBeenLastCalledWith(expect.objectContaining({ depth: 0 }));
+    });
+
     it('a finished thread leaves no checkpoint behind, while a waiting one keeps its checkpoint until it is decided', async () => {
         planned([newTask('Two')]);
         const run = await start(agent());

--- a/tests/agent-loop-depth.test.js
+++ b/tests/agent-loop-depth.test.js
@@ -1,0 +1,134 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn(), on: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../Modules/Tasks/helpers/completionStore', () => ({ forStatusChange: jest.fn(async () => null), recordWork: jest.fn(async () => null) }));
+jest.mock('../Modules/Agents/permissions', () => ({ holderMay: jest.fn(async () => ({ allowed: true, reason: '' })) }));
+jest.mock('../Modules/Agents/budget', () => ({ check: jest.fn(async () => ({ ok: true, reason: '' })) }));
+jest.mock('../Modules/AIProjectGenerator/usage', () => ({ checkConfiguredModelPriced: () => ({ ok: true, reason: '' }), unpricedMessage: (m) => `No price on file for ${m}`, summarize: jest.fn() }));
+jest.mock('../Modules/Agents/engine/graph', () => ({ resumeGraph: jest.fn(async () => ({ resumed: false })) }));
+jest.mock('../Modules/Agents/engine/persistence', () => {
+    const deleteThread = jest.fn(async () => {});
+    return { deleteThread, saverFor: jest.fn(() => ({ deleteThread })), storeFor: jest.fn(() => { throw new Error('no store in this suite'); }), ready: jest.fn(async () => {}) };
+});
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const socketEmitter = require('../event/socketEventEmitter');
+const bus = require('../event/domainEventBus');
+const actions = require('../Modules/Agents/actions');
+const runs = require('../Modules/Agents/runs');
+const proposals = require('../Modules/Agents/proposals');
+const memory = require('../Modules/Agents/memory');
+const runAgent = require('../Modules/Automations/engine/actions/runAgent');
+
+const C = '6a8ee973d625fca52e519a12';
+const AGENT_ID = '6f0000000000000000000a01';
+const RULE_ID = '6f0000000000000000000b01';
+const TASK_ID = '6f0000000000000000000701';
+const PROJECT_ID = '6a9954186dd786246031e47b';
+const ITERATION_CAP = 20;
+const originDepth = (run) => Math.max(0, Number(run && run.triggerDepth) || 0);
+
+const agentDoc = () => ({ _id: AGENT_ID, name: 'Code Reviewer', account: 'workspace', autonomy: 2, projectIds: [], allowedActions: [], deletedStatusKey: 0 });
+const taskDoc = () => ({ _id: TASK_ID, CompanyId: C, ProjectID: PROJECT_ID, TaskName: 'Fix the thing', TaskKey: 'AR-1', Task_Priority: 'LOW' });
+const taskEmits = () => socketEmitter.emit.mock.calls.map(([, p]) => p).filter((p) => p && p.module === 'task');
+const runRows = () => mockDb.store[SCHEMA_TYPE.AGENT_RUNS] || [];
+const refusalRows = () => (mockDb.store[SCHEMA_TYPE.AUDIT_LOGS] || []).filter((r) => r.action === 'agent.action_refused');
+
+const bumpPriority = (companyId, actor, depth, agent) => actions.perform({
+    companyId, actor, action: 'task.update', params: { taskId: TASK_ID, fields: { Task_Priority: 'HIGH' } },
+    reason: 'qa-review finding', allowedActions: agent.allowedActions, depth,
+});
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    mockDb.seed(SCHEMA_TYPE.AGENTS, agentDoc());
+    mockDb.seed(SCHEMA_TYPE.TASKS, taskDoc());
+    mockDb.seed(SCHEMA_TYPE.AUTOMATION_RULES, { _id: RULE_ID, name: 'Re-review', createdBy: 'u1', reactToAutomation: true });
+    jest.spyOn(runs, 'executeSkill').mockImplementation(async (companyId, run, agent, task, deps) => {
+        await bumpPriority(companyId, deps.actor, originDepth(run), agent);
+        return { status: runs.STATUS.DONE, outcome: '1 change(s) applied', refusals: 0 };
+    });
+});
+
+describe('loop depth through an agent hop (defect 14)', () => {
+    const ruleHop = (envelope) => runAgent.run({
+        companyId: C, entity: envelope.entity, config: { agent: 'Code Reviewer', skill: 'qa-review' },
+        context: { runId: `auto-${envelope.depth}`, ruleId: RULE_ID, ruleName: 'Re-review', depth: envelope.depth, eventId: envelope.id, task: envelope.data },
+    });
+
+    it('a rule → agent → event → same rule chain trips the guard at MAX_DEPTH instead of recursing', async () => {
+        const hops = [];
+        let envelope = bus.buildEnvelope({ companyId: C, type: 'task.updated', doc: taskDoc(), changedFields: ['Task_Priority'], actor: { kind: 'user', userId: 'u1' }, depth: 0 });
+        let dropped = false;
+        for (let i = 0; i < ITERATION_CAP; i++) {
+            socketEmitter.emit.mockClear();
+            let refused = null;
+            // eslint-disable-next-line no-await-in-loop
+            try { await ruleHop(envelope); } catch (e) { refused = e; }
+            hops.push({ depth: envelope.depth, refused: refused ? refused.message : null });
+            if (refused) break;
+            const [emitted] = taskEmits();
+            expect(emitted).toBeDefined();
+            envelope = bus.buildEnvelope({ companyId: C, type: 'task.updated', doc: emitted.data, changedFields: Object.keys(emitted.updatedFields), actor: emitted.actor, depth: emitted.depth });
+            if (envelope.depth > bus.MAX_DEPTH) { dropped = true; break; }
+        }
+
+        expect(dropped).toBe(false);
+        expect(hops).toHaveLength(bus.MAX_DEPTH + 1);
+        expect(hops.map((h) => h.depth)).toEqual([0, 1, 2, 3]);
+        expect(hops.slice(0, -1).every((h) => h.refused === null)).toBe(true);
+        expect(hops[hops.length - 1].refused).toMatch(/loop_depth_exceeded/);
+
+        expect(runRows()).toHaveLength(bus.MAX_DEPTH);
+        expect(runRows().map((r) => r.triggerDepth)).toEqual([0, 1, 2]);
+        expect(runRows().every((r) => typeof r.triggerEventId === 'string' && r.triggerEventId.length > 0)).toBe(true);
+        expect(refusalRows()).toHaveLength(1);
+        expect(refusalRows()[0].meta).toMatchObject({ action: 'run.start', reason: 'loop_depth_exceeded' });
+    });
+
+    it('a rule-triggered run stores the envelope depth and correlation id, and its actions emit one deeper', async () => {
+        const envelope = bus.buildEnvelope({ companyId: C, type: 'task.updated', doc: taskDoc(), changedFields: ['Task_Priority'], actor: { kind: 'user', userId: 'u1' }, depth: 1 });
+        await ruleHop(envelope);
+        expect(runRows()[0]).toMatchObject({ trigger: 'rule', triggerDepth: 1, triggerEventId: envelope.id });
+        expect(taskEmits()[0]).toMatchObject({ actor: { kind: expect.not.stringMatching(/^user$/) }, depth: 2 });
+    });
+
+    it('canStart refuses at the max depth before a run row is written', async () => {
+        const check = await runs.canStart(agentDoc(), { trigger: 'rule', companyId: C, depth: bus.MAX_DEPTH });
+        expect(check).toMatchObject({ ok: false, reason: 'loop_depth_exceeded', code: 'loop_depth_exceeded' });
+        expect(await runs.canStart(agentDoc(), { trigger: 'rule', companyId: C, depth: bus.MAX_DEPTH - 1 })).toMatchObject({ ok: true });
+        expect(runRows()).toHaveLength(0);
+    });
+});
+
+describe('depth on runs that did not come from a rule', () => {
+    it('a user-started run starts at depth 0 and emits at depth 1', async () => {
+        const agent = agentDoc();
+        const run = await runs.create(C, { agent, taskId: TASK_ID, projectId: PROJECT_ID, skill: 'qa-review', trigger: 'manual', startedBy: 'u1' });
+        expect(run.triggerDepth).toBe(0);
+        expect(run.triggerEventId).toBeNull();
+
+        const actor = { kind: 'agent', userId: 'u1', agentId: AGENT_ID, agentName: agent.name, runId: String(run._id), viaAccount: 'workspace', tokenId: null };
+        await bumpPriority(C, actor, originDepth(run), agent);
+        expect(taskEmits()).toHaveLength(1);
+        expect(taskEmits()[0].depth).toBe(1);
+    });
+
+    it('an approved proposal carries its run\'s depth into the applied actions', async () => {
+        jest.spyOn(memory, 'rememberApprovedChanges').mockResolvedValue([]);
+        const run = mockDb.seed(SCHEMA_TYPE.AGENT_RUNS, { agentId: AGENT_ID, agentName: 'Code Reviewer', status: 'waiting_approval', skill: 'qa-review', taskId: TASK_ID, projectId: PROJECT_ID, trigger: 'rule', triggerDepth: 2, startedAt: new Date(), spend: { usd: 0 }, actions: [], proposals: [] });
+        const p = mockDb.seed(SCHEMA_TYPE.AGENT_PROPOSALS, {
+            agentId: AGENT_ID, agentName: 'Code Reviewer', runId: String(run._id), taskId: TASK_ID, projectId: PROJECT_ID, status: 'pending', gate: null,
+            changes: [{ action: 'task.update', params: { taskId: TASK_ID, fields: { Task_Priority: 'HIGH' } }, label: 'Raise priority' }],
+        });
+
+        const out = await proposals.approve(C, String(p._id), { decider: { kind: 'human', userId: 'u1' }, isPrivileged: true, ip: '' });
+        expect(out.error).toBeUndefined();
+        expect(taskEmits()).toHaveLength(1);
+        expect(taskEmits()[0].depth).toBe(3);
+    });
+});

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -808,6 +808,9 @@ const schema = {
         projectId: { type: String, required: false },
         skill: { type: String, required: false },
         trigger: { type: String, required: false },
+        // Depth of the domain event that started a rule-triggered run; its actions emit at depth + 1
+        triggerDepth: { type: Number, default: 0, required: false },
+        triggerEventId: { type: String, required: false },
         // queued | running | waiting_approval | done | failed | stopped
         status: { type: String, default: 'queued', required: true },
         viaAccount: { type: String, required: false },


### PR DESCRIPTION
## Summary

Closes **defect 14** (task 024, Sprint 1 step 4): the agent action context hardcoded loop depth to 0, so the domain-event bus's `MAX_DEPTH` guard could never trip through an agent hop. A rule that starts an agent whose action re-fires the same rule looped forever, bounded only by budgets.

## What changed

- **Depth travels into the run.** `Modules/Automations/engine/runner.js` passes the envelope's `depth` and `id` into the action context; `run_agent` stores them on the run as `triggerDepth` / `triggerEventId` (declared on the `agentRuns` schema; `trigger` stays the existing string enum). User-started and assignment runs default to depth 0.
- **`actions.perform` emits at `depth + 1`.** `perform()` takes `depth`; the tool-layer context and `emitTask` no longer hardcode 0 / 1. The graph's `act` node passes `runs.originDepth(run)`, and proposal approval passes the run's depth so a later approval still lands one deeper than the event that started the run.
- **The guard applies to agent hops.** `runs.canStart` refuses a run whose incoming depth is already `MAX_DEPTH` with `reason: 'loop_depth_exceeded'` (plus `code`, `depth`, `maxDepth`). `run_agent` records that as an `agent.action_refused` audit row (`action: 'run.start'`) rather than running and having its events dropped silently by the bus.

The guard lives in `event/domainEventBus.js` (`MAX_DEPTH = 3`, drops envelopes with `depth > 3`); `runs.canStart` now refuses at `depth >= 3` so the run never produces an envelope the bus would drop.

## Reproduction

`tests/agent-loop-depth.test.js` drives a rule -> agent -> `task.update` -> same rule chain through the real `run_agent` action, `runs.create`, `actions.perform` and `tools.updateTask`, rebuilding each envelope from the emitted socket payload with `domainEventBus.buildEnvelope`, capped at 20 hops.

- On the parent commit (`e1ef3e37`, test only) it fails: 20 hops, every one at depth 1, no refusal.
- On this branch: hops at depth 0, 1, 2 run (3 run rows with `triggerDepth` 0/1/2 and a `triggerEventId`), the hop at depth 3 is refused with `loop_depth_exceeded` and one audited refusal, and no envelope was ever silently dropped.

Also covered: a user-started run stores depth 0 and emits at 1; an approved proposal on a run at depth 2 emits at 3; `agent-graph.test.js` asserts `act` hands `perform` the run's depth.

## Verification

- `npx jest --selectProjects unit` - 1772 passed
- `npx jest tests/conventions` - 88 passed
- eslint on all touched files: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
