### PR TITLE
fix(permissions): backfill member defaults and judge api requests by project rules

### DIFF
--- a/Config/permissionGuard.js
+++ b/Config/permissionGuard.js
@@ -1,26 +1,24 @@
 /**
  * Server-side permission enforcement — the backend counterpart of the
- * frontend `checkPermission()` (frontend/src/composable/index.js).
+ * frontend `checkPermission()` (frontend/src/composable/index.js) and of what
+ * the Security & Permissions matrix shows an admin.
  *
  * WHY: permission/role checks were previously evaluated ONLY in the Vue
  * app. Any API client (curl, scripts, the MCP server) using a valid token
  * could bypass them. This module re-evaluates the SAME rule model on the
- * server so every client — web, MCP, anything — obeys the same roles &
- * permissions. Single source of truth (MCP plan decision D4).
+ * server. Single source of truth (MCP plan decision D4).
  *
  * Model (mirrors the frontend exactly):
  *   - roleType 1 (owner) and 2 (admin) bypass all permission checks.
- *   - roleType >= 3 is evaluated against the company RULES document.
- *   - The RULES collection is a flat array of rule docs:
- *       { _id, key, name, isParent, parentId, roles: [{ key: roleType,
- *         permission: null | false | true }] }
- *     arranged into { parentKey: { ...parent, childKey: childRule } }
- *     (see frontend mutateArrangedRules). Three-value result:
- *       null  = no access (hidden)   false = read-only   true = write
+ *   - Any other role is evaluated against the company RULES, or the project's
+ *     own PROJECT_RULES when that project has isGlobalPermission === false.
+ *   - A role with no entry on a rule, or a rule that does not exist, is
+ *     null: the matrix shows it as "None".
+ *   - null = no access, false = read-only, true = write,
+ *     1 | 2 = "Own" | "Everyone" on the selection fields.
  */
 const mongoose = require("mongoose");
 const { myCache } = require("./config");
-const { dbCollections } = require("./collections");
 const { SCHEMA_TYPE } = require("./schemaType");
 const { MongoDbCrudOpration } = require("../utils/mongo-handler/mongoQueries");
 const { fetchRules } = require("../Modules/settings/securityPermissions/controller");
@@ -30,6 +28,10 @@ const ROLE_OWNER = 1;
 const ROLE_ADMIN = 2;
 const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
 const ROLE_CACHE_TTL_SECONDS = 60;
+const PROJECT_RULES_TTL_SECONDS = 604800;
+
+// A project's own rules never hold these two keys, and checkPermission(path, false) grants them.
+const PROJECT_CONTEXT_GRANTED = ['project.project_list', 'project.public_projects'];
 
 // Ops escape hatch (runbook kill switch): if a fine-grained permission edge
 // case ever blocks a legitimate member workflow in production, set
@@ -41,16 +43,12 @@ const fineGrainedEnforced = () => process.env.DISABLE_PERMISSION_ENFORCEMENT !==
 // HARD ISOLATION (2026-06-15): these guards must NEVER affect the web app.
 // Web-app requests authenticate via JWT session and set `req.uid` but NOT
 // `req.apiToken`. MCP / PAT requests (Authorization: Bearer ahp_…) set
-// `req.apiToken` (see Config/jwt.js verifyApiTokenRequest). We therefore run
-// permission/role enforcement ONLY for PAT requests and let every JWT/web
-// request fall straight through — so the existing frontend/backend behavior
-// is byte-for-byte unchanged. (The backend mirror of frontend checkPermission
-// is not yet a perfect match for per-project overrides, so gating shared web
-// routes caused false denials in production — e.g. assigning a task.)
+// `req.apiToken` (see Config/jwt.js verifyApiTokenRequest). Enforcement runs
+// ONLY for PAT requests; gating shared web routes once caused false denials
+// in production (e.g. assigning a task).
 const isApiTokenRequest = (req) => Boolean(req && req.apiToken);
 
