### PR TITLE
docs(024): record the sprint 1 pull requests and gates

### DIFF
--- a/Tasks/HANDOFF.md
+++ b/Tasks/HANDOFF.md
@@ -1,12 +1,13 @@
 # Handoff — where to start next session
 
-Updated 2026-09-10. Read this first, then `Tasks/index.md`. Overwrite this file at the end of every session.
+Updated 2026-09-11. Read this first, then `Tasks/index.md`. Overwrite this file at the end of every session.
 
-## State of `beta` (94dc7df7)
+## State of `beta` (3dc9d97f)
 
+- Sprint 1 (task 024) is **code-complete and merged**: PRs #566–#572, one per step. `Modules/AICore/` exists with shims at the old paths; consumers are not yet repointed. Progress ticked in `Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md`.
 - Sprint 0 (task 023) is **code-complete and merged**: PRs #555–#562, one per step, each with a test that reproduced its defect first. Progress ticked in `Tasks/active/023-sprint-0-stop-the-bleeding/progress.md`.
 - Task 017 (agent memory and the run engine on LangGraph JS) merged via #552. ADR 003 and `docs/AI-PLATFORM-ARCHITECTURE.md` merged via #554. The twelve sprint tasks (023–032, rewritten 018/019) merged via #553.
-- All gates green on merged beta: backend jest 144 suites / 1766 tests, `tests/conventions` 88, frontend vitest 126, `npm run i18n:check` exit 0, eslint 0 errors, `vue-cli-service build` done.
+- All gates green on merged beta: backend jest 155 suites / 1857 tests, `tests/conventions` 92, frontend vitest 129, `npm run i18n:check` exit 0, eslint 0 errors, `vue-cli-service build` done.
 - No open PRs. No unmerged branches with work on them.
 
 ## Still open on task 023 (needs the live environment, owner does these)
@@ -15,23 +16,25 @@ Updated 2026-09-10. Read this first, then `Tasks/index.md`. Overwrite this file 
 2. The in-process sweep with the real model: confirm every configured provider books a non-zero cost, and that an unpriced model is refused with the named reason.
 3. Owner and member browser sweep of the undo deadline: run detail page and Settings → Audit log; record it in 023's progress.md, then move 023 to `done/`.
 
-## Next: Sprint 1 — task 024 (`Tasks/backlog/024-sprint-1-shared-core-run-correctness/`)
+## Still open on task 024 (Sprint 1)
 
-Move it to `active/` and work the seven scope steps, one PR each, from `beta`:
-1. `Modules/AICore/` with re-export shims (provider factory, usage/pricing, instruction guard, single model call, persistence factory); `Modules/ProjectTemplates/controller.js` onto the factory.
-2. Run idempotency key + in-flight claim (partial unique index, duplicate-key catch) and a reaper for proposals stuck in applying.
-3. Job lock aligned with the model timeout; missing server timeouts set.
-4. Loop depth threaded from the envelope through agent actions (`Modules/Agents/actions.js` context).
-5. Spend recorded at the core boundary for every AI feature.
-6. Run spend cap checked before the model call from a token estimate, reconciled after.
-7. `agent_runs` TTL keyed to terminal status only (`utils/mongo-handler/createSchema.js`).
+1. Repoint the thirteen consumers off the shim paths (`Modules/AIProjectGenerator/usage.js`, `llmProvider/`, `instructionGuard.js`, `Modules/Agents/engine/persistence.js`) onto `Modules/AICore/`, one module per PR, then delete the shims and the allowlist entries in `tests/conventions/ai-core-boundary.test.js`.
+2. `npm run migrate -- up` on the dev database (migration `008-agent-run-expiry`, after 007).
+3. In-process sweep with the real model; owner and member sweep of the Instance console → AI agents spend card; then move 024 to `done/`.
 
