### PR TITLE
test(e2e): add api integration and playwright harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,62 @@ jobs:
           VUE_APP_IS_GOOGLE_LOGIN: "false"
           VUE_APP_IS_GITHUB_LOGIN: "false"
           VUE_APP_IS_GITLAB_LOGIN: "false"
+
+  e2e:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      E2E_MONGODB_URL: mongodb://127.0.0.1:27017
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+      - run: npm ci
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+          VUE_APP_ENVIRONMENT: ci
+          VUE_APP_APIKEY: placeholder
+          VUE_APP_AUTHDOMAIN: placeholder
+          VUE_APP_PROJECTID: placeholder
+          VUE_APP_STORAGEBUCKET: placeholder
+          VUE_APP_MESSAGINGSENDERID: placeholder
+          VUE_APP_APPID: placeholder
+          VUE_APP_MEASUREMENTID: placeholder
+          VUE_APP_STORAGE_TYPE: server
+          VUE_APP_AFFILIATEON: "false"
+          VUE_APP_IS_GOOGLE_LOGIN: "false"
+          VUE_APP_IS_GITHUB_LOGIN: "false"
+          VUE_APP_IS_GITLAB_LOGIN: "false"
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:integration
+      - run: npm run e2e
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: |
+            e2e/report
+            e2e/test-results
+            e2e/.state/*.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ package-lock.json
 
 # Build stamp written by npm run version:stamp
 /build-info.json
+
+# End-to-end suite output
+/e2e/.state/
+/e2e/report/
+/e2e/test-results/

--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -1,0 +1,153 @@
+# End-to-end testing
+
+AlianHub has two end-to-end layers on top of the unit and convention tests. Both run against a real server (`node index.js`), a real MongoDB and, for the UI layer, the real built frontend in Chromium.
+
+| Layer | Runner | Files | Command |
+|-------|--------|-------|---------|
+| API integration | Jest project `integration` | `tests/integration/<area>.int.test.js` | `npm run test:integration` |
+| UI | Playwright (Chromium) | `e2e/specs/<area>.spec.js` | `npm run e2e` |
+
+Neither layer runs in `npm test`, which stays unit + conventions only. CI runs both in the `e2e` job on every pull request to `beta`, `staging` and `main`.
+
+## Running locally
+
+Requirements: Node 20, Docker, and a frontend build (the server serves `frontend/dist`).
+
+```bash
+cd frontend && npm run build && cd ..   # once, and again after frontend changes
+npm run e2e:db                          # starts alianhub-e2e-mongo on port 27018 (safe to re-run)
+export E2E_MONGODB_URL=mongodb://127.0.0.1:27018
+npx playwright install chromium         # once per machine
+npm run test:integration
+npm run e2e
+npm run e2e:db:stop                     # when you are done
+```
+
+The Playwright HTML report lands in `e2e/report` (`npx playwright show-report e2e/report`). Server output for each run is in `e2e/.state/integration-server.log` and `e2e/.state/e2e-server.log`.
+
+### The suite never touches your data
+
+- It only talks to the database in `E2E_MONGODB_URL`. Global setup refuses to start when that variable is missing, or when it points at port 27017 (where the `alianhub-mongo` development container listens) outside CI.
+- Every run **drops every database** on that instance before it starts, because the setup wizard only runs on an empty instance. Never point `E2E_MONGODB_URL` at a database you care about.
+- The server is started with an environment built from scratch and does not read the repository `.env`, so your mail, AI and OAuth credentials are never used.
+- Uploaded files go to `storage/<companyId>` (local storage has no configurable root). Teardown deletes the folders of every company in the test database; nothing else under `storage/` is touched.
+- Do not run both layers at the same time against the same database: each run wipes it.
+
+## How the harness works
+
+`e2e/support/` holds everything both layers share:
+
+| File | What it does |
+|------|--------------|
+| `env.js` | Resolves `E2E_MONGODB_URL` and enforces the port rule. |
+| `database.js` | Drops the test databases before a run; lists companies for cleanup. |
+| `server.js` | Starts `node index.js` on a free port with a random `JWT_SECRET`, `STORAGE_TYPE=server`, a temp log/backup directory, migrations on, cron off, the automation engine on its inline queue, rate limits off, no AI keys, and mail pointed at a closed port. Waits for `/health` to return 200, and kills the process on teardown. |
+| `harness.js` | One run = reset database, start one server, create fixtures, write `e2e/.state/run.json`. |
+| `fixtures.js` | Fixture creation and the helpers tests use: `loginAs`, `createProject`, `createTask`, `inviteMember`, `readState`, `storageStatePath`. |
+| `api.js` | `createApiClient`, a small wrapper over the built-in `fetch`. Calls resolve to `{ status, body, headers }` and never throw on 4xx/5xx. |
+| `pages.js` | Shared UI steps: `signInThroughForm`, `settingsNav`. |
+| `test.js` | The Playwright `test` to import in specs, with `state`, `loginAs` and `asRole`. |
+| `global-setup.js` | Playwright global setup: starts the harness, then signs every role in through the real login form and saves its storage state. |
+
+Jest uses `tests/integration/globalSetup.js` / `globalTeardown.js`, which call the same `startHarness`.
+
+### Fixtures and roles
+
+Everything is created through the real HTTP APIs, in this order:
+
+1. **Owner** — `POST /api/v2/setup/complete`, the setup wizard, with `sampleData: false`. This creates the owner (`users.isProductOwner`, the instance owner) and the company.
+2. **Admin, member, guest** — through the same calls the invitation page makes, without mail:
+   1. the owner calls `POST /api/v2/sendInvitationEmail` with the role; the `company_users` row is saved and returned even though delivery fails (mail points at a closed port);
+   2. the invitee registers with `POST /api/v2/createUser` and `isInvitation: true`, which is what marks the email verified and assigns the company;
+   3. signed in as the invitee, `PUT /api/v1/root-members` links the row and sets `status: 2`, then `POST /api/v1/importSettingsNotification` and `POST /api/v1/removeUserNotification` finish what `Invitation.vue` does.
+3. **Projects** — `POST /api/v1/createproject` with the Blank template: `E2E Shared Project` (every role assigned) and `E2E Owner Only` (private, owner only).
+4. **Tasks** — three tasks in the shared project through `POST /api/v2/tasks`.
+
+| Role | `roleType` | Email | Notes |
+|------|-----------|-------|-------|
+| `owner` | 1 | `owner@e2e.alianhub.test` | Instance owner; sees the Instance section |
+| `admin` | 2 | `admin@e2e.alianhub.test` | |
+| `member` | 3 | `member@e2e.alianhub.test` | |
+| `guest` | 0 | `guest@e2e.alianhub.test` | Most restricted role |
+
+Every account uses the password in `PASSWORD` (`fixtures.js`). The run state (`readState()` / the Playwright `state` fixture) holds `baseURL`, `companyId`, `password`, `users.<role>` (`email`, `userId`, `roleType`), `projects.shared` / `projects.restricted` and `tasks`.
+
+## Rules for every test
+
+1. **Create your own data.** The shared fixtures (company, the four users, two projects, three tasks) are read-only context. If a test changes something, it creates that thing first with `createProject`, `createTask` or `inviteMember`, and uses `uniqueSuffix()` for names and codes.
+2. **Never depend on test order.** Any test must pass when run alone (`npx playwright test -g "<title>"`, `npx jest -t "<title>"`) and in parallel with every other test. No test reads what another test wrote.
+3. **Assert through the product.** Sign in with `loginAs` or a role's storage state; do not write to MongoDB from a test.
+4. **Keep strings stable.** UI assertions use the English copy from `frontend/src/locales/en.js` or a `data-test` attribute. Add a `data-test` to the component when a selector would otherwise depend on layout.
+5. **A known product bug stays visible.** Write the correct assertion and mark it `it.failing(...)` (Jest) or `test.fail(...)` (Playwright) with a one-line reason. It passes while the bug exists and fails once fixed, which is the reminder to flip it.
+
+## Adding a feature area
+
+Say the area is `timesheets`.
+
+### 1. API tests: `tests/integration/timesheets.int.test.js`
+
+```js
+const { createProject, createTask, loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+
+describe('timesheets', () => {
+    it('lets a member log time on a task in their project', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid, member.uid], createdBy: owner.uid });
+        const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+
+        const res = await member.api.post('/api/v2/...', { taskId: task._id /* ... */ });
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(true);
+    });
+
+    it('refuses a guest', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.get('/api/v2/...');
+        expect(res.status).toBe(403);
+    });
+});
+```
+
+- `loginAs(role)` performs a real `POST /api/v2/auth/login` and returns `{ uid, accessToken, refreshToken, companyId, email, roleType, api }`. `api` sends `authorization: Bearer <token>` and `companyid` on every call; use `api.withCompany(otherId)` to aim at another company.
+- For an unauthenticated call use `createApiClient({ baseURL: state.baseURL })` from `e2e/support/api.js`.
+- Run just your file: `npx jest --selectProjects integration tests/integration/timesheets.int.test.js`.
+
+### 2. UI tests: `e2e/specs/timesheets.spec.js`
+
+```js
+const { test, expect, asRole } = require('../support/test');
+
+test.describe('timesheets as a member', () => {
+    test.use(asRole('member'));
+
+    test('shows the week grid', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/timesheet`);
+        await expect(page.getByRole('heading', { name: 'Timesheet' })).toBeVisible();
+    });
+});
+
+test.describe('timesheets as the owner', () => {
+    test.use(asRole('owner'));
+
+    test('shows a task created for this test', async ({ page, state, loginAs }) => {
+        const owner = await loginAs('owner');
+        // create what the test needs through owner.api, then drive the page
+        await page.goto(`/#/${state.companyId}/timesheet`);
+    });
+});
+```
+
+- `asRole(role)` sets `storageState` to the session global setup saved by signing that role in through the real login form, so the page opens already signed in. Without it a test starts signed out; use `signInThroughForm` from `../support/pages` when the sign-in itself is under test.
+- `baseURL` is already the harness server; navigate with hash routes (`/#/<companyId>/...`).
+- The `state` and `loginAs` fixtures are the same as in the API layer, so a UI test can prepare data through the API first.
+- Run just your file: `npm run e2e -- e2e/specs/timesheets.spec.js`, or add `--headed` / `--debug` to watch it.
+
+### 3. Before you open the PR
+
+- `npm run test:integration` and `npm run e2e` pass locally.
+- The new tests pass on their own and with the whole suite.
+- If you needed a new fixture helper, add it to `e2e/support/fixtures.js` (or `pages.js` for UI steps) and document it in the tables above instead of copying setup code between files.

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,21 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+    testDir: './specs',
+    outputDir: './test-results',
+    globalSetup: require.resolve('./support/global-setup.js'),
+    fullyParallel: true,
+    forbidOnly: Boolean(process.env.CI),
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 2 : undefined,
+    timeout: 60000,
+    expect: { timeout: 15000 },
+    reporter: [['list'], ['html', { outputFolder: 'report', open: 'never' }]],
+    use: {
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+    },
+    projects: [
+        { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    ],
+});