-// PATCH /api/v2/tasks dispatches many actions; map each to its permission
-// key (mirrors the frontend per-field gates). Actions not listed pass
+// PATCH /api/v2/tasks dispatches many actions; actions not listed pass
 // through (structural ops like moveTask/convert have no single key).
 const TASK_ACTION_PERMISSION = {
     updateStatus: 'task.task_status',
@@ -63,6 +61,8 @@ const TASK_ACTION_PERMISSION = {
     updateTaskTotalEstimate: 'task.task_estimated_hours',
     updatePoints: 'task.task_estimated_hours',
 };
+
+const toObjectId = (value) => (OBJECT_ID_PATTERN.test(String(value || '')) ? new mongoose.Types.ObjectId(String(value)) : null);
 
 /** Resolve a user's roleType within a company (cached 60s). null if not a member. */
 const getRoleType = async (companyId, uid) => {
@@ -106,41 +106,70 @@ const arrangeRules = (rawRules) => {
     return arranged;
 };
 
-/**
- * Evaluate a permission path (e.g. "task.task_status") for a user.
- * Returns null | false | true exactly like the frontend.
- * (Global company rules; project-scoped overrides are a future addition.)
- */
-const evaluatePermission = async (companyId, uid, path) => {
-    const roleType = await getRoleType(companyId, uid);
-    if (roleType === null) return null;
-    if (isPrivileged(roleType)) return true;
-
-    let arranged;
-    try {
-        arranged = arrangeRules(await fetchRules(companyId));
-    } catch (error) {
-        logger.error(`evaluatePermission fetchRules error: ${error.message || error}`);
-        return null;
-    }
-
+const lookupRule = (arranged, path) => {
     let rule = null;
-    for (const segment of String(path).split(".")) {
+    for (const segment of String(path).split('.')) {
         rule = rule ? rule[segment] : arranged[segment];
         if (rule === undefined || rule === null) return null;
     }
-    if (!rule || !Array.isArray(rule.roles)) return null;
+    return rule && Array.isArray(rule.roles) ? rule : null;
+};
+
+/* Same cache key as Modules/projectRules, so an edit there invalidates this too. */
+const loadProjectRules = async (companyId, projectId) => {
+    const key = `projectRules:${projectId}`;
+    const cached = myCache.get(key);
+    if (Array.isArray(cached) && cached.length) return cached;
+    const rules = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.PROJECT_RULES, data: [{ projectId: String(projectId) }] }, 'find');
+    myCache.set(key, rules || [], PROJECT_RULES_TTL_SECONDS);
+    return rules || [];
+};
+
+const rulesFor = async (companyId, projectId) => {
+    const id = toObjectId(projectId);
+    const project = id
+        ? await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.PROJECTS, data: [{ _id: id }, { isGlobalPermission: 1 }] }, 'findOne')
+        : null;
+    if (project && project.isGlobalPermission === false) {
+        return { arranged: arrangeRules(await loadProjectRules(companyId, projectId)), projectScoped: true };
+    }
+    return { arranged: arrangeRules(await fetchRules(companyId)), projectScoped: false };
+};
+
+/**
+ * null | false | true (or 1 | 2 for scoped keys), exactly as the matrix stores it.
+ * Throws when the rules cannot be read; callers decide, and every guard refuses.
+ */
+const evaluatePermission = async (companyId, uid, path, { projectId } = {}) => {
+    const roleType = await getRoleType(companyId, uid);
+    if (roleType === null) return null;
+    if (isPrivileged(roleType)) return true;
+    const { arranged, projectScoped } = await rulesFor(companyId, projectId);
+    if (projectScoped && PROJECT_CONTEXT_GRANTED.includes(path)) return true;
+    const rule = lookupRule(arranged, path);
+    if (!rule) return null;
     const match = rule.roles.find((r) => r.key === roleType);
     return match ? match.permission : null;
+};
+
+/* A task named in the body decides the project, so a client cannot borrow a more permissive project's rules. */
+const projectIdForRequest = async (companyId, req) => {
+    const body = (req && req.body) || {};
+    const taskId = toObjectId(body.taskData && body.taskData._id);
+    if (taskId) {
+        const task = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [{ _id: taskId }, { ProjectID: 1 }] }, 'findOne');
+        return task && task.ProjectID ? String(task.ProjectID) : null;
+    }
+    const direct = [body.data && body.data.ProjectID, body.projectId].find((value) => OBJECT_ID_PATTERN.test(String(value || '')));
+    return direct ? String(direct) : null;
 };
 
 /**
  * Express middleware: require the caller's roleType to be in `allowed`.
  * Use for owner/admin-only endpoints (settings, members, permissions).
- * Reads req.uid (set by both the JWT and PAT auth branches) + companyid header.
  */
 const requireRole = (allowed = [ROLE_OWNER, ROLE_ADMIN]) => async (req, res, next) => {
-    if (!isApiTokenRequest(req)) return next(); // web/JWT requests pass through untouched
+    if (!isApiTokenRequest(req)) return next();
     try {
         const companyId = req.headers["companyid"] || "";
         const roleType = await getRoleType(companyId, req.uid);
@@ -156,46 +185,31 @@ const requireRole = (allowed = [ROLE_OWNER, ROLE_ADMIN]) => async (req, res, nex
     }
 };
 
-/**
- * Express middleware: require a permission KEY.
- * - write:true (default) needs permission === true.
- * - write:false (read) needs permission !== null.
- * Owner/admin always pass.
- */
-// Normalize heterogeneous permission values to a write/read decision.
-// boolean keys: true = read+write, false = read-only, null = none.
-// scoped keys: 1 = Own (write own), 2 = Everyone (write all), null/0 = none.
 const isWritable = (permission) => permission === true || permission === 1 || permission === 2;
 const isReadable = (permission) => permission !== null && permission !== undefined && permission !== 0;
 
+/**
+ * Express middleware: require a permission KEY for the request's project.
+ * write:true (default) needs a writable value, write:false any readable one.
+ */
 const requirePermission = (path, { write = true } = {}) => async (req, res, next) => {
-    if (!isApiTokenRequest(req)) return next(); // web/JWT requests pass through untouched
+    if (!isApiTokenRequest(req)) return next();
     if (!fineGrainedEnforced()) return next();
+    const forbid = (statusText) => res.status(403).json({ status: false, statusText, error: "Forbidden", permission: path });
     try {
         const companyId = req.headers["companyid"] || "";
-        const permission = await evaluatePermission(companyId, req.uid, path);
-        const ok = write ? isWritable(permission) : isReadable(permission);
-        if (ok) return next();
-        return res.status(403).json({
-            status: false,
-            statusText: "You do not have permission to perform this action.",
-            error: "Forbidden",
-            permission: path,
-        });
+        const projectId = await projectIdForRequest(companyId, req);
+        const permission = await evaluatePermission(companyId, req.uid, path, { projectId });
+        if (write ? isWritable(permission) : isReadable(permission)) return next();
+        return forbid("You do not have permission to perform this action.");
     } catch (error) {
-        // Fail-open on internal errors (e.g. transient rules-fetch failure)
-        // so a glitch never blocks the whole app; real denials still block.
         logger.error(`requirePermission error (${path}): ${error.message || error}`);
-        return next();
+        return forbid("Permission check failed.");
     }
 };
 
-/**
- * Express middleware for PATCH /api/v2/tasks: enforce the permission key
- * mapped to req.body.action. Unmapped actions pass through.
- */
 const requireTaskActionPermission = () => async (req, res, next) => {
-    if (!isApiTokenRequest(req)) return next(); // web/JWT requests pass through untouched
+    if (!isApiTokenRequest(req)) return next();
     if (!fineGrainedEnforced()) return next();
     const action = req.body && req.body.action;
     const key = action && TASK_ACTION_PERMISSION[action];
@@ -230,10 +244,8 @@ const MCP_PERMISSION_KEYS = [
 ];
 
 /**
- * Evaluate many permission keys at once for a user.
- * Returns { roleType, permissions: { key: null|false|true } }.
- * Used by the whoami endpoint so the MCP server gets the full effective
- * permission map in one call at connect time.
+ * The company-wide effective map { roleType, permissions: { key: value } } the
+ * whoami endpoint hands the MCP server at connect time.
  */
 const evaluateMany = async (companyId, uid, keys = MCP_PERMISSION_KEYS) => {
     const roleType = await getRoleType(companyId, uid);
@@ -253,18 +265,9 @@ const evaluateMany = async (companyId, uid, keys = MCP_PERMISSION_KEYS) => {
         logger.error(`evaluateMany fetchRules error: ${error.message || error}`);
     }
     for (const key of keys) {
-        let rule = null;
-        let ok = true;
-        for (const segment of String(key).split('.')) {
-            rule = rule ? rule[segment] : arranged[segment];
-            if (rule === undefined || rule === null) { ok = false; break; }
-        }
-        if (ok && rule && Array.isArray(rule.roles)) {
-            const match = rule.roles.find((r) => r.key === roleType);
-            permissions[key] = match ? match.permission : null;
-        } else {
-            permissions[key] = null;
-        }
+        const rule = lookupRule(arranged, key);
+        const match = rule && rule.roles.find((r) => r.key === roleType);
+        permissions[key] = match ? match.permission : null;
     }
     return { roleType, permissions };
 };

--- a/Modules/Agents/permissions.js
+++ b/Modules/Agents/permissions.js
@@ -1,50 +1,19 @@
 const mongoose = require('mongoose');
 const { SCHEMA_TYPE } = require('../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
-const { myCache } = require('../../Config/config');
-const { getRoleType, isPrivileged, arrangeRules, isWritable, isReadable } = require('../../Config/permissionGuard');
-const { fetchRules } = require('../settings/securityPermissions/controller');
+const { evaluatePermission, isWritable, isReadable } = require('../../Config/permissionGuard');
 const registry = require('./registry');
 
 // The person behind an agent decides what the agent may do: the token holder,
 // the person who started the run, or the approver of a proposal. Their
-// Security & Permissions catalogue is evaluated for the action's project the
-// same way the web app evaluates it for them — global rules, or the project's
-// own rules when the project opted out of the global ones. Anything that
-// cannot be resolved (no person, not a member, rules unreadable) is refused.
+// Security & Permissions catalogue is evaluated for the action's project by the
+// same evaluator the API guards use. Anything that cannot be resolved (no
+// person, not a member, rules unreadable) is refused.
 
 const OBJECT_ID = /^[0-9a-fA-F]{24}$/;
-const PROJECT_RULES_TTL_SECONDS = 604800;
 const REASON = 'permission_denied';
 
 const oid = (v) => (OBJECT_ID.test(String(v || '')) ? new mongoose.Types.ObjectId(String(v)) : null);
-
-const lookup = (arranged, path) => {
-    let rule = null;
-    for (const segment of String(path).split('.')) {
-        rule = rule ? rule[segment] : arranged[segment];
-        if (rule === undefined || rule === null) return null;
-    }
-    return rule && Array.isArray(rule.roles) ? rule : null;
-};
-
-/* Same cache key as Modules/projectRules, so an edit there invalidates this too. */
-const projectRules = async (companyId, projectId) => {
-    const key = `projectRules:${projectId}`;
-    const cached = myCache.get(key);
-    if (Array.isArray(cached) && cached.length) return cached;
-    const rules = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.PROJECT_RULES, data: [{ projectId: String(projectId) }] }, 'find');
-    myCache.set(key, rules || [], PROJECT_RULES_TTL_SECONDS);
-    return rules || [];
-};
-
-const rulesFor = async (companyId, projectId) => {
-    const project = projectId && oid(projectId)
-        ? await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.PROJECTS, data: [{ _id: oid(projectId) }, { isGlobalPermission: 1 }] }, 'findOne')
-        : null;
-    if (project && project.isGlobalPermission === false) return arrangeRules(await projectRules(companyId, projectId));
-    return arrangeRules(await fetchRules(companyId));
-};
 
 const projectOf = async (companyId, params = {}) => {
     if (params.projectId) return String(params.projectId);
@@ -52,17 +21,6 @@ const projectOf = async (companyId, params = {}) => {
     if (!taskId) return null;
     const task = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [{ _id: taskId }, { ProjectID: 1 }] }, 'findOne');
     return task && task.ProjectID ? String(task.ProjectID) : null;
