### PR TITLE
fix(024): check the run spend cap before the model call and reconcile after

### DIFF
--- a/Modules/AICore/README.md
+++ b/Modules/AICore/README.md
@@ -6,8 +6,9 @@ The shared AI core: what every AI feature needs and no feature owns (ADR 003, ph
 |-------|------|------|
 | Provider factory | `llmProvider/` | `getProvider()` / `isAnyProviderConfigured()` plus the OpenAI, Anthropic and DeepSeek adapters behind one `chat()` interface |
 | Usage and pricing | `usage.js` | token accounting, cost estimation, the unpriced-model gate |
+| Pre-call estimate | `estimate.js` | `estimateCall()` — what a call will cost before it is made (chars/4 with a safety factor, plus the max output), for spend gates |
 | Instruction guard | `instructionGuard.js` | detects prompt-injection phrasing in user-supplied text before it reaches a prompt or memory |
-| Model call | `modelCall.js` | `askModel()` — the single "call the model and parse JSON" helper — and `parseModelJson()` |
+| Model call | `modelCall.js` | `askModel()` — the single "call the model and parse JSON" helper, with an optional `budget.guard` that reserves the estimate before the call and reconciles after — and `parseModelJson()` |
 | Persistence | `persistence.js` | per-company LangGraph checkpointer and store (Mongo, or in-memory under tests) |
 
 ## The rule

--- a/Modules/AICore/estimate.js
+++ b/Modules/AICore/estimate.js
@@ -1,0 +1,43 @@
+const usage = require('./usage');
+
+/**
+ * What a model call is about to cost, before it is made.
+ *
+ * No tokenizer ships with the app (neither tiktoken nor gpt-tokenizer is a
+ * dependency), so input is sized from characters. Four characters per token is
+ * the documented rule of thumb for English prose and JSON on the GPT and Claude
+ * tokenizers; code, URLs and non-Latin text tokenize denser, hence the safety
+ * factor. Output is taken at the configured maximum because nothing shorter is
+ * guaranteed. The number is a ceiling for a spend gate: erring high refuses a
+ * call that would have fit, erring low lets one through, and the second is the
+ * defect the gate exists to stop.
+ */
+const CHARS_PER_TOKEN = 4;
+const SAFETY_FACTOR = 1.25;
+const PER_MESSAGE_OVERHEAD_TOKENS = 4;
+
+const textOf = (value) => {
+    if (typeof value === 'string') return value;
+    if (value == null) return '';
+    try { return JSON.stringify(value); } catch (e) { return String(value); }
+};
+
+function estimateTokens(text) {
+    const chars = textOf(text).length;
+    return chars ? Math.ceil((chars / CHARS_PER_TOKEN) * SAFETY_FACTOR) : 0;
+}
+
+/**
+ * @returns {{inputTokens:number, outputTokens:number, totalTokens:number,
+ *            model:string, priced:boolean, costUsd:number|null}}
+ *          `costUsd` is null and `priced` false for a model with no price on file.
+ */
+function estimateCall({ systemPrompt, messages, prompt, maxTokens, model } = {}) {
+    const turns = Array.isArray(messages) ? messages : (prompt ? [{ role: 'user', content: prompt }] : []);
+    const inputTokens = estimateTokens(systemPrompt) + turns.reduce((n, m) => n + estimateTokens(m && m.content) + PER_MESSAGE_OVERHEAD_TOKENS, 0);
+    const outputTokens = Math.max(0, Math.ceil(Number(maxTokens) || 0));
+    const priced = usage.summarize({ inputTokens, outputTokens }, model || usage.configuredModel() || '');
+    return { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens, model: priced.model, priced: priced.priced, costUsd: priced.costUsd };
+}
+
+module.exports = { estimateTokens, estimateCall, CHARS_PER_TOKEN, SAFETY_FACTOR, PER_MESSAGE_OVERHEAD_TOKENS };

--- a/Modules/AICore/index.js
+++ b/Modules/AICore/index.js
@@ -1,7 +1,8 @@
 const llmProvider = require('./llmProvider');
 const usage = require('./usage');
+const estimate = require('./estimate');
 const instructionGuard = require('./instructionGuard');
 const modelCall = require('./modelCall');
 const persistence = require('./persistence');
 
-module.exports = { llmProvider, usage, instructionGuard, modelCall, persistence };
+module.exports = { llmProvider, usage, estimate, instructionGuard, modelCall, persistence };

--- a/Modules/AICore/modelCall.js
+++ b/Modules/AICore/modelCall.js
@@ -1,6 +1,7 @@
 const logger = require('../../Config/loggerConfig');
 const { getProvider, isAnyProviderConfigured } = require('./llmProvider');
 const { emptyUsage, usageFromResult, addUsage } = require('./usage');
+const { estimateCall } = require('./estimate');
 
 const LOG_PREFIX = '[agent]';
 
@@ -13,32 +14,46 @@ function parseModelJson(raw) {
 }
 
 /* The one model call. `raw` stays null when the provider is missing, fails or
- * answers with something that is not JSON; `degraded` says which. */
+ * answers with something that is not JSON; `degraded` says which.
+ *
+ * `budget.guard` ({ reserve, reconcile, release }) sees the estimated cost
+ * before the vendor request: a refusal comes back as `refused` and nothing is
+ * bought; a reservation is settled to the real cost after the call, or
+ * released when the call throws. */
 async function askModel(skill, { prompt, budget }) {
     let usage = emptyUsage();
-    let raw = null; let model = null; let degraded = null;
+    let raw = null; let model = null; let degraded = null; let refused = null;
     if (isAnyProviderConfigured() && budget.allowModel !== false) {
+        const guard = budget.guard || null;
+        let ticket = null;
         try {
             const provider = getProvider();
-            const result = await provider.chat({
+            const request = {
                 systemPrompt: skill.systemPrompt,
                 messages: [{ role: 'user', content: prompt }],
                 maxTokens: Math.min(skill.maxTokens, budget.maxTokens || skill.maxTokens),
                 temperature: 0.2,
                 jsonMode: true,
-            });
+            };
+            if (guard) {
+                ticket = await guard.reserve(estimateCall({ ...request, model: provider.model }));
+                if (!ticket.ok) return { raw, model: provider.model || null, degraded: ticket.reason, refused: ticket, usage };
+            }
+            const result = await provider.chat(request);
             usage = addUsage(usage, usageFromResult(result));
             model = result.model || null;
+            if (ticket) { const settled = ticket; ticket = null; await guard.reconcile(settled, usage, model); }
             const parsed = parseModelJson(result.content);
             if (parsed.ok) raw = parsed.value; else degraded = parsed.error;
         } catch (error) {
             degraded = `model call failed: ${error.message}`;
             logger.error(`${LOG_PREFIX} ${degraded}`);
+            if (ticket) await guard.release(ticket).catch((e) => logger.error(`${LOG_PREFIX} reservation not released: ${e.message}`));
         }
     } else {
         degraded = 'no LLM provider configured';
     }
-    return { raw, model, degraded, usage };
+    return { raw, model, degraded, refused, usage };
 }
 
 module.exports = { askModel, parseModelJson };

--- a/Modules/Agents/budget.js
+++ b/Modules/Agents/budget.js
@@ -79,12 +79,20 @@ const provider = () => {
     };
 };
 