-Cross-links to tick when done: 006 progress "Budgets enforced pre-call + usage accounting" (step 5) and "Evaluate `run.spendCapUsd` before the model call" (step 6).
+## Next: Sprint 2 — task 025 (`Tasks/backlog/025-sprint-2-revisions-and-skill-record/`)
+
+Move it to `active/` and work its four steps, one PR each, from `beta`:
+1. Immutable agent and skill revisions; a run pins both at start; promote and rollback endpoints; states draft, candidate, live, superseded.
+2. The `agent_skills` record, its validator, the frozen catalogues, the `GET /api/v2/agents/skills` manifest, hybrid `getSkill` honouring `enabled: false`.
+3. Save-time validation of emitted actions; effective actions = skill ∩ agent.allowedActions ∩ registry.
+4. `brief.parse` re-expressed as a data skill.
 
 ## Things learned today that affect the next session
 
 - Merging PRs needs the owner's say-so each session; the auto-mode classifier denies `gh pr merge` otherwise.
 - Agent worktrees have no `node_modules` and cannot source nvm; give agents `PATH="$HOME/.nvm/versions/node/v20.20.2/bin:<repo>/node_modules/.bin:$PATH"` and let them symlink the parent's `node_modules` (root and `frontend/`) without committing it. Husky's pre-push rejects a detached HEAD; rebase on a throwaway branch and push `HEAD:<branch>`.
+- Every Sprint 1 step touched `agent_runs`, so parallel branches conflicted in turn; when several PRs share a schema file, merge them in order and rebase each on the freshly merged beta (an agent per rebase works well).
 - The frontend builds with `vue-cli-service build`, not vite. The "magic comment" warnings in that build are pre-existing.
 - Approximate permission mappings in `Modules/Agents/registry.js` (reminder.create, page.draft, docs.read, chat.post, task.link, deploy.staging) are documented in PR #560 and worth a reviewer's eye during Sprint 8.
 - `markUndone` in `Modules/Agents/undo.js` still swallows its own failure; scheduled for Sprint 8 (task 031), not a Sprint 0 gap.

--- a/Tasks/active/006-agent-engine-foundation/progress.md
+++ b/Tasks/active/006-agent-engine-foundation/progress.md
@@ -9,12 +9,12 @@
 - [x] Toolbelt scoping on top of task 005's tool layer
 - [x] 5-phase orchestrator
 - [x] Verifier: evidence gate, dedup, volume cap (confidence floor not built — severity is used instead)
