### PR TITLE
fix(025): refuse revisions that name skills which cannot run

### DIFF
--- a/Modules/Agents/controller.js
+++ b/Modules/Agents/controller.js
@@ -233,7 +233,9 @@ exports.createRevision = async (req, res) => {
         const ctx = await revisionAccess(req, res);
         if (!ctx) return undefined;
         const body = req.body || {};
-        const row = await revisions.createDraft(ctx.companyId, ctx.agent, { fields: agentPatchFields(body), state: body.state, note: body.note, actor: ctx.actor });
+        const fields = agentPatchFields(body);
+        if (await refuseSkills(res, ctx.companyId, fields)) return undefined;
+        const row = await revisions.createDraft(ctx.companyId, ctx.agent, { fields, state: body.state, note: body.note, actor: ctx.actor });
         return res.send({ status: true, statusText: `Revision ${row.n} saved as ${row.state}.`, data: revisionRow(row) });
     } catch (e) { logger.error(`createRevision: ${e.message}`); return fail(res, e.message, e.status || 200); }
 };
@@ -246,7 +248,7 @@ exports.promoteRevision = async (req, res) => {
         const n = revisionN(req.params.n);
         if (!n) return fail(res, 'Revision not found.', 404);
         const out = await revisions.promote(ctx.companyId, ctx.agent, n, { actor: ctx.actor, ip: req.ip || '' });
-        if (out.error) return fail(res, out.error, out.status || 200);
+        if (out.error) return fail(res, out.error, out.status || 200, out.errors ? { data: { errors: out.errors } } : undefined);
         return res.send({ status: true, statusText: out.unchanged ? `Revision ${n} is already live.` : `Revision ${n} is live.`, data: { revision: revisionRow(out.revision), from: out.from, agent: out.agent || null } });
     } catch (e) { logger.error(`promoteRevision: ${e.message}`); return fail(res, e.message); }
 };
@@ -259,7 +261,7 @@ exports.rollbackRevision = async (req, res) => {
         const n = revisionN(req.params.n);
         if (!n) return fail(res, 'Revision not found.', 404);
         const out = await revisions.rollback(ctx.companyId, ctx.agent, n, { actor: ctx.actor, ip: req.ip || '', note: (req.body || {}).note });
-        if (out.error) return fail(res, out.error, out.status || 200);
+        if (out.error) return fail(res, out.error, out.status || 200, out.errors ? { data: { errors: out.errors } } : undefined);
         return res.send({ status: true, statusText: `Rolled back to revision ${n} as revision ${out.revision.n}.`, data: { revision: revisionRow(out.revision), from: out.from, rollbackOf: out.rollbackOf, agent: out.agent || null } });
     } catch (e) { logger.error(`rollbackRevision: ${e.message}`); return fail(res, e.message); }
 };

--- a/Modules/Agents/revisions.js
+++ b/Modules/Agents/revisions.js
@@ -202,6 +202,14 @@ const oidOf = (id) => {
     try { return new mongoose.Types.ObjectId(String(id)); } catch (e) { return String(id); }
 };
 