--- a/e2e/specs/smoke.spec.js
+++ b/e2e/specs/smoke.spec.js
@@ -1,0 +1,36 @@
+const { test, expect, asRole } = require('../support/test');
+const { settingsNav, signInThroughForm } = require('../support/pages');
+
+test.describe('sign-in', () => {
+    test('the owner signs in through the form and lands on Home', async ({ page, state }) => {
+        await signInThroughForm(page, { email: state.users.owner.email, password: state.password, companyId: state.companyId });
+        await expect(page.locator('.ah-toolbar__title')).toHaveText('Today & Overdue');
+    });
+});
+
+test.describe('instance console as the owner', () => {
+    test.use(asRole('owner'));
+
+    test('Instance > Stats shows the running version', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/notifications`);
+        const nav = settingsNav(page);
+        await expect(nav.getByText('Instance', { exact: true })).toBeVisible();
+        await nav.getByRole('link', { name: 'Stats', exact: true }).click();
+        await expect(page.locator('[data-test="version-label"]')).toHaveText(/^v14\./);
+    });
+});
+
+test.describe('instance console as a member', () => {
+    test.use(asRole('member'));
+
+    test('the Instance section is not offered', async ({ page, state }) => {
+        const access = page.waitForResponse((res) => res.url().includes('/api/v2/instance/access'));
+        await page.goto(`/#/${state.companyId}/settings/notifications`);
+        expect((await access).status()).toBe(403);
+
+        const nav = settingsNav(page);
+        await expect(nav.getByText('Personal', { exact: true })).toBeVisible();
+        await expect(nav.getByText('Instance', { exact: true })).toHaveCount(0);
+        await expect(nav.getByRole('link', { name: 'Stats', exact: true })).toHaveCount(0);
+    });
+});