-- [ ] Budgets enforced pre-call + usage accounting
+- [x] Budgets enforced pre-call + usage accounting — done in 024 (#571, #572)
 - [x] `run_agent` action (synchronous, so `waitForResult` is implicit)
 - [ ] Review inbox + `AGENT_REVIEW_ITEMS`
 - [ ] Two-week trial on a real sprint — folds into 019 (evals)
 - [ ] Prompt-injection regression test on the agent run path
-- [ ] Evaluate `run.spendCapUsd` before the model call
+- [x] Evaluate `run.spendCapUsd` before the model call — done in 024 (#571)
 - [ ] Confidence floor in `verify()`
 
 ## Last step

--- a/Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md
+++ b/Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md
@@ -3,23 +3,25 @@
 ## Checklist
 One pull request per step; tick with the merge commit.
 
-- [ ] Step 1: Move the provider factory, usage and pricing, the instruction guard, the single model call and the persistence
-- [ ] Step 2: Agent runs gain an idempotency key and an in-flight claim: a partial unique index on agent, task and open stat
-- [ ] Step 3: Align the job lock with the model timeout per job, and set the server-level timeouts that are missing today.
-- [ ] Step 4: Thread loop depth from the originating envelope through agent actions instead of resetting it to zero
-- [ ] Step 5: Record spend at the core boundary so every AI feature, not only agent runs, reaches the budget.
-- [ ] Step 6: Check the run spend cap before the model call from a token estimate, and reconcile after.
-- [ ] Step 7: (added) The run collection's expiry is keyed to terminal status only, so a run waiting on a person is never de
-- [ ] Interface: Instance console → AI agents (extend)
-- [ ] Defects closed: #12, #13, #14, #15, #16, #18
-- [ ] Exit gate met and gates green
+- [x] Step 1: `Modules/AICore/` (provider factory, usage, instruction guard, `modelCall`, persistence) with shims at every old path; ProjectTemplates onto the factory; boundary conventions test — #566 `db21784a`. Consumers still on the shim paths; repoint and shim deletion pending (1a–1n)
+- [x] Step 2: `idempotencyKey`, partial unique indexes, `runs.start` insert-and-catch, reaper `agent.reap-stuck-proposals` every 5 min — #570 `bacb9207`
+- [x] Step 3: `Modules/Agents/engine/timeouts.js`; Agenda `lockLifetime` 17 min with `job.touch()` between graph nodes; server, SSE and Mongo timeouts — #569 `0a13449c`
+- [x] Step 4: `triggerDepth`/`triggerEventId` on the run; `canStart` refuses `loop_depth_exceeded` at depth 3; actions emit depth + 1 — #568 `8b84214c`
+- [x] Step 5: `Modules/AICore/spend.js` meters every `chat()` into `ai_usage` by feature; budget sums the ledger; Instance console per-feature breakdown — #572 `3dc9d97f`
+- [x] Step 6: `Modules/AICore/estimate.js` + `spendGuard` reserve/reconcile/release on `reservedUsd`; `spend_cap_exceeded` before the vendor call — #571 `8d618a29`
+- [x] Step 7: `expiresAt` set only by `terminalUpdate`; migration `008-agent-run-expiry`; approve refuses `run_missing` — #567 `03675ee7`
+- [x] Interface: Instance console → AI agents (extend) — per-feature spend in #572; owner and member sweep still to record
+- [x] Defects closed: #12 (#570), #13 (#569), #14 (#568), #15 (#571), #16 (#567), #18 (#572)
+- [ ] Exit gate met and gates green — code gates green on `beta` at `3dc9d97f`; migration 008, the in-process sweep, and the owner/member sweeps still to run; consumer repoint and shim deletion still open
 
 ## Log
 | Date | Entry |
 |---|---|
 | 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 1) |
+| 2026-09-11 | Steps 1–7 merged into `beta` as seven PRs (#566–#572). Four needed a rebase over the run-schema changes (#568, #569, #570, #571, #572 in turn) because every step touched `agent_runs`. Gates on merged beta: backend 155 suites / 1857 tests, conventions 92, frontend vitest 129, `npm run i18n:check` exit 0, eslint 0 errors, `vue-cli-service build` done. Cross-links to tick on 006: budgets pre-call (step 6) and usage accounting (step 5). |
+| 2026-09-11 | Deviations: `trigger.depth` stored flat as `triggerDepth` because `trigger` is a string enum; `transcribe.js` and `probes.js` still name a vendor host (allowlisted, not chat calls); the reaper also fails the run waiting on a stuck proposal; the pre-call guard exempts personal and local accounts; migration 008 uses `syncIndexes`, which drops any undeclared index on `agent_runs`. |
 | 2026-09-11 | Step 5 on `feat/s1-spend-at-core`: `Modules/AICore/spend.js` meters every `chat()` into a new `ai_usage` collection keyed by feature (`Modules/AICore/features.js`); `budget.js` sums the ledger; Instance console card shows spend per feature. Closes defect #18. |
 | 2026-09-11 | Step 6 on `fix/s1-precall-spend-cap`: `Modules/AICore/estimate.js` prices a call before it is made; `Modules/Agents/spendGuard.js` reserves it on the run (`reservedUsd`, atomic `$inc`), refuses over the run cap or the company month as `spend_cap_exceeded` with an audit row, reconciles to the real cost after. Reproduced on beta first: the fake provider was called for a run capped under its estimate. Closes defect 15 and 006's "spend cap evaluated after the model call". |
 
 ## Last step
-Step 5 implemented, awaiting review (PR from `feat/s1-spend-at-core`).
+All seven steps merged. Remaining: repoint the consumers off the shim paths one module per PR and delete the shims; run migration 008 on the dev database; the in-process sweep; the owner and member sweep of the Instance console spend card; then move 024 to `done/`.


### PR DESCRIPTION
Ticks steps 1–7 of task 024 with their merge commits (#566–#572), records the gate results on merged beta, ticks 006's two budget cross-links, and refreshes `Tasks/HANDOFF.md` with what remains on 024 and the Sprint 2 step list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)