-};
-
-/* null | false | true (or 1 | 2 for scoped keys), exactly as the catalogue stores it. */
-const evaluate = async (companyId, uid, key, { projectId } = {}) => {
-    const roleType = await getRoleType(companyId, uid);
-    if (roleType === null) return null;
-    if (isPrivileged(roleType)) return true;
-    const rule = lookup(await rulesFor(companyId, projectId), key);
-    if (!rule) return null;
-    const match = rule.roles.find((r) => r.key === roleType);
-    return match ? match.permission : null;
 };
 
 const denied = (key, why) => ({ allowed: false, reason: `${REASON}: ${key} ${why}`, permission: key });
@@ -73,11 +31,10 @@ const holderMay = async (companyId, actor, action, params = {}) => {
     if (!required.length) return { allowed: true, reason: '', permission: null };
     const uid = String((actor && actor.userId) || '');
     if (!OBJECT_ID.test(uid)) return denied(required[0].key, 'cannot be checked — no person is behind this agent');
-    let projectId;
     try {
-        projectId = await projectOf(companyId, params);
+        const projectId = await projectOf(companyId, params);
         for (const { key, write } of required) {
-            const value = await evaluate(companyId, uid, key, { projectId });
+            const value = await evaluatePermission(companyId, uid, key, { projectId });
             if (!(write ? isWritable(value) : isReadable(value))) return denied(key, 'is not granted to the person behind this agent');
         }
     } catch (e) {
@@ -86,4 +43,4 @@ const holderMay = async (companyId, actor, action, params = {}) => {
     return { allowed: true, reason: '', permission: null };
 };
 
-module.exports = { holderMay, evaluate, REASON };
+module.exports = { holderMay, evaluate: evaluatePermission, REASON };

--- a/Modules/settings/securityPermissions/memberDefaults.js
+++ b/Modules/settings/securityPermissions/memberDefaults.js
@@ -1,0 +1,72 @@
+// Safe to hardcode here and nowhere else: importCompanyRoles in utils/data.js is what creates role
+// key 3 as "Member", so at seed time the number and the role are the same thing. Runtime code must
+// never assume it — a company can rename or add roles afterwards.
+const MEMBER_ROLE_TYPE = 3;
+
+// What a brand-new company gives the Member role. Before this existed the rules were seeded with
+// empty role lists, so an invited teammate saw a product with almost everything hidden and the
+// owner had to set ~100 switches by hand before anyone could work.
+//
+// These are not invented. Two established companies were read and compared: where both owners had
+// independently made the same choice, that choice is the default; where they differed, the more
+// restrictive of the two is used, never below Read if both allowed at least Read. Keys absent from
+// this map get nothing, so anything unlisted or newly added fails closed.
+//
+// false = Read, true = Read & Write, a number = the "Own (1) / Everyone (2)" selection fields.
+const MEMBER_DEFAULT_PERMISSIONS = Object.freeze({
+    // Sections. `settings` and `artificial_intelligence` are deliberately absent.
+    project: false,
+    task: true,
+    chat: true,
+    sheet_settings: false,
+
+    // Projects: members work inside them, they do not administer them.
+    project_list: false,
+    public_projects: false,
+    private_projects: 1,
+    project_details: false,
+
+    // Tasks: the day-to-day job, so this group is open.
+    task_list: true,
+    task_create: true,
+    sub_task_create: true,
+    task_name_edit: true,
+    task_total_estimate: true,
+    task_status: true,
+    task_assignee: true,
+    task_priority: true,
+    task_due_date: true,
+    task_start_date: true,
+    task_description: true,
+    task_checklist: true,
+    task_checklist_assign_remove: true,
+    task_attachments: true,
+    task_tag: true,
+    task_type: true,
+    task_comment: true,
+    task_details: true,
+    task_duplicate: true,
+    task_move: true,
+    task_merge: true,
+    task_archive: true,
+    task_delete: true,
+    task_convert_to_list: true,
+    task_convert_to_subtask: true,
+    convert_to_task: true,
+    task_activity_log: false,
+    task_estimated_hours: 1,
+    show_tasks: 1,
+    queue_list: true,
+    list_view_column: true,
+    advance_search: true,
+
+    // Chat.
+    one_to_one_chat: true,
+    chat_category: true,
+    chat_channel: true,
+
+    // Timesheets: their own only.
+    user_timesheet: 1,
+});
+
+module.exports = { MEMBER_ROLE_TYPE, MEMBER_DEFAULT_PERMISSIONS };

--- a/migrations/011-member-default-rules.js
+++ b/migrations/011-member-default-rules.js
@@ -1,0 +1,86 @@
+const { MEMBER_ROLE_TYPE, MEMBER_DEFAULT_PERMISSIONS } = require('../Modules/settings/securityPermissions/memberDefaults');
+
+/* Companies seeded before the Member defaults shipped (PR #506) hold rules with no Member entry at
+ * all, and a missing entry reads as "None" everywhere: the settings matrix, the web app and the
+ * API. Their members could do almost nothing. 003 cannot help, it only looks for missing keys.
+ *
+ * Only a company where no global rule has a Member entry is touched, because any entry means an
+ * owner has used the matrix for that role and a gap there is their choice. Each added entry carries
+ * SEEDED_BY so down() removes exactly those, and only while the value is still the default. */
+
+const ID = '011-member-default-rules';
+const SEEDED_BY = ID;
+
+const hasMember = (rule) => (rule.roles || []).some((role) => role && role.key === MEMBER_ROLE_TYPE);
+
+async function memberRoleExists(ctx, companyId) {
+    const roles = await ctx.company(companyId, { type: ctx.SCHEMA_TYPE.SETTINGS, data: [{ name: ctx.settingsCollectionDocs.ROLES }] }, 'findOne');
+    return Array.isArray(roles && roles.settings) && roles.settings.some((role) => role && role.key === MEMBER_ROLE_TYPE);
+}
+
+async function backfillCompany(ctx, companyId) {
+    const type = ctx.SCHEMA_TYPE.RULES;
+    const rules = await ctx.company(companyId, { type, data: [{ projectId: { $exists: false } }] }, 'find') || [];
+    if (!rules.length) return { added: 0, skipped: 'unseeded' };
+    if (rules.some(hasMember)) return { added: 0, skipped: 'configured' };
+    if (!(await memberRoleExists(ctx, companyId))) return { added: 0, skipped: 'no-member-role' };
+
+    let added = 0;
+    for (const rule of rules) {
+        const permission = MEMBER_DEFAULT_PERMISSIONS[rule.key];
+        if (permission === undefined) continue;
+        const result = await ctx.company(companyId, {
+            type,
+            data: [
+                { _id: rule._id, 'roles.key': { $ne: MEMBER_ROLE_TYPE } },
+                { $push: { roles: { key: MEMBER_ROLE_TYPE, permission, seededBy: SEEDED_BY } } },
+            ],
+        }, 'updateOne');
+        added += result && result.modifiedCount ? 1 : 0;
+    }
+    return { added, rules: rules.length };
+}
+
+async function revertCompany(ctx, companyId) {
+    const type = ctx.SCHEMA_TYPE.RULES;
+    const rules = await ctx.company(companyId, { type, data: [{ projectId: { $exists: false } }] }, 'find') || [];
+    let removed = 0;
+    let keptChanged = 0;
+    for (const rule of rules) {
+        const roles = rule.roles || [];
+        const seeded = roles.filter((role) => role && role.seededBy === SEEDED_BY);
+        if (!seeded.length) continue;
+        const untouched = (role) => role.seededBy === SEEDED_BY && role.key === MEMBER_ROLE_TYPE && role.permission === MEMBER_DEFAULT_PERMISSIONS[rule.key];
+        const kept = roles.filter((role) => !(role && untouched(role)));
+        keptChanged += seeded.length - (roles.length - kept.length);
+        if (kept.length === roles.length) continue;
+        await ctx.company(companyId, { type, data: [{ _id: rule._id }, { $set: { roles: kept } }] }, 'updateOne');
+        removed += roles.length - kept.length;
+    }
+    return { removed, keptChanged };
+}
+
+module.exports = {
+    id: ID,
+    scope: 'company',
+    SEEDED_BY,
+    backfillCompany,
+    async up(ctx) {
+        const { removeCache } = require('../utils/commonFunctions');
+        await ctx.forEachCompany(async (companyId) => {
+            const counts = await backfillCompany(ctx, companyId);
+            if (counts.added) removeCache(`rules:${companyId}`);
+            ctx.logger.info(`[migrations] 011 ${companyId}: ${JSON.stringify(counts)}`);
+            return counts;
+        });
+    },
+    async down(ctx) {
+        const { removeCache } = require('../utils/commonFunctions');
+        await ctx.forEachCompany(async (companyId) => {
+            const counts = await revertCompany(ctx, companyId);
+            if (counts.removed) removeCache(`rules:${companyId}`);
+            ctx.logger.info(`[migrations] 011 down ${companyId}: ${JSON.stringify(counts)}`);
+            return counts;
+        });
+    },
+};

--- a/tests/integration/member-permissions.int.test.js
+++ b/tests/integration/member-permissions.int.test.js
@@ -1,0 +1,126 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { createProject, createTask, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const forbidden = (res) => res.status === 403 && res.body && res.body.status === false;
+
+/* The API guards only judge personal API tokens (web sessions pass through by design), so every
+ * call here is made the way the MCP server makes it: with a token the member minted for themself. */
+async function tokenClientFor(session) {
+    const res = await session.api.post('/api/v2/api-tokens', { name: `Member permissions ${uniqueSuffix()}`, scopes: ['read', 'write'] });
+    if (!res.body || res.body.status !== true) throw new Error(`token for ${session.email} failed: ${JSON.stringify(res.body)}`);
+    return createApiClient({ baseURL: state.baseURL, accessToken: res.body.data.token, companyId: state.companyId });
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+let owner;
+let member;
+let memberApi;
+let project;
+
+beforeAll(async () => {
+    owner = await loginAs('owner');
+    member = await loginAs('member');
+    memberApi = await tokenClientFor(member);
+    project = await createProject(owner.api, { assigneeIds: [owner.uid, member.uid], createdBy: owner.uid });
+});
+
+describe('a member of a brand-new company', () => {
+    it('holds the Member defaults the Security & Permissions matrix shows', async () => {
+        const res = await memberApi.get('/api/v2/api-tokens/me');
+        expect(res.status).toBe(200);
+        expect(res.body.data.roleType).toBe(3);
+        expect(res.body.data.permissions).toMatchObject({
+            'task.task_list': true,
+            'task.task_create': true,
+            'task.task_comment': true,
+            'task.task_priority': true,
+            'sheet_settings.user_timesheet': 1,
+            'project.project_details': false,
+            'project.project_create': null,
+            'project.project_sprint_create': null,
+            'project.project_name_edit': null,
+            'sheet_settings.workload_timesheet': null,
+        });
+    });
+
+    it('creates a task in a project they belong to', async () => {
+        const task = await createTask(memberApi, { project, user: member, companyOwnerId: owner.uid });
+        expect(task._id).toMatch(/^[a-f0-9]{24}$/);
+    });
+
+    it('comments on that task', async () => {
+        const task = await createTask(memberApi, { project, user: member, companyOwnerId: owner.uid });
+        const res = await memberApi.post('/api/v1/comments', {
+            data: {
+                message: 'Member comment',
+                type: 'text',
+                userId: member.uid,
+                objId: { projectId: project._id, sprintId: task.sprintId, taskId: task._id },
+                project: false,
+                mentionIds: [],
+                isDeleted: false,
+                hasReply: false,
+                replyMessageId: '',
+                mediaURL: '',
+                mediaName: '',
+                mediaSize: 0,
+            },
+        });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ status: true, data: { userId: member.uid } });
+    });
+
+    it('logs time on that task', async () => {
+        const task = await createTask(memberApi, { project, user: member, companyOwnerId: owner.uid });
+        const res = await memberApi.post('/api/v2/manualLogtime', {
+            logTimeDate: today(),
+            description: 'Member log',
+            startLogTime: '09:00',
+            endLogTime: '09:30',
+            timeDuration: '00:30',
+            ticketId: task._id,
+            projectId: project._id,
+            companyId: state.companyId,
+            userId: member.uid,
+            isEdit: false,
+            userName: 'Max Member',
+            dateFormat: 'DD/MM/YYYY',
+            timeSheetId: '',
+            sprintId: task.sprintId,
+            taskName: 'E2E Task',
+            companyOwnerId: owner.uid,
+            projectName: project.ProjectName,
+            previousLoggedTime: '',
+            timeZone: 'UTC',
+            timeFormat: '24',
+            billable: true,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(true);
+    });
+
+    it('is refused what the defaults leave at None', async () => {
+        expect(forbidden(await memberApi.post('/api/v1/createproject', { ProjectName: `Member project ${uniqueSuffix()}` }))).toBe(true);
+        expect(forbidden(await memberApi.post('/api/v1/sprint', { projectId: project._id, sprintName: `Member sprint ${uniqueSuffix()}` }))).toBe(true);
+        expect(forbidden(await memberApi.put('/api/v1/securityPermissions', { type: 'updateOne', key: '$set', id: project._id, updateObject: { roles: [] } }))).toBe(true);
+    });
+
+    it('is refused a task in a project whose own rules set Task create to None', async () => {
+        const own = await createProject(owner.api, { assigneeIds: [owner.uid, member.uid], createdBy: owner.uid });
+        const imported = await owner.api.post('/api/v1/importSettingsProjectFunction', { companyId: state.companyId, type: 'project', projectId: own._id });
+        expect(imported.body.status).toBe(true);
+        expect((await owner.api.put(`/api/v1/project/${own._id}`, { updateObject: { isGlobalPermission: false } })).status).toBe(200);
+
+        const rules = await owner.api.get(`/api/v1/projectRules/${own._id}`);
+        const taskCreate = rules.body.find((rule) => rule.key === 'task_create');
+        expect(taskCreate.roles.find((role) => role.key === 3)).toMatchObject({ permission: true });
+        const roles = [...taskCreate.roles.filter((role) => role.key !== 3), { key: 3, permission: null }];
+        const updated = await owner.api.put('/api/v1/projectRules/update', { updateObject: { roles }, key: '$set', id: taskCreate._id, projectId: own._id });
+        expect(updated.status).toBe(200);
+
+        await expect(createTask(memberApi, { project: own, user: member, companyOwnerId: owner.uid })).rejects.toThrow(/\(403\)/);
+        await expect(createTask(memberApi, { project, user: member, companyOwnerId: owner.uid })).resolves.toMatchObject({ projectId: project._id });
+    });
+});

--- a/tests/migration-member-default-rules.test.js
+++ b/tests/migration-member-default-rules.test.js
@@ -1,0 +1,117 @@
+const mockDbs = {};
+const mockDbFor = (companyId) => { mockDbs[companyId] = mockDbs[companyId] || require('./fixtures/fakeMongo').create(); return mockDbs[companyId]; };
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (companyId, q, method) => mockDbFor(String(companyId)).crud(companyId, q, method) }));
+jest.mock('../Config/config', () => ({ myCache: { get: () => undefined, set: () => {}, del: () => {}, getTtl: () => 0 } }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+
+const { buildContext, validateMigration, listMigrations } = require('../migrations');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { settingsCollectionDocs } = require('../Config/collections');
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { removeCache } = require('../utils/commonFunctions');
+const { evaluatePermission } = require('../Config/permissionGuard');
+const { MEMBER_DEFAULT_PERMISSIONS } = require('../Modules/settings/securityPermissions/memberDefaults');
+const migration = require('../migrations/011-member-default-rules');
+
+const LEGACY = '6f0000000000000000000c01';
+const CONFIGURED = '6f0000000000000000000c02';
+const UNSEEDED = '6f0000000000000000000c03';
+const MEMBER = '6f0000000000000000000002';
+const GUEST_ONLY = [{ key: 0, permission: false }];
+const logger = { info: jest.fn(), error: jest.fn() };
+const contextFor = (companies) => buildContext({ MongoDbCrudOpration, SCHEMA_TYPE, settingsCollectionDocs, logger, listCompanies: async () => companies.map((_id) => ({ _id })) });
+const rules = (companyId) => mockDbFor(companyId).store[SCHEMA_TYPE.RULES] || [];
+const ruleFor = (companyId, key) => rules(companyId).find((r) => r.key === key);
+const memberEntry = (companyId, key) => (ruleFor(companyId, key).roles || []).find((r) => r.key === 3);
+
+/* The shape Local360 (6a8ee973d625fca52e519a12) has: every rule seeded with a Guest entry only. */
+const seedCompany = (companyId, { member = null } = {}) => {
+    const db = mockDbFor(companyId);
+    db.seed(SCHEMA_TYPE.SETTINGS, { name: settingsCollectionDocs.ROLES, settings: [{ key: 0, name: 'Guest' }, { key: 1, name: 'Owner' }, { key: 2, name: 'Admin' }, { key: 3, name: 'Member' }] });
+    db.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: MEMBER, roleType: 3 });
+    const project = db.seed(SCHEMA_TYPE.RULES, { key: 'project', name: 'Project', isParent: true, roles: [...GUEST_ONLY] });
+    const task = db.seed(SCHEMA_TYPE.RULES, { key: 'task', name: 'Task', isParent: true, roles: [...GUEST_ONLY] });
+    const settings = db.seed(SCHEMA_TYPE.RULES, { key: 'settings', name: 'Company Settings', isParent: true, roles: [...GUEST_ONLY] });
+    const child = (key, parent, roles = [...GUEST_ONLY]) => db.seed(SCHEMA_TYPE.RULES, { key, name: key, isParent: false, parentId: String(parent._id), roles });
+    child('project_create', project);
+    child('task_create', task, member === null ? [...GUEST_ONLY] : [...GUEST_ONLY, { key: 3, permission: member }]);
+    child('task_comment', task);
+    child('settings_security_permissions', settings);
+    db.seed(SCHEMA_TYPE.RULES, { key: 'toggle', name: 'toggle', isParent: false, roles: [] });
+};
+
+beforeEach(() => {
+    Object.keys(mockDbs).forEach((k) => { delete mockDbs[k]; });
+    jest.clearAllMocks();
+});
+
+describe('011-member-default-rules', () => {
+    test('is a valid company-scoped migration listed after 010, with a down()', () => {
+        expect(() => validateMigration(migration, '011-member-default-rules')).not.toThrow();
+        expect(typeof migration.down).toBe('function');
+        const ids = listMigrations().map((m) => m.id);
+        expect(ids.indexOf('011-member-default-rules')).toBeGreaterThan(ids.indexOf('010-seed-brief-parse-skill'));
+    });
+
+    test('a member of a company seeded without Member entries is denied what the defaults allow, and allowed after the backfill', async () => {
+        seedCompany(LEGACY);
+        expect(await evaluatePermission(LEGACY, MEMBER, 'task.task_create')).toBeNull();
+        expect(await evaluatePermission(LEGACY, MEMBER, 'task.task_comment')).toBeNull();
+
+        const ctx = contextFor([LEGACY]);
+        await migration.up(ctx);
+
+        expect(ctx.companies[LEGACY]).toEqual({ ok: true, added: 4, rules: 8 });
+        expect(await evaluatePermission(LEGACY, MEMBER, 'task.task_create')).toBe(true);
+        expect(await evaluatePermission(LEGACY, MEMBER, 'task.task_comment')).toBe(true);
+        expect(await evaluatePermission(LEGACY, MEMBER, 'project.project_create')).toBeNull();
+        expect(await evaluatePermission(LEGACY, MEMBER, 'settings.settings_security_permissions')).toBeNull();
+        expect(memberEntry(LEGACY, 'project')).toEqual({ key: 3, permission: MEMBER_DEFAULT_PERMISSIONS.project, seededBy: '011-member-default-rules' });
+        expect(ruleFor(LEGACY, 'toggle').roles).toEqual([]);
+        expect(ruleFor(LEGACY, 'task_create').roles[0]).toEqual({ key: 0, permission: false });
+        expect(removeCache).toHaveBeenCalledWith(`rules:${LEGACY}`);
+        expect(mockDbFor(LEGACY).calls.every((call) => call.companyId === LEGACY)).toBe(true);
+    });
+
+    test('is idempotent: a second run adds nothing', async () => {
+        seedCompany(LEGACY);
+        await migration.up(contextFor([LEGACY]));
+        const again = contextFor([LEGACY]);
+        await migration.up(again);
+        expect(again.companies[LEGACY]).toEqual({ ok: true, added: 0, skipped: 'configured' });
+        expect(rules(LEGACY).flatMap((r) => r.roles).filter((r) => r.key === 3)).toHaveLength(4);
+    });
+
+    test('never touches a company where an admin has set any Member entry, even None', async () => {
+        seedCompany(CONFIGURED, { member: null });
+        ruleFor(CONFIGURED, 'task_comment').roles.push({ key: 3, permission: null });
+        const ctx = contextFor([CONFIGURED]);
+        await migration.up(ctx);
+        expect(ctx.companies[CONFIGURED]).toEqual({ ok: true, added: 0, skipped: 'configured' });
+        expect(memberEntry(CONFIGURED, 'task_comment')).toEqual({ key: 3, permission: null });
+        expect(ruleFor(CONFIGURED, 'task_create').roles.some((r) => r.key === 3)).toBe(false);
+    });
+
+    test('skips a company whose rules were never seeded', async () => {
+        mockDbFor(UNSEEDED);
+        const ctx = contextFor([UNSEEDED]);
+        await migration.up(ctx);
+        expect(ctx.companies[UNSEEDED]).toEqual({ ok: true, added: 0, skipped: 'unseeded' });
+    });
+
+    test('down() removes only the entries it added that still hold the default', async () => {
+        seedCompany(LEGACY);
+        await migration.up(contextFor([LEGACY]));
+        memberEntry(LEGACY, 'task_comment').permission = null;
+
+        const ctx = contextFor([LEGACY]);
+        await migration.down(ctx);
+
+        expect(ctx.companies[LEGACY]).toEqual({ ok: true, removed: 3, keptChanged: 1 });
+        expect(memberEntry(LEGACY, 'task_create')).toBeUndefined();
+        expect(memberEntry(LEGACY, 'task_comment')).toEqual({ key: 3, permission: null, seededBy: '011-member-default-rules' });
+        expect(ruleFor(LEGACY, 'task_create').roles).toEqual([{ key: 0, permission: false }]);
+    });
+});

--- a/tests/permission-guard-member-rules.test.js
+++ b/tests/permission-guard-member-rules.test.js
@@ -1,0 +1,127 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+const mockFailing = { rules: false };
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({
+    MongoDbCrudOpration: (companyId, q, method) => {
+        if (mockFailing.rules && q.type === 'rules') return Promise.reject(new Error('rules unreadable'));
+        return mockDb.crud(companyId, q, method);
+    },
+}));
+jest.mock('../Config/config', () => ({ myCache: { get: () => undefined, set: () => {}, del: () => {}, getTtl: () => 0 } }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { evaluatePermission, requirePermission, requireTaskActionPermission } = require('../Config/permissionGuard');
+const { holderMay } = require('../Modules/Agents/permissions');
+
+const CID = '6f00000000000000000000c1';
+const OWNER = '6f0000000000000000000001';
+const ADMIN = '6f0000000000000000000002';
+const MEMBER = '6f0000000000000000000003';
+const OUTSIDER = '6f0000000000000000000009';
+const GLOBAL_PROJECT = '6f0000000000000000000a01';
+const OWN_RULES_PROJECT = '6f0000000000000000000a02';
+const TASK_IN_OWN_RULES = '6f0000000000000000000b01';
+
+const seedRules = (type, grants, extra = {}) => {
+    const project = mockDb.seed(type, { key: 'project', name: 'Project', isParent: true, roles: [{ key: 3, permission: false }], ...extra });
+    const task = mockDb.seed(type, { key: 'task', name: 'Task', isParent: true, roles: [{ key: 3, permission: true }], ...extra });
+    Object.entries(grants).forEach(([key, roles]) => mockDb.seed(type, {
+        key, name: key, isParent: false, parentId: String(key.startsWith('project') ? project._id : task._id), roles, ...extra,
+    }));
+};
+
+const run = async (middleware, req) => {
+    const res = { code: 200 };
+    res.status = (c) => { res.code = c; return res; };
+    res.json = (b) => { res.body = b; return res; };
+    let passed = false;
+    await middleware(req, res, () => { passed = true; });
+    return { passed, code: res.code, body: res.body };
+};
+const patRequest = (uid, body) => ({ apiToken: { _id: 't' }, uid, headers: { companyid: CID }, body });
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    mockFailing.rules = false;
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: OWNER, roleType: 1 });
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: ADMIN, roleType: 2 });
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: MEMBER, roleType: 3 });
+    mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: GLOBAL_PROJECT, isGlobalPermission: true });
+    mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: OWN_RULES_PROJECT, isGlobalPermission: false });
+    mockDb.seed(SCHEMA_TYPE.TASKS, { _id: TASK_IN_OWN_RULES, ProjectID: OWN_RULES_PROJECT });
+    seedRules(SCHEMA_TYPE.RULES, {
+        task_create: [{ key: 3, permission: true }],
+        task_comment: [{ key: 3, permission: false }],
+        task_priority: [{ key: 3, permission: true }],
+        task_delete: [{ key: 3, permission: null }],
+        task_move: [{ key: 0, permission: false }],
+        project_create: [],
+    });
+    seedRules(SCHEMA_TYPE.PROJECT_RULES, {
+        task_create: [{ key: 3, permission: null }],
+        task_priority: [{ key: 3, permission: false }],
+        task_comment: [{ key: 3, permission: true }],
+    }, { projectId: OWN_RULES_PROJECT });
+});
+
+describe('the truth table the Security & Permissions matrix shows', () => {
+    test.each([
+        ['owner bypasses', OWNER, 'task.task_delete', true],
+        ['admin bypasses', ADMIN, 'project.project_create', true],
+        ['a non-member gets nothing', OUTSIDER, 'task.task_create', null],
+        ['a member with true may write', MEMBER, 'task.task_create', true],
+        ['a member with false may read', MEMBER, 'task.task_comment', false],
+        ['a member with null gets nothing', MEMBER, 'task.task_delete', null],
+        ['a member with no entry gets nothing (the matrix shows None)', MEMBER, 'task.task_move', null],
+        ['a rule with no roles gets nothing', MEMBER, 'project.project_create', null],
+        ['a rule that does not exist gets nothing', MEMBER, 'task.task_nonexistent', null],
+    ])('%s', async (_, uid, path, expected) => {
+        expect(await evaluatePermission(CID, uid, path, { projectId: GLOBAL_PROJECT })).toBe(expected);
+    });
+
+    test('a project with its own rules is evaluated against them, as checkPermission(path, false) does', async () => {
+        expect(await evaluatePermission(CID, MEMBER, 'task.task_create', { projectId: OWN_RULES_PROJECT })).toBeNull();
+        expect(await evaluatePermission(CID, MEMBER, 'task.task_comment', { projectId: OWN_RULES_PROJECT })).toBe(true);
+        expect(await evaluatePermission(CID, MEMBER, 'task.task_move', { projectId: OWN_RULES_PROJECT })).toBeNull();
+        expect(await evaluatePermission(CID, MEMBER, 'project.project_list', { projectId: OWN_RULES_PROJECT })).toBe(true);
+        expect(await evaluatePermission(CID, OWNER, 'task.task_create', { projectId: OWN_RULES_PROJECT })).toBe(true);
+    });
+});
+
+describe('the API guards follow the same table for PAT requests', () => {
+    test('task create is allowed in a global-rules project and refused where the project rules say None', async () => {
+        const allowed = await run(requirePermission('task.task_create'), patRequest(MEMBER, { data: { ProjectID: GLOBAL_PROJECT } }));
+        expect(allowed.passed).toBe(true);
+
+        const refused = await run(requirePermission('task.task_create'), patRequest(MEMBER, { data: { ProjectID: OWN_RULES_PROJECT } }));
+        expect(refused.passed).toBe(false);
+        expect(refused.code).toBe(403);
+        expect(refused.body).toMatchObject({ status: false, permission: 'task.task_create' });
+    });
+
+    test('a task update is judged by the task\'s own project, not a project id the client claims', async () => {
+        const req = patRequest(MEMBER, { action: 'updatePriority', projectId: GLOBAL_PROJECT, taskData: { _id: TASK_IN_OWN_RULES } });
+        const result = await run(requireTaskActionPermission(), req);
+        expect(result.passed).toBe(false);
+        expect(result.code).toBe(403);
+    });
+
+    test('a rules read failure refuses instead of letting the request through', async () => {
+        mockFailing.rules = true;
+        const result = await run(requirePermission('task.task_create'), patRequest(MEMBER, { data: { ProjectID: GLOBAL_PROJECT } }));
+        expect(result.passed).toBe(false);
+        expect(result.code).toBe(403);
+    });
+
+    test('web sessions are still not gated here', async () => {
+        const result = await run(requirePermission('project.project_create'), { uid: MEMBER, headers: { companyid: CID }, body: {} });
+        expect(result.passed).toBe(true);
+    });
+
+    test('the agent holder check uses the same evaluator', async () => {
+        const verdict = await holderMay(CID, { kind: 'agent', userId: MEMBER }, 'task.update', { taskId: TASK_IN_OWN_RULES, fields: { Task_Priority: 'HIGH' } });
+        expect(verdict.allowed).toBe(false);
+        expect(verdict.reason).toContain('task_priority');
+    });
+});