--- a/e2e/support/api.js
+++ b/e2e/support/api.js
@@ -1,0 +1,37 @@
+/* A thin wrapper over the global fetch: every call resolves to { status, body, headers }
+ * and never throws on a 4xx/5xx, so a test can assert on a refusal directly. */
+function createApiClient({ baseURL, accessToken = null, companyId = null } = {}) {
+    if (!baseURL) throw new Error('createApiClient needs a baseURL');
+
+    async function request(method, urlPath, { body, headers = {}, query } = {}) {
+        const url = new URL(urlPath, baseURL);
+        for (const [key, value] of Object.entries(query || {})) url.searchParams.set(key, String(value));
+        const finalHeaders = { accept: 'application/json', ...headers };
+        if (accessToken) finalHeaders.authorization = `Bearer ${accessToken}`;
+        if (companyId) finalHeaders.companyid = companyId;
+        if (body !== undefined) finalHeaders['content-type'] = 'application/json';
+
+        const res = await fetch(url, { method, headers: finalHeaders, body: body === undefined ? undefined : JSON.stringify(body) });
+        const text = await res.text();
+        let parsed = text;
+        try {
+            parsed = text ? JSON.parse(text) : null;
+        } catch {}
+        return { status: res.status, body: parsed, headers: res.headers };
+    }
+
+    return {
+        baseURL,
+        accessToken,
+        companyId,
+        request,
+        get: (urlPath, options) => request('GET', urlPath, options),
+        post: (urlPath, body, options) => request('POST', urlPath, { ...options, body }),
+        put: (urlPath, body, options) => request('PUT', urlPath, { ...options, body }),
+        patch: (urlPath, body, options) => request('PATCH', urlPath, { ...options, body }),
+        delete: (urlPath, options) => request('DELETE', urlPath, options),
+        withCompany: (otherCompanyId) => createApiClient({ baseURL, accessToken, companyId: otherCompanyId }),
+    };
+}
+
+module.exports = { createApiClient };

--- a/e2e/support/database.js
+++ b/e2e/support/database.js
@@ -1,0 +1,30 @@
+const { MongoClient } = require('mongodb');
+const { resolveMongoUrl } = require('./env');
+
+const SYSTEM_DATABASES = new Set(['admin', 'config', 'local']);
+
+async function resetDatabase(mongoUrl = resolveMongoUrl()) {
+    const client = new MongoClient(mongoUrl, { serverSelectionTimeoutMS: 5000 });
+    try {
+        await client.connect();
+        const { databases } = await client.db('admin').admin().listDatabases({ nameOnly: true });
+        for (const { name } of databases) {
+            if (!SYSTEM_DATABASES.has(name)) await client.db(name).dropDatabase();
+        }
+    } finally {
+        await client.close();
+    }
+}
+
+async function listCompanyIds(mongoUrl = resolveMongoUrl()) {
+    const client = new MongoClient(mongoUrl, { serverSelectionTimeoutMS: 5000 });
+    try {
+        await client.connect();
+        const rows = await client.db('global').collection('companies').find({}, { projection: { _id: 1 } }).toArray();
+        return rows.map((row) => String(row._id));
+    } finally {
+        await client.close();
+    }
+}
+
+module.exports = { resetDatabase, listCompanyIds };

--- a/e2e/support/env.js
+++ b/e2e/support/env.js
@@ -1,0 +1,34 @@
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const STATE_DIR = path.join(ROOT, 'e2e', '.state');
+const LOCAL_DB_HINT = 'Run `npm run e2e:db` and export E2E_MONGODB_URL=mongodb://127.0.0.1:27018';
+
+function hostsOf(url) {
+    const match = /^mongodb(\+srv)?:\/\/(?:[^@/]*@)?([^/?]+)/.exec(url);
+    if (!match) throw new Error(`E2E_MONGODB_URL is not a MongoDB connection string: ${url}`);
+    return { srv: Boolean(match[1]), hosts: match[2].split(',') };
+}
+
+function usesOwnerPort(url) {
+    const { srv, hosts } = hostsOf(url);
+    if (srv) return false;
+    return hosts.some((host) => {
+        const port = /:(\d+)$/.exec(host);
+        return !port || Number(port[1]) === 27017;
+    });
+}
+
+/* 27017 is where the owner's own alianhub-mongo container listens, and the harness
+ * drops every database it can see. CI runs a disposable service container on that
+ * port, so the rule only applies outside CI. */
+function resolveMongoUrl(env = process.env) {
+    const url = String(env.E2E_MONGODB_URL || '').trim().replace(/\/+$/, '');
+    if (!url) throw new Error(`E2E_MONGODB_URL is not set. ${LOCAL_DB_HINT}`);
+    if (!env.CI && usesOwnerPort(url)) {
+        throw new Error(`Refusing to run against ${url}: port 27017 is the local development database. ${LOCAL_DB_HINT}`);
+    }
+    return url;
+}
+
+module.exports = { ROOT, STATE_DIR, resolveMongoUrl, usesOwnerPort };