-const spentThisMonth = async (companyId, month) => {
+/* Booked spend, plus what open runs hold for calls in flight. A reservation left
+ * on a finished run is a leftover, never spend, so only open runs count. */
+const ledgerThisMonth = async (companyId, month) => {
     const from = new Date(`${month}-01T00:00:00.000Z`);
     const to = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth() + 1, 1));
-    const rows = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AGENT_RUNS, data: [{ startedAt: { $gte: from } }, 'startedAt spend'] }, 'find').catch(() => []);
-    return money((rows || []).filter((r) => new Date(r.startedAt).getTime() < to.getTime()).reduce((s, r) => s + Number((r.spend && r.spend.usd) || 0), 0));
+    const rows = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AGENT_RUNS, data: [{ startedAt: { $gte: from } }, 'startedAt status spend reservedUsd'] }, 'find').catch(() => []);
+    const inMonth = (rows || []).filter((r) => new Date(r.startedAt).getTime() < to.getTime());
+    return {
+        usedUsd: money(inMonth.reduce((s, r) => s + Number((r.spend && r.spend.usd) || 0), 0)),
+        reservedUsd: money(inMonth.filter((r) => runs.OPEN.includes(r.status)).reduce((s, r) => s + Number(r.reservedUsd || 0), 0)),
+    };
 };