--- a/utils/data.js
+++ b/utils/data.js
@@ -18,77 +18,7 @@ const {defaultProjectTours} = require("../utils/Tempates/projectTours");
 const { addSprintFun } = require('../Modules/Sprints/controller');
 const { updateMainChat } = require('../Modules/MainChats/controller');
 const { toSlug } = require('../Modules/settings/ProjectSkills/skillRules');
-
-// Safe to hardcode here and nowhere else: importCompanyRoles below is what creates role key 3 as
-// "Member", so at seed time the number and the role are the same thing. Runtime code must never
-// assume it — a company can rename or add roles afterwards.
-const MEMBER_ROLE_TYPE = 3;
-
-// What a brand-new company gives the Member role. Before this existed the rules were seeded with
-// empty role lists, so an invited teammate saw a product with almost everything hidden and the
-// owner had to set ~100 switches by hand before anyone could work.
-//
-// These are not invented. Two established companies were read and compared: where both owners had
-// independently made the same choice, that choice is the default; where they differed, the more
-// restrictive of the two is used, never below Read if both allowed at least Read. Keys absent from
-// this map get nothing, so anything unlisted or newly added fails closed.
-//
-// false = Read, true = Read & Write, a number = the "Own (1) / Everyone (2)" selection fields.
-const MEMBER_DEFAULT_PERMISSIONS = {
-    // Sections. `settings` and `artificial_intelligence` are deliberately absent.
-    project: false,
-    task: true,
-    chat: true,
-    sheet_settings: false,
-
-    // Projects: members work inside them, they do not administer them.
-    project_list: false,
-    public_projects: false,
-    private_projects: 1,
-    project_details: false,
-
-    // Tasks: the day-to-day job, so this group is open.
-    task_list: true,
-    task_create: true,
-    sub_task_create: true,
-    task_name_edit: true,
-    task_total_estimate: true,
-    task_status: true,
-    task_assignee: true,
-    task_priority: true,
-    task_due_date: true,
-    task_start_date: true,
-    task_description: true,
-    task_checklist: true,
-    task_checklist_assign_remove: true,
-    task_attachments: true,
-    task_tag: true,
-    task_type: true,
-    task_comment: true,
-    task_details: true,
-    task_duplicate: true,
-    task_move: true,
-    task_merge: true,
-    task_archive: true,
-    task_delete: true,
-    task_convert_to_list: true,
-    task_convert_to_subtask: true,
-    convert_to_task: true,
-    task_activity_log: false,
-    task_estimated_hours: 1,
-    show_tasks: 1,
-    queue_list: true,
-    list_view_column: true,
-    advance_search: true,
-
-    // Chat.
-    one_to_one_chat: true,
-    chat_category: true,
-    chat_channel: true,
-
-    // Timesheets: their own only.
-    user_timesheet: 1,
-};
+const { MEMBER_ROLE_TYPE, MEMBER_DEFAULT_PERMISSIONS } = require('../Modules/settings/securityPermissions/memberDefaults');
 
 //IMPORT CURRENCY
 exports.importCurrency = (companyName) => {


### PR DESCRIPTION
## Summary

Task 034 found that in Local360 (`6a8ee973d625fca52e519a12`) the permission rules only carry Guest (role 0) entries, so every Member permission check answered "no access". This PR finds the cause, adds the data repair as a migration, and fixes the one real place where the backend disagreed with what the Security & permissions screen shows.

## Which of (a), (b), (c)

**(c) is the cause, and a gap in the migrations let it stay. New companies are fine. (b) is not the cause, but one real divergence turned up and is fixed here.**

Evidence (read-only scripts against the dev database and a fresh harness company):

| Database | `rules` docs | Role 0 entries | Role 3 (Member) entries | Seeded at |
|---|---|---|---|---|
| Local360 `6a8ee973…` | 99 | 98 (97 `false`, 1 number) | **0** | 2026-08-26 14:24 UTC, all within 54 ms |
| Fresh setup-wizard company (e2e harness, this branch's base) | 99 | 98 (97 `false`, 1 number) | **44** (34 `true`, 6 `false`, 4 numbers) | at company creation |

- The 44 Member entries a new company gets are exactly the keys in `MEMBER_DEFAULT_PERMISSIONS` (added by PR #506, merged into beta 2026-08-26 06:15 UTC). `importCompanyRules` adds a Member entry only when none exists, so seeding cannot produce the Local360 shape on current code. That rules out (a) for new companies.
- Local360's single seeding pass left no Member entries, so it ran on code without #506. Every company seeded before #506 whose owner never used the Member column is in the same state.
- `003-permission-catalogue` cannot repair it. It only checks for the sentinel key `task_total_estimate`, and `global.schema_versions` records `{"repaired":false}` for Local360.
- The other local database with rules (`6a8c18fd…`, seeded 2026-08-24, not in `global.companies`) has Member entries on 98 rules. Its owner set them by hand.
- There is no global catalogue collection. `003` rewrites each company's own `rules` from `utils/data.js`.

## Truth table

Frontend `checkPermission` (`frontend/src/composable/index.js`), the matrix (`PermissionMatrix.vue`: `value()` is the entry's permission or `null`, and `null` renders as "None"), backend `evaluatePermission` (`Config/permissionGuard.js`) and the agent holder check (`Modules/Agents/permissions.js`):

| Case | Matrix shows | Frontend | Backend before | Backend after |
|---|---|---|---|---|
| Owner (1) / Admin (2) | fixed check | `true` | `true` | `true` |
| Not a company member | n/a | n/a | `null` | `null` |
| Role has no entry on the rule | None | `null` | `null` | `null` |
| Rule key does not exist | row absent | `null` | `null` | `null` |
| `permission: null` | None | `null` | `null` | `null` |
| `permission: false` | Read | `false` | `false` | `false` |
| `permission: true` | Write | `true` | `true` | `true` |
| `1` / `2` (selection fields) | Own / Everyone | `1` / `2` | `1` / `2` | `1` / `2` |
| Project with `isGlobalPermission: false` | project's own matrix | project rules | **API guards: global rules**; agent check: project rules | project rules, for both |
| `project_list` / `public_projects` in such a project | n/a | `true` | global rule | `true` |
| Rules cannot be read | n/a | n/a | guard: `null`, so refused; agent: refused | refused (403 "Permission check failed.") |

Guards turn the value into a decision with `isWritable` (`true`, `1`, `2`) or `isReadable` (anything except `null`/`undefined`/`0`).

On "a missing entry means allowed in the frontend but denied in the backend": no layer ever read a missing entry as allowed, so (b) was not the cause. The only disagreement was per-project rules. The API guards used the company rules for a project that had its own; the web app and the agent check did not.

## What changed

- `migrations/011-member-default-rules.js` (company scope):
  - A company whose global rules have **no Member entry at all** gets the Member defaults added, one `updateOne` per rule, guarded by `'roles.key': { $ne: 3 }`.
  - A company with any Member entry, even `null`, is skipped as `configured`: an admin has used that column. Companies with no rules (`unseeded`) or no role 3 in the `roles` setting are skipped too.
  - Every added entry carries `seededBy: '011-member-default-rules'`. `down()` removes only marked entries whose value still equals the default; anything an admin changed since is kept and counted as `keptChanged`.
  - It clears `rules:<companyId>`.
- `Modules/settings/securityPermissions/memberDefaults.js`: `MEMBER_ROLE_TYPE` and `MEMBER_DEFAULT_PERMISSIONS` moved out of `utils/data.js`, so the migration does not load the whole seeding module. Values are unchanged.
- `Config/permissionGuard.js`:
  - `evaluatePermission(companyId, uid, path, { projectId })` reads the project's own rules when the project opted out of the global ones, and grants `project_list` / `public_projects` there, as the frontend does.
  - `requirePermission` takes the project from `taskData._id` (looked up in the database, so a client cannot borrow another project's rules), then `data.ProjectID`, then `projectId`.
  - A failed check now returns 403 instead of calling `next()`.
  - Web (JWT) requests still pass through untouched. The hard isolation is kept.
- `Modules/Agents/permissions.js`: the holder check uses that shared evaluator instead of its own copy. It still fails closed.

## Local data repair (not part of the PR's code path)

Dry run of 011 against the dev database, read only: `6a8ee973d625fca52e519a12 Local360 rules=99 add 44`. That is the only company in `global.companies`. It runs after this PR is green, and the result is reported separately.

Verified on the e2e Mongo with the real strict Mongoose schema (member entries stripped to the Local360 shape first):
- `up` gave `{"added":44,"rules":99}`, and all 44 entries kept `seededBy`.
- A second `up` gave `{"added":0,"skipped":"configured"}`.
- `down` gave `{"removed":44,"keptChanged":0}`.
- `up` again gave `{"added":44}`.

## Tests

Written first; each fails on `origin/beta` and passes here.

- `tests/migration-member-default-rules.test.js` (6 tests):
  - A member of a Guest-only company is denied `task.task_create` / `task.task_comment` before the backfill and allowed after, while `project_create` / `settings_security_permissions` stay `null`.
  - The migration is idempotent, never touches a configured company, skips an unseeded one, and `down()` keeps admin-changed values.
  - Fails on beta: the migration and defaults module do not exist.
- `tests/permission-guard-member-rules.test.js` (15 tests): the truth table above, the PAT guards, and the agent holder check.
  - Fails on beta: "a project with its own rules is evaluated against them", "task create is allowed in a global-rules project and refused where the project rules say None" and "a task update is judged by the task's own project".
  - The rules-read-failure case already refused on beta, because the old evaluator returned `null`; it is kept as a regression test.
- `tests/integration/member-permissions.int.test.js` (6 tests):
  - A member of a fresh harness company, calling with their own API token, holds the matrix defaults.
  - They can create a task in a project they belong to, comment on it and log time on it.
  - They are refused (403) creating a project, creating a sprint and editing security permissions.
  - They are refused a task in a project whose own rules set Task create to None. That last case fails on beta, where the create went through.

Gates: `npx jest --selectProjects unit` 181 suites / 2133 tests, `npx jest tests/conventions` 8 / 94, `npm run test:integration` 2 / 16, eslint 0 errors on touched files (10 existing warnings in `utils/data.js`). Frontend untouched.

## Not covered

- Web (JWT) sessions are still not permission-gated on the server, by the existing hard-isolation decision. A member's web session can create a project, and the UI is what stops it. Commenting and manual time logs have no server-side permission guard for any client.
- 011 does not add Member entries to `projectRules`. Those copy the company rules when a project opts out, and an owner who opted out has already configured them.
- A company that set only some Member entries keeps its gaps (skipped as `configured`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