--- a/e2e/support/fixtures.js
+++ b/e2e/support/fixtures.js
@@ -1,0 +1,236 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createApiClient } = require('./api');
+const { STATE_DIR } = require('./env');
+
+const PASSWORD = 'E2e-Passw0rd!';
+const STATE_FILE = path.join(STATE_DIR, 'run.json');
+const COMPANY_NAME = 'E2E Workspace';
+
+/* roleType values from utils/data.js importCompanyRoles. Guest is the most restricted. */
+const ROLES = {
+    owner: { roleType: 1, firstName: 'Olivia', lastName: 'Owner' },
+    admin: { roleType: 2, firstName: 'Ada', lastName: 'Admin' },
+    member: { roleType: 3, firstName: 'Max', lastName: 'Member' },
+    guest: { roleType: 0, firstName: 'Gus', lastName: 'Guest' },
+};
+const ROLE_NAMES = Object.keys(ROLES);
+
+const uniqueSuffix = () => crypto.randomBytes(3).toString('hex');
+const emailFor = (role, suffix = '') => `${role}${suffix ? `.${suffix}` : ''}@e2e.alianhub.test`;
+
+function assertOk(res, what) {
+    const refused = res.status >= 400 || (res.body && typeof res.body === 'object' && res.body.status === false);
+    if (refused) throw new Error(`${what} failed (${res.status}): ${JSON.stringify(res.body).slice(0, 500)}`);
+    return res.body;
+}
+
+async function login(baseURL, email, password = PASSWORD) {
+    const res = await createApiClient({ baseURL }).post('/api/v2/auth/login', { email, password });
+    const body = assertOk(res, `login as ${email}`);
+    if (!body.accessToken) throw new Error(`login as ${email} returned no session: ${JSON.stringify(body)}`);
+    return { uid: String(body.uid), accessToken: body.accessToken, refreshToken: body.refreshToken };
+}
+
+async function setupOwner(baseURL) {
+    const { firstName, lastName } = ROLES.owner;
+    const email = emailFor('owner');
+    const res = await createApiClient({ baseURL }).post('/api/v2/setup/complete', {
+        firstName, lastName, email, password: PASSWORD, companyName: COMPANY_NAME, sampleData: false,
+    });
+    const { data } = assertOk(res, 'setup wizard');
+    return { role: 'owner', roleType: ROLES.owner.roleType, email, userId: String(data.userId), companyId: String(data.companyId) };
+}
+
+/* Invite acceptance without mail, through the same calls the /invitation page makes
+ * (frontend/src/views/Authentication/Invitation/Invitation.vue): the owner sends the
+ * invite, which stores the company_users row even when the mail cannot be delivered and
+ * returns it; the invitee registers with isInvitation, which marks the email verified;
+ * then, signed in as the invitee, the row is linked and activated (status 2). */
+async function inviteMember({ baseURL, ownerApi, companyId, role, email, firstName, lastName }) {
+    const { roleType } = ROLES[role];
+    const invite = await ownerApi.post('/api/v2/sendInvitationEmail', {
+        email, companyId, companyName: COMPANY_NAME, role: roleType, designation: 0,
+    });
+    const inviteRow = invite.body && invite.body.data;
+    if (invite.status !== 200 || !inviteRow || !inviteRow._id) {
+        throw new Error(`invite ${email} failed (${invite.status}): ${JSON.stringify(invite.body).slice(0, 500)}`);
+    }
+
+    const anon = createApiClient({ baseURL });
+    const created = await anon.post('/api/v2/createUser', {
+        firstName, lastName, email, password: PASSWORD, isInvitation: true, assignCompany: companyId,
+    });
+    const user = assertOk(created, `register ${email}`).statusText;
+    const userId = String(user._id);
+
+    const session = await login(baseURL, email);
+    const api = createApiClient({ baseURL, accessToken: session.accessToken, companyId });
+    assertOk(await api.put('/api/v1/root-members', { id: inviteRow._id, data: { userId, status: 2 }, companyId }), `accept invite for ${email}`);
+    assertOk(await api.post('/api/v1/importSettingsNotification', { companyId, userId }), `notification settings for ${email}`);
+    assertOk(await api.post('/api/v1/removeUserNotification', { companyId, userId, type: 'Add' }), `notification counter for ${email}`);
+
+    return { role, roleType, email, userId, companyUserId: String(inviteRow._id) };
+}
+
+async function createProject(api, { name, code, assigneeIds, createdBy, isPrivate = false }) {
+    const suffix = uniqueSuffix();
+    const res = await api.post('/api/v1/createproject', {
+        AssigneeUserId: assigneeIds,
+        ProjectName: name || `E2E Project ${suffix}`,
+        CompanyId: api.companyId,
+        ProjectCode: code || `E${suffix.toUpperCase()}`,
+        ProjectType: 'Fix',
+        LeadUserId: [],
+        markAsStar: false,
+        sprintsObj: {},
+        sprintsfolders: {},
+        DueDate: '',
+        proposalId: '',
+        skills: [],
+        source: 'other',
+        projectIcon: { type: 'color', data: '#6473e8' },
+        TemplateName: '',
+        TemplateId: 'blank',
+        useTemplateProj: 'category',
+        isPrivateSpace: isPrivate,
+        TaskTypeTemplateId: '',
+        statusType: 'active',
+        lastTaskId: 0,
+        ProjectRequiredDefaultComponent: 'ProjectListView',
+        ProjectCurrency: {},
+        projectCreatedBy: createdBy,
+        isGlobalPermission: true,
+        customFiedlsValue: [],
+        includeSampleTasks: false,
+        sampleFocus: '',
+        apps: [],
+    });
+    return assertOk(res, `create project ${name}`).data;
+}
+
+async function listSprints(api, projectId) {
+    const res = await api.get(`/api/v1/project/sprintFolder/${projectId}`, { query: { collection: 'sprints' } });
+    if (res.status !== 200) throw new Error(`list sprints for ${projectId} failed (${res.status}): ${JSON.stringify(res.body).slice(0, 500)}`);
+    return Array.isArray(res.body) ? res.body : (res.body && res.body.data) || [];
+}
+
+/* Same payload the create-task forms send (see ConvertNoteToTask.vue). */
+async function createTask(api, { project, name, user, companyOwnerId }) {
+    const [sprint] = await listSprints(api, project._id);
+    if (!sprint) throw new Error(`project ${project._id} has no sprint to hold a task`);
+    const sprintId = String(sprint._id || sprint.id);
+    const status = project.taskStatusData.find((x) => x.type === 'default_active');
+    const taskType = project.taskTypeCounts[0];
+    const res = await api.post('/api/v2/tasks', {
+        data: {
+            TaskName: name || `E2E Task ${uniqueSuffix()}`,
+            TaskKey: '--',
+            AssigneeUserId: [],
+            watchers: [user.userId],
+            DueDate: '',
+            dueDateDeadLine: [],
+            TaskType: taskType.value,
+            TaskTypeKey: taskType.key,
+            ParentTaskId: '',
+            ProjectID: project._id,
+            CompanyId: api.companyId,
+            status: { text: status.name, key: status.key, value: status.value, type: status.type },
+            statusKey: status.key,
+            statusType: status.type,
+            isParentTask: true,
+            Task_Leader: user.userId,
+            sprintArray: { id: sprintId, name: sprint.name, value: sprint.value || sprint.name },
+            Task_Priority: 'MEDIUM',
+            deletedStatusKey: 0,
+            sprintId,
+        },
+        user: { id: user.userId, Employee_Name: `${ROLES[user.role]?.firstName || ''} ${ROLES[user.role]?.lastName || ''}`.trim(), companyOwnerId },
+        projectData: { _id: project._id, CompanyId: api.companyId, lastTaskId: project.lastTaskId || 0, ProjectName: project.ProjectName, ProjectCode: project.ProjectCode },
+        indexObj: { indexName: 'groupByStatusIndex', searchKey: 'statusKey', searchValue: status.key },
+    });
+    const body = assertOk(res, `create task in ${project.ProjectName}`);
+    return { _id: String(body.id), name: res.body && name, projectId: String(project._id), sprintId };
+}
+
+const pickProject = (project) => ({ _id: String(project._id), name: project.ProjectName, code: project.ProjectCode, isPrivate: Boolean(project.isPrivateSpace) });
+
+async function createFixtures(baseURL) {
+    const owner = await setupOwner(baseURL);
+    const { companyId } = owner;
+    const ownerSession = await login(baseURL, owner.email);
+    const ownerApi = createApiClient({ baseURL, accessToken: ownerSession.accessToken, companyId });
+
+    const users = { owner };
+    for (const role of ROLE_NAMES.filter((name) => name !== 'owner')) {
+        const { firstName, lastName } = ROLES[role];
+        users[role] = await inviteMember({ baseURL, ownerApi, companyId, role, email: emailFor(role), firstName, lastName });
+    }
+
+    const everyone = ROLE_NAMES.map((role) => users[role].userId);
+    const shared = await createProject(ownerApi, { name: 'E2E Shared Project', code: 'SHARED', assigneeIds: everyone, createdBy: owner.userId });
+    const restricted = await createProject(ownerApi, { name: 'E2E Owner Only', code: 'OWNER', assigneeIds: [owner.userId], createdBy: owner.userId, isPrivate: true });
+
+    const tasks = [];
+    for (const name of ['E2E Task One', 'E2E Task Two', 'E2E Task Three']) {
+        tasks.push(await createTask(ownerApi, { project: shared, name, user: owner, companyOwnerId: owner.userId }));
+    }
+
+    return {
+        baseURL,
+        companyId,
+        companyName: COMPANY_NAME,
+        password: PASSWORD,
+        users,
+        projects: { shared: pickProject(shared), restricted: pickProject(restricted) },
+        tasks,
+    };
+}
+
+function writeState(state) {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+function readState() {
+    const file = process.env.E2E_STATE_FILE || STATE_FILE;
+    if (!fs.existsSync(file)) {
+        throw new Error(`No harness state at ${file}. Run the suite through \`npm run test:integration\` or \`npm run e2e\`.`);
+    }
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+async function loginAs(role, { state = readState() } = {}) {
+    const user = state.users[role];
+    if (!user) throw new Error(`Unknown role "${role}". Known roles: ${Object.keys(state.users).join(', ')}`);
+    const session = await login(state.baseURL, user.email, state.password);
+    return {
+        ...user,
+        ...session,
+        companyId: state.companyId,
+        api: createApiClient({ baseURL: state.baseURL, accessToken: session.accessToken, companyId: state.companyId }),
+    };
+}
+
+const storageStatePath = (role) => path.join(STATE_DIR, 'auth', `${role}.json`);
+
+module.exports = {
+    PASSWORD,
+    ROLES,
+    ROLE_NAMES,
+    STATE_FILE,
+    assertOk,
+    createFixtures,
+    createProject,
+    createTask,
+    emailFor,
+    inviteMember,
+    listSprints,
+    login,
+    loginAs,
+    readState,
+    storageStatePath,
+    uniqueSuffix,
+    writeState,
+};

--- a/e2e/support/global-setup.js
+++ b/e2e/support/global-setup.js
@@ -1,0 +1,33 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { chromium } = require('@playwright/test');
+const { startHarness } = require('./harness');
+const { ROLE_NAMES, storageStatePath } = require('./fixtures');
+const { signInThroughForm } = require('./pages');
+
+async function saveStorageState(browser, state, role) {
+    const context = await browser.newContext({ baseURL: state.baseURL });
+    try {
+        const page = await context.newPage();
+        await signInThroughForm(page, { email: state.users[role].email, password: state.password, companyId: state.companyId });
+        const file = storageStatePath(role);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        await context.storageState({ path: file });
+    } finally {
+        await context.close();
+    }
+}
+
+module.exports = async () => {
+    const harness = await startHarness({ name: 'e2e' });
+    const browser = await chromium.launch();
+    try {
+        for (const role of ROLE_NAMES) await saveStorageState(browser, harness.state, role);
+    } catch (error) {
+        await harness.stop();
+        throw error;
+    } finally {
+        await browser.close();
+    }
+    return () => harness.stop();
+};

--- a/e2e/support/harness.js
+++ b/e2e/support/harness.js
@@ -1,0 +1,31 @@
+const path = require('node:path');
+const { listCompanyIds, resetDatabase } = require('./database');
+const { STATE_DIR, resolveMongoUrl } = require('./env');
+const { STATE_FILE, createFixtures, writeState } = require('./fixtures');
+const { startServer } = require('./server');
+
+/* One server and one fixture set per run of a layer. The database is wiped first:
+ * the setup wizard only runs on an empty instance. */
+async function startHarness({ name }) {
+    const mongoUrl = resolveMongoUrl();
+    await resetDatabase(mongoUrl);
+    const server = await startServer({ mongoUrl, logFile: path.join(STATE_DIR, `${name}-server.log`) });
+
+    const stop = async () => {
+        const companyIds = await listCompanyIds(mongoUrl).catch(() => []);
+        await server.stop({ companyIds });
+    };
+
+    try {
+        const state = await createFixtures(server.baseURL);
+        writeState(state);
+        process.env.E2E_BASE_URL = server.baseURL;
+        process.env.E2E_STATE_FILE = STATE_FILE;
+        return { state, server, stop };
+    } catch (error) {
+        await stop();
+        throw new Error(`${error.message}\nServer log: ${server.logFile}`);
+    }
+}
+
+module.exports = { startHarness };

--- a/e2e/support/ignore-dotenv.js
+++ b/e2e/support/ignore-dotenv.js
@@ -1,0 +1,7 @@
+/* Preloaded into the harness server. The app fills every variable the environment
+ * leaves unset from the repository .env, which would hand the suite a developer's
+ * mail, AI and OAuth credentials. The server gets exactly the environment server.js builds. */
+const dotenv = require('dotenv');
+
+dotenv.config = () => ({ parsed: {} });
+dotenv.parse = () => ({});

--- a/e2e/support/pages.js
+++ b/e2e/support/pages.js
@@ -1,0 +1,16 @@
+const escapeRegex = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/* Login.vue finishes with a full reload, and the router then sends a signed-in user
+ * to Home at #/<companyId>. */
+async function signInThroughForm(page, { email, password, companyId }) {
+    await page.goto('/#/login');
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill(password);
+    await page.locator('.auth__actions button[type="submit"]').click();
+    await page.waitForURL(new RegExp(`#/${escapeRegex(companyId)}(/|$)`), { timeout: 60000 });
+    await page.waitForFunction("window.localStorage.getItem('isLogging') === 'true'");
+}
+
+const settingsNav = (page) => page.getByRole('navigation', { name: 'Settings navigation' });
+
+module.exports = { signInThroughForm, settingsNav };

--- a/e2e/support/server.js
+++ b/e2e/support/server.js
@@ -1,0 +1,123 @@
+const { spawn } = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { ROOT } = require('./env');
+
+const HEALTH_TIMEOUT_MS = 120000;
+const STOP_TIMEOUT_MS = 10000;
+
+function freePort() {
+    return new Promise((resolve, reject) => {
+        const probe = net.createServer();
+        probe.unref();
+        probe.on('error', reject);
+        probe.listen(0, '127.0.0.1', () => {
+            const { port } = probe.address();
+            probe.close(() => resolve(port));
+        });
+    });
+}
+
+function serverEnv({ port, mongoUrl, workDir }) {
+    const baseURL = `http://127.0.0.1:${port}`;
+    return {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        TMPDIR: os.tmpdir(),
+        NODE_ENV: 'development',
+        PORT: String(port),
+        APIURL: `${baseURL}/`,
+        WEBURL: baseURL,
+        MONGODB_URL: mongoUrl,
+        JWT_SECRET: crypto.randomBytes(32).toString('hex'),
+        JWT_EXP: '24h',
+        JWT_ALGORITHM: 'HS256',
+        PRECOMPANYKEY: crypto.randomBytes(16).toString('hex'),
+        STORAGE_TYPE: 'server',
+        LOG_DIR: path.join(workDir, 'log'),
+        BACKUP_DIR: path.join(workDir, 'backups'),
+        MIGRATIONS_AUTO: 'true',
+        CRON_ENABLED: 'false',
+        AUTOMATION_ENGINE: 'true',
+        AUTOMATION_QUEUE_DRIVER: 'inline',
+        GLOBAL_RATE_LIMIT_PER_MIN: 'off',
+        AUTH_RATE_LIMIT_MAX_ATTEMPTS: '10000',
+        MEMBERSHIP_CACHE_TTL_SECONDS: '0',
+        // Port 9 (discard) refuses at once, so invite mail fails fast instead of timing out.
+        NODEMAILER_HOST: '127.0.0.1',
+        NODEMAILER_PORT: '9',
+        MAGIC_LINK_ENABLED: 'false',
+    };
+}
+
+async function waitForHealth(baseURL, child, logTail) {
+    const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        if (child.exitCode !== null) {
+            throw new Error(`Server exited with code ${child.exitCode} before /health answered.\n${logTail()}`);
+        }
+        try {
+            const res = await fetch(`${baseURL}/health`);
+            if (res.status === 200) return;
+        } catch {}
+        await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    throw new Error(`Server did not report healthy within ${HEALTH_TIMEOUT_MS / 1000}s.\n${logTail()}`);
+}
+
+function stopChild(child) {
+    if (child.exitCode !== null) return Promise.resolve();
+    return new Promise((resolve) => {
+        const timer = setTimeout(() => child.kill('SIGKILL'), STOP_TIMEOUT_MS);
+        child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+        });
+        child.kill('SIGTERM');
+    });
+}
+
+async function startServer({ mongoUrl, logFile }) {
+    const port = await freePort();
+    const baseURL = `http://127.0.0.1:${port}`;
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alianhub-e2e-'));
+    fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    const log = fs.createWriteStream(logFile);
+    const tail = [];
+    const record = (chunk) => {
+        log.write(chunk);
+        tail.push(...String(chunk).split('\n'));
+        tail.splice(0, Math.max(0, tail.length - 60));
+    };
+
+    const child = spawn(process.execPath, ['-r', path.join(__dirname, 'ignore-dotenv.js'), 'index.js'], {
+        cwd: ROOT,
+        env: serverEnv({ port, mongoUrl, workDir }),
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout.on('data', record);
+    child.stderr.on('data', record);
+
+    const stop = async ({ companyIds = [] } = {}) => {
+        await stopChild(child);
+        log.end();
+        fs.rmSync(workDir, { recursive: true, force: true });
+        // Local storage has no configurable root: company files land in <repo>/storage/<companyId>.
+        for (const companyId of companyIds) {
+            if (/^[a-f0-9]{24}$/i.test(companyId)) fs.rmSync(path.join(ROOT, 'storage', companyId), { recursive: true, force: true });
+        }
+    };
+
+    try {
+        await waitForHealth(baseURL, child, () => `--- last lines of ${logFile} ---\n${tail.join('\n')}`);
+    } catch (error) {
+        await stop();
+        throw error;
+    }
+    return { baseURL, port, logFile, logDir: path.join(workDir, 'log'), pid: child.pid, stop };
+}
+
+module.exports = { startServer };

--- a/e2e/support/start-db.js
+++ b/e2e/support/start-db.js
@@ -1,0 +1,39 @@
+const { execFileSync } = require('node:child_process');
+const { MongoClient } = require('mongodb');
+
+const CONTAINER = 'alianhub-e2e-mongo';
+const URL = 'mongodb://127.0.0.1:27018';
+
+const docker = (...args) => execFileSync('docker', args, { encoding: 'utf8' }).trim();
+
+async function waitForPing(deadline) {
+    for (;;) {
+        const client = new MongoClient(URL, { serverSelectionTimeoutMS: 1000 });
+        try {
+            await client.connect();
+            await client.db('admin').command({ ping: 1 });
+            return;
+        } catch (error) {
+            if (Date.now() > deadline) throw error;
+            await new Promise((resolve) => setTimeout(resolve, 500));
+        } finally {
+            await client.close().catch(() => {});
+        }
+    }
+}
+
+async function main() {
+    if (docker('ps', '-q', '--filter', `name=^${CONTAINER}$`)) {
+        console.log(`${CONTAINER} is already running on 27018.`);
+    } else {
+        docker('run', '-d', '--rm', '--name', CONTAINER, '-p', '27018:27017', 'mongo:7');
+        console.log(`Started ${CONTAINER} on 27018.`);
+    }
+    await waitForPing(Date.now() + 30000);
+    console.log(`\nexport E2E_MONGODB_URL=${URL}\n`);
+}
+
+main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+});

