### PR TITLE
test(034): sweep and cover the access and accounts area

### DIFF
--- a/Tasks/active/034-end-to-end-qa-programme/findings/access.md
+++ b/Tasks/active/034-end-to-end-qa-programme/findings/access.md
@@ -1,0 +1,246 @@
+# Access and accounts — QA findings (task 034)
+
+Area slug `access`, finding prefix `ACC`. Modules: Auth, SSO, Scim, OAuth, googleOAuth,
+githubOAuth, gitlabOAuth, ApiTokens, Users, UserId, Setup, Company, Teams,
+trackerUserPermission.
+
+Swept live against the local server (http://localhost:4000, beta, company
+`6a8ee973d625fca52e519a12` / Local360) as owner (in-app browser, Local PM), and as
+admin (`rahul.manager`), two members (`priya.frontend`, `arjun.backend`) and guest
+(`kabir.intern`) via one-hour demo tokens. OAuth flows checked only up to the redirect;
+SSO/SCIM/OAuth settings of Local360 were read, never changed; no setup wizard was run on
+the local server; the one API token created (`[QA access] temp`) was deleted again.
+
+## Coverage
+
+Routes registered by the area's modules: **101** (walked from each module's `routes.js`
+plus `Modules/ApiTokens/publicApi.js`, classified against `Config/setMiddleware.js`).
+
+| Role | Routes exercised | Notes |
+|---|---|---|
+| anon (no token) | 30 | every route classified auth-`NONE`, plus 401 controls on protected routes |
+| owner | 14 (API) + 9 screens | in-app browser + `fetch` from the owner page |
+| admin | 22 | full auth+company routes, SSO/SCIM config, api-tokens CRUD |
+| member | 16 | refusals + shared reads (member RBAC gap is a known issue) |
+| guest | 18 | refusals + the cross-scope reads that should refuse |
+
+Screens (from `frontend/src/router/{auth,settings,team,people}`): the area owns **9**
+authenticated screens — My Profile, Change Password, Two-Factor Auth, Members, SSO, SCIM,
+Teams, Company, Integrations — plus the pre-auth screens (Login, SSO login, Forgot/Reset
+password, Verify email, Verify invitation, Invitation, Create company, Setup wizard).
+All 9 authenticated screens were opened as owner and rendered with **no console errors**.
+Pre-auth screens other than Login were not driven (they need mail / an IdP, which is off).
+
+Not fully exercisable, and why:
+- OAuth login (`/api/v1/{google,github,gitlab}/access-token`, `google/github/gitlab-signup`)
+  need a real provider token — checked only that they exist and reject junk.
+- SSO OIDC/SAML initiate/callback/acs need a configured IdP — checked they 404 / return
+  metadata when unconfigured, not a full round trip.
+- Magic link, forgot/verify/invitation email delivery — SMTP is off locally.
+- SCIM protocol CRUD needs a provisioning bearer token (SCIM disabled on Local360); checked
+  only that every `/scim/v2/*` route rejects a missing bearer with 401.
+- `POST /api/v2/setup/complete` — not called (area rule: no setup wizard on the local
+  server); confirmed only via `GET /api/v2/setup/status` that the instance reports installed.
+
+---
+
+## ACC-01 — `POST /api/v1/mongoOpration` is a fully unauthenticated arbitrary MongoDB gateway
+
+- **Severity:** critical (auth bypass, cross-tenant data leak, data loss)
+- **Role:** anon (no token, no company header)
+- **Request:** `POST /api/v1/mongoOpration` with `{ dbName, collection, methodName, dataObj }`
+- **Expected:** the route requires a valid session and refuses an anonymous caller (401).
+- **Actual:** the handler runs any Mongoose method against any database and collection with
+  no authentication. Confirmed live as anon:
+  - `{"dbName":"global","collection":"userAuth","methodName":"countDocuments","dataObj":[{}]}` → `200 {status:true, statusText:9}`
+  - `{"dbName":"global","collection":"users","methodName":"find","dataObj":[{},{"Employee_Email":1}]}` → `200` returning all 9 users' emails.
+  A caller can equally pass `deleteMany`, `updateMany`, `drop`, etc. against any tenant's
+  database — read, tamper or destroy every company's data.
+- **Reproduction:**
+  ```bash
+  curl -s -X POST http://localhost:4000/api/v1/mongoOpration \
+    -H 'content-type: application/json' \
+    -d '{"dbName":"global","collection":"users","methodName":"find","dataObj":[{},{"Employee_Email":1}]}'
+  ```
+- **Suspected file/line:** `Modules/Auth/routes.js` `initSignup` registers `POST /api/v1/mongoOpration`
+  (~line 653) with no middleware; the path is absent from both lists in `Config/setMiddleware.js`.
+- **Suggested fix:** remove this endpoint entirely (nothing in the shipped frontend calls it),
+  or, if it must stay, put it behind `verifyJWTTokenWithCV2`, restrict `methodName` to a read
+  allow-list, and force `dbName` to the caller's `req.aud`.
+
+## ACC-02 — `POST /api/v1/generateToken` mints a valid session JWT for any user id, no password
+
+- **Severity:** critical (authentication bypass / account takeover)
+- **Role:** anon
+- **Request:** `POST /api/v1/generateToken` `{ "uid": "<any user _id>" }`
+- **Expected:** issuing a session token requires proof of identity (a password login, a valid
+  refresh token, or an authenticated admin). An anonymous caller must be refused.
+- **Actual:** returns `200 {status:true, token:<signed JWT with that uid + its companies>}`.
+  The uid is trivially discoverable (ACC-01, or `GET /api/v1/user/find`). The minted token is a
+  full session for that user, so anyone can log in as the instance owner. Confirmed live
+  against the real owner id `6a8ee972d625fca52e519a05` (token value not recorded).
+- **Reproduction:** `POST /api/v1/generateToken` with a real user `_id`; the response carries a
+  usable `token`. (The v2 sibling `POST /api/v2/generateToken` is safe — it requires a valid
+  `refresh-token` header.)
+- **Suspected file/line:** `Modules/Auth/controller/createUser.js` `exports.generateToken` (~line 142),
+  routed at `Modules/Auth/routes.js` `POST /api/v1/generateToken` (~line 697), unlisted in
+  `Config/setMiddleware.js`.
+- **Suggested fix:** delete the route, or require the caller to already hold a valid session
+  and only mint a token for `req.uid`.
+
+## ACC-03 — Session routes are unauthenticated: forge a session, or wipe everyone's sessions
+
+- **Severity:** critical (auth bypass + availability / forced-logout DoS)
+- **Role:** anon
+- **Requests (all under `/api/v2/session`, none in either middleware list):**
+  - `POST /api/v2/session/register` `{ "userId": "<id>" }` → creates a session row for that user
+    and returns a fresh `refreshToken`. Paired with `POST /api/v2/generateToken` (uid +
+    `refresh-token` header) this is a second, self-contained account-takeover chain.
+  - `DELETE /api/v2/session/delete` (empty body) → `deleteSessionFun("")` runs `deleteMany({})`
+    on the sessions collection: **every session of every user is deleted**, logging out the
+    whole instance.
+  - `DELETE /api/v2/session/delete/:id` → deletes all sessions for an arbitrary user id.
+- **Expected:** all three require the caller's own valid session and act only on it.
+- **Actual:** reachable with no token. `session/register` and `session/delete/:id` (with a bogus
+  id, so nothing was actually deleted) were confirmed to reach their handlers as anon; the
+  destructive empty-body `session/delete` was **not executed** against the live server — it
+  would have logged out Local360 — and is reported from code.
+- **Suspected file/line:** `Modules/Auth/routes.js` lines 285–298 (`session/register`,
+  `session/delete`, `session/delete/:id`); handlers in `Modules/Auth/session.js`
+  (`deleteSessionFun` builds `deleteMany` with an empty filter when no id is given).
+- **Suggested fix:** register the `/api/v2/session` prefix under `verifyJWTTokenV2`, take the
+  user from `req.uid` (never the body/params), and never issue `deleteMany({})`.
+
+## ACC-04 — OAuth credentials endpoint is unauthenticated (reads secrets, rewrites server .env)
+
+- **Severity:** critical (secret disclosure + unauthenticated config write)
+- **Role:** anon
+- **Requests:** `GET /api/v1/settings/oauth`, `POST /api/v1/settings/oauth`
+- **Expected:** only the instance owner may read or change OAuth provider credentials; secrets
+  should never be returned to an unauthenticated caller.
+- **Actual:** `GET` returns `clientSecret`, `githubClientSecret`, `gitlabClientSecret` (empty on
+  Local360, but the shape proves secrets are served with no auth). `POST` calls
+  `updateEnvVariablesUtil(pathType, variables)` and rewrites the server `.env` for anyone —
+  confirmed `200 {status:true}` as anon with an empty `variables` no-op. An attacker can point
+  OAuth login at their own client id/secret and harvest logins.
+- **Reproduction:** `curl -s http://localhost:4000/api/v1/settings/oauth` returns the credential
+  block with no token.
+- **Suspected file/line:** `Modules/OAuth/routes.js` lines 4–5; handlers
+  `Modules/OAuth/controller.js` `getOAuthCred` / `updateOAuthCred`. Path absent from
+  `Config/setMiddleware.js`.
+- **Suggested fix:** put both behind `verifyJWTTokenWithCV2` and an owner/instance check;
+  never return secret values (return only booleans / last-4).
+
+## ACC-05 — User routes are jwt-only and unscoped: any role reads/edits any user
+
+- **Severity:** critical (cross-tenant PII/secret read + horizontal & vertical privilege escalation)
+- **Role:** guest (and any authenticated user)
+- **Requests (registered under `verifyJWTToken` — a bare JWT check with no company scope and no
+  ownership check):**
+  - `GET /api/v1/user/:id` — guest read the owner's full user document, including
+    `webTokens` (web-push/session tokens), `agentAccount.email`, `isProductOwner`, and the
+    company list. Cross-user and cross-company.
+  - `POST /api/v1/user/find` `{ query:{}, companyId }` — guest enumerated all 9 users of the
+    instance with full documents.
+  - `PUT /api/v1/user` `{ userId, updateObject }` — guest write to an arbitrary user by id.
+    Confirmed `200 {status:true, statusText:"User Status Updated"}` (tested against a
+    non-existent id `0000…` so no real record was changed). A caller can flip
+    `isActive`, `isProductOwner`, `AssignCompany`, etc. on anyone.
+- **Expected:** these must require the target to be the caller (`req.uid`) or an owner/admin of
+  the same company, and must be company-scoped.
+- **Suspected file/line:** `Modules/Users/routes.js` lines 5–8; handlers in
+  `Modules/Users/controller.js` (`updateUserStatus`, `getUserById`, `getUserByQuey` take the id
+  and company straight from the request). Listed under `verifyJWTToken` in
+  `Config/setMiddleware.js`, which does not check company membership.
+- **Suggested fix:** move these to `verifyJWTTokenWithCV2`, scope every query to `req.aud`,
+  and gate writes/other-user reads behind an owner/admin permission check; never echo
+  `webTokens`/token fields.
+
+## ACC-06 — Admin company endpoints let any member or guest enumerate every company
+
+- **Severity:** high (cross-tenant data disclosure; critical on a multi-company instance)
+- **Role:** member, guest
+- **Requests:** `POST /api/v1/admin/company` `{ fetchAllCompany:true }`,
+  `POST /api/v1/admin/company/find` `{ findQuery:{…} }`
+- **Expected:** "admin" company routes are instance-admin only.
+- **Actual:** both sit under `verifyJWTToken` (jwt only, no role or company check). A guest read
+  the full Local360 company document (owner id, `planFeature`, project counts, billing plan);
+  `fetchAllCompany:true` / an aggregate returns **all** companies on the instance. On Local360
+  there is only one company, so this reads as one company today, but the missing check is a
+  cross-tenant leak on any real multi-tenant deployment.
+- **Suspected file/line:** `Modules/Company/routes.js` lines 128–129, 131; handlers
+  `Modules/Company/controller/updateCompany.js` `getCompany` / `getCompanyByAggregate`.
+- **Suggested fix:** gate the `/api/v1/admin/*` company routes behind an instance-owner check,
+  and scope non-admin company reads to the caller's `req.aud`.
+
+## ACC-07 — `POST /api/v1/manageTrackerUserPermission` is unauthenticated
+
+- **Severity:** high (unauthenticated mutation of company/member state)
+- **Role:** anon
+- **Request:** `POST /api/v1/manageTrackerUserPermission` `{ CompanyId, DataObj }`
+- **Expected:** owner/admin of the company only.
+- **Actual:** reaches its handler with no token (returned a body-validation refusal
+  "Company Id is requried", not an auth refusal), so with a real `CompanyId`/`DataObj` it will
+  `$inc` the company `trackerUsers` counter and flip a member's `isTrackerUser` flag for anyone.
+  Not executed against real data.
+- **Suspected file/line:** `Modules/trackerUserPermission/routes.js` line 40; handler
+  `Modules/trackerUserPermission/controller.js` `handleTrackerUserPermission`. Path absent from
+  `Config/setMiddleware.js`.
+- **Suggested fix:** register under `verifyJWTTokenWithCV2` and add an owner/admin check.
+
+## ACC-08 — `PATCH /api/v2/auth/:id/change-password` needs no session
+
+- **Severity:** medium (missing authentication; still gated by knowing the old password)
+- **Role:** anon
+- **Request:** `PATCH /api/v2/auth/:id/change-password` `{ oldPassword, newPassword }`
+- **Expected:** an authenticated session whose `req.uid` equals `:id`.
+- **Actual:** the route is unlisted in `Config/setMiddleware.js`, so no JWT runs; the only guard
+  is the bcrypt check of `oldPassword`. Confirmed it reaches the handler as anon (returned
+  `400 "user not found"` for a bogus id, i.e. auth was never required). A stolen/guessed old
+  password is enough, from anywhere, with no session and no rate-limit tie to the account.
+- **Suspected file/line:** `Modules/Auth/routes.js` line 143; handler
+  `Modules/Auth/controller/password.js` `changePassword`.
+- **Suggested fix:** require `verifyJWTTokenWithCV2` and assert `req.uid === req.params.id`.
+
+## ACC-09 — `POST /api/v1/checkSendInviatation` is an unauthenticated membership oracle
+
+- **Severity:** medium (unauthenticated account/membership enumeration)
+- **Role:** anon
+- **Request:** `POST /api/v1/checkSendInviatation` `{ email, companyId }`
+- **Expected:** only an owner/admin of the company checks invitation state.
+- **Actual:** unauthenticated. For `priya.frontend@demo.test` + Local360 it returned
+  `"User is already in the company."`; for a stranger it returns `furtherProceed:true`. Anyone
+  can probe whether an email belongs to a given company. (`/api/v1/admin/checkSendInviatation`
+  is correctly behind jwt.)
+- **Suspected file/line:** `Modules/Auth/routes.js` line 564; handler
+  `Modules/Auth/controller/sendInvitation.js` `checkSendInviatation`.
+- **Suggested fix:** require a session + owner/admin gate, matching the `admin/` sibling.
+
+---
+
+## Related known issue (not re-filed)
+
+The tracked `fix/unauthenticated-v1-routes` branch adds only `POST /api/v1/removeCache` to the
+JWT list; it does **not** cover ACC-01/02/03/04/07/08/09, which are separate open routes.
+Member RBAC gaps (`fix/member-permission-rules`) and the guest role-id mismatch
+(`fix/guest-role-id`) are the reason member/guest checks here focus on refusals that should
+hold regardless of the role catalogue.
+
+## Checks that passed
+
+- `GET /api/v2/setup/status` → installed (owner setup path not re-run, per area rule).
+- `POST /api/v2/auth/login` mints a session for owner, admin, member and guest (demo tokens).
+- SSO admin config (`GET/PUT /api/v2/sso/config`) is owner/admin only — member and guest get
+  403 "Owner/admin only."; admin gets the config.
+- SCIM admin config (`GET/PUT /api/v2/scim/config`, `POST /api/v2/scim/token`) is owner/admin
+  only — guest 403; admin reads config.
+- Every `/scim/v2/*` protocol route returns 401 with no/invalid bearer.
+- `GET /api/public-v1/*` returns 401 without a valid `ahp_` token.
+- API tokens (`/api/v2/api-tokens`): admin create → list → delete round-trip works
+  (`[QA access] temp`, deleted); a member sees only their own tokens (count 0), never the
+  admin's; PATs cannot manage tokens (jwt.js PAT block).
+- `GET /api/v2/api-tokens/me` (whoami) resolves the effective role/permissions per role.
+- `GET/POST/PUT /api/v1/teams` are company-scoped (jwt+company); `GET /api/v1/sso/discover`,
+  `/oidc/initiate`, `/saml/metadata` behave correctly when no IdP is configured.
+- Owner UI: My Profile, Change Password, Two-Factor Auth, Members, SSO, SCIM, Teams, Company
+  and Integrations all render with no console errors.

