### PR TITLE
test(034): sweep and cover the automations and ai features area

### DIFF
--- a/Tasks/active/034-end-to-end-qa-programme/findings/automations.md
+++ b/Tasks/active/034-end-to-end-qa-programme/findings/automations.md
@@ -1,0 +1,230 @@
+# Automations and AI features — sweep findings
+
+Area: Automations, AI, AIProjectGenerator, Mcp · finding prefix `AUT` · swept 2026-09-11 against the local server (beta, build 14.36.0-beta.68, company Local360) and a throwaway database on port 27108.
+
+## Coverage
+
+### Routes
+
+44 routes: Automations 15 (9 v2, 6 v1), AI 17, AIProjectGenerator 9, Mcp 3. The MCP token route `POST /api/v2/api-tokens/mcp` belongs to ApiTokens (access area) but was exercised here too.
+
+| Role | Live sweep | Throwaway suite | Not exercised, and why |
+|---|---|---|---|
+| anonymous | 31 / 44 | 21 / 44 | `updateAiModel` not called live: it rewrites the server `.env`. The suite probes it only where no `.env` exists (CI, a fresh worktree). |
+| owner | 9 / 44 (in-app `fetch` from the owner tab) | 36 / 44 | Model-backed generation (plan, clarify, brief, guide, execute into a new project) needs a provider; the suite has none. |
+| admin | 33 / 44 | 12 / 44 | v1 create, update, apply and delete not called live: v1 create saves the rule switched on (AUT-05), which the area rules forbid. |
+| member | 34 / 44 | 23 / 44 | Same v1 limit. |
+| guest | 33 / 44 | 22 / 44 | Same v1 limit. |
+
+Routes no role reached live with a real payload: `POST /api/v1/ai/transcribe` with audio (forwards to api.openai.com, an external host), `POST /api/v1/ai/project/plan|brief|guide|execute` and `tasks/plan` with valid input (model calls beyond the budget), `GET /api/v1/generatePrompt/events/:id` (opened anonymously, no event to observe).
+
+### Screens
+
+4 surfaces: 3 routed screens and 1 embedded surface. All 4 were opened as owner, with no console errors. The only 400 in the tab came from a deliberate probe.
+
+| Screen | Route | Result |
+|---|---|---|
+| Automations | `/:cid/automations` | Renders list and builder; rule toggles, sentence compile and backtest call the v2 API |
+| Ask | `/:cid/ai/ask` | Renders, "8 projects in scope", scope note shown |
+| Coding accounts (MCP tokens) | `/:cid/ai/accounts` | Renders modes, policy and token section |
+| Create project with AI | modal from Projects › New project | Step 1 renders; cancelled without generating |
+
+### Budget and data used
+
+- **Automation rules:** eight created, all switched off and all in QA Sandbox. One rule was switched on (task created, add a comment), fired once on a `[QA automations]` task, then was switched off and deleted. Zero `[QA automations]` rules remain.
+- **MCP tokens:** two tokens created in turn, both scoped to QA Sandbox and both revoked.
+  - Priya (member): every read was refused by the known missing member permission rules.
+  - Rahul (admin): reads, plus one write, a comment on QAS-12.
+- **Real model calls:** about 6–7, over the budget of 5.
+  - Planned: Ask on QA Sandbox (1) and task summary on QAS-12 (1).
+  - Unplanned (1): the anonymous `ai/description` probe that uncovered AUT-02.
+  - Unplanned (about 3–4): while probing private-project scope as a member, two Ask calls and one clarify call reached the model, because members can see a private project they are not assigned to (projects area, below). Clarify can add a repair call.
+  - Only QA test strings were sent in the unplanned calls.
+- **Left in place (no delete route for projects or tasks):**
+  - project `[QA automations] Private scope` (key `QAUJYM`) and its task;
+  - task `[QA automations] trigger task` in QA Sandbox;
+  - the MCP comment on QAS-12.
+
+### Blocked or out of area
+
+- Member MCP reads are refused with `task.task_list is not granted`: the known member permission rules gap (`fix/member-permission-rules`).
+- Out of area, for the projects agent: member `priya.frontend` sees and can Ask about a private project whose only assignee is `rahul.manager` (`GET /api/v1/project`, `scope.visibleProjects`). Guest `kabir.intern` does not.
+
+## Findings
+
+### AUT-01 — `POST /api/v1/updateAiModel` rewrites the server `.env` without a session
+
+- **Severity:** critical
+- **Role:** anonymous (and every role)
+- **Request:** `POST /api/v1/updateAiModel` with body `{ "key": "JWT_SECRET", "value": "..." }`, no `Authorization`
+- **Expected:** 401. Only the instance owner may change instance configuration, and never through a key-value write to `.env`.
+- **Actual:** the route is in neither JWT list in `Config/setMiddleware.js`. The handler writes `${key}="${value}"` into `<repo>/.env`, appending the key when it is absent. The value is not escaped, so a newline in `value` adds arbitrary lines. An anonymous caller can replace `JWT_SECRET`, `MONGODB_URL` or the mail and AI keys, which take effect on the next restart. In the throwaway suite the route answers 200 to an anonymous call; it only fails there because no `.env` exists.
+- **Reproduction:** not run against the local server, because it would modify instance configuration. Run `tests/integration/automations.int.test.js` › `AUT-01` in a checkout with no `.env`.
+- **Suspected file:**
+  - `Modules/AI/routes.js:15` registers it with no auth;
+  - `Modules/AI/controller.js:388-420` does the write (`envFilePath` at 390, unescaped `replacement` at 399).
+- **Fix:** remove the route; the frontend has no caller in `frontend/src/config/env.js`. If it must stay, put it behind the owner-only instance guard with an allow-list of keys and reject values containing newlines or quotes.
+
+### AUT-02 — AI-Assist and "Write with AI" routes run model calls for anonymous callers
+
+- **Severity:** critical
+- **Role:** anonymous
+- **Request:** `POST /api/v1/ai/description` with `companyid: 6a8ee973d625fca52e519a12` and no `Authorization`
+- **Expected:** 401.
+- **Actual:** 200 with a real model answer: `{"status":true,"data":{"questions":["What is the task about?", ...]}}`. That spent the company's LLM budget and attributed the spend to whatever `companyid` the caller typed.
+  - The same class answers 200 anonymously: `generatePrompt` (runs the model for any valid prompt id), `generatePromptChat`, `deleteUserChat` (deletes the in-memory chat of any `userId` or `uniqueUserId`), `getPrompts`, `findOnePrompts`, `getAiCategory`, `getAiModels`, `findOneAiModel` and `GET /api/v1/generatePrompt/events/:id`.
+  - `fix/unauthenticated-v1-routes` only covers `/api/v1/removeCache`.
+- **Reproduction:** `curl -X POST localhost:4000/api/v1/ai/description -H 'content-type: application/json' -H 'companyid: <any company>' -d '{}'`
+- **Suspected file:**
+  - `Modules/AI/routes.js:8-21`: none of `/api/v1/generatePrompt*`, `deleteUserChat`, `getPrompts`, `findOnePrompts`, `getAiCategory`, `getAiModels`, `updateAiModel`, `findOneAiModel` or `/api/v1/ai/description` is listed in `Config/setMiddleware.js`. The `/api/v1/ai/*` entries at 206-215 are exact paths, not a prefix.
+- **Fix:** add these paths, or a `/api/v1/ai` prefix plus the legacy names, to `verifyJWTTokenWithCRoute`, and take `userId` and `companyId` from `req.uid` and `req.headers.companyid` instead of the body.
+- **Regression:** `AUT-02 refuses anonymous callers on the AI-Assist and description routes`.
+
+### AUT-03 — Automation backtest and v1 preview return task names from private projects to any role
+
+- **Severity:** critical
+- **Role:** guest, member
+- **Request:** as guest `kabir.intern`, `POST /api/v2/automations/backtest` with `{ rule: { scope: { allProjects: false, projectIds: ["<private project>"] } } }`, and `POST /api/v1/automations/preview` with `{ conditions: { projectId: "<private project>" } }`
+- **Expected:** only tasks from projects the caller can open, so 0 matches for a private project the guest is not in.
+- **Actual:** both return the private project's tasks.
+  - Backtest: `{"matched":1,"sample":[{"id":"6aa3b875a91fde6b0a34a738","key":"QAUJYM-1","name":"[QA automations] zebraquokka private task"}]}`.
+  - Preview: `{"count":1,"sample":[{... "priority":"MEDIUM"}]}`.
+  - With no scope, backtest searches every task in the company by title (`conditions: { op: "contains", field: "task.TaskName", value: "..." }`), so any word can be probed.
+- **Reproduction:** as admin, create a private project with only yourself assigned and add a task. As guest, call either endpoint with that project id or a word from the title.
+- **Suspected file:** `Modules/Automations/controller.js:314` (`backtest`) and `:86` (`preview`) build the task match from caller input only.
+- **Fix:** intersect with `require('../Agents/scope').visibleProjectIds(companyId, req.uid)`, the same helper Ask uses.
+- **Regression:** `AUT-03 keeps private-project tasks out of a guest backtest` and `AUT-03 keeps private-project tasks out of a guest v1 preview`.
+
+### AUT-04 — Any role can create, edit, switch on and delete any automation rule
+
+- **Severity:** high
+- **Role:** guest, member
+- **Request:** as guest, `POST /api/v2/automations`, `PUT /api/v2/automations/:id`, `PATCH /api/v2/automations/:id/enabled` and `DELETE /api/v2/automations/:id`. As member `priya.frontend`, `PUT` on a rule created by admin `rahul.manager`. As guest, `PATCH .../enabled` on that admin rule.
+- **Expected:** rule management limited to owner and admin (or the project lead), and a rule another person created is not editable by a member or guest.
+- **Actual:** every call returns `status: true`.
+  - "member PUT admin rule" and "guest PATCH admin rule enabled" both succeeded live.
+  - A guest can switch on a rule with `allProjects: true`. It then comments on, reprioritises or runs agents against every task in the company under the automation identity.
+  - The v1 routes behave the same, and the builder offers a guest "New automation".
+  - The known member-rules gap does not explain this: here the calls are allowed, not denied.
+- **Reproduction:** see `s2` in the sweep. As guest, create a v2 rule, then rename, switch on and delete a rule created by admin.
+- **Suspected file:** `Modules/Automations/controller.js:22-83` and `:179-240`. No `getRoleType` or `isPrivileged` check, and `createdBy` is never compared.
+- **Fix:** gate writes with `Config/permissionGuard` (owner and admin, or a dedicated `automation.manage` permission), and hide the builder in `AutomationsPage.vue` for roles without it.
+- **Regression:**
+  - integration: `AUT-04 refuses a guest creating a rule`, `AUT-04 refuses a member editing a rule someone else created`, `AUT-04 refuses a guest switching a rule on`;
+  - Playwright: `AUT-04 does not offer a guest the rule builder`.
+
+### AUT-05 — v1 rules save switched on, and v1 apply bulk-updates priorities with no role or project check
+
+- **Severity:** high
+- **Role:** guest
+- **Request:** as guest, `POST /api/v1/automations` with `{ conditions: { projectId: "<private project>" }, actions: [{ type: "set_priority", value: "HIGH" }] }`, then `POST /api/v1/automations/:id/apply`
+- **Expected:** refused. Failing that, a new rule starts switched off, like v2.
+- **Actual:**
+  - The rule is saved with `enabled: true`. The engine's matcher loads every `{ enabled: true, deletedStatusKey: 0 }` rule regardless of version.
+  - `apply` runs `updateMany` on every parent task that matches, in the whole company when `conditions` is empty. It returns `Applied to 1 task(s).`; afterwards the owner sees the private task at `HIGH`.
+  - No history row, socket event or task cache invalidation is written for the changed tasks.
+- **Reproduction:** throwaway suite (`AUT-05 refuses a guest bulk-changing priorities in a private project`). Not run live: v1 create switches the rule on.
+- **Suspected file:**
+  - `Modules/Automations/controller.js:28` (`enabled: true`) and `:105-122` (`applyRule`);
+  - `Modules/Automations/engine/matcher.js:38`.
+- **Fix:**
+  - save v1 rules `enabled: false`;
+  - gate `apply` like AUT-04;
+  - intersect the match with the caller's visible projects;
+  - write through the task update helper so history and sockets fire;
+  - or retire the v1 routes, since the frontend only calls v2.
+- **Regression:** `AUT-05 saves a new v1 rule switched off` and `AUT-05 refuses a guest bulk-changing priorities in a private project`.
+
+### AUT-06 — AI task summary and task category read any task by id, including private projects
+
+- **Severity:** critical
+- **Role:** guest
+- **Request:** as guest `kabir.intern`, `POST /api/v1/ai/task-summary` and `POST /api/v1/ai/task-category` with `{ "taskId": "6aa3b875a91fde6b0a34a738" }`, a task in a private project the guest cannot open
+- **Expected:** `task not found` (or 403) before anything is read.
+- **Actual:**
+  - Summary: `{"status":true,"data":{"summary":"","commentCount":0,...}}`, so the lookup succeeded.
+  - Category: `{"status":true,"data":{"configured":true,"category":null,"reason":"no-vocabulary"}}`.
+  - Once the task has comments, the summary sends the whole thread to the model and returns its summary, with commenter names, to the guest. It is also cached for 6 hours under a key shared across callers.
+  - Live on QAS-12, the guest got the summary of a thread they can see; the code path is identical for a private task.
+- **Reproduction:** as admin, create a private project and task. As guest, call both routes with the task id.
+- **Suspected file:**
+  - `Modules/AI/taskSummary.js:158`;
+  - `Modules/AI/taskCategory.js:190-196`;
+  - `Modules/AI/controller.js` `summarizeTask` and `categoriseTask`, which pass no `req.uid`.
+- **Fix:** pass `req.uid` and refuse unless the task's `ProjectID` is in `visibleProjectIds(companyId, uid)`. Keep the cache key per task (it is), but check visibility before reading the cache.
+- **Regression:** none in the suite. Both helpers return before the task lookup when no provider is configured, and the throwaway server runs with no AI keys. A unit test with a stubbed provider in `tests/` is the right place; that is outside the files this sweep may edit.
+
+### AUT-07 — AI task generation writes sprints and tasks into a project the caller cannot open
+
+- **Severity:** high
+- **Role:** guest
+- **Request:** as guest, `POST /api/v1/ai/project/<private project>/tasks/execute` with `{ "mode": "sprints", "plan": { "sprints": [{ "sprintName": "Injected" }] } }`
+- **Expected:** 404 `Project not found`, as `clarify`, `brief` and `guide` answer through `projectAccess.resolveProjectId`.
+- **Actual:** `{"status":true,"jobId":"..."}`, and a new sprint appears in the private project. `mode: "full"` or `"tasks"` creates tasks the same way. `tasks/plan` has the same gap and sends the project's context to the model.
+- **Reproduction:** throwaway suite (`AUT-07 ...`). Live, only the validation step was reached, to avoid writing into a project outside QA Sandbox.
+- **Suspected file:**
+  - `Modules/AIProjectGenerator/controller.js:911-956` (`tasksPlan`) and `:958-1015` (`tasksExecute`);
+  - `Modules/AIProjectGenerator/orchestrator.js:1421` (`loadProjectForTasks`) loads by id only.
+- **Fix:** call `resolveProjectId({ companyId, uid, projectId })` in both handlers and return 404 when `hidden`.
+- **Regression:** `AUT-07 refuses a guest adding sprints to a private project they cannot open`.
+
+### AUT-08 — MCP `task.get` ignores the token's project scope
+
+- **Severity:** high
+- **Role:** admin (any token holder)
+- **Request:** MCP token minted with `projectIds: ["6aa3b13ed1b2a9fd26131a1e"]` (QA Sandbox), then `tools/call` `task.get` with the id of a task in another project
+- **Expected:** refused, or `task not found`. `tasks.search` and `tasks.next` already filter to the token's projects.
+- **Actual:** the full brief of `QD99CA8-1` from another project: title, status, description, comments, linked docs.
+- **Reproduction:** mint a scoped token on Coding accounts, then call `task.get` with a task id from a project outside the scope.
+- **Suspected file:** `Modules/Mcp/brief.js:75` (`getTask(ctx.companyId, taskId)` with no `ctx.projectIds` check), reached from `Modules/Mcp/tools.js:88`.
+- **Fix:** in `buildBrief`, refuse when `ctx.projectIds.length && !ctx.projectIds.includes(String(task.ProjectID))`. `docs.read` already applies `projectScope`.
+- **Regression:** `AUT-08 keeps task.get inside the projects a token is scoped to`.
+
+### AUT-09 — v2 update and switch report success for a rule that does not exist
+
+- **Severity:** medium
+- **Role:** admin
+- **Request:** `PUT /api/v2/automations/0123456789abcdef01234567` and `PATCH /api/v2/automations/0123456789abcdef01234567/enabled`
+- **Expected:** `{ status: false, statusText: "Not found." }`, as v1 `updateRule` does.
+- **Actual:** `{"status":true,"statusText":"Automation updated.","data":null}` and `{"status":true,"statusText":"Automation on.","data":null}`. The filter also ignores `deletedStatusKey`, so a soft-deleted rule can be edited and switched on while staying hidden from the list.
+- **Suspected file:** `Modules/Automations/controller.js:208-213` and `:228-233`.
+- **Fix:** add `deletedStatusKey: { $ne: 1 }` to the filter and answer `Not found.` when `updated` is null.
+- **Regression:** `AUT-09 reports a missing rule instead of claiming it was updated`.
+
+### AUT-10 — Ask sends `[object Object]` as each task's status to the model and the screen
+
+- **Severity:** low
+- **Role:** member
+- **Request:** `POST /api/v1/ai/ask` with a question that matches QA Sandbox tasks
+- **Expected:** the status name, for example `To Do`.
+- **Actual:** every source's `detail` starts `[object Object] · HIGH · ...`, both in the prompt and in the `sources` returned to the Ask screen.
+- **Suspected file:** `Modules/AI/ask.js:82`, where `t.status` is the stored `{ text, key, type }` object.
+- **Fix:** use `(t.status && t.status.text) || t.statusType`, as `Modules/Mcp/tools.js` `taskRow` does.
+
+### AUT-11 — Automation runs for `task.created` record the placeholder key `--`
+
+- **Severity:** low
+- **Role:** admin
+- **Request:** `GET /api/v2/automations/:id/runs` after a `task.created` rule fired
+- **Expected:** the run's entity carries the new task's key, for example `QAS-13`.
+- **Actual:** `{"status":"success","entity":{"kind":"task","id":"6aa3b814a91fde6b0a348bc2","key":"--"}}`. The envelope is built from the create payload (`TaskKey: '--'`) before the key is assigned.
+- **Suspected file:** the `task.created` publisher behind `event/domainEventBus` (envelope `data.TaskKey`).
+- **Fix:** emit after the key is set, or resolve the key in the runner.
+
+## Checks that passed
+
+- Every Automations, Ask, meeting notes, transcribe, task summary and category, and AI project generator route refuses a caller without a session (401). `companyid` of a company the caller is not in is refused (401).
+- v2 rules start switched off. Validation returns field-level errors. The sentence compiler round-trips deterministically with no model. Delete is a soft delete that drops the rule from the list.
+- A switched-on `task.created` rule scoped to QA Sandbox fired exactly once, with run status `success`, and stopped once switched off.
+- Ask and Ask sources only list projects the caller can open: the guest never saw the private project, and `projectId` of a hidden project yields no sources.
+- AI project generator: `clarify` and `brief` answer 404 for a hidden `projectId`. `plan`, `clarify` and `brief` need 20 characters. `execute` and `tasks/execute` re-validate the plan server-side. Tasks mode needs `targetSprintId`. `upload-brief` extracts a text file and rejects `application/x-msdownload`. A body `companyId` of another company is ignored.
+- MCP:
+  - the manifest is public and secret-free;
+  - `POST` and `GET /mcp` without a token, with a web JWT, or with another company answer 401;
+  - a revoked token is refused on the next call;
+  - a token cannot mint tokens (403);
+  - `task.status.set` to Done is refused and audited;
+  - unknown tools and methods answer -32601;
+  - `tasks.search` stays inside the token's projects;
+  - the single write (`task.comment`) is audited and undoable.
+- Owner screens (Automations, Ask, Coding accounts, Create project with AI) render without console errors.