--- a/e2e/support/test.js
+++ b/e2e/support/test.js
@@ -1,0 +1,20 @@
+const base = require('@playwright/test');
+const { loginAs, readState, storageStatePath } = require('./fixtures');
+
+const test = base.test.extend({
+    // Playwright reads fixture dependencies from the destructuring pattern, so an empty one is required.
+    // eslint-disable-next-line no-empty-pattern
+    state: async ({}, use) => {
+        await use(readState());
+    },
+    baseURL: async ({ state }, use) => {
+        await use(state.baseURL);
+    },
+    loginAs: async ({ state }, use) => {
+        await use((role) => loginAs(role, { state }));
+    },
+});
+
+const asRole = (role) => ({ storageState: storageStatePath(role) });
+
+module.exports = { test, expect: base.expect, asRole, storageStatePath };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,15 @@ const base = {
 module.exports = {
     projects: [
         { ...base, displayName: 'unit', testMatch: ['<rootDir>/tests/*.test.js'] },
-        { ...base, displayName: 'conventions', testMatch: ['<rootDir>/tests/conventions/*.test.js'] }
+        { ...base, displayName: 'conventions', testMatch: ['<rootDir>/tests/conventions/*.test.js'] },
+        {
+            ...base,
+            displayName: 'integration',
+            testMatch: ['<rootDir>/tests/integration/*.int.test.js'],
+            globalSetup: '<rootDir>/tests/integration/globalSetup.js',
+            globalTeardown: '<rootDir>/tests/integration/globalTeardown.js',
+            testTimeout: 60000
+        }
     ],
     maxWorkers: '50%',
     verbose: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
+        "@playwright/test": "1.63.0",
         "eslint": "^8.57.1",
         "husky": "^9.1.7",
         "jest": "^30.4.2",
@@ -5190,6 +5191,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -13260,6 +13277,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/png-js": {

--- a/package.json
+++ b/package.json
@@ -98,10 +98,14 @@
     "@authenio/samlify-xsd-schema-validator": "^1.0.5"
   },
   "scripts": {
-    "test": "jest",
+    "test": "jest --selectProjects unit conventions",
     "test:unit": "jest --selectProjects unit",
     "test:conventions": "jest --selectProjects conventions",
-    "test:watch": "jest --watch",
+    "test:integration": "jest --selectProjects integration --runInBand",
+    "e2e": "playwright test --config e2e/playwright.config.js",
+    "e2e:db": "node e2e/support/start-db.js",
+    "e2e:db:stop": "docker stop alianhub-e2e-mongo",
+    "test:watch": "jest --selectProjects unit conventions --watch",
     "lint": "eslint .",
     "start": "node server.js",
     "nodemon": "nodemon index.js",
@@ -123,6 +127,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
+    "@playwright/test": "1.63.0",
     "eslint": "^8.57.1",
     "husky": "^9.1.7",
     "jest": "^30.4.2",

--- a/tests/integration/globalSetup.js
+++ b/tests/integration/globalSetup.js
@@ -1,0 +1,5 @@
+const { startHarness } = require('../../e2e/support/harness');
+
+module.exports = async () => {
+    globalThis.__E2E_HARNESS__ = await startHarness({ name: 'integration' });
+};

--- a/tests/integration/globalTeardown.js
+++ b/tests/integration/globalTeardown.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+    if (globalThis.__E2E_HARNESS__) await globalThis.__E2E_HARNESS__.stop();
+};

--- a/tests/integration/smoke.int.test.js
+++ b/tests/integration/smoke.int.test.js
@@ -1,0 +1,64 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { ROLE_NAMES, createProject, loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anonymous = createApiClient({ baseURL: state.baseURL });
+const refused = (res) => res.status >= 400 || (res.body && res.body.status === false);
+
+describe('harness', () => {
+    it('answers /health with a healthy database', async () => {
+        const res = await anonymous.get('/health');
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ status: 'ok', db: { ok: true } });
+    });
+
+    it('answers /version with the running version', async () => {
+        const res = await anonymous.get('/version');
+        expect(res.status).toBe(200);
+        expect(res.body.data.version).toMatch(/^14\./);
+    });
+
+    it.each(ROLE_NAMES)('signs %s in with the fixture password', async (role) => {
+        const session = await loginAs(role);
+        expect(session.accessToken).toBeTruthy();
+        expect(session.uid).toBe(state.users[role].userId);
+    });
+});
+
+describe('projects', () => {
+    it('lets the owner list projects', async () => {
+        const { api } = await loginAs('owner');
+        const res = await api.get('/api/v1/project');
+        expect(res.status).toBe(200);
+        expect(res.body.map((project) => project._id)).toContain(state.projects.shared._id);
+    });
+
+    // Known gap: PUT /api/v1/project/:id checks no project membership for a web session,
+    // so today the member's edit lands. Flip to it() once the route enforces it.
+    it.failing('refuses a member editing a project they are not in', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid, isPrivate: true });
+
+        const res = await member.api.put(`/api/v1/project/${project._id}`, { updateObject: { ProjectName: 'Renamed by member' } });
+        const after = await owner.api.get(`/api/v1/project/${project._id}`);
+
+        expect(refused(res)).toBe(true);
+        expect(after.body.ProjectName).toBe(project.ProjectName);
+    });
+});
+
+describe('instance console', () => {
+    it('refuses a member', async () => {
+        const { api } = await loginAs('member');
+        const res = await api.get('/api/v2/instance/stats');
+        expect(res.status).toBe(403);
+    });
+
+    it('answers the owner', async () => {
+        const { api } = await loginAs('owner');
+        const res = await api.get('/api/v2/instance/stats');
+        expect(res.status).toBe(200);
+        expect(res.body.data.version).toMatch(/^14\./);
+    });
+});

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,10 +1,3 @@
-/**
- * BUG-045 bootstrap test — minimal smoke test that always runs to
- * confirm the jest harness is wired up correctly. As more helpers
- * land in the codebase, more behaviour tests can be added alongside
- * (tests/<module>/<module>.test.js).
- */
-
 const path = require('path');
 const fs = require('fs');
 