+
+const spentThisMonth = async (companyId, month) => (await ledgerThisMonth(companyId, month)).usedUsd;
 
 const alertsOf = (company, month) => {
     const a = (company && company.agentBudgetAlerts) || {};
@@ -102,6 +110,13 @@ const status = async (companyId) => {
         percent: monthlyBudgetUsd > 0 ? Math.round((usedUsd / monthlyBudgetUsd) * 100) : 0,
         alerts: alertsOf(company, month),
     };
+};
+
+/* What the month can still absorb, for the pre-call gate. `budgetUsd` 0 means no budget. */
+const headroom = async (companyId) => {
+    const { monthlyBudgetUsd } = await settings(companyId);
+    const ledger = await ledgerThisMonth(companyId, runs.monthKey());
+    return { budgetUsd: monthlyBudgetUsd, ...ledger, remainingUsd: money(monthlyBudgetUsd - ledger.usedUsd - ledger.reservedUsd) };
 };
 
 const check = async (companyId) => {
@@ -154,4 +169,4 @@ const alertIfCrossed = async (companyId, run) => {
     return { level, at };
 };
 
-module.exports = { DEFAULTS, UNDO_HOURS_MIN, UNDO_HOURS_MAX, settings, validate, updateSettings, provider, status, check, alertIfCrossed };
+module.exports = { DEFAULTS, UNDO_HOURS_MIN, UNDO_HOURS_MAX, settings, validate, updateSettings, provider, status, headroom, check, alertIfCrossed };

--- a/Modules/Agents/engine/graph.js
+++ b/Modules/Agents/engine/graph.js
@@ -8,6 +8,7 @@ const skillIndex = require('../skills');
 const policy = require('../policy');
 const { rating: ratingOf } = require('../actions');
 const runs = require('../runs');
+const spendGuard = require('../spendGuard');
 
 // The run engine as a LangGraph thread, one per run (thread_id = run id):
 //
@@ -83,15 +84,22 @@ async function gather(state, config) {
     return { context: { ...gathered.context, memory: block } };
 }
 
+const statusAfter = (result) => {
+    if (result.status === 'skipped') return STATUS.SKIPPED;
+    if (result.status === 'refused') return STATUS.STOPPED;
+    return STATUS.FAILED;
+};
+
+/* The guard prices the call before it is made; recordSpend books what it
+ * actually cost afterwards, so the cap check below still catches an under-estimate. */
 async function analyse(state, config) {
     await renewLock(state, config);
-    const { companyId } = config.context;
+    const { companyId, deps } = config.context;
     const { run, task } = state;
-    const result = state.result || await orchestrator.analyse({ skillSlug: slugOf(run), task, context: state.context, budget: MODEL_BUDGET });
+    const guard = spendGuard.forRun({ companyId, run, actor: deps && deps.actor });
+    const result = state.result || await orchestrator.analyse({ skillSlug: slugOf(run), task, context: state.context, budget: { ...MODEL_BUDGET, guard } });
     const spend = await runs.recordSpend(companyId, run, result.usage, result.model);
-    if (result.status !== 'success') {
-        return { result, spend, outcome: result.reason || null, finalStatus: result.status === 'skipped' ? STATUS.SKIPPED : STATUS.FAILED };
-    }
+    if (result.status !== 'success') return { result, spend, outcome: result.reason || null, finalStatus: statusAfter(result) };
     const cap = Number(run.spendCapUsd) > 0 ? Number(run.spendCapUsd) : 0;
     if (cap && spend.usd >= cap) return { result, spend, outcome: `Run spend cap reached ($${spend.usd.toFixed(2)} of $${cap})`, finalStatus: STATUS.STOPPED };
     return { result, spend };

--- a/Modules/Agents/engine/orchestrator.js
+++ b/Modules/Agents/engine/orchestrator.js
@@ -82,6 +82,10 @@ function findingsWithoutModel(auditResult, skill) {
 
 const skipped = (skill, reason, started) => ({ status: 'skipped', reason, skill: skill.slug, findings: [], usage: emptyUsage(), durationMs: Date.now() - started });
 
+/* The spend guard refused the call before the vendor saw it: no fallback, no
+ * findings, the run stops with the guard's reason. */
+const refused = (skill, { refused: ticket, model, usage }, started) => ({ status: 'refused', reason: ticket.reason, code: ticket.code, skill: skill.slug, findings: [], usage, model, durationMs: Date.now() - started });
+
 /* PHASE 1 — gather. A generic skill collects its own input; the page audit
  * needs a public URL in the task. Either declines with `skipped`. */
 async function gather({ skillSlug = 'qa-review', task, companyId, memory }) {
@@ -105,7 +109,9 @@ async function gather({ skillSlug = 'qa-review', task, companyId, memory }) {
  * context and hand back a summary plus the changes the run should propose or apply. */
 async function analyseGeneric(skill, { task, context, budget }) {
     const started = Date.now();
-    const { raw: answer, model, degraded, usage } = await askModel(skill, { prompt: skill.buildUserPrompt({ task, context }), budget });
+    const asked = await askModel(skill, { prompt: skill.buildUserPrompt({ task, context }), budget });
+    if (asked.refused) return refused(skill, asked, started);
+    const { raw: answer, model, degraded, usage } = asked;
     if (!answer && !context.fallback) {
         return { status: 'failed', reason: degraded || 'the model returned nothing usable', skill: skill.slug, usage, model, durationMs: Date.now() - started };
     }
@@ -131,7 +137,9 @@ async function analyseAudit(skill, { task, context, budget }) {
         return { status: 'failed', reason: auditResult.fatal, skill: skill.slug, url, findings: [], usage: emptyUsage(), durationMs: Date.now() - started };
     }
 
-    const { raw, model, degraded, usage } = await askModel(skill, { prompt: skill.buildUserPrompt({ task, audit: auditResult }), budget });
+    const asked = await askModel(skill, { prompt: skill.buildUserPrompt({ task, audit: auditResult }), budget });
+    if (asked.refused) return refused(skill, asked, started);
+    const { raw, model, degraded, usage } = asked;
 
     const proposed = raw?.findings ?? findingsWithoutModel(auditResult, skill);
     const { findings, dropped } = raw

--- a/Modules/Agents/runs.js
+++ b/Modules/Agents/runs.js
@@ -112,6 +112,7 @@ const start = async (companyId, { agent, taskId, projectId, skill, trigger, star
                 triggerDepth: clampDepth(triggerDepth), triggerEventId: triggerEventId ? String(triggerEventId) : null,
                 startedBy: startedBy ? String(startedBy) : null, startedAt: new Date(), elapsedMs: 0,
                 spend: { tokens: 0, usd: 0, model: null, billedToWorkspace: via === 'workspace' },
+                reservedUsd: 0,
                 actions: note ? [{ action: 'mention', note: String(note).slice(0, 2000), at: new Date() }] : [],
                 proposals: [], refusals: 0, decisions: [],
                 ...(Number(spendCapUsd) > 0 ? { spendCapUsd: Number(spendCapUsd) } : {}),

--- a/Modules/Agents/spendGuard.js
+++ b/Modules/Agents/spendGuard.js
@@ -1,0 +1,83 @@
+const logger = require('../../Config/loggerConfig');
+const usage = require('../AICore/usage');
+const runs = require('./runs');
+const budget = require('./budget');
+const agentAudit = require('./agentAudit');
+
+// The pre-call spend gate for one run. Every model call is priced from an
+// estimate first and refused before the vendor request when it does not fit
+// the run's cap or the company's month; the post-call check in the graph
+// remains, booking the real cost and catching an under-estimate.
+//
+// The hold is an atomic $inc on the run row: two calls in flight in one run
+// each add their estimate and read the total back, so the second sees the
+// first's hold and backs out rather than both fitting the same remainder.
+
+const REASON = 'spend_cap_exceeded';
+const ACTION = 'model.call';
+const money = (n) => Math.round(Number(n || 0) * 10000) / 10000;
+const dollars = (n) => `$${money(n).toFixed(4)}`;
+
+const billed = (run) => run.viaAccount !== 'personal' && run.viaAccount !== 'local';
+
+const hold = (companyId, runId, usd) => runs.patch(companyId, runId, {}, { $inc: { reservedUsd: money(usd) } });
+
+const refusal = ({ estimate, cap, limit, remaining }) => {
+    const reason = `${REASON}: the next call is estimated at ${dollars(estimate.costUsd)} (${estimate.totalTokens} tokens) but the ${cap} cap of ${dollars(limit)} has ${dollars(remaining)} left`;
+    return { ok: false, code: REASON, reason, cap, limit: money(limit), remaining: money(remaining), estimate };
+};
+
+const forRun = ({ companyId, run, actor }) => {
+    const runId = run._id;
+    const cap = Number(run.spendCapUsd) > 0 ? Number(run.spendCapUsd) : 0;
+
+    const exceeded = async (held, usd) => {
+        const spent = money(held.spend && held.spend.usd);
+        const others = money(Number(held.reservedUsd || 0) - usd);
+        if (cap && money(spent + others + usd) > cap) return { cap: 'run', limit: cap, remaining: cap - spent - others };
+        const month = await budget.headroom(companyId);
+        if (month.budgetUsd > 0 && money(month.usedUsd + month.reservedUsd) > month.budgetUsd) {
+            return { cap: 'company', limit: month.budgetUsd, remaining: month.budgetUsd - month.usedUsd - (month.reservedUsd - usd) };
+        }
+        return null;
+    };
+
+    const audit = (ticket) => agentAudit.recordRefusal(companyId, actor || { kind: 'agent', agentId: run.agentId, agentName: run.agentName, runId: String(runId), viaAccount: run.viaAccount }, {
+        action: ACTION, reason: ticket.reason, entityType: 'agent_run', entityId: runId,
+        params: { runId: String(runId), cap: ticket.cap, limitUsd: ticket.limit, remainingUsd: ticket.remaining, estimatedUsd: money(ticket.estimate.costUsd), estimatedTokens: ticket.estimate.totalTokens, model: ticket.estimate.model },
+    });
+
+    return {
+        async reserve(estimate) {
+            if (!billed(run)) return { ok: true, usd: 0, estimate };
+            if (!estimate.priced) {
+                const reason = usage.unpricedMessage(estimate.model);
+                const ticket = { ok: false, code: usage.UNPRICED_MODEL, reason, cap: 'run', limit: cap, remaining: cap, estimate };
+                await audit(ticket);
+                return ticket;
+            }
+            const usd = money(estimate.costUsd);
+            const held = await hold(companyId, runId, usd);
+            if (!held) return { ok: false, code: 'run_missing', reason: 'the run no longer exists', estimate };
+            const over = await exceeded(held, usd);
+            if (!over) return { ok: true, usd, estimate };
+            await hold(companyId, runId, -usd);
+            const ticket = refusal({ estimate, ...over });
+            logger.info(`[agent-run] ${runId}: ${ticket.reason}`);
+            await audit(ticket);
+            return ticket;
+        },
+        async reconcile(ticket, tally, model) {
+            if (!ticket.usd) return;
+            const actual = usage.summarize(tally || {}, model || ticket.estimate.model);
+            const inc = { reservedUsd: -ticket.usd, 'spend.usd': actual.priced ? money(actual.costUsd) : 0, 'spend.tokens': actual.totalTokens };
+            await runs.patch(companyId, runId, {}, { $inc: inc });
+        },
+        async release(ticket) {
+            if (!ticket.usd) return;
+            await hold(companyId, runId, -ticket.usd);
+        },
+    };
+};
+
+module.exports = { forRun, REASON, ACTION };

--- a/Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md
+++ b/Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md
@@ -18,6 +18,7 @@ One pull request per step; tick with the merge commit.
 | Date | Entry |
 |---|---|
 | 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 1) |
+| 2026-09-11 | Step 6 on `fix/s1-precall-spend-cap`: `Modules/AICore/estimate.js` prices a call before it is made; `Modules/Agents/spendGuard.js` reserves it on the run (`reservedUsd`, atomic `$inc`), refuses over the run cap or the company month as `spend_cap_exceeded` with an audit row, reconciles to the real cost after. Reproduced on beta first: the fake provider was called for a run capped under its estimate. Closes defect 15 and 006's "spend cap evaluated after the model call". |
 
 ## Last step
 Not started.

--- a/tests/agent-graph.test.js
+++ b/tests/agent-graph.test.js
@@ -78,7 +78,7 @@ describe('a run is a LangGraph thread', () => {
         expect(proposalRows()[0]).toMatchObject({ _id: out.proposalId, runId: String(run._id), what: 'plan: 2 change(s) on AR-1', why: 'planned', cost: { usd: 0.01, tokens: 100, model: 'm' } });
 
         expect(memory.contextFor).toHaveBeenCalledWith({ companyId: C, projectId: 'p1', userId: 'u1' });
-        expect(orchestrator.analyse).toHaveBeenCalledWith({ skillSlug: 'plan', task: TASK, context: { projectName: 'Launch', memory: expect.stringContaining('Budget is fixed') }, budget: { maxTokens: 4000 } });
+        expect(orchestrator.analyse).toHaveBeenCalledWith({ skillSlug: 'plan', task: TASK, context: { projectName: 'Launch', memory: expect.stringContaining('Budget is fixed') }, budget: { maxTokens: 4000, guard: expect.objectContaining({ reserve: expect.any(Function), reconcile: expect.any(Function), release: expect.any(Function) }) } });
 
         const thread = await threadOf(C, run);
         expect(thread.next).toEqual(['hold']);

--- a/tests/agent-spend-precall.test.js
+++ b/tests/agent-spend-precall.test.js
@@ -1,0 +1,197 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../Config/permissionGuard', () => ({ ROLE_OWNER: 1, ROLE_ADMIN: 2, getRoleType: jest.fn(async () => 1), isPrivileged: (r) => r === 1 || r === 2 }));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+jest.mock('../Modules/notification/prepare-notification-data/controllerV2', () => ({ handleNotificationtFun: jest.fn(async () => ({ status: true })) }));
+jest.mock('../Modules/AICore/llmProvider', () => ({ getProvider: jest.fn(), isAnyProviderConfigured: jest.fn(() => true) }));
+jest.mock('../Modules/Agents/engine/pageAudit', () => ({ ...jest.requireActual('../Modules/Agents/engine/pageAudit'), audit: jest.fn() }));
+jest.mock('../Modules/Agents/engine/findingMemory', () => ({ load: jest.fn(async () => new Map()), decide: jest.fn(), record: jest.fn(), touch: jest.fn() }));
+jest.mock('../Modules/Agents/memory', () => ({ contextFor: jest.fn(async () => ''), recordEpisode: jest.fn(async () => null) }));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { dbCollections } = require('../Config/collections');
+const { getProvider } = require('../Modules/AICore/llmProvider');
+const { estimateCall } = require('../Modules/AICore/estimate');
+const pageAudit = require('../Modules/Agents/engine/pageAudit');
+const findingMemory = require('../Modules/Agents/engine/findingMemory');
+const persistence = require('../Modules/Agents/engine/persistence');
+const runs = require('../Modules/Agents/runs');
+const spendGuard = require('../Modules/Agents/spendGuard');
+
+const C = '6f0000000000000000000c01';
+const AGENT_ID = '6f0000000000000000000a01';
+const MODEL = 'gpt-4.1';
+const TASK = { _id: '6f0000000000000000000701', TaskName: 'Review https://example.com', TaskKey: 'AR-1', ProjectID: 'p1' };
+const agent = (over = {}) => ({ _id: AGENT_ID, name: 'Reviewer', autonomy: 1, allowedActions: [], projectIds: [], account: 'workspace', spendCapUsd: 0, paused: false, deletedStatusKey: 0, ...over });
+const actor = { kind: 'agent', userId: 'u1', agentId: AGENT_ID, agentName: 'Reviewer', runId: null, viaAccount: 'workspace', tokenId: null };
+const answer = { summary: 'one issue', findings: [{ factId: 'f1', title: 'Missing alt', severity: 'high', why: 'w' }] };
+
+const reply = (over = {}) => ({ content: JSON.stringify(answer), inputTokens: 1000, outputTokens: 500, model: MODEL, ...over });
+const chat = jest.fn();
+const provider = { name: 'openai', model: MODEL, isConfigured: true, chat };
+const deps = () => ({ proposals: { create: jest.fn(async () => ({ _id: 'prop1' })) }, actions: { perform: jest.fn(async () => ({ auditId: 'aud1', result: {} })) }, actor });
+const runRow = (id) => mockDb.store[SCHEMA_TYPE.AGENT_RUNS].find((r) => String(r._id) === String(id));
+const refusalRows = () => (mockDb.store[SCHEMA_TYPE.AUDIT_LOGS] || []).filter((r) => r.action === 'agent.action_refused');
+const start = (over = {}) => runs.create(C, { agent: agent(), taskId: TASK._id, projectId: 'p1', skill: 'qa-review', startedBy: 'u1', ...over });
+const execute = (run) => runs.executeSkill(C, run, agent(), TASK, deps());
+const money = (n) => Math.round(n * 10000) / 10000;
+
+/* The first (and only) request the fake vendor received, priced the way the guard priced it. */
+const estimateOfRequest = () => estimateCall({ ...chat.mock.calls[0][0], model: MODEL });
+
+let mem;
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    jest.clearAllMocks();
+    mem = persistence.useInMemory();
+    getProvider.mockReturnValue(provider);
+    chat.mockResolvedValue(reply());
+    pageAudit.audit.mockResolvedValue({ ok: true, facts: [{ id: 'f1', ok: false, detail: 'img without alt' }, { id: 'title', ok: true, detail: 'has title' }], blindSpots: [] });
+    findingMemory.decide.mockImplementation(async (companyId, taskId, findings) => findings.map((f) => ({ finding: f, action: 'file', reason: 'new' })));
+    mockDb.seed(SCHEMA_TYPE.AGENTS, agent());
+    mockDb.seed(dbCollections.COMPANIES, { _id: C });
+});
+afterEach(() => { mem.reset(); persistence.useMongo(); });
+
+describe('the run spend cap is checked before the model call (defect 15)', () => {
+    it('a call estimated over the run cap never reaches the vendor and the run stops as spend_cap_exceeded', async () => {
+        const run = await start({ spendCapUsd: 0.01 });
+        const out = await execute(run);
+
+        expect(chat).not.toHaveBeenCalled();
+        expect(out.status).toBe('stopped');
+        expect(out.outcome).toMatch(/^spend_cap_exceeded: the next call is estimated at \$0\.0\d{3} \(\d+ tokens\) but the run cap of \$0\.0100 has \$0\.0100 left$/);
+
+        const row = runRow(run._id);
+        expect(row).toMatchObject({ status: 'stopped', outcome: out.outcome, reservedUsd: 0, spend: { usd: 0, tokens: 0 } });
+        expect(row.finishedAt).toBeInstanceOf(Date);
+        expect(row.expiresAt).toBeInstanceOf(Date);
+
+        expect(refusalRows()).toHaveLength(1);
+        expect(refusalRows()[0]).toMatchObject({
+            actorId: AGENT_ID, entityType: 'agent_run', entityId: String(run._id),
+            meta: { actorType: 'agent', agentId: AGENT_ID, action: 'model.call', reason: out.outcome, ran: false, params: { cap: 'run', limitUsd: 0.01, remainingUsd: 0.01, model: MODEL, estimatedTokens: expect.any(Number), estimatedUsd: expect.any(Number) } },
+        });
+        expect(refusalRows()[0].meta.params.estimatedUsd).toBeGreaterThan(0.01);
+    });
+
+    it('counts what the run already spent: a second call that would cross the cap is refused', async () => {
+        const run = await start({ spendCapUsd: 0.05 });
+        await runs.patch(C, run._id, { 'spend.usd': 0.03 });
+        const out = await execute(run);
+        expect(chat).not.toHaveBeenCalled();
+        expect(out.outcome).toMatch(/the run cap of \$0\.0500 has \$0\.0200 left$/);
+    });
+
+    it('a call estimated over the company\'s remaining monthly budget is refused naming the company cap', async () => {
+        mockDb.store[dbCollections.COMPANIES][0].agentMonthlyBudgetUsd = 0.05;
+        mockDb.seed(SCHEMA_TYPE.AGENT_RUNS, { agentId: AGENT_ID, status: 'done', startedAt: new Date(), viaAccount: 'workspace', spend: { usd: 0.03, tokens: 10, billedToWorkspace: true } });
+        const run = await start();
+        const out = await execute(run);
+
+        expect(chat).not.toHaveBeenCalled();
+        expect(out).toMatchObject({ status: 'stopped', outcome: expect.stringMatching(/the company cap of \$0\.0500 has \$0\.0200 left$/) });
+        expect(refusalRows()[0].meta.params).toMatchObject({ cap: 'company', limitUsd: 0.05, remainingUsd: 0.02 });
+        expect(runRow(run._id).reservedUsd).toBe(0);
+    });
+
+    it('a call that fits is made once, held for its estimate while in flight, then reconciled to the real cost', async () => {
+        let heldDuringCall = null;
+        const run = await start({ spendCapUsd: 1 });
+        chat.mockImplementation(async () => { heldDuringCall = runRow(run._id).reservedUsd; return reply(); });
+
+        const out = await execute(run);
+        expect(chat).toHaveBeenCalledTimes(1);
+        expect(chat.mock.calls[0][0]).toMatchObject({ maxTokens: 4000, jsonMode: true });
+        expect(out.status).toBe('waiting_approval');
+
+        const estimate = estimateOfRequest();
+        expect(estimate.costUsd).toBeGreaterThan(0.032);
+        expect(heldDuringCall).toBe(estimate.costUsd);
+        expect(runRow(run._id)).toMatchObject({ reservedUsd: 0, spend: { usd: 0.006, tokens: 1500, model: MODEL } });
+        expect(refusalRows()).toHaveLength(0);
+    });
+
+    it('a failed vendor call releases the reservation and books nothing', async () => {
+        const run = await start({ spendCapUsd: 1 });
+        chat.mockRejectedValue(new Error('upstream 503'));
+        await execute(run);
+        expect(chat).toHaveBeenCalledTimes(1);
+        expect(runRow(run._id)).toMatchObject({ reservedUsd: 0, spend: { usd: 0, tokens: 0 } });
+    });
+
+    it('the post-call check stays: an under-estimated call still stops the run once the real cost is booked', async () => {
+        const run = await start({ spendCapUsd: 0.05 });
+        chat.mockResolvedValue(reply({ outputTokens: 20000 }));
+        const out = await execute(run);
+        expect(chat).toHaveBeenCalledTimes(1);
+        expect(out).toMatchObject({ status: 'stopped', outcome: 'Run spend cap reached ($0.16 of $0.05)' });
+        expect(runRow(run._id)).toMatchObject({ status: 'stopped', reservedUsd: 0, spend: { usd: 0.162 } });
+    });
+
+    it('a run without a cap under a company without a budget is not gated', async () => {
+        const run = await start();
+        const out = await execute(run);
+        expect(chat).toHaveBeenCalledTimes(1);
+        expect(out.status).toBe('waiting_approval');
+    });
+});
+
+describe('the reservation is atomic on the run row', () => {
+    const estimate = { priced: true, costUsd: 0.03, totalTokens: 1234, model: MODEL, inputTokens: 234, outputTokens: 1000 };
+
+    it('two concurrent calls inside one run cannot both fit the same remainder', async () => {
+        const run = await start({ spendCapUsd: 0.05 });
+        const guard = spendGuard.forRun({ companyId: C, run, actor });
+        const [first, second] = await Promise.all([guard.reserve(estimate), guard.reserve(estimate)]);
+
+        expect(first).toEqual({ ok: true, usd: 0.03, estimate });
+        expect(second).toMatchObject({ ok: false, code: 'spend_cap_exceeded', cap: 'run', limit: 0.05, remaining: 0.02 });
+        expect(second.reason).toBe('spend_cap_exceeded: the next call is estimated at $0.0300 (1234 tokens) but the run cap of $0.0500 has $0.0200 left');
+        expect(runRow(run._id).reservedUsd).toBe(0.03);
+        expect(refusalRows()).toHaveLength(1);
+    });
+
+    it('reconcile replaces the reservation with the actual cost; release drops it', async () => {
+        const run = await start({ spendCapUsd: 0.05 });
+        const guard = spendGuard.forRun({ companyId: C, run, actor });
+        const ticket = await guard.reserve(estimate);
+        expect(runRow(run._id).reservedUsd).toBe(0.03);
+
+        await guard.reconcile(ticket, { inputTokens: 1000, outputTokens: 500 }, MODEL);
+        expect(runRow(run._id)).toMatchObject({ reservedUsd: 0, spend: { usd: 0.006, tokens: 1500 } });
+
+        const again = await guard.reserve(estimate);
+        expect(again.ok).toBe(true);
+        expect(runRow(run._id).reservedUsd).toBe(0.03);
+        await guard.release(again);
+        expect(runRow(run._id)).toMatchObject({ reservedUsd: 0, spend: { usd: 0.006 } });
+    });
+
+    it('a company budget counts other open runs\' reservations too', async () => {
+        mockDb.store[dbCollections.COMPANIES][0].agentMonthlyBudgetUsd = 0.05;
+        mockDb.seed(SCHEMA_TYPE.AGENT_RUNS, { agentId: AGENT_ID, status: 'running', startedAt: new Date(), viaAccount: 'workspace', spend: { usd: 0 }, reservedUsd: 0.03 });
+        mockDb.seed(SCHEMA_TYPE.AGENT_RUNS, { agentId: AGENT_ID, status: 'done', startedAt: new Date(), viaAccount: 'workspace', spend: { usd: 0 }, reservedUsd: 0.5 });
+        const run = await start();
+        const ticket = await spendGuard.forRun({ companyId: C, run, actor }).reserve(estimate);
+        expect(ticket).toMatchObject({ ok: false, cap: 'company', limit: 0.05, remaining: money(0.02) });
+        expect(runRow(run._id).reservedUsd).toBe(0);
+    });
+
+    it('an unpriced model is refused before any token is bought', async () => {
+        const run = await start({ spendCapUsd: 1 });
+        const ticket = await spendGuard.forRun({ companyId: C, run, actor }).reserve({ ...estimate, priced: false, costUsd: null, model: 'gpt-9-mystery' });
+        expect(ticket).toMatchObject({ ok: false, code: 'unpriced_model', reason: expect.stringContaining('No price on file for gpt-9-mystery') });
+        expect(refusalRows()).toHaveLength(1);
+    });
+
+    it('a personal or local run is not held against the workspace caps', async () => {
+        const run = await start({ spendCapUsd: 0.001, viaAccount: 'personal' });
+        const ticket = await spendGuard.forRun({ companyId: C, run, actor }).reserve(estimate);
+        expect(ticket).toEqual({ ok: true, usd: 0, estimate });
+        expect(runRow(run._id).reservedUsd).toBe(0);
+    });
+});

--- a/tests/ai-core-estimate.test.js
+++ b/tests/ai-core-estimate.test.js
@@ -1,0 +1,72 @@
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../Modules/AICore/llmProvider', () => ({ getProvider: jest.fn(() => ({ name: 'openai', model: 'gpt-4.1', isConfigured: true })), isAnyProviderConfigured: jest.fn(() => true) }));
+
+const estimate = require('../Modules/AICore/estimate');
+const usage = require('../Modules/AICore/usage');
+
+const { estimateTokens, estimateCall, CHARS_PER_TOKEN, SAFETY_FACTOR, PER_MESSAGE_OVERHEAD_TOKENS } = estimate;
+
+describe('estimateTokens sizes text from characters with a safety factor', () => {
+    it('is chars / 4 * 1.25, rounded up, and zero for nothing', () => {
+        expect(CHARS_PER_TOKEN).toBe(4);
+        expect(SAFETY_FACTOR).toBe(1.25);
+        expect(estimateTokens('')).toBe(0);
+        expect(estimateTokens(null)).toBe(0);
+        expect(estimateTokens(undefined)).toBe(0);
+        expect(estimateTokens('abcd')).toBe(2);
+        expect(estimateTokens('x'.repeat(400))).toBe(125);
+        expect(estimateTokens('x'.repeat(401))).toBe(126);
+    });
+
+    it('sizes non-string content from its JSON form', () => {
+        const value = { a: 1, b: 'two' };
+        expect(estimateTokens(value)).toBe(estimateTokens(JSON.stringify(value)));
+    });
+
+    it('is deterministic', () => {
+        const text = 'The quick brown fox jumps over the lazy dog. '.repeat(50);
+        expect(estimateTokens(text)).toBe(estimateTokens(text));
+    });
+});
+
+describe('estimateCall prices the prompt plus the configured maximum output', () => {
+    const system = 's'.repeat(800);
+    const prompt = 'p'.repeat(1200);
+
+    it('adds the system prompt, every message with its overhead, and maxTokens as output', () => {
+        const out = estimateCall({ systemPrompt: system, messages: [{ role: 'user', content: prompt }], maxTokens: 4000, model: 'gpt-4.1' });
+        const inputTokens = estimateTokens(system) + estimateTokens(prompt) + PER_MESSAGE_OVERHEAD_TOKENS;
+        expect(out).toEqual({
+            inputTokens, outputTokens: 4000, totalTokens: inputTokens + 4000, model: 'gpt-4.1', priced: true,
+            costUsd: usage.summarize({ inputTokens, outputTokens: 4000 }, 'gpt-4.1').costUsd,
+        });
+        expect(out.inputTokens).toBe(250 + 375 + 4);
+        expect(out.costUsd).toBe(Math.round(((629 / 1e6) * 2 + (4000 / 1e6) * 8) * 10000) / 10000);
+    });
+
+    it('accepts a bare prompt in place of messages and counts one turn', () => {
+        const a = estimateCall({ prompt, maxTokens: 10, model: 'gpt-4.1' });
+        const b = estimateCall({ messages: [{ role: 'user', content: prompt }], maxTokens: 10, model: 'gpt-4.1' });
+        expect(a).toEqual(b);
+        expect(a.inputTokens).toBe(375 + PER_MESSAGE_OVERHEAD_TOKENS);
+    });
+
+    it('treats a missing or junk maxTokens as no output and never goes negative', () => {
+        expect(estimateCall({ prompt: 'hi', model: 'gpt-4.1' }).outputTokens).toBe(0);
+        expect(estimateCall({ prompt: 'hi', maxTokens: 'lots', model: 'gpt-4.1' }).outputTokens).toBe(0);
+        expect(estimateCall({ prompt: 'hi', maxTokens: -5, model: 'gpt-4.1' }).outputTokens).toBe(0);
+    });
+
+    it('falls back to the configured model when none is named', () => {
+        expect(estimateCall({ prompt: 'hi', maxTokens: 100 })).toMatchObject({ model: 'gpt-4.1', priced: true });
+    });
+
+    it('reports an unknown model as unpriced rather than free', () => {
+        expect(estimateCall({ prompt, maxTokens: 4000, model: 'gpt-9-mystery' })).toMatchObject({ priced: false, costUsd: null, model: 'gpt-9-mystery' });
+    });
+
+    it('is deterministic for the same request', () => {
+        const request = { systemPrompt: system, messages: [{ role: 'user', content: prompt }], maxTokens: 4000, model: 'claude-sonnet-4-6' };
+        expect(estimateCall(request)).toEqual(estimateCall(request));
+    });
+});

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -824,6 +824,8 @@ const schema = {
         elapsedMs: { type: Number, default: 0, required: false },
         // { tokens, usd, model, billedToWorkspace }
         spend: { type: Object, required: false },
+        // Estimated cost of the model calls in flight, held against the caps until each settles
+        reservedUsd: { type: Number, default: 0, required: false },
         actions: { type: Array, default: [], required: false },
         proposals: { type: Array, default: [], required: false },
         refusals: { type: Number, default: 0, required: false },


### PR DESCRIPTION
## Summary

Sprint 1, step 6 of task 024. **Closes defect 15** — the run spend cap (`run.spendCapUsd`) and the tenant monthly budget were evaluated only after the model returned, so they could stop the acting phase but never the spend. Also closes 006's remaining item **"spend cap evaluated after the model call"**.

- `Modules/AICore/estimate.js` — `estimateCall()` prices a call before it is made: input from the system prompt and every message at chars/4 with a 1.25 safety factor (no tokenizer dependency ships; the rationale is documented in the file), output at the configured `maxTokens`, cost via `usage.priceFor`. Deterministic; an unknown model comes back `priced: false`, never free.
- `Modules/Agents/spendGuard.js` — per-run guard `{ reserve, reconcile, release }`. `reserve` adds the estimate to the new `reservedUsd` field on the run row with an atomic `$inc`, reads the total back, and refuses when `spend.usd + reservedUsd` exceeds the run cap or when the company's month (`budget.headroom`: spend plus open runs' reservations) is exceeded. A refusal rolls the hold back, is logged, and writes an `agent.action_refused` audit row (`meta.action: 'model.call'`, cap, limit, remaining, estimate). `reconcile` swaps the reservation for the real cost; `release` drops it after a failed call.
- `Modules/AICore/modelCall.js` — `askModel` takes the guard through `budget.guard`, reserves before `provider.chat`, returns `refused` without calling the vendor, reconciles after, releases in the catch. The provider factory's `chat()` is untouched, so `feat/s1-spend-at-core` merges cleanly.
- `Modules/Agents/engine/orchestrator.js` — a refused call becomes a `status: 'refused'` result (no deterministic fallback for the page audit; a refusal is not a degraded call).
- `Modules/Agents/engine/graph.js` — a refused result finishes the run `stopped` with the guard's reason (through `remember` → `runs.finish`); the existing post-call cap check stays as the reconcile step and still catches an under-estimate.
- Schema: `agentRuns.reservedUsd` (Number, default 0); `runs.create` initialises it.

Refusal reason format: `spend_cap_exceeded: the next call is estimated at $0.0353 (4620 tokens) but the run cap of $0.0100 has $0.0100 left` (or `the company cap of …`).

## Reproduction

`tests/agent-spend-precall.test.js` — "a call estimated over the run cap never reaches the vendor". A `qa-review` run with `spendCapUsd: 0.01` on `gpt-4.1` (max output 4000 tokens ≈ $0.032 alone) is executed against a fake provider. On beta the suite was run with the source stashed: the fake provider is called (`Expected number of calls: 0, Received: 1`) and the run only stops afterwards. With this change the provider is never called, the run finishes `stopped` with `spend_cap_exceeded`, `reservedUsd` is back to 0 and one refusal audit row exists.

## Tests

- `tests/ai-core-estimate.test.js` — estimator units (chars/4 × 1.25, per-message overhead, max output, pricing, unpriced, determinism).
- `tests/agent-spend-precall.test.js` — refusal on the run cap, on already-spent run cost, on the company month; a fitting call is held for its estimate during the vendor call and reconciled to the real cost; a failed call releases; the post-call check still stops an under-estimate; concurrent reserves inside one run cannot both fit; other open runs' reservations count against the company budget; unpriced model refused; personal/local runs not held.
- `tests/agent-graph.test.js` — the one exact-match assertion on `budget` now expects the guard.

`npx jest --selectProjects unit`: 149 suites, 1800 tests green. `npx jest tests/conventions`: 8 suites, 92 tests green. eslint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