+const unrunnableSkills = async (companyId, snapshot) => {
+    const skills = (snapshot && snapshot.skills) || [];
+    // eslint-disable-next-line global-require
+    return skills.length ? require('./skillRecord').checkAgentSkills(companyId, skills) : [];
+};
+
+const refusedForSkills = (n, errors) => ({ error: `Revision ${n} names skills that cannot run.`, status: 400, errors });
+
 /* Pointer move: :n becomes live, the previous live is superseded, and the agent
  * record is written from the snapshot so everything that reads the record agrees. */
 const promote = async (companyId, agent, n, { actor, ip, kind } = {}) => {
@@ -210,6 +218,8 @@ const promote = async (companyId, agent, n, { actor, ip, kind } = {}) => {
     if (!target) return { error: 'Revision not found.', status: 404 };
     if (target.state === STATE.LIVE) return { revision: plain(target), from: Number(target.n), unchanged: true };
     if (!PROMOTABLE.includes(target.state)) return { error: `Revision ${target.n} is ${target.state}; roll back to it instead.`, status: 409 };
+    const skillErrors = await unrunnableSkills(companyId, target.snapshot);
+    if (skillErrors.length) return refusedForSkills(target.n, skillErrors);
     const from = await supersedeLive(companyId, a._id, n);
     await setState(companyId, target._id, { state: STATE.LIVE, promotedAt: new Date(), promotedBy: actor && actor.userId ? String(actor.userId) : null });
     const updatedAgent = await applyToAgent(companyId, oidOf(a._id), target.snapshot);
@@ -225,6 +235,8 @@ const rollback = async (companyId, agent, n, { actor, ip, note } = {}) => {
     const target = await getRevision(companyId, a._id, n);
     if (!target) return { error: 'Revision not found.', status: 404 };
     if (target.state === STATE.LIVE) return { error: `Revision ${target.n} is already live.`, status: 409 };
+    const skillErrors = await unrunnableSkills(companyId, target.snapshot);
+    if (skillErrors.length) return refusedForSkills(target.n, skillErrors);
     const copy = await createRevision(companyId, a._id, { snapshot: target.snapshot, state: STATE.DRAFT, createdBy: actor && actor.userId, source: SOURCE.ROLLBACK, rollbackOf: Number(target.n), note });
     const out = await promote(companyId, a, copy.n, { actor, ip, kind: SOURCE.ROLLBACK });
     return { ...out, rollbackOf: Number(target.n) };

--- a/tests/agent-revisions.test.js
+++ b/tests/agent-revisions.test.js
@@ -217,3 +217,35 @@ describe('a run pins the live revision', () => {
         expect(revisions.applyRevision(baseAgent(), await revisions.forRun(C, old)).autonomy).toBe(1);
     });
 });
+
+describe('a revision cannot name a skill that cannot run', () => {
+    const gone = [{ key: 'no-such-skill', name: 'Gone', enabled: true }];
+
+    it('POST /revisions refuses an unknown skill key and writes no revision', async () => {
+        await revisions.liveFor(C, baseAgent());
+        const r = await call(ctrl.createRevision, { body: { state: 'draft', skills: ['qa-review', 'no-such-skill'] } });
+        expect(r.code).toBe(400);
+        expect(r.body).toMatchObject({ status: false, data: { errors: [{ field: 'skills[1].key', code: 'unknown_skill' }] } });
+        expect(rows().map((x) => x.state)).toEqual(['live']);
+    });
+
+    it('promote refuses a revision whose skills no longer resolve and changes nothing', async () => {
+        await revisions.liveFor(C, baseAgent());
+        const stale = await revisions.createDraft(C, baseAgent(), { fields: { skills: gone }, state: 'candidate', actor: { userId: 'owner1' } });
+        const r = await call(ctrl.promoteRevision, { params: { id: AGENT_ID, n: String(stale.n) } });
+        expect(r.code).toBe(400);
+        expect(r.body.data.errors).toEqual([expect.objectContaining({ field: 'skills[0].key', code: 'unknown_skill' })]);
+        expect(rows().map((x) => [x.n, x.state])).toEqual([[1, 'live'], [2, 'candidate']]);
+        expect(agentRow().skills).toEqual(baseAgent().skills);
+    });
+
+    it('rollback refuses before copying, so no orphan draft is left behind', async () => {
+        await revisions.liveFor(C, baseAgent());
+        const stale = await revisions.createDraft(C, baseAgent(), { fields: { skills: gone }, state: 'draft', actor: { userId: 'owner1' } });
+        const r = await call(ctrl.rollbackRevision, { params: { id: AGENT_ID, n: String(stale.n) } });
+        expect(r.code).toBe(400);
+        expect(r.body.data.errors).toEqual([expect.objectContaining({ code: 'unknown_skill' })]);
+        expect(rows()).toHaveLength(2);
+        expect(agentRow().skills).toEqual(baseAgent().skills);
+    });
+});


### PR DESCRIPTION
## What

Closes the gap left open by #578: agent create and update refused unknown or disabled skill keys, but the revision routes from #577 did not.

- `POST /api/v2/agents/:id/revisions` runs the same skill check as create and update.
- Promote refuses a revision whose snapshot names a skill that no longer resolves. A skill can be disabled or retired after the draft was written.
- Rollback checks before copying, so a refusal leaves no orphan draft behind.

Refusals use the existing field-level shape: `{status:false, message, data:{errors:[{field, code}]}}` with `unknown_skill` or `skill_disabled`, HTTP 400.

## Reproduction

The three new tests in `tests/agent-revisions.test.js` fail on the previous source (a draft with an unknown skill was stored, then promoted live, and rollback left a copy) and pass with the fix.

## Gates

Backend unit and conventions suites green; eslint 0 errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)