### PR TITLE
docs(025): record the sprint 2 pull requests and point the handoff at sprint 3

### DIFF
--- a/Tasks/HANDOFF.md
+++ b/Tasks/HANDOFF.md
@@ -2,12 +2,14 @@
 
 Updated 2026-09-11. Read this first, then `Tasks/index.md`. Overwrite this file at the end of every session.
 
-## State of `beta` (3dc9d97f)
+## State of `beta` (4d967052)
 
+- Sprint 2 (task 025) is **code-complete and merged**: PRs #576–#580. Agents have immutable revisions pinned per run, skills are data with a validator and manifest, and `brief.parse` runs as a data skill. Progress ticked in `Tasks/active/025-sprint-2-revisions-and-skill-record/progress.md`.
+- The AI-core shims are gone (#575); every consumer requires `Modules/AICore/` and a conventions test rejects the old paths.
 - Sprint 1 (task 024) is **code-complete and merged**: PRs #566–#572, one per step. `Modules/AICore/` exists with shims at the old paths; consumers are not yet repointed. Progress ticked in `Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md`.
 - Sprint 0 (task 023) is **code-complete and merged**: PRs #555–#562, one per step, each with a test that reproduced its defect first. Progress ticked in `Tasks/active/023-sprint-0-stop-the-bleeding/progress.md`.
 - Task 017 (agent memory and the run engine on LangGraph JS) merged via #552. ADR 003 and `docs/AI-PLATFORM-ARCHITECTURE.md` merged via #554. The twelve sprint tasks (023–032, rewritten 018/019) merged via #553.
-- All gates green on merged beta: backend jest 155 suites / 1857 tests, `tests/conventions` 92, frontend vitest 129, `npm run i18n:check` exit 0, eslint 0 errors, `vue-cli-service build` done.
+- All gates green on merged beta: backend jest 1965 tests, `tests/conventions` 94, frontend vitest 142, `npm run i18n:check` exit 0, eslint 0 errors, `vue-cli-service build` done.
 - No open PRs. No unmerged branches with work on them.
 
 ## Still open on task 023 (needs the live environment, owner does these)
@@ -18,19 +20,30 @@ Updated 2026-09-11. Read this first, then `Tasks/index.md`. Overwrite this file 
 
 ## Still open on task 024 (Sprint 1)
 
-1. Repoint the thirteen consumers off the shim paths (`Modules/AIProjectGenerator/usage.js`, `llmProvider/`, `instructionGuard.js`, `Modules/Agents/engine/persistence.js`) onto `Modules/AICore/`, one module per PR, then delete the shims and the allowlist entries in `tests/conventions/ai-core-boundary.test.js`.
-2. `npm run migrate -- up` on the dev database (migration `008-agent-run-expiry`, after 007).
-3. In-process sweep with the real model; owner and member sweep of the Instance console → AI agents spend card; then move 024 to `done/`.
+1. Run the migrations on the dev database: `npm run migrate -- up` (007 and 008, then Sprint 2's 009 and 010).
+2. In-process sweep with the real model; owner and member sweep of Instance console → AI agents spend card; then move 024 to `done/`.
 
-## Next: Sprint 2 — task 025 (`Tasks/backlog/025-sprint-2-revisions-and-skill-record/`)
+## Still open on task 025 (Sprint 2)
 
-Move it to `active/` and work its four steps, one PR each, from `beta`:
-1. Immutable agent and skill revisions; a run pins both at start; promote and rollback endpoints; states draft, candidate, live, superseded.
-2. The `agent_skills` record, its validator, the frozen catalogues, the `GET /api/v2/agents/skills` manifest, hybrid `getSkill` honouring `enabled: false`.
-3. Save-time validation of emitted actions; effective actions = skill ∩ agent.allowedActions ∩ registry.
-4. `brief.parse` re-expressed as a data skill.
+1. Owner and member sweep of Agent settings → revision history and Run detail → pinned revision.
+2. In-process sweep: change an agent, promote and roll back a revision, start a run and confirm it names its revision; run `brief.parse` on a real task through the seeded data skill.
+3. Then move 025 to `done/`.
+
+## Next: Sprint 3 — task 026 (`Tasks/backlog/026-sprint-3-observability-foundation/`)
+
+Move it to `active/` and work its steps, one PR each, from `beta`:
+
+1. OpenTelemetry with the trace identifier on the run row, every step row, every audit row and every log line; logs move to structured records; the exporter is off unless an endpoint is configured.
+2. The replay record per model call: prompt hash and reference, retrieved chunk identifiers, raw response, model and parameters, agent and skill revisions, with a retention and redaction policy. (absorbs 019 "trace per run")
+3. A metrics endpoint behind admin auth: rate, errors and duration per workflow, step, agent and model; token and cost counters; approval, decline and revert rates. (absorbs 019 "dashboard in /ai", the health half)
+4. Provider error codes preserved end to end and grouped, so an error tracker has something to group.
+5. Alerts on rates: error rate per agent, approval rate falling, cost against forecast, queue age.
+6. (added) The two competing uncaught-exception handlers collapse into one path that reports, flushes and exits.
 
 ## Things learned today that affect the next session
+
+- Background agents can stop on the account usage limit mid-task. Check the remote branch and the worktree before relaunching; so far none had pushed partial work.
+- Use `grep -a` in this repo: some `.js` files are detected as binary and plain `grep` skips them silently.
 
 - Merging PRs needs the owner's say-so each session; the auto-mode classifier denies `gh pr merge` otherwise.
 - Agent worktrees have no `node_modules` and cannot source nvm; give agents `PATH="$HOME/.nvm/versions/node/v20.20.2/bin:<repo>/node_modules/.bin:$PATH"` and let them symlink the parent's `node_modules` (root and `frontend/`) without committing it. Husky's pre-push rejects a detached HEAD; rebase on a throwaway branch and push `HEAD:<branch>`.

--- a/Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md
+++ b/Tasks/active/024-sprint-1-shared-core-run-correctness/progress.md
@@ -3,7 +3,7 @@
 ## Checklist
 One pull request per step; tick with the merge commit.
 
-- [x] Step 1: `Modules/AICore/` (provider factory, usage, instruction guard, `modelCall`, persistence) with shims at every old path; ProjectTemplates onto the factory; boundary conventions test — #566 `db21784a`. Consumers still on the shim paths; repoint and shim deletion pending (1a–1n)
+- [x] Step 1: `Modules/AICore/` (provider factory, usage, instruction guard, `modelCall`, persistence) with shims at every old path; ProjectTemplates onto the factory; boundary conventions test — #566 `db21784a`; consumers repointed and the shims deleted in one PR, #575 `255be10d`, because jest mocks tie each test to its consumer
 - [x] Step 2: `idempotencyKey`, partial unique indexes, `runs.start` insert-and-catch, reaper `agent.reap-stuck-proposals` every 5 min — #570 `bacb9207`
 - [x] Step 3: `Modules/Agents/engine/timeouts.js`; Agenda `lockLifetime` 17 min with `job.touch()` between graph nodes; server, SSE and Mongo timeouts — #569 `0a13449c`
 - [x] Step 4: `triggerDepth`/`triggerEventId` on the run; `canStart` refuses `loop_depth_exceeded` at depth 3; actions emit depth + 1 — #568 `8b84214c`
@@ -24,4 +24,4 @@ One pull request per step; tick with the merge commit.
 | 2026-09-11 | Step 6 on `fix/s1-precall-spend-cap`: `Modules/AICore/estimate.js` prices a call before it is made; `Modules/Agents/spendGuard.js` reserves it on the run (`reservedUsd`, atomic `$inc`), refuses over the run cap or the company month as `spend_cap_exceeded` with an audit row, reconciles to the real cost after. Reproduced on beta first: the fake provider was called for a run capped under its estimate. Closes defect 15 and 006's "spend cap evaluated after the model call". |
 
 ## Last step
-All seven steps merged. Remaining: repoint the consumers off the shim paths one module per PR and delete the shims; run migration 008 on the dev database; the in-process sweep; the owner and member sweep of the Instance console spend card; then move 024 to `done/`.
+All seven steps merged. Remaining: run migration 008 on the dev database; the in-process sweep; the owner and member sweep of the Instance console spend card; then move 024 to `done/`.

--- a/Tasks/active/025-sprint-2-revisions-and-skill-record/progress.md
+++ b/Tasks/active/025-sprint-2-revisions-and-skill-record/progress.md
@@ -3,13 +3,13 @@
 ## Checklist
 One pull request per step; tick with the merge commit.
 
-- [ ] Step 1: Agent revisions and skill revisions as immutable documents; a run pins both at start; promote and roll back ar
-- [ ] Step 2: The skill record, its validator returning field-level errors like the automation rule validator, the frozen ca
-- [ ] Step 3: Save-time validation of emitted actions, and the effective-actions intersection with the agent's allowed actio
-- [ ] Step 4: The intake skill
-- [ ] Interface: Agent settings → revision history (new)
-- [ ] Interface: Run detail → pinned revision (extend)
-- [ ] Exit gate met and gates green
+- [x] Step 1: `agent_revisions`, run pins `agentRevision` and `skillRevision` (data skills pin their version), promote and rollback endpoints, migration 009, revision history panel — #577 `ec93c373`; revision routes check skills since #580 `4d967052`
+- [x] Step 2: `agent_skills` record, field-level validator, frozen catalogues, `GET /api/v2/agents/skills` manifest and catalogues, hybrid resolver — #576 `f43df39a`
+- [x] Step 3: skill keys validated on agent create and update, `effectiveActions` for code and data skills, `GET /api/v2/agents/manifest` — #578 `9a63c426`; the same check on draft, promote and rollback — #580 `4d967052`
+- [x] Step 4: `brief.parse` as a data skill, seeded by migration 010, parity test against the code skill — #579 `abb79e47`
+- [x] Interface: Agent settings → revision history (new) — shipped in #577; owner and member sweep still to record
+- [x] Interface: Run detail → pinned revision (extend) — shipped in #577; owner and member sweep still to record
+- [ ] Exit gate met and gates green — code gates green on `beta` at `4d967052`; migrations 009 and 010, the in-process sweep and the owner and member sweeps still to run
 
 ## Log
 | Date | Entry |
@@ -19,6 +19,9 @@ One pull request per step; tick with the merge commit.
 | 2026-09-11 | Step 2 on `feat/s2-skill-record`: `agent_skills` record and validator, frozen catalogues (5 inputs, 5 readers, 9 partials, 14 emit actions), `GET /api/v2/agents/skills` + `/catalogues`, owner/admin create, update and retire, hybrid `getSkill` (data first, code second, `enabled: false` skipped), `skillSlugOf` skips disabled skills; a data skill runs end to end through the graph with the fake provider |
 | 2026-09-11 | Step 3 on `feat/s2-effective-actions`: agent create and update refuse unknown (`unknown_skill`) and disabled or retired (`skill_disabled`) skill keys with field errors; `effectiveActions(agent, skill)` in `Modules/Agents/skills/effectiveActions.js` narrows every generic skill's changes in the orchestrator (code and data alike); `GET /api/v2/agents/manifest` lists agents by id with each skill's source and effective actions |
 | 2026-09-11 | Step 4 on `feat/s2-brief-parse-data`: `brief.parse` written as a data skill (`Modules/Agents/skills/seeds/briefParse.js`), seeded per company by migration `010-seed-brief-parse-skill` (insert if absent, idempotent); parity test holds its proposals equal to the code skill's on four fixtures. Vocabulary learned: filters (`trim`, `clip`, `int`, `bullets`), sections `{{#x}}`/`{{^x}}`, the `emitted` root and an optional `summary` template |
+| 2026-09-11 | Steps 1–4 merged into `beta` (#576, #577, #578, #579), plus #580 closing the gap #578 left: revision routes skipped the skill check, so a draft could name an unknown skill and be promoted live. #577 and #576 each needed one rebase. Two agents stopped on the usage limit and were relaunched with no work lost. |
+| 2026-09-11 | Gates on merged beta: backend unit 1965 tests, conventions 94, frontend vitest 142, `npm run i18n:check` exit 0, eslint 0 errors, `vue-cli-service build` done. |
+| 2026-09-11 | Deviations: a settings save still goes live in one step, and draft or candidate revisions exist only through `POST /agents/:id/revisions`; qa-review and pr.summary stay code skills because their readers are outside the vocabulary; brief.parse needed four vocabulary additions (filters, sections, the `emitted` root, a `summary` template). |
 
 ## Last step
-Step 1 implemented and under review (PR from `feat/s2-agent-revisions`); the owner's sweeps against the real database and browser are outstanding.
+All four steps merged. Remaining: migrations 009 and 010 on the dev database, the in-process sweep, and the owner and member sweep of the revision history panel and the run's pinned revision; then move 025 to `done/`.


### PR DESCRIPTION
Ticks task 025's four steps and both interface rows with their merge commits (#576–#580), records the gates on merged beta and the deviations, notes in 024 that the shims are gone (#575), and refreshes `Tasks/HANDOFF.md` with what remains on 024 and 025 and the Sprint 3 step list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)