--- a/e2e/specs/access.spec.js
+++ b/e2e/specs/access.spec.js
@@ -1,0 +1,48 @@
+const { test, expect, asRole } = require('../support/test');
+
+test.describe('access screens as the owner', () => {
+    test.use(asRole('owner'));
+
+    test('Members lists the workspace members', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/members`);
+        await expect(page.getByText('Members', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText('Invite', { exact: true }).first()).toBeVisible();
+    });
+
+    test('SSO screen renders the sign-in options', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/sso`);
+        await expect(page.getByText('Sign-in & SSO', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText('SAML / OIDC single sign-on')).toBeVisible();
+    });
+
+    test('SCIM screen renders the provisioning panel', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/scim`);
+        await expect(page.getByText('SCIM Provisioning')).toBeVisible();
+        await expect(page.getByText('SCIM base URL')).toBeVisible();
+    });
+
+    test('Teams screen renders', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/teams`);
+        await expect(page.getByText('Teams', { exact: true }).first()).toBeVisible();
+    });
+
+    test('Two-factor and change-password screens render', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/two-factor-auth`);
+        await expect(page).toHaveTitle(/Two-Factor/i);
+        await page.goto(`/#/${state.companyId}/settings/change-password`);
+        await expect(page).toHaveTitle(/Change Password/i);
+    });
+});
+
+test.describe('access — SSO admin config is refused for a member', () => {
+    test.use(asRole('member'));
+
+    test('the SSO config request is 403 for a member', async ({ page, state }) => {
+        const configResponse = page.waitForResponse(
+            (res) => res.url().includes('/api/v2/sso/config'),
+            { timeout: 30000 },
+        );
+        await page.goto(`/#/${state.companyId}/settings/sso`);
+        expect((await configResponse).status()).toBe(403);
+    });
+});