--- a/e2e/specs/automations.spec.js
+++ b/e2e/specs/automations.spec.js
@@ -1,0 +1,65 @@
+const { test, expect, asRole } = require('../support/test');
+const { uniqueSuffix } = require('../support/fixtures');
+
+const ruleFor = (projectId, body) => ({
+    name: `E2E automation ${uniqueSuffix()}`,
+    trigger: { event: 'task.created' },
+    scope: { allProjects: false, projectIds: [projectId] },
+    conditions: {},
+    steps: [{ id: 's1', type: 'action', action: 'add_comment', config: { body } }],
+});
+
+test.describe('automations as the owner', () => {
+    test.use(asRole('owner'));
+
+    test('lists a rule switched off and compiles a sentence in the builder', async ({ page, state, loginAs }) => {
+        const owner = await loginAs('owner');
+        const marker = `E2E ui ${uniqueSuffix()}`;
+        const created = await owner.api.post('/api/v2/automations', ruleFor(state.projects.shared._id, marker));
+        const ruleId = created.body.data._id;
+        try {
+            await page.goto(`/#/${state.companyId}/automations`);
+            await expect(page.locator('.ah-toolbar__title')).toHaveText('Automations');
+            const row = page.locator('.au__rule', { hasText: marker });
+            await expect(row).toBeVisible();
+            await expect(row).toHaveClass(/au__rule--off/);
+
+            await page.getByRole('button', { name: 'New automation' }).first().click();
+            const sentence = page.getByPlaceholder('When a task status changes to Blocked, post a comment saying "needs help".');
+            await sentence.fill('When a task is created, post a comment saying "hello"');
+            await sentence.press('Enter');
+            await expect(page.getByText('COMPILED RULE · EDIT ANY PART')).toBeVisible();
+            await page.getByRole('button', { name: 'Cancel' }).click();
+            await expect(row).toBeVisible();
+        } finally {
+            await owner.api.delete(`/api/v2/automations/${ruleId}`);
+        }
+    });
+
+    test('opens the coding accounts screen for MCP tokens', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/ai/accounts`);
+        await expect(page.locator('.ah-toolbar__title').first()).toHaveText('Coding accounts');
+    });
+});
+
+test.describe('ask as a guest', () => {
+    test.use(asRole('guest'));
+
+    test('shows the question box scoped to the projects the guest can open', async ({ page, state }) => {
+        const sources = page.waitForResponse((res) => res.url().includes('/api/v1/ai/ask/sources'));
+        await page.goto(`/#/${state.companyId}/ai/ask`);
+        expect((await sources).status()).toBe(200);
+        await expect(page.locator('.ah-toolbar__title').first()).toHaveText('Ask');
+        await expect(page.getByText('Only projects you can already open. Ask never widens what you can see.')).toBeVisible();
+    });
+});
+
+test.describe('automations as a guest', () => {
+    test.use(asRole('guest'));
+
+    test.fail('AUT-04 does not offer a guest the rule builder', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/automations`);
+        await expect(page.locator('.ah-toolbar__title')).toHaveText('Automations');
+        await expect(page.getByRole('button', { name: 'New automation' })).toHaveCount(0, { timeout: 3000 });
+    });
+});

--- a/tests/integration/automations.int.test.js
+++ b/tests/integration/automations.int.test.js
@@ -1,0 +1,463 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { createApiClient } = require('../../e2e/support/api');
+const { ROOT } = require('../../e2e/support/env');
+const { ROLE_NAMES, createProject, createTask, listSprints, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anonymous = createApiClient({ baseURL: state.baseURL });
+const anonymousWithCompany = createApiClient({ baseURL: state.baseURL, companyId: state.companyId });
+const OTHER_COMPANY = '0123456789abcdef01234567';
+const MISSING_ID = '0123456789abcdef01234567';
+
+const refused = (res) => res.status >= 400 || (res.body && res.body.status === false);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(check, { timeout = 10000, interval = 250 } = {}) {
+    const deadline = Date.now() + timeout;
+    let value = await check();
+    while (!value && Date.now() < deadline) {
+        await sleep(interval);
+        value = await check();
+    }
+    return value;
+}
+
+const ruleFor = (projectId, overrides = {}) => ({
+    name: `E2E automation ${uniqueSuffix()}`,
+    trigger: { event: 'task.priority_changed' },
+    scope: { allProjects: false, projectIds: [String(projectId)] },
+    conditions: {},
+    steps: [{ id: 's1', type: 'action', action: 'add_comment', config: { body: 'E2E automation comment' } }],
+    ...overrides,
+});
+
+async function privateProjectWithTask(owner) {
+    const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid, isPrivate: true });
+    const task = await createTask(owner.api, { project, name: `E2E private task ${uniqueSuffix()}`, user: state.users.owner, companyOwnerId: owner.uid });
+    return { project, task };
+}
+
+async function createRule(api, rule) {
+    const res = await api.post('/api/v2/automations', rule);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe(true);
+    return res.body.data;
+}
+
+const removeRule = (api, id) => (id ? api.delete(`/api/v2/automations/${id}`) : null);
+
+async function mcpCall(pat, method, params = {}) {
+    const client = createApiClient({ baseURL: state.baseURL, accessToken: pat, companyId: state.companyId });
+    return client.post('/mcp', { jsonrpc: '2.0', id: 1, method, params });
+}
+
+describe('automation rules (v2)', () => {
+    it('refuses a caller without a session', async () => {
+        for (const client of [anonymous, anonymousWithCompany]) {
+            expect((await client.get('/api/v2/automations/registry')).status).toBe(401);
+            expect((await client.get('/api/v2/automations')).status).toBe(401);
+            expect((await client.post('/api/v2/automations', ruleFor(state.projects.shared._id))).status).toBe(401);
+        }
+    });
+
+    it('refuses a company the caller does not belong to', async () => {
+        const { api } = await loginAs('owner');
+        const res = await api.withCompany(OTHER_COMPANY).get('/api/v2/automations');
+        expect(res.status).toBe(401);
+    });
+
+    it.each(ROLE_NAMES)('lets %s read the registry and the rule list', async (role) => {
+        const { api } = await loginAs(role);
+        const registry = await api.get('/api/v2/automations/registry');
+        expect(registry.status).toBe(200);
+        expect(registry.body.data.triggers.map((t) => t.key)).toContain('task.created');
+        expect(registry.body.data.actions.map((a) => a.key)).toContain('add_comment');
+
+        const list = await api.get('/api/v2/automations');
+        expect(list.status).toBe(200);
+        expect(list.body.status).toBe(true);
+        expect(Array.isArray(list.body.data)).toBe(true);
+    });
+
+    it('lets the owner create a rule that starts switched off, edit it, toggle it and delete it', async () => {
+        const { api } = await loginAs('owner');
+        const rule = await createRule(api, ruleFor(state.projects.shared._id));
+        expect(rule).toMatchObject({ enabled: false, version: 2, createdBy: state.users.owner.userId });
+
+        const renamed = await api.put(`/api/v2/automations/${rule._id}`, { ...ruleFor(state.projects.shared._id), name: `${rule.name} renamed` });
+        expect(renamed.body.data.name).toBe(`${rule.name} renamed`);
+
+        expect((await api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: true })).body.data.enabled).toBe(true);
+        expect((await api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: false })).body.data.enabled).toBe(false);
+
+        const runs = await api.get(`/api/v2/automations/${rule._id}/runs`);
+        expect(runs.body).toEqual({ status: true, data: [] });
+
+        expect((await api.delete(`/api/v2/automations/${rule._id}`)).body.status).toBe(true);
+        const list = await api.get('/api/v2/automations');
+        expect(list.body.data.map((r) => r._id)).not.toContain(rule._id);
+    });
+
+    it('rejects an invalid rule with field-level errors', async () => {
+        const { api } = await loginAs('admin');
+        const res = await api.post('/api/v2/automations', { name: '', steps: [] });
+        expect(res.body.status).toBe(false);
+        expect(res.body.errors).toEqual(expect.arrayContaining(['name: required', 'steps: at least one action is required']));
+    });
+
+    it('compiles a sentence into a rule and back without a model', async () => {
+        const { api } = await loginAs('member');
+        const res = await api.post('/api/v2/automations/compile', { sentence: 'When a task priority changes, post a comment saying "hi"' });
+        expect(res.body.status).toBe(true);
+        expect(res.body.data.rule.trigger.event).toBe('task.priority_changed');
+        expect(res.body.data.errors).toEqual([]);
+
+        const back = await api.post('/api/v2/automations/compile', { rule: res.body.data.rule });
+        expect(back.body.data.sentence).toBe(res.body.data.sentence);
+
+        expect((await api.post('/api/v2/automations/compile', {})).body.status).toBe(false);
+    });
+
+    it('backtests a rule scoped to a project the owner can open', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+        const res = await owner.api.post('/api/v2/automations/backtest', { rule: ruleFor(project._id) });
+        expect(res.body.status).toBe(true);
+        expect(res.body.data).toMatchObject({ windowDays: 30, matched: 1 });
+        expect(res.body.data.sample.map((t) => t.id)).toEqual([task._id]);
+    });
+
+    it('runs an enabled rule when a task is created in its project', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const rule = await createRule(owner.api, ruleFor(project._id, { trigger: { event: 'task.created' } }));
+        try {
+            await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: true });
+            const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+
+            const runs = await waitFor(async () => {
+                const res = await owner.api.get(`/api/v2/automations/${rule._id}/runs`);
+                return (res.body.data || []).length ? res.body.data : null;
+            });
+            expect(runs).toHaveLength(1);
+            expect(runs[0]).toMatchObject({ status: 'success', entity: { kind: 'task', id: task._id } });
+        } finally {
+            await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: false });
+            await removeRule(owner.api, rule._id);
+        }
+    });
+
+    it.failing('AUT-04 refuses a guest creating a rule', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const res = await guest.api.post('/api/v2/automations', ruleFor(state.projects.shared._id));
+        try {
+            expect(refused(res)).toBe(true);
+        } finally {
+            await removeRule(owner.api, res.body && res.body.data && res.body.data._id);
+        }
+    });
+
+    it.failing('AUT-04 refuses a member editing a rule someone else created', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const rule = await createRule(owner.api, ruleFor(state.projects.shared._id));
+        try {
+            const res = await member.api.put(`/api/v2/automations/${rule._id}`, { ...ruleFor(state.projects.shared._id), name: 'Renamed by member' });
+            const list = await owner.api.get('/api/v2/automations');
+            expect(refused(res)).toBe(true);
+            expect(list.body.data.find((r) => r._id === rule._id).name).toBe(rule.name);
+        } finally {
+            await removeRule(owner.api, rule._id);
+        }
+    });
+
+    it.failing('AUT-04 refuses a guest switching a rule on', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const rule = await createRule(owner.api, ruleFor(state.projects.shared._id));
+        try {
+            const res = await guest.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: true });
+            const list = await owner.api.get('/api/v2/automations');
+            expect(refused(res)).toBe(true);
+            expect(list.body.data.find((r) => r._id === rule._id).enabled).toBe(false);
+        } finally {
+            await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: false });
+            await removeRule(owner.api, rule._id);
+        }
+    });
+
+    it.failing('AUT-09 reports a missing rule instead of claiming it was updated', async () => {
+        const { api } = await loginAs('owner');
+        const put = await api.put(`/api/v2/automations/${MISSING_ID}`, ruleFor(state.projects.shared._id));
+        const patch = await api.patch(`/api/v2/automations/${MISSING_ID}/enabled`, { enabled: true });
+        expect(put.body.status).toBe(false);
+        expect(patch.body.status).toBe(false);
+    });
+
+    it.failing('AUT-03 keeps private-project tasks out of a guest backtest', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const { project, task } = await privateProjectWithTask(owner);
+        const res = await guest.api.post('/api/v2/automations/backtest', { rule: ruleFor(project._id) });
+        expect(res.body.data.matched).toBe(0);
+        expect(res.body.data.sample.map((t) => t.id)).not.toContain(task._id);
+    });
+});
+
+describe('automation rules (v1)', () => {
+    it.each(ROLE_NAMES)('lets %s list rules', async (role) => {
+        const { api } = await loginAs(role);
+        const res = await api.get('/api/v1/automations');
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(true);
+    });
+
+    it('lets the owner create, update and remove a v1 rule', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const created = await owner.api.post('/api/v1/automations', { name: `E2E v1 ${uniqueSuffix()}`, conditions: { projectId: project._id }, actions: [{ type: 'set_priority', value: 'HIGH' }] });
+        expect(created.body.status).toBe(true);
+        const id = created.body.data._id;
+
+        const updated = await owner.api.put(`/api/v1/automations/${id}`, { enabled: false });
+        expect(updated.body.data.enabled).toBe(false);
+        expect((await owner.api.put(`/api/v1/automations/${id}`, {})).body.statusText).toBe('Nothing to update.');
+        expect((await owner.api.post('/api/v1/automations', { name: 'x', actions: [] })).body.status).toBe(false);
+        expect((await owner.api.delete(`/api/v1/automations/${id}`)).body.status).toBe(true);
+        expect((await owner.api.post(`/api/v1/automations/${id}/apply`, {})).body.statusText).toBe('Not found.');
+    });
+
+    it('previews and applies a v1 rule to the owner project', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+        const created = await owner.api.post('/api/v1/automations', { name: `E2E v1 ${uniqueSuffix()}`, conditions: { projectId: project._id }, actions: [{ type: 'set_priority', value: 'HIGH' }] });
+        const id = created.body.data._id;
+        try {
+            const applied = await owner.api.post(`/api/v1/automations/${id}/apply`, {});
+            expect(applied.body).toMatchObject({ status: true, data: { modified: 1 } });
+            const preview = await owner.api.post('/api/v1/automations/preview', { conditions: { projectId: project._id } });
+            expect(preview.body.data.sample).toEqual([expect.objectContaining({ id: task._id, priority: 'HIGH' })]);
+        } finally {
+            await owner.api.delete(`/api/v1/automations/${id}`);
+        }
+    });
+
+    it.failing('AUT-05 saves a new v1 rule switched off', async () => {
+        const { api } = await loginAs('owner');
+        const created = await api.post('/api/v1/automations', { name: `E2E v1 ${uniqueSuffix()}`, actions: [{ type: 'set_priority', value: 'LOW' }] });
+        try {
+            expect(created.body.data.enabled).toBe(false);
+        } finally {
+            await api.delete(`/api/v1/automations/${created.body.data._id}`);
+        }
+    });
+
+    it.failing('AUT-05 refuses a guest bulk-changing priorities in a private project', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const { project, task } = await privateProjectWithTask(owner);
+        const created = await guest.api.post('/api/v1/automations', { name: `E2E guest v1 ${uniqueSuffix()}`, conditions: { projectId: project._id }, actions: [{ type: 'set_priority', value: 'HIGH' }] });
+        const id = created.body && created.body.data && created.body.data._id;
+        try {
+            const applied = id ? await guest.api.post(`/api/v1/automations/${id}/apply`, {}) : created;
+            const preview = await owner.api.post('/api/v1/automations/preview', { conditions: { projectId: project._id } });
+            expect(refused(applied)).toBe(true);
+            expect(preview.body.data.sample.find((t) => t.id === task._id).priority).toBe('MEDIUM');
+        } finally {
+            if (id) await owner.api.delete(`/api/v1/automations/${id}`);
+        }
+    });
+
+    it.failing('AUT-03 keeps private-project tasks out of a guest v1 preview', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const { project, task } = await privateProjectWithTask(owner);
+        const res = await guest.api.post('/api/v1/automations/preview', { conditions: { projectId: project._id } });
+        expect(res.body.data.count).toBe(0);
+        expect(res.body.data.sample.map((t) => t.id)).not.toContain(task._id);
+    });
+});
+
+describe('AI features', () => {
+    it('refuses the session-protected AI routes without a session', async () => {
+        for (const [method, url] of [
+            ['post', '/api/v1/ai/task-summary'], ['post', '/api/v1/ai/task-category'], ['get', '/api/v1/ai/ask/sources'],
+            ['post', '/api/v1/ai/ask'], ['post', '/api/v1/ai/meeting-notes'], ['post', '/api/v1/ai/transcribe'],
+        ]) {
+            const res = method === 'get' ? await anonymousWithCompany.get(url) : await anonymousWithCompany.post(url, {});
+            expect([url, res.status]).toEqual([url, 401]);
+        }
+    });
+
+    it.each(ROLE_NAMES)('answers Ask sources for %s without a model', async (role) => {
+        const { api } = await loginAs(role);
+        const res = await api.get('/api/v1/ai/ask/sources');
+        expect(res.body.status).toBe(true);
+        expect(res.body.data.configured).toBe(false);
+        expect(res.body.data.projects.map((p) => p.id)).toContain(state.projects.shared._id);
+    });
+
+    it('leaves a private project out of what Ask searches for a guest', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const { project, task } = await privateProjectWithTask(owner);
+
+        const sources = await guest.api.get('/api/v1/ai/ask/sources');
+        expect(sources.body.data.projects.map((p) => p.id)).not.toContain(project._id);
+
+        const asked = await guest.api.post('/api/v1/ai/ask', { question: 'E2E private task', projectId: project._id });
+        expect(asked.body.status).toBe(true);
+        expect(asked.body.data.sources.map((s) => s.id)).not.toContain(task._id);
+
+        const ownerAsked = await owner.api.post('/api/v1/ai/ask', { question: 'E2E private task', projectId: project._id });
+        expect(ownerAsked.body.data.sources.map((s) => s.id)).toContain(task._id);
+    });
+
+    it('validates the inputs of the other AI routes', async () => {
+        const { api } = await loginAs('member');
+        expect((await api.post('/api/v1/ai/ask', { question: ' ' })).body.statusText).toBe('Ask a question first.');
+        expect((await api.post('/api/v1/ai/meeting-notes', { transcript: '' })).body.statusText).toBe('Nothing to summarise.');
+        expect((await api.post('/api/v1/ai/task-summary', { taskId: 'nope' })).body.statusText).toBe('taskId is required');
+        expect((await api.post('/api/v1/ai/task-category', { taskId: 'nope' })).body.statusText).toBe('taskId is required');
+        const transcribe = await api.post('/api/v1/ai/transcribe', {});
+        expect(transcribe.status).toBe(503);
+    });
+
+    it.failing('AUT-02 refuses anonymous callers on the AI-Assist and description routes', async () => {
+        const probes = [
+            ['/api/v1/ai/description', { title: 'E2E' }],
+            ['/api/v1/generatePrompt', { prompt: '' }],
+            ['/api/v1/generatePromptChat', { isRegenerate: true, uniqueUserId: `e2e-${uniqueSuffix()}` }],
+            ['/api/v1/deleteUserChat', { userId: `e2e-${uniqueSuffix()}` }],
+            ['/api/v1/getPrompts', {}],
+            ['/api/v1/getAiModels', {}],
+        ];
+        for (const [url, body] of probes) {
+            const res = await anonymousWithCompany.post(url, body);
+            expect([url, res.status]).toEqual([url, 401]);
+        }
+    });
+
+    // The handler rewrites <repo>/.env, so the probe only runs where no .env exists (CI, a fresh worktree).
+    (fs.existsSync(path.join(ROOT, '.env')) ? it.skip : it.failing)('AUT-01 refuses an anonymous AI model update', async () => {
+        const res = await anonymous.post('/api/v1/updateAiModel', { key: 'E2E_PROBE', value: 'x' });
+        expect(res.status).toBe(401);
+    });
+});
+
+describe('AI project generator', () => {
+    it.each(ROLE_NAMES)('tells %s that no provider is configured before any model work', async (role) => {
+        const { api } = await loginAs(role);
+        const description = 'An internal tool for tracking E2E test runs across teams';
+        for (const url of ['/api/v1/ai/project/plan', '/api/v1/ai/project/clarify', '/api/v1/ai/project/brief', '/api/v1/ai/project/upload-brief', `/api/v1/ai/project/${state.projects.shared._id}/tasks/plan`]) {
+            const res = await api.post(url, { description });
+            expect([url, res.status, res.body.status]).toEqual([url, 503, false]);
+        }
+    });
+
+    it('validates a plan before executing anything', async () => {
+        const { api } = await loginAs('member');
+        expect((await api.post('/api/v1/ai/project/guide', { approvedBrief: 'short' })).status).toBe(400);
+        expect((await api.post('/api/v1/ai/project/execute', {})).body.statusText).toBe('plan required in request body');
+        expect((await api.post('/api/v1/ai/project/execute', { plan: { project: {} } })).status).toBe(400);
+        expect((await api.post('/api/v1/ai/project/not-an-id/tasks/execute', { plan: {} })).status).toBe(400);
+        const tasksMode = await api.post(`/api/v1/ai/project/${state.projects.shared._id}/tasks/execute`, { mode: 'tasks', plan: {} });
+        expect(tasksMode.body.statusText).toBe('targetSprintId required for tasks mode');
+    });
+
+    it('refuses the generator without a session and ignores a body company the caller is not in', async () => {
+        expect((await anonymousWithCompany.post('/api/v1/ai/project/execute', {})).status).toBe(401);
+        const { api } = await loginAs('owner');
+        const res = await api.post('/api/v1/ai/project/execute', { companyId: OTHER_COMPANY, plan: { project: {} } });
+        expect(res.status).toBe(400);
+    });
+
+    it('adds sprints to a project the owner can open', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const before = (await listSprints(owner.api, project._id)).length;
+        const res = await owner.api.post(`/api/v1/ai/project/${project._id}/tasks/execute`, { mode: 'sprints', plan: { sprints: [{ sprintName: 'E2E sprint' }] } });
+        expect(res.body).toMatchObject({ status: true, jobId: expect.any(String) });
+        const after = await waitFor(async () => {
+            const count = (await listSprints(owner.api, project._id)).length;
+            return count > before ? count : null;
+        });
+        expect(after).toBe(before + 1);
+    });
+
+    it.failing('AUT-07 refuses a guest adding sprints to a private project they cannot open', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid, isPrivate: true });
+        const before = (await listSprints(owner.api, project._id)).length;
+        const res = await guest.api.post(`/api/v1/ai/project/${project._id}/tasks/execute`, { mode: 'sprints', plan: { sprints: [{ sprintName: 'E2E injected' }] } });
+        const after = await waitFor(async () => {
+            const count = (await listSprints(owner.api, project._id)).length;
+            return count > before ? count : null;
+        }, { timeout: 4000 });
+        expect(refused(res)).toBe(true);
+        expect(after).toBeNull();
+    });
+
+    it('streams job progress without a session, by design', async () => {
+        const controller = new AbortController();
+        const res = await fetch(`${state.baseURL}/api/v1/ai-progress/${uniqueSuffix()}${uniqueSuffix()}${uniqueSuffix()}${uniqueSuffix()}`, { signal: controller.signal });
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('text/event-stream');
+        controller.abort();
+    });
+});
+
+describe('MCP', () => {
+    it('publishes the manifest without a session', async () => {
+        const res = await anonymous.get('/mcp/manifest');
+        expect(res.status).toBe(200);
+        expect(res.body.data.tools.map((t) => t.name)).toEqual(expect.arrayContaining(['tasks.next', 'task.get', 'task.comment']));
+        expect(res.body.data.never).toEqual(expect.arrayContaining(['task.delete']));
+    });
+
+    it('refuses a call without a token, or with a web session token', async () => {
+        const member = await loginAs('member');
+        expect((await anonymousWithCompany.post('/mcp', { jsonrpc: '2.0', id: 1, method: 'tools/list' })).status).toBe(401);
+        expect((await mcpCall(member.accessToken, 'tools/list')).status).toBe(401);
+    });
+
+    it('lets a member mint a token, list tools and revoke it', async () => {
+        const member = await loginAs('member');
+        const minted = await member.api.post('/api/v2/api-tokens/mcp', { name: `E2E MCP ${uniqueSuffix()}`, mode: 'personal', projectIds: [state.projects.shared._id], expiresInDays: 1 });
+        expect(minted.body.status).toBe(true);
+        const { token, _id: tokenId } = minted.body.data;
+        try {
+            const init = await mcpCall(token, 'initialize', { protocolVersion: '2025-06-18' });
+            expect(init.body.result.serverInfo.name).toBe('alianhub');
+            const tools = await mcpCall(token, 'tools/list');
+            expect(tools.body.result.tools.length).toBeGreaterThan(5);
+            expect((await mcpCall(token, 'nope/nope')).body.error.code).toBe(-32601);
+            const mintWithPat = await createApiClient({ baseURL: state.baseURL, accessToken: token, companyId: state.companyId }).post('/api/v2/api-tokens/mcp', { name: 'x' });
+            expect(mintWithPat.status).toBe(403);
+        } finally {
+            expect((await member.api.delete(`/api/v2/api-tokens/${tokenId}`)).body.status).toBe(true);
+        }
+        expect((await mcpCall(token, 'tools/list')).status).toBe(401);
+    });
+
+    it.failing('AUT-08 keeps task.get inside the projects a token is scoped to', async () => {
+        const owner = await loginAs('owner');
+        const inScope = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const outOfScope = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const task = await createTask(owner.api, { project: outOfScope, user: state.users.owner, companyOwnerId: owner.uid });
+        const minted = await owner.api.post('/api/v2/api-tokens/mcp', { name: `E2E MCP scope ${uniqueSuffix()}`, mode: 'personal', projectIds: [inScope._id], expiresInDays: 1 });
+        const { token, _id: tokenId } = minted.body.data;
+        try {
+            const res = await mcpCall(token, 'tools/call', { name: 'task.get', arguments: { taskId: task._id } });
+            const payload = JSON.parse(res.body.result.content[0].text);
+            expect(payload.taskId).toBeUndefined();
+        } finally {
+            await owner.api.delete(`/api/v2/api-tokens/${tokenId}`);
+        }
+    });
+});


### PR DESCRIPTION
Automations and AI features wave of task 034: Automations, AI, AIProjectGenerator and Mcp.

## What is in it
- `Tasks/active/034-end-to-end-qa-programme/findings/automations.md`: coverage per role (44 routes, 4 screens) and 11 findings (AUT-01..AUT-11).
- `tests/integration/automations.int.test.js`: 47 tests: rule lifecycle, engine run on an enabled rule, v1 preview/apply, Ask scoping, AI and generator validation, MCP token mint/call/revoke, and one `it.failing` per encodable finding.
- `e2e/specs/automations.spec.js`: 4 tests: Automations list and builder as owner, Coding accounts, Ask as guest, and `test.fail` for AUT-04.

No product code and no `e2e/support` helpers changed.

## Findings
| Id | Severity | Title |
|---|---|---|
| AUT-01 | critical | `POST /api/v1/updateAiModel` rewrites the server `.env` without a session |
| AUT-02 | critical | AI-Assist and "Write with AI" routes run model calls for anonymous callers |
| AUT-03 | critical | Automation backtest and v1 preview return private-project task names to any role |
| AUT-06 | critical | AI task summary and category read any task by id, including private projects |
| AUT-04 | high | Any role can create, edit, switch on and delete any automation rule |
| AUT-05 | high | v1 rules save switched on; v1 apply bulk-updates priorities with no role or project check |
| AUT-07 | high | AI task generation writes sprints and tasks into a project the caller cannot open |
| AUT-08 | high | MCP `task.get` ignores the token's project scope |
| AUT-09 | medium | v2 update and switch report success for a rule that does not exist |
| AUT-10 | low | Ask sends `[object Object]` as each task's status |
| AUT-11 | low | Automation runs for `task.created` record the placeholder key `--` |

AUT-06 has no suite test: both helpers return before the task lookup when no provider is configured, and the harness has no AI keys. AUT-01 runs only where no `.env` exists (CI, fresh worktree), because the handler writes that file.

## Checks
- `npx jest --selectProjects integration tests/integration/automations.int.test.js`: 47 passed, against a throwaway database. Each `it.failing` was confirmed to fail on its product assertion.
- `npx playwright test e2e/specs/automations.spec.js`: 4 passed.
- `npx jest tests/conventions`: 94 passed.
- eslint: 0 problems on both spec files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