@@ -18,11 +11,17 @@ describe('jest harness smoke', () => {
         expect(pkg.scripts && pkg.scripts.test).toMatch(/^jest/);
     });
 
+    test('npm test leaves the integration layer to npm run test:integration', () => {
+        const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
+        expect(pkg.scripts.test).toBe('jest --selectProjects unit conventions');
+        expect(pkg.scripts['test:integration']).toMatch(/--selectProjects integration/);
+    });
+
     test('jest.config.js exists and points at tests/', () => {
         const cfgPath = path.resolve(__dirname, '../jest.config.js');
         expect(fs.existsSync(cfgPath)).toBe(true);
         const cfg = require(cfgPath);
-        expect(cfg.projects.map((p) => p.displayName)).toEqual(['unit', 'conventions']);
+        expect(cfg.projects.map((p) => p.displayName)).toEqual(['unit', 'conventions', 'integration']);
         for (const project of cfg.projects) {
             expect(project.testMatch).toEqual(expect.arrayContaining([expect.stringContaining('tests')]));
         }


### PR DESCRIPTION
## What

Foundation for the permanent end-to-end suite (task 034): a harness later areas build on with one spec file per feature, for two layers.

| Layer | Runner | Files | Command |
|-------|--------|-------|---------|
| API integration | Jest project `integration` | `tests/integration/<area>.int.test.js` | `npm run test:integration` |
| UI | Playwright, Chromium only | `e2e/specs/<area>.spec.js` | `npm run e2e` |

Neither runs in `npm test`, which now selects `unit` and `conventions` only.

Full guide, including the "add a feature area" steps and templates: `docs/TESTING-E2E.md`.

## How it works

- **Database isolation.** The harness only uses `E2E_MONGODB_URL`. Global setup refuses to start when it is unset, or when it points at port 27017 outside CI. `npm run e2e:db` starts `alianhub-e2e-mongo` on 27018 and can be re-run safely. Each run drops the databases on that instance, because the setup wizard only runs on an empty instance.
- **Server** (`e2e/support/server.js`). Starts `node index.js` on a free port with an environment built from scratch:
  - random `JWT_SECRET`, `STORAGE_TYPE=server`, temp log and backup directories
  - `MIGRATIONS_AUTO=true`, cron off, the automation engine on the inline queue
  - rate limits off, no AI keys, mail pointed at a closed port
  - a preload that stops the app from reading the repository `.env`

  It waits for `/health` to return 200 and kills the process on teardown. It also deletes the `storage/<companyId>` folders of the test companies, because local storage has no configurable root.
- **Fixtures** (`e2e/support/fixtures.js`). Everything goes through real HTTP:
  - **Owner:** created by `POST /api/v2/setup/complete`.
  - **Admin (2), member (3) and guest (0), the most restricted role:** go through the same calls `Invitation.vue` makes, with no mail. The owner calls `sendInvitationEmail`, which saves and returns the `company_users` row even when delivery fails. The invitee then calls `createUser` with `isInvitation: true`, which marks the email verified. Finally, signed in as the invitee, `root-members` sets status 2, followed by the two notification calls.
  - **Data:** two projects (one shared, one private and owner-only) through `createproject` with the Blank template, and three tasks through `POST /api/v2/tasks`.
  - **Helpers:** `loginAs(role)` does a real login and returns the session plus an API client. Playwright global setup signs every role in through the real login form and saves a storage state per role, used as `test.use(asRole('member'))`.
- **CI.** A new `e2e` job runs on pull requests only, with `services: mongo: mongo:7` on 27017. It runs the frontend build, `playwright install --with-deps chromium`, `test:integration` and `e2e`, and uploads `e2e/report`, `e2e/test-results` and the server logs when it fails. The `backend` and `frontend` jobs are unchanged.

## Dependencies

- `@playwright/test` **1.63.0** (exact pin) as a dev dependency. It pulls in `playwright` and `playwright-core`.
- The API tests use Node's built-in `fetch`; no HTTP client was added.

## Found while building it

`PUT /api/v1/project/:id` does not check project membership for a web session. A member renamed a private project they are not assigned to, and the server returned 200. The smoke test keeps the correct assertion and marks it `it.failing(...)`, so the suite stays green today and goes red once the route enforces membership, which is the reminder to flip it to `it(...)`.

## Local run (Node 20.20.2, macOS, `mongo:7` on 27018)

```
cd frontend && npm run build                  # built with the CI placeholder env
npm run e2e:db
npm run test:integration   Tests: 10 passed, 10 total   (includes the it.failing case)
npm run e2e                3 passed (15.7s)
npx jest --selectProjects unit   Test Suites: 166 passed; Tests: 1978 passed
npx jest tests/conventions       Test Suites: 8 passed;   Tests: 94 passed
npm run lint                     0 errors (473 warnings, none from new files)
```

Also checked:
- The port guard refuses an unset URL, `:27017` and a URL with no port, and accepts `:27017` when `CI` is set.
- After both runs no harness server process was left, and no test company folders remained under `storage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