--- a/tests/integration/access.int.test.js
+++ b/tests/integration/access.int.test.js
@@ -1,0 +1,171 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anon = createApiClient({ baseURL: state.baseURL });
+const anonWithCompany = createApiClient({ baseURL: state.baseURL, companyId: state.companyId });
+const refused = (res) => res.status === 401 || res.status === 403 || (res.body && res.body.status === false);
+const randomId = () => uniqueSuffix() + uniqueSuffix() + uniqueSuffix() + uniqueSuffix();
+
+describe('access — authentication happy paths', () => {
+    it('logs in every role', async () => {
+        for (const role of ['owner', 'admin', 'member', 'guest']) {
+            const session = await loginAs(role);
+            expect(session.accessToken).toBeTruthy();
+            expect(session.uid).toBe(state.users[role].userId);
+        }
+    });
+
+    it('reports the instance as already set up', async () => {
+        const res = await anon.get('/api/v2/setup/status');
+        expect(res.status).toBe(200);
+        expect(res.body.data.installed).toBe(true);
+    });
+
+    it('refuses a second setup on an installed instance', async () => {
+        const res = await anon.post('/api/v2/setup/complete', {
+            firstName: 'Dup', lastName: 'Owner', email: `dup.${uniqueSuffix()}@e2e.test`,
+            password: state.password, companyName: `Dup ${uniqueSuffix()}`, sampleData: false,
+        });
+        expect(res.status).toBeGreaterThanOrEqual(400);
+        expect(res.body.status).toBe(false);
+    });
+});
+
+describe('access — SSO / SCIM admin config is owner/admin only', () => {
+    it('lets an admin read SSO config', async () => {
+        const admin = await loginAs('admin');
+        const res = await admin.api.get('/api/v2/sso/config');
+        expect(res.status).toBe(200);
+    });
+
+    it('refuses a member reading SSO config', async () => {
+        const member = await loginAs('member');
+        const res = await member.api.get('/api/v2/sso/config');
+        expect(res.status).toBe(403);
+    });
+
+    it('lets an admin read SCIM config and refuses a guest', async () => {
+        const admin = await loginAs('admin');
+        const guest = await loginAs('guest');
+        expect((await admin.api.get('/api/v2/scim/config')).status).toBe(200);
+        expect((await guest.api.get('/api/v2/scim/config')).status).toBe(403);
+    });
+
+    it('rejects the SCIM protocol without a bearer token', async () => {
+        const res = await anon.get('/scim/v2/Users');
+        expect(res.status).toBe(401);
+    });
+});
+
+describe('access — API tokens', () => {
+    it('lets a user create, list and revoke their own token', async () => {
+        const admin = await loginAs('admin');
+        const created = await admin.api.post('/api/v2/api-tokens', { name: `[QA access] ${uniqueSuffix()}`, scopes: ['read'] });
+        expect(created.status).toBe(200);
+        const id = created.body.data && (created.body.data._id || created.body.data.id);
+        expect(id).toBeTruthy();
+
+        const list = await admin.api.get('/api/v2/api-tokens');
+        expect(list.body.data.some((t) => String(t._id || t.id) === String(id))).toBe(true);
+
+        const del = await admin.api.delete(`/api/v2/api-tokens/${id}`);
+        expect(del.status).toBe(200);
+        expect(del.body.status).toBe(true);
+    });
+
+    it('shows a user only their own tokens', async () => {
+        const admin = await loginAs('admin');
+        const member = await loginAs('member');
+        const created = await admin.api.post('/api/v2/api-tokens', { name: `[QA access] ${uniqueSuffix()}`, scopes: ['read'] });
+        const id = created.body.data && (created.body.data._id || created.body.data.id);
+        try {
+            const memberList = await member.api.get('/api/v2/api-tokens');
+            expect(memberList.body.data.every((t) => String(t._id || t.id) !== String(id))).toBe(true);
+        } finally {
+            await admin.api.delete(`/api/v2/api-tokens/${id}`);
+        }
+    });
+
+    it('rejects the public API namespace without a token', async () => {
+        expect((await anon.get('/api/public-v1/projects')).status).toBe(401);
+    });
+});
+
+describe('access — regression tests for confirmed findings (flip to it() once fixed)', () => {
+    // ACC-01: POST /api/v1/mongoOpration runs arbitrary Mongo with no auth.
+    it.failing('ACC-01 refuses an anonymous arbitrary Mongo operation', async () => {
+        const res = await anon.post('/api/v1/mongoOpration', {
+            dbName: 'global', collection: 'users', methodName: 'countDocuments', dataObj: [{}],
+        });
+        expect(res.status).toBe(401);
+    });
+
+    // ACC-02: POST /api/v1/generateToken mints a JWT for any uid with no password.
+    it.failing('ACC-02 refuses minting a token for an arbitrary user id', async () => {
+        const owner = await loginAs('owner');
+        const res = await anon.post('/api/v1/generateToken', { uid: owner.uid });
+        expect(refused(res)).toBe(true);
+        expect(res.body && res.body.token).toBeFalsy();
+    });
+
+    // ACC-03: /api/v2/session/* is unauthenticated (forge a session; wipe sessions).
+    it.failing('ACC-03 refuses registering a session anonymously', async () => {
+        const owner = await loginAs('owner');
+        const res = await anon.post('/api/v2/session/register', { userId: owner.uid });
+        expect(refused(res)).toBe(true);
+    });
+
+    it.failing('ACC-03 refuses deleting another user\'s sessions anonymously', async () => {
+        const res = await anon.delete(`/api/v2/session/delete/${randomId()}`);
+        expect(res.status).toBe(401);
+    });
+
+    // ACC-04: /api/v1/settings/oauth reads secrets and rewrites .env with no auth.
+    it.failing('ACC-04 refuses reading OAuth credentials anonymously', async () => {
+        const res = await anon.get('/api/v1/settings/oauth');
+        expect(res.status).toBe(401);
+    });
+
+    // ACC-05: user routes are jwt-only, unscoped — any role reads/edits any user.
+    it.failing('ACC-05 refuses a guest reading another user by id', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.get(`/api/v1/user/${state.users.owner.userId}`);
+        expect(refused(res)).toBe(true);
+    });
+
+    it.failing('ACC-05 refuses a guest updating an arbitrary user', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.put('/api/v1/user', { userId: randomId(), updateObject: { isActive: true } });
+        expect(refused(res)).toBe(true);
+    });
+
+    // ACC-06: admin company routes let any member/guest enumerate companies.
+    it.failing('ACC-06 refuses a guest listing all companies via the admin route', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.post('/api/v1/admin/company', { fetchAllCompany: true, companyIds: [] });
+        expect(refused(res)).toBe(true);
+    });
+
+    // ACC-07: manageTrackerUserPermission is unauthenticated.
+    it.failing('ACC-07 refuses an anonymous tracker-permission change', async () => {
+        const res = await anon.post('/api/v1/manageTrackerUserPermission', {
+            CompanyId: state.companyId, DataObj: { ops: true, data: { status: 2, userId: randomId() } },
+        });
+        expect(refused(res)).toBe(true);
+    });
+
+    // ACC-08: change-password requires no session (only the old password).
+    it.failing('ACC-08 refuses an anonymous change-password', async () => {
+        const res = await anon.patch(`/api/v2/auth/${randomId()}/change-password`, { oldPassword: 'x', newPassword: 'y' });
+        expect(res.status).toBe(401);
+    });
+
+    // ACC-09: checkSendInviatation is an unauthenticated membership oracle.
+    it.failing('ACC-09 refuses an anonymous membership probe', async () => {
+        const res = await anonWithCompany.post('/api/v1/checkSendInviatation', {
+            email: state.users.member.email, companyId: state.companyId,
+        });
+        expect(res.status).toBe(401);
+    });
+});


### PR DESCRIPTION
QA wave for task 034, **Access and accounts** area (slug `access`, prefix `ACC`).
Modules: Auth, SSO, Scim, OAuth, googleOAuth, githubOAuth, gitlabOAuth, ApiTokens, Users, UserId, Setup, Company, Teams, trackerUserPermission.

## What this adds (three files only)
- `Tasks/active/034-end-to-end-qa-programme/findings/access.md` — coverage table + findings.
- `tests/integration/access.int.test.js` — 21 tests (10 happy-path/refusal, 11 `it.failing` regressions, one per confirmed finding). Green against a throwaway Mongo (27101).
- `e2e/specs/access.spec.js` — owner screen renders + a member SSO-config 403. Follows `docs/TESTING-E2E.md` and the `smoke.spec.js` pattern.

No product code changed; each fix is described in the finding.

## Findings (9)
**Critical (5)**
- ACC-01 `POST /api/v1/mongoOpration` — unauthenticated arbitrary MongoDB gateway (read/write/delete any DB); leaks all user emails as anon.
- ACC-02 `POST /api/v1/generateToken` — mints a valid session JWT for any user id with no password (owner takeover).
- ACC-03 `/api/v2/session/{register,delete,delete/:id}` — unauthenticated: forge a session, or `deleteMany({})` wipes everyone's sessions (destructive variant not executed live).
- ACC-04 `GET/POST /api/v1/settings/oauth` — unauthenticated read of OAuth secrets and rewrite of server `.env`.
- ACC-05 `GET /api/v1/user/:id`, `POST /api/v1/user/find`, `PUT /api/v1/user` — jwt-only, unscoped: any role reads/edits any user (incl. `webTokens`), cross-company.

**High (2)**
- ACC-06 `POST /api/v1/admin/company[/find]` — any member/guest enumerates every company (cross-tenant).
- ACC-07 `POST /api/v1/manageTrackerUserPermission` — unauthenticated mutation of company/member tracker state.

**Medium (2)**
- ACC-08 `PATCH /api/v2/auth/:id/change-password` — no session required (only old password).
- ACC-09 `POST /api/v1/checkSendInviatation` — unauthenticated membership oracle.

The tracked `fix/unauthenticated-v1-routes` branch only covers `removeCache`, not these routes.

## Gates
- `npm run test:integration` (this file): 21 passed.
- `npx jest tests/conventions`: 94 passed.
- eslint on both spec files: 0 errors.
- Playwright spec: syntax-checked; not run locally because `@playwright/test` is absent from the provided `node_modules` and installing is disallowed — it runs in the CI `e2e` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)