### PR TITLE
test(034): sweep and cover the instance and administration area

### DIFF
--- a/Tasks/active/034-end-to-end-qa-programme/findings/instance.md
+++ b/Tasks/active/034-end-to-end-qa-programme/findings/instance.md
@@ -46,10 +46,12 @@ Screens (from `frontend/src/router/settings/index.js`): 16 in the area — Insta
 
 | Severity | Count | Ids |
 |---|---|---|
-| Critical | 5 | INS-01, INS-02, INS-03, INS-04, INS-05 |
+| Critical | 5 | INS-01, INS-02, INS-03 (fixed), INS-04 (fixed), INS-05 |
 | High | 2 | INS-06, INS-07 |
-| Medium | 4 | INS-08, INS-09, INS-10, INS-11 |
+| Medium | 4 | INS-08, INS-09, INS-10, INS-11 (fixed) |
 | Low | 1 | INS-12 |
+
+INS-03, INS-04 and INS-11 were closed on `beta` by 2954eb91 ("guard the routes that answered without a session") while this sweep ran; their regression tests are now plain `it` and guard against a return.
 
 ### INS-01 — A member can promote themselves to owner through `PUT /api/v1/members`
 
@@ -76,6 +78,7 @@ Screens (from `frontend/src/router/settings/index.js`): 16 in the area — Insta
 
 ### INS-03 — Notification settings are readable and writable without a session
 
+- **Status:** fixed on `beta` by 2954eb91 (the prefixes now carry their leading slash). Whether a signed-in member can still change another user's settings through `PUT /api/v1/notifications` was not re-checked.
 - **Severity:** critical (authentication bypass)
 - **Role:** no session
 - **Requests:** `GET /api/v1/notifications/:userId` and `PUT /api/v1/notifications`, with only a `companyid` header.
@@ -90,6 +93,7 @@ Screens (from `frontend/src/router/settings/index.js`): 16 in the area — Insta
 
 ### INS-04 — Project skills can be changed without a session; milestone range readable without one
 
+- **Status:** fixed on `beta` by 2954eb91 (both prefixes added to `Config/setMiddleware.js`).
 - **Severity:** critical (authentication bypass on a company setting write)
 - **Role:** no session
 - **Requests:** `PUT /api/v1/setting/skills` `{ operation: 'add', name }`; `GET /api/v1/setting/skills`; `GET /api/v1/milestoneRange`; each with only a `companyid` header.
@@ -174,6 +178,7 @@ Screens (from `frontend/src/router/settings/index.js`): 16 in the area — Insta
 
 ### INS-11 — `POST /api/v1/versionUpdateNotify` works without a session
 
+- **Status:** fixed on `beta` by 2954eb91 (the route now requires the instance owner).
 - **Severity:** medium (unauthenticated write, limited to one flag)
 - **Role:** no session
 - **Request:** `POST /api/v1/versionUpdateNotify` `{ flag: true|false }`

--- a/Tasks/active/034-end-to-end-qa-programme/findings/instance.md
+++ b/Tasks/active/034-end-to-end-qa-programme/findings/instance.md
@@ -1,0 +1,213 @@
+# Findings — Instance and administration
+
+Area modules: Instance, settings, Admin, Audit, common, Template, swaggerAPI, typesense.
+Swept 2026-09-11 on the local server (beta, builds 14.36.0-beta.68 to beta.73 while other merges landed), company Local360, and in the throwaway harness (Mongo on 27110).
+
+Specs: `tests/integration/instance.int.test.js`, `e2e/specs/instance.spec.js`.
+
+## Coverage
+
+Routes are every `app.get|post|put|patch|delete|use` the area modules register, plus `/health` and `/version` from `index.js`.
+
+| Module | Routes |
+|---|---|
+| Instance (`/api/v2/instance/*`) | 21 |
+| Audit (`/api/v1/audit-logs*`) | 3 |
+| settings (Members 7, templates 14, ProjectStatusTemplate 4, settingMilestone 4, settingNotifications 3, Roles 2, Designation 2, ProjectSkills 2, securityPermissions 2, settingCurrency 2, taskPriority 2, fileExtensions 2, commonDateFormate 2, Category 1, CompanyUserStatus 1, restrictedExtensions 1) | 51 |
+| common (`getTime`, `getEmailTemplates`, `/connections/:id`, `versionUpdateNotify`) | 4 |
+| Admin (`getlogo`, `getBrandSettingsData`) | 2 |
+| swaggerAPI (`/apidocs`) | 1 |
+| typesense | 0 (a schema file only, no routes, nothing wired) |
+| `/health`, `/version` | 2 |
+| **Total** | **84** |
+
+Routes exercised, per role:
+
+| Role | Local server | Harness (integration + Playwright) |
+|---|---|---|
+| Owner (Local PM, browser session) | 38 (every read of the console, audit, settings, admin routes; no mutations, per area rules) | 62 |
+| Admin (rahul.manager / fixture admin) | 53 | 44 |
+| Member (priya.frontend, sara.qa / fixture member) | 53 | 47 |
+| Guest (kabir.intern / fixture guest) | 53 | 52 |
+| No session | 53 | 55 |
+| **Any role** | 55 | 81 |
+
+Not exercised anywhere: `PUT /api/v1/setting/taskType`, `PUT /api/v1/setting/taskStatus`, `PUT /api/v1/setting/projectStatus` (each appends a permanent entry to the company catalogue and has no delete route, so they were kept out of both Local360 and the shared harness), and the success path of `POST /api/v1/audit-logs/:id/undo` (needs an agent action row; the 404 path was exercised).
+
+Screens (from `frontend/src/router/settings/index.js`): 16 in the area — Instance Health, Settings, Backups, Upgrade, Logs, Stats; Settings General, Language & Region, Members, Projects, Templates, Security & Permissions, Notifications, Company, Time Tracking, Audit Log.
+
+| Role | Local server | Harness |
+|---|---|---|
+| Owner | 16 of 16 opened | 16 of 16 opened |
+| Admin | — | 2 (Notifications shell, Instance address) plus Audit Log link |
+| Member, guest | — | 2 each (Notifications shell, Instance address) |
+
+## Findings
+
+| Severity | Count | Ids |
+|---|---|---|
+| Critical | 5 | INS-01, INS-02, INS-03, INS-04, INS-05 |
+| High | 2 | INS-06, INS-07 |
+| Medium | 4 | INS-08, INS-09, INS-10, INS-11 |
+| Low | 1 | INS-12 |
+
+### INS-01 — A member can promote themselves to owner through `PUT /api/v1/members`
+
+- **Severity:** critical (privilege escalation)
+- **Role:** member (any signed-in member of the company)
+- **Request:** `PUT /api/v1/members` with `{ id: <own company_users _id>, data: { roleType: 1 } }`
+- **Expected:** refused (403); only an owner grants owner or admin, and only a user with `settings.settings_member_list` edits members.
+- **Actual:** 200 `{status: true}`; the stored `roleType` becomes 1. Confirmed in the harness: a fresh member read back `roleType` 3 before and 1 after. Owner-only routes open for them once the 60-second role cache (`roleType:<company>:<uid>`) expires.
+- **Reproduce:** sign in as a member; `GET /api/v1/members/<own userId>` to read `_id`; send the PUT above; `GET` again as the owner.
+- **Suspected:** `Config/permissionGuard.js:172` — `requirePermission` returns `next()` for every request that is not an API token, so the route guard in `Modules/settings/Members/routes.js:15` never runs for the web app; `Modules/settings/Members/controller.js:248` limits the owner-only role check to `req.apiToken`. The controller `$set`s whatever `data` holds.
+- **Fix direction:** enforce the owner/admin rule for session requests too (at least for `roleType`, `status`, `isDelete`), and allow-list the fields a member may change.
+- **Regression test:** `INS-01 refuses a member promoting themselves to owner through PUT /api/v1/members` (`it.failing`).
+
+### INS-02 — A guest can promote themselves to admin through `PUT /api/v1/root-members`
+
+- **Severity:** critical (privilege escalation)
+- **Role:** guest (any signed-in user)
+- **Request:** `PUT /api/v1/root-members` with `{ id: <own company_users _id>, data: { roleType: 2 }, companyId }`
+- **Expected:** refused; this route exists for invite acceptance and should only link `userId` and set `status` on the caller's own pending invite.
+- **Actual:** 200 `{status: true}`; stored `roleType` goes from 0 to 2 (harness).
+- **Reproduce:** as a guest, read your own `company_users` row from `GET /api/v1/members/<userId>`, send the PUT above, read it back as the owner.
+- **Suspected:** `Modules/settings/Members/controller.js:377` (`rootUpdateMember` spreads `data` into `$set` with no field allow-list); `Modules/settings/Members/routes.js:16` relies on the same API-token-only `requirePermission`; `Config/setMiddleware.js` lists it under `verifyJWTToken`, which checks the session but not the role.
+- **Regression test:** `INS-02 refuses a guest promoting themselves to admin through PUT /api/v1/root-members` (`it.failing`).
+
+### INS-03 — Notification settings are readable and writable without a session
+
+- **Severity:** critical (authentication bypass)
+- **Role:** no session
+- **Requests:** `GET /api/v1/notifications/:userId` and `PUT /api/v1/notifications`, with only a `companyid` header.
+- **Expected:** 401 without a session; a user can only read or change their own settings.
+- **Actual:**
+  - On Local360, an anonymous `GET /api/v1/notifications/<userId>` returned 200 with the user's full notification settings.
+  - In the harness, an anonymous `PUT` flipped another member's `chat.items[0].email` from false to true (`modifiedCount: 1`).
+  - The GET also runs `ensureNotificationDefaults` for any `companyid` value, so an anonymous caller can create databases. On local Mongo, my sweep's single request with a made-up company id created database `0123456789abcdef01234567` holding one `notifications_settings` document; see "Could not do" below.
+- **Reproduce:** `curl -H 'companyid: <companyId>' http://localhost:4000/api/v1/notifications/<userId>`.
+- **Suspected:** `Config/setMiddleware.js:139-140` lists `'api/v1/notifications'` and `'api/v1/notifications/:id'` without the leading slash, so the JWT middleware never matches them (`/api/v1/notifications/preferences` on line 232 is correct and guarded). `Modules/settings/settingNotifications/controller.js:8` takes `userId` from the body and never compares it with `req.uid`; `:90` creates defaults for any company. Not covered by `fix/unauthenticated-v1-routes`, which only adds `/api/v1/removeCache`.
+- **Regression tests:** `INS-03/INS-04 refuses /api/v1/notifications/<id> without a session`, `INS-03 refuses an anonymous change to someone else notification settings` (`it.failing`).
+
+### INS-04 — Project skills can be changed without a session; milestone range readable without one
+
+- **Severity:** critical (authentication bypass on a company setting write)
+- **Role:** no session
+- **Requests:** `PUT /api/v1/setting/skills` `{ operation: 'add', name }`; `GET /api/v1/setting/skills`; `GET /api/v1/milestoneRange`; each with only a `companyid` header.
+- **Expected:** 401.
+- **Actual:**
+  - `PUT` returned 200 and stored `{ key: 49, name: 'Anonymous Skill', active: true }` (harness).
+  - Both GETs return 200 on Local360, and also for a company id the caller does not belong to.
+- **Reproduce:** `curl -X PUT -H 'companyid: <companyId>' -H 'content-type: application/json' -d '{"operation":"add","name":"x"}' http://localhost:4000/api/v1/setting/skills` (harness only).
+- **Suspected:** neither `/api/v1/setting/skills` nor `/api/v1/milestoneRange` is in either list in `Config/setMiddleware.js`; `Modules/settings/ProjectSkills/routes.js:6` relies on `requirePermission`, which passes non-token requests (`Config/permissionGuard.js:172`).
+- **Regression tests:** `INS-03/INS-04 refuses /api/v1/milestoneRange|/api/v1/setting/skills without a session`, `INS-04 refuses an anonymous project skill write` (`it.failing`).
+
+### INS-05 — `PUT /api/v1/currency/:cid/:id` writes to the company named in the path
+
+- **Severity:** critical (cross-tenant write)
+- **Role:** admin (any signed-in member)
+- **Request:** `PUT /api/v1/currency/<another companyId>/<currencyId>` `{ key: '$set', updateObject: {...} }` with the caller's own `companyid` header.
+- **Expected:** refused unless the path company is the session's company.
+- **Actual:** 200 with the other database's update result (`acknowledged: true, matchedCount: 0` against a made-up company; a real company id with a matching currency `_id` would be modified). The client also chooses the update operator (`key`).
+- **Reproduce:** harness, as admin: `GET /api/v1/currency`, take `_id`, send the PUT with a different 24-hex company id.
+- **Suspected:** `Modules/settings/settingCurrency/controller.js:35` uses `req.params.cid` for `MongoDbCrudOpration`; `verifyJWTTokenWithCV2` (`Config/jwt.js`) only checks the `companyid` header against the token audience.
+- **Regression test:** `INS-05 refuses a currency write aimed at another company` (`it.failing`).
+
+### INS-06 — Company settings writes have no role check, and some accept arbitrary update documents
+
+- **Severity:** high (wrong role enforcement)
+- **Role:** guest (and therefore member)
+- **Requests, all accepted for a guest in the harness:**
+  - `PUT /api/v1/setting/roles/update` and `PUT /api/v1/setting/designation/update`: `{ queryFilter, queryObj }` is passed straight to `findOneAndUpdate` with `upsert: true` on the settings collection. A guest wrote `qaMarker` onto the real `roles` document and could just as well overwrite or `$unset` the role catalogue.
+  - `PUT /api/v1/commonDateFormate`, `PUT /api/v1/taskPriority`, `PUT /api/v1/fileExtensions`, `PUT /api/v1/milestoneStatus`: the client picks the update operator through `key`.
+  - `POST /api/v1/templates/taskStatus` (and the other template create, update and delete routes).
+  - `PUT /api/v1/securityPermissions`: a guest modified a permission rule document (`modifiedCount: 1`), so a guest can grant themselves any permission.
+- **Expected:** refused for anyone below admin, or below the matching `settings.*` permission; never a client-supplied filter or operator.
+- **Actual:** 200 for every request above.
+- **Reproduce:** harness, as guest: `PUT /api/v1/setting/roles/update` `{ "queryFilter": { "name": "roles" }, "queryObj": { "$set": { "qaMarker": true } } }`.
+- **Suspected:** `Modules/settings/Roles/controller.js:40`, `Modules/settings/Designation/controller.js:40`, the `update*` handlers in `commonDateFormate`, `taskPriority`, `fileExtensions`, `settingMilestone`, `templates`, `ProjectStatusTemplate`; `Modules/settings/securityPermissions/routes.js:11` and `ProjectSkills/routes.js:6` rely on `requirePermission`, which is API-token-only (`Config/permissionGuard.js:172`). `ProjectSkills` already shows the safer shape (explicit operations, no passthrough).
+- **Regression tests:** `INS-06 refuses a guest on <route>` (7 routes) and `INS-06 refuses a guest editing a security permission rule` (`it.failing`).
+
+### INS-07 — Instance settings cannot be saved from the owner's session
+
+- **Severity:** high (broken core function)
+- **Role:** owner
+- **Request / screen:** Settings › Instance › Settings, change any value, Save → `PUT /api/v2/instance/settings`.
+- **Expected:** 200 "Saved." and the value applied.
+- **Actual:**
+  - The API answers 400 `{ statusText: 'Some settings are not valid.', data: { errors: { refreshToken: 'unknown' } } }` for every session request.
+  - On screen nothing happens: `InstanceSettings.vue` copies the field errors into `errors`, but no field row exists for `refreshToken`, so no toast and no error is shown.
+  - Saving only works with `INSTANCE_ADMIN_KEY`.
+- **Reproduce:** harness, as owner: `PUT /api/v2/instance/settings` `{ "APP_NAME": "x" }`. On Local360 this was not attempted (area rule: no instance setting changes).
+- **Suspected:** `Config/jwt.js:229` (`checkToken` writes `req.body.refreshToken`) meets `Modules/Instance/controller.js:30` → `validateSettings` (`Modules/Instance/settingsCatalog.js:80`), which rejects unknown keys. Drop `refreshToken` before validating (other controllers allow-list it), and have `InstanceSettings.vue:131-133` toast errors that match no row.
+- **Regression tests:** `INS-07 saves a setting from the owner session, shows it in the public config and restores it` (`it.failing`), `INS-07 saves a changed setting from Instance > Settings` (`test.fail`).
+
+### INS-08 — Audit log CSV export stops at 100 rows
+
+- **Severity:** medium
+- **Role:** owner, admin
+- **Request:** `GET /api/v1/audit-logs/export?entityId=<id>` for a filter with 101 rows.
+- **Expected:** every row of the filter, up to the documented 1000 cap.
+- **Actual:** 100 rows; the list reports `metadata.total: 101`.
+- **Reproduce:** harness: 101 × owner `PUT /api/v1/members` on one member, then export with `entityId`.
+- **Suspected:** `Modules/Audit/controller.js:123` asks `listAuditLogs` for `limit: 1000`, but `:70` caps `limit` at 100.
+- **Regression test:** `INS-08 exports every row of the filter, not only the first 100` (`it.failing`).
+
+### INS-09 — Audit rows take the actor name from the request body; CSV cells are not neutralised
+
+- **Severity:** medium (audit integrity)
+- **Role:** any caller of an audited route
+- **Request:** `PUT /api/v1/members` with `userData: { name: '=HYPERLINK("http://example.invalid","Rahul")' }` in the body.
+- **Expected:** `actorName` resolved from `req.uid`; exported cells starting with `= + - @` prefixed so a spreadsheet does not run them.
+- **Actual:** the audit row stores the body-supplied name and the export writes it unchanged.
+- **Suspected:** `Modules/Audit/recorder.js:27` (`actorName: userData.name || ...` from `req.body.userData`); `Modules/Audit/controller.js:129` and `Modules/Instance/controller.js` `csvCell` escape quotes only.
+- **Regression test:** `INS-09 records the signed-in actor, not a name from the request body` (`it.failing`).
+
+### INS-10 — A member can edit another member's private views
+
+- **Severity:** medium
+- **Role:** member
+- **Request:** `POST /api/v1/members/private-view` `{ id: <another member's company_users _id>, operation: 'push', data: {...} }`
+- **Expected:** refused unless `id` is the caller's own row.
+- **Actual:** 200 `{status: true}`; the view is pushed onto the other member's `ProjectRequiredComponent` (harness). `delete` and `update` work the same way.
+- **Suspected:** `Modules/settings/Members/controller.js:156` (`handlePrivateView` never checks `req.uid` against the row's `userId`).
+- **Regression test:** `INS-10 refuses a member editing another member private views` (`it.failing`).
+
+### INS-11 — `POST /api/v1/versionUpdateNotify` works without a session
+
+- **Severity:** medium (unauthenticated write, limited to one flag)
+- **Role:** no session
+- **Request:** `POST /api/v1/versionUpdateNotify` `{ flag: true|false }`
+- **Expected:** 401; only the instance owner (or the release process) sets it.
+- **Actual:** 200 `{status: true}`; `users.isVesionUpdate` of the product owner is set to the body value.
+- **Suspected:** `Modules/common/routes.js:59` with no entry in `Config/setMiddleware.js`; `Modules/common/controller.js` updates the owner record unconditionally.
+- **Regression test:** `INS-11 refuses an anonymous version update flag` (`it.failing`).
+
+### INS-12 — `GET /api/v1/getTime` without a zone answers 200 with plain text
+
+- **Severity:** low
+- **Role:** any
+- **Request:** `GET /api/v1/getTime`
+- **Expected:** `{ status: false, statusText: 'zone is required' }` with a 400.
+- **Actual:** 200 `No zone specified` as text; the success path is a bare JSON string rather than `{status, data}`. The sibling `getEmailTemplates` also returns a bare object with the misspelt key `invitationEamil`.
+- **Suspected:** `Modules/common/routes.js:13-25`.
+- **Regression test:** `INS-12 answers getTime without a zone with the standard error shape` (`it.failing`).
+
+## Checks that passed
+
+- `/version`, `/health`, Instance › Stats and Instance › Upgrade all show the beta build label on Local360 (`14.36.0-beta.73`, channel `beta`, commit and build log present; Upgrade lists 20 builds and "Next release: v14.36.0"). The harness asserts the four agree.
+- The instance console guard: all 20 admin routes answer 403 for admin, member and guest, and 401 without a session, locally and in the harness, including restore, delete, maintenance, migrations and settings writes. `public-config` is open by design.
+- In the harness, as owner: settings read, invalid keys and unknown test groups refused with 400, health, maintenance on (other API calls answer 503 while health and the console stay up) and off, migrations run, log list and tail, unknown log kinds 400, log download refuses a traversal name (404), backup create, list, manifest, download, wrong-confirm restore 400, a real restore of a fresh backup (the instance keeps serving), delete, stats, companies and the company history CSV.
+- Audit log: owner and admin list and export; member and guest get 403; no session 401; another company's id 401; a member update is recorded and filterable by entity; undo of an unknown row 404.
+- Every settings catalogue read requires a session (401 without), refuses another company (401), and answers every role with the company's data.
+- Owner writes: task status and task type templates (create, rename, delete), project status templates (create, rename, delete), project skills (add, hide), and member updates recorded in the audit log.
+- `PUT /api/v1/notifications/preferences` only changes the caller's own document (404 for someone else's).
+- `getlogo`, `getBrandSettingsData`, `getEmailTemplates` and `/apidocs` are available without a session. `/connections/:id` refuses without the preset key. Every logo folder `getlogo` can read exists, so no request reaches the `readdir` error path.
+- On screen: all 16 area screens render for the owner, with no Instance error banner and no page errors. The Audit log offers Export CSV and the export returns `text/csv`. The admin sees Audit Log but not Instance. Member and guest see neither, and opening an Instance address shows no console.
+
+## Could not do / notes
+
+- The owner browser pane was at its tab cap for most of the sweep; owner live checks ran once a tab could be opened (tab closed afterwards).
+- My first anonymous `GET /api/v1/notifications/<userId>` with a made-up `companyid` (part of INS-03) created database `0123456789abcdef01234567` with one `notifications_settings` document in the local `alianhub-mongo`. Dropping it was refused by the permission classifier, so it is still there; it is safe to drop.
+- Instance › Upgrade calls `api.github.com` for the latest release (cached 6 h). Opening the screen locally triggered it; the harness test hits it too and tolerates failure.
+- typesense has no routes or wiring in this build, and swagger (`/apidocs`) documents Instance but not Audit or settings; availability only was checked.
+- Playwright is not installed in the main checkout's `node_modules`; the spec was run with the `@playwright/test` 1.63.0 install of another worktree through `NODE_PATH`, without installing anything.

--- a/e2e/specs/instance.spec.js
+++ b/e2e/specs/instance.spec.js
@@ -1,0 +1,161 @@
+const { test, expect, asRole } = require('../support/test');
+const { settingsNav } = require('../support/pages');
+
+const INSTANCE_SCREENS = [
+    ['Health', 'health'],
+    ['Settings', 'settings'],
+    ['Backups', 'backups'],
+    ['Upgrade', 'upgrade'],
+    ['Logs', 'logs'],
+    ['Stats', 'stats'],
+];
+
+const WORKSPACE_SCREENS = ['setting', 'language', 'members', 'projects', 'template', 'security-permissions', 'notifications', 'company', 'time-tracking', 'audit-logs'];
+
+function trackPageErrors(page) {
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    return errors;
+}
+
+async function runningVersion(request, state) {
+    const res = await request.get(`${state.baseURL}/version`);
+    return (await res.json()).data;
+}
+
+test.describe('instance console as the owner', () => {
+    test.use(asRole('owner'));
+
+    test('opens every Instance screen from the settings navigation', async ({ page, state }) => {
+        const errors = trackPageErrors(page);
+        await page.goto(`/#/${state.companyId}/settings/notifications`);
+        const nav = settingsNav(page);
+        await expect(nav.getByText('Instance', { exact: true })).toBeVisible();
+
+        for (const [label, path] of INSTANCE_SCREENS) {
+            const access = page.waitForResponse((res) => res.url().includes('/api/v2/instance/') && res.request().method() === 'GET');
+            await nav.getByRole('link', { name: label, exact: true }).click();
+            await expect(page).toHaveURL(new RegExp(`/settings/instance/${path}$`));
+            expect((await access).status()).toBe(200);
+            await expect(page.locator('.in-banner--danger')).toHaveCount(0);
+            await expect(page.locator('.ah-empty', { hasText: 'Loading…' })).toHaveCount(0);
+        }
+        expect(errors).toEqual([]);
+    });
+
+    test('Health shows a healthy database', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/instance/health`);
+        await expect(page.getByText('Healthy', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText('Database', { exact: true }).first()).toBeVisible();
+    });
+
+    test('Stats shows the running build label', async ({ page, request, state }) => {
+        const build = await runningVersion(request, state);
+        await page.goto(`/#/${state.companyId}/settings/instance/stats`);
+        await expect(page.locator('[data-test="version-label"]')).toHaveText(`v${build.version}`);
+        const line = page.locator('[data-test="version-line"]');
+        await expect(line).toContainText(build.channel);
+        if (build.commit) await expect(line).toContainText(build.commit);
+        await expect(page.getByText(state.companyName).first()).toBeVisible();
+    });
+
+    test('Upgrade shows the running build label and the build log', async ({ page, request, state }) => {
+        const build = await runningVersion(request, state);
+        await page.goto(`/#/${state.companyId}/settings/instance/upgrade`);
+        await expect(page.locator('.ah-chip--mono', { hasText: `v${build.version}` })).toBeVisible({ timeout: 30000 });
+        await expect(page.getByText('Migrations', { exact: true })).toBeVisible();
+        if (build.channel === 'beta') {
+            await expect(page.locator('[data-test="build-row"]').first()).toBeVisible();
+        }
+    });
+
+    test.fail('INS-07 saves a changed setting from Instance > Settings', async ({ page, state, loginAs }) => {
+        const owner = await loginAs('owner');
+        const name = `[QA instance] ${Date.now()}`;
+        try {
+            await page.goto(`/#/${state.companyId}/settings/instance/settings`);
+            await page.locator('#f-APP_NAME').fill(name);
+            const saved = page.waitForResponse((res) => res.url().includes('/api/v2/instance/settings') && res.request().method() === 'PUT');
+            await page.getByRole('button', { name: 'Save', exact: true }).click();
+            expect((await saved).status()).toBe(200);
+            await expect(page.getByText('Settings saved.')).toBeVisible();
+        } finally {
+            await owner.api.put('/api/v2/instance/settings', { APP_NAME: '' });
+        }
+    });
+
+    test('opens the workspace settings screens of the area without page errors', async ({ page, state }) => {
+        const errors = trackPageErrors(page);
+        for (const path of WORKSPACE_SCREENS) {
+            await page.goto(`/#/${state.companyId}/settings/${path}`);
+            await expect(page).toHaveURL(new RegExp(`/settings/${path}$`));
+            await expect(settingsNav(page)).toBeVisible();
+        }
+        expect(errors).toEqual([]);
+    });
+
+    test('General settings loads the task priority icons', async ({ page, state }) => {
+        const icons = [];
+        page.on('response', (res) => {
+            const { pathname } = new URL(res.url());
+            if (pathname.includes('/taskPriorities/') && !pathname.includes('generateSignedUrl')) icons.push(`${res.status()} ${pathname.split('/').pop()}`);
+        });
+        await page.goto(`/#/${state.companyId}/settings/setting`);
+        await expect.poll(() => icons.length, { timeout: 30000 }).toBeGreaterThanOrEqual(3);
+        expect(icons.filter((line) => !line.startsWith('200'))).toEqual([]);
+    });
+
+    test('Audit log lists events and offers the CSV export', async ({ page, state }) => {
+        const list = page.waitForResponse((res) => res.url().includes('/api/v1/audit-logs?'));
+        await page.goto(`/#/${state.companyId}/settings/audit-logs`);
+        expect((await list).status()).toBe(200);
+        await expect(page.getByRole('button', { name: 'Export CSV' })).toBeVisible();
+
+        const exported = page.waitForResponse((res) => res.url().includes('/api/v1/audit-logs/export'));
+        await page.getByRole('button', { name: 'Export CSV' }).click();
+        const res = await exported;
+        expect(res.status()).toBe(200);
+        expect(res.headers()['content-type']).toContain('text/csv');
+    });
+});
+
+test.describe('instance console as an admin', () => {
+    test.use(asRole('admin'));
+
+    test('offers the Audit log but not the Instance section', async ({ page, state }) => {
+        const access = page.waitForResponse((res) => res.url().includes('/api/v2/instance/access'));
+        await page.goto(`/#/${state.companyId}/settings/notifications`);
+        expect((await access).status()).toBe(403);
+
+        const nav = settingsNav(page);
+        await expect(nav.getByRole('link', { name: 'Audit Log', exact: true })).toBeVisible();
+        await expect(nav.getByText('Instance', { exact: true })).toHaveCount(0);
+    });
+
+    test('an Instance address does not show the console', async ({ page, state }) => {
+        await page.goto(`/#/${state.companyId}/settings/instance/stats`);
+        await expect(page.locator('[data-test="version-label"]')).toHaveCount(0);
+    });
+});
+
+for (const role of ['member', 'guest']) {
+    test.describe(`administration as a ${role}`, () => {
+        test.use(asRole(role));
+
+        test('hides the Audit log and the Instance section', async ({ page, state }) => {
+            const access = page.waitForResponse((res) => res.url().includes('/api/v2/instance/access'));
+            await page.goto(`/#/${state.companyId}/settings/notifications`);
+            expect((await access).status()).toBe(403);
+
+            const nav = settingsNav(page);
+            await expect(nav.getByText('Personal', { exact: true })).toBeVisible();
+            await expect(nav.getByRole('link', { name: 'Audit Log', exact: true })).toHaveCount(0);
+            await expect(nav.getByText('Instance', { exact: true })).toHaveCount(0);
+        });
+
+        test('an Instance address does not show the console', async ({ page, state }) => {
+            await page.goto(`/#/${state.companyId}/settings/instance/stats`);
+            await expect(page.locator('[data-test="version-label"]')).toHaveCount(0);
+        });
+    });
+}

--- a/e2e/specs/instance.spec.js
+++ b/e2e/specs/instance.spec.js
@@ -94,17 +94,6 @@ test.describe('instance console as the owner', () => {
         expect(errors).toEqual([]);
     });
 
-    test('General settings loads the task priority icons', async ({ page, state }) => {
-        const icons = [];
-        page.on('response', (res) => {
-            const { pathname } = new URL(res.url());
-            if (pathname.includes('/taskPriorities/') && !pathname.includes('generateSignedUrl')) icons.push(`${res.status()} ${pathname.split('/').pop()}`);
-        });
-        await page.goto(`/#/${state.companyId}/settings/setting`);
-        await expect.poll(() => icons.length, { timeout: 30000 }).toBeGreaterThanOrEqual(3);
-        expect(icons.filter((line) => !line.startsWith('200'))).toEqual([]);
-    });
-
     test('Audit log lists events and offers the CSV export', async ({ page, state }) => {
         const list = page.waitForResponse((res) => res.url().includes('/api/v1/audit-logs?'));
         await page.goto(`/#/${state.companyId}/settings/audit-logs`);

--- a/tests/integration/instance.int.test.js
+++ b/tests/integration/instance.int.test.js
@@ -1,0 +1,578 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { emailFor, inviteMember, login, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anonymous = createApiClient({ baseURL: state.baseURL });
+const anonymousWithCompany = createApiClient({ baseURL: state.baseURL, companyId: state.companyId });
+const OTHER_COMPANY = '0123456789abcdef01234567';
+const NON_OWNERS = ['admin', 'member', 'guest'];
+const ALL_ROLES = ['owner', ...NON_OWNERS];
+
+const refused = (res) => res.status >= 400 || Boolean(res.body && typeof res.body === 'object' && res.body.status === false);
+
+/* One login per role per file: the refresh token is derived from the second a session starts. */
+const sessions = {};
+const as = async (role) => {
+    if (!sessions[role]) sessions[role] = await loginAs(role);
+    return sessions[role];
+};
+
+async function freshUser(role) {
+    const owner = await as('owner');
+    const suffix = uniqueSuffix();
+    const email = emailFor(role, `ins${suffix}`);
+    const user = await inviteMember({ baseURL: state.baseURL, ownerApi: owner.api, companyId: state.companyId, role, email, firstName: 'QA', lastName: `Instance ${suffix}` });
+    const session = await login(state.baseURL, email);
+    return { ...user, api: createApiClient({ baseURL: state.baseURL, accessToken: session.accessToken, companyId: state.companyId }) };
+}
+
+async function waitFor(check, { timeoutMs = 15000, intervalMs = 250 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        const value = await check();
+        if (value) return value;
+        if (Date.now() > deadline) return value;
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+}
+
+const statusTemplate = (TemplateName) => ({ TemplateName, ActiveStatusList: [], DoneStatusList: [], defaultActive: {}, defaultComplete: {} });
+
+const roleTypeOf = async (userId) => {
+    const owner = await as('owner');
+    const res = await owner.api.get(`/api/v1/members/${userId}`);
+    return res.body && res.body.roleType;
+};
+
+describe('build version', () => {
+    it('reports one version on /version, /health, Stats and Upgrade', async () => {
+        const owner = await as('owner');
+        const version = await anonymous.get('/version');
+        expect(version.status).toBe(200);
+        expect(version.body.status).toBe(true);
+        const { data } = version.body;
+        expect(data).toEqual(expect.objectContaining({ version: expect.stringMatching(/^14\./), release: expect.any(String), channel: expect.any(String) }));
+        if (data.channel === 'beta') {
+            expect(data.version).toMatch(new RegExp(`-beta\\.${data.build}$`));
+            expect(data.build).toBeGreaterThan(0);
+        }
+
+        const health = await anonymous.get('/health');
+        expect(health.status).toBe(200);
+        expect(health.body).toMatchObject({ status: 'ok', version: data.version, db: { ok: true }, maintenance: false });
+
+        const stats = await owner.api.get('/api/v2/instance/stats');
+        expect(stats.body.data).toMatchObject({ version: data.version, channel: data.channel, build: data.build });
+
+        const upgrade = await owner.api.get('/api/v2/instance/upgrade');
+        expect(upgrade.status).toBe(200);
+        expect(upgrade.body.data).toMatchObject({ currentVersion: data.version, release: data.release, build: { channel: data.channel } });
+        expect(Array.isArray(upgrade.body.data.buildLog)).toBe(true);
+    }, 30000);
+});
+
+const INSTANCE_ROUTES = [
+    ['get', '/api/v2/instance/access'],
+    ['get', '/api/v2/instance/settings'],
+    ['put', '/api/v2/instance/settings', { APP_NAME: '[QA instance] refused' }],
+    ['post', '/api/v2/instance/settings/test', { group: 'storage' }],
+    ['get', '/api/v2/instance/health'],
+    ['post', '/api/v2/instance/maintenance', { on: false }],
+    ['get', '/api/v2/instance/upgrade'],
+    ['post', '/api/v2/instance/migrations/run', {}],
+    ['get', '/api/v2/instance/logs'],
+    ['get', '/api/v2/instance/logs/files'],
+    ['get', '/api/v2/instance/logs/download?name=error-2026-01-01.log'],
+    ['get', '/api/v2/instance/backups'],
+    ['post', '/api/v2/instance/backups', {}],
+    ['get', '/api/v2/instance/backups/alianhub-14.0.0-20260101-000000.tar.gz/manifest'],
+    ['get', '/api/v2/instance/backups/alianhub-14.0.0-20260101-000000.tar.gz/download'],
+    ['post', '/api/v2/instance/backups/alianhub-14.0.0-20260101-000000.tar.gz/restore', { confirm: 'alianhub-14.0.0-20260101-000000.tar.gz' }],
+    ['delete', '/api/v2/instance/backups/alianhub-14.0.0-20260101-000000.tar.gz'],
+    ['get', '/api/v2/instance/stats'],
+    ['get', '/api/v2/instance/companies'],
+    ['get', `/api/v2/instance/audit-export?companyId=${state.companyId}`],
+];
+
+describe('instance console refusals', () => {
+    const cases = NON_OWNERS.flatMap((role) => INSTANCE_ROUTES.map(([method, path, body]) => [role, method.toUpperCase(), path, body]));
+
+    it.each(cases)('refuses %s on %s %s', async (role, method, path, body) => {
+        const { api } = await as(role);
+        const res = await api.request(method, path, { body });
+        expect(res.status).toBe(403);
+        expect(res.body).toMatchObject({ status: false });
+    });
+
+    it.each(INSTANCE_ROUTES.map(([method, path, body]) => [method.toUpperCase(), path, body]))('answers 401 without a session on %s %s', async (method, path, body) => {
+        const res = await anonymousWithCompany.request(method, path, { body });
+        expect(res.status).toBe(401);
+    });
+
+    it('serves the public config to anyone', async () => {
+        const res = await anonymous.get('/api/v2/instance/public-config');
+        expect(res.status).toBe(200);
+        expect(res.body.data).toEqual(expect.objectContaining({ version: expect.any(String), appName: expect.any(String), auth: expect.any(Object) }));
+    });
+});
+
+describe('instance console as the owner', () => {
+    it('confirms owner access', async () => {
+        const { api } = await as('owner');
+        const res = await api.get('/api/v2/instance/access');
+        expect(res.body).toEqual({ status: true, statusText: expect.any(String), data: { allowed: true, via: 'owner' } });
+    });
+
+    it.failing('INS-07 saves a setting from the owner session, shows it in the public config and restores it', async () => {
+        const { api } = await as('owner');
+        const before = await api.get('/api/v2/instance/settings');
+        expect(before.body.data.groups).toEqual(expect.arrayContaining(['general', 'mail', 'storage']));
+        const appName = before.body.data.settings.find((s) => s.key === 'APP_NAME');
+        expect(appName).toBeDefined();
+        const restore = appName.source === 'saved' ? appName.value : '';
+        const name = `[QA instance] ${uniqueSuffix()}`;
+        try {
+            const saved = await api.put('/api/v2/instance/settings', { APP_NAME: name });
+            expect(saved.status).toBe(200);
+            expect(saved.body.data.applied).toEqual(['APP_NAME']);
+            const pub = await anonymous.get('/api/v2/instance/public-config');
+            expect(pub.body.data.appName).toBe(name);
+        } finally {
+            await api.put('/api/v2/instance/settings', { APP_NAME: restore });
+        }
+        const after = await api.get('/api/v2/instance/settings');
+        expect(after.body.data.settings.find((s) => s.key === 'APP_NAME').value).toBe(appName.value);
+    });
+
+    it('rejects unknown settings and unknown test groups', async () => {
+        const { api } = await as('owner');
+        const bad = await api.put('/api/v2/instance/settings', { NOT_A_SETTING: 'x' });
+        expect(bad.status).toBe(400);
+        expect(bad.body).toMatchObject({ status: false, data: { errors: { NOT_A_SETTING: 'unknown' } } });
+
+        const test = await api.post('/api/v2/instance/settings/test', { group: 'nothing' });
+        expect(test.status).toBe(400);
+        expect(test.body.status).toBe(false);
+    });
+
+    it('reports health', async () => {
+        const { api } = await as('owner');
+        const res = await api.get('/api/v2/instance/health');
+        expect(res.status).toBe(200);
+        expect(res.body.data).toMatchObject({ status: 'ok', db: { ok: true }, maintenance: false });
+        expect(res.body.data.readiness).toEqual(expect.objectContaining({ storageChosen: true }));
+    });
+
+    it('blocks the API during maintenance and keeps the console and health open', async () => {
+        const { api } = await as('owner');
+        try {
+            const on = await api.post('/api/v2/instance/maintenance', { on: true });
+            expect(on.body.data).toEqual({ maintenance: true });
+
+            const blocked = await api.get('/api/v1/setting/roles');
+            expect(blocked.status).toBe(503);
+            expect(blocked.body).toMatchObject({ status: false, maintenance: true });
+            expect((await api.get('/api/v2/instance/health')).status).toBe(200);
+            expect((await anonymous.get('/health')).body.maintenance).toBe(true);
+        } finally {
+            await api.post('/api/v2/instance/maintenance', { on: false });
+        }
+        expect((await api.get('/api/v1/setting/roles')).status).toBe(200);
+    });
+
+    it('runs pending migrations', async () => {
+        const { api } = await as('owner');
+        const res = await api.post('/api/v2/instance/migrations/run', {});
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(true);
+        expect(Array.isArray(res.body.data.applied)).toBe(true);
+    });
+
+    it('lists and tails logs and refuses a path outside the log directory', async () => {
+        const { api } = await as('owner');
+        const files = await api.get('/api/v2/instance/logs/files');
+        expect(Array.isArray(files.body.data.files)).toBe(true);
+
+        const tail = await api.get('/api/v2/instance/logs', { query: { file: 'combined', lines: 5 } });
+        expect(tail.status).toBe(200);
+        expect(tail.body.data).toEqual(expect.objectContaining({ kind: 'combined', lines: expect.any(Array) }));
+
+        expect((await api.get('/api/v2/instance/logs', { query: { file: 'secrets' } })).status).toBe(400);
+        expect((await api.get('/api/v2/instance/logs/download', { query: { name: '../../.env' } })).status).toBe(404);
+    });
+
+    it('creates, inspects, downloads and deletes a backup', async () => {
+        const { api } = await as('owner');
+        const created = await api.post('/api/v2/instance/backups', {});
+        expect(created.status).toBe(200);
+        const { name } = created.body.data;
+        expect(name).toMatch(/^[a-z0-9.-]+-\d{8}-\d{6}\.tar\.gz$/);
+        try {
+            const list = await api.get('/api/v2/instance/backups');
+            expect(list.body.data.backups.map((b) => b.name)).toContain(name);
+
+            const manifest = await api.get(`/api/v2/instance/backups/${name}/manifest`);
+            expect(manifest.body.data).toMatchObject({ format: 'alianhub-backup', includeFiles: false });
+            expect(Object.keys(manifest.body.data.databases)).toEqual(expect.arrayContaining(['global', state.companyId]));
+
+            const download = await api.get(`/api/v2/instance/backups/${name}/download`);
+            expect(download.status).toBe(200);
+            expect(download.headers.get('content-disposition')).toContain(name);
+
+            const wrongConfirm = await api.post(`/api/v2/instance/backups/${name}/restore`, { confirm: 'yes' });
+            expect(wrongConfirm.status).toBe(400);
+        } finally {
+            expect((await api.delete(`/api/v2/instance/backups/${name}`)).status).toBe(200);
+        }
+        expect((await api.get(`/api/v2/instance/backups/${name}/manifest`)).status).toBe(404);
+    }, 60000);
+
+    it('restores a backup and keeps serving', async () => {
+        const { api } = await as('owner');
+        const created = await api.post('/api/v2/instance/backups', {});
+        const { name } = created.body.data;
+        try {
+            const restored = await api.post(`/api/v2/instance/backups/${name}/restore`, { confirm: name });
+            expect(restored.status).toBe(200);
+            expect(restored.body.status).toBe(true);
+            expect((await anonymous.get('/health')).body).toMatchObject({ status: 'ok', maintenance: false });
+            expect((await api.get('/api/v2/instance/stats')).status).toBe(200);
+        } finally {
+            await api.delete(`/api/v2/instance/backups/${name}`);
+        }
+    }, 90000);
+
+    it('lists companies and exports company history as CSV', async () => {
+        const { api } = await as('owner');
+        const stats = await api.get('/api/v2/instance/stats');
+        expect(stats.body.data.companies).toBeGreaterThanOrEqual(1);
+        expect(stats.body.data.users).toBeGreaterThanOrEqual(4);
+
+        const companies = await api.get('/api/v2/instance/companies');
+        expect(companies.body.data.map((c) => String(c._id))).toContain(state.companyId);
+
+        const csv = await api.get('/api/v2/instance/audit-export', { query: { companyId: state.companyId } });
+        expect(csv.status).toBe(200);
+        expect(csv.headers.get('content-type')).toContain('text/csv');
+        expect(String(csv.body).replace(/^\uFEFF/, '').split('\r\n')[0]).toBe('CreatedAt,Type,Key,UserId,ProjectId,TaskId,Message');
+
+        expect((await api.get('/api/v2/instance/audit-export', { query: { companyId: 'nope' } })).status).toBe(400);
+    });
+});
+
+const AUDIT_CSV_HEADER = 'time,actorType,actor,agent,run,event,entity,reason,cost_usd,undone_at';
+
+describe('audit log', () => {
+    it.each(['owner', 'admin'])('lists and exports for %s', async (role) => {
+        const { api } = await as(role);
+        const list = await api.get('/api/v1/audit-logs', { query: { limit: 5 } });
+        expect(list.status).toBe(200);
+        expect(list.body).toEqual({ status: true, data: expect.any(Array), metadata: expect.objectContaining({ total: expect.any(Number), page: 1 }) });
+
+        const csv = await api.get('/api/v1/audit-logs/export');
+        expect(csv.status).toBe(200);
+        expect(String(csv.body).split('\n')[0]).toBe(AUDIT_CSV_HEADER);
+    });
+
+    it.each(['member', 'guest'])('refuses %s', async (role) => {
+        const { api } = await as(role);
+        expect((await api.get('/api/v1/audit-logs')).status).toBe(403);
+        expect((await api.get('/api/v1/audit-logs/export')).status).toBe(403);
+    });
+
+    it('refuses without a session or for another company', async () => {
+        expect((await anonymousWithCompany.get('/api/v1/audit-logs')).status).toBe(401);
+        const { api } = await as('admin');
+        expect((await api.withCompany(OTHER_COMPANY).get('/api/v1/audit-logs')).status).toBe(401);
+    });
+
+    it('records a member update and filters by entity', async () => {
+        const owner = await as('owner');
+        const user = await freshUser('member');
+        const update = await owner.api.put('/api/v1/members', { id: user.companyUserId, data: { designation: 0 } });
+        expect(update.body.status).toBe(true);
+
+        const rows = await waitFor(async () => {
+            const res = await owner.api.get('/api/v1/audit-logs', { query: { entityId: user.companyUserId } });
+            return res.body.data.length ? res.body.data : null;
+        });
+        expect(rows[0]).toMatchObject({ action: 'member.update', entityType: 'member', entityId: user.companyUserId });
+    });
+
+    it('answers 404 when undoing a row that does not exist', async () => {
+        const { api } = await as('owner');
+        const res = await api.post(`/api/v1/audit-logs/${OTHER_COMPANY}/undo`, {});
+        expect(res.status).toBe(404);
+    });
+
+    it.failing('INS-08 exports every row of the filter, not only the first 100', async () => {
+        const owner = await as('owner');
+        const user = await freshUser('member');
+        for (let i = 0; i < 101; i += 1) {
+            await owner.api.put('/api/v1/members', { id: user.companyUserId, data: { designation: 0 } });
+        }
+        const total = await waitFor(async () => {
+            const res = await owner.api.get('/api/v1/audit-logs', { query: { entityId: user.companyUserId, limit: 1 } });
+            return res.body.metadata.total >= 101 ? res.body.metadata.total : 0;
+        });
+        expect(total).toBe(101);
+
+        const csv = await owner.api.get('/api/v1/audit-logs/export', { query: { entityId: user.companyUserId } });
+        expect(String(csv.body).split('\n').length - 1).toBe(total);
+    }, 120000);
+
+    it.failing('INS-09 records the signed-in actor, not a name from the request body', async () => {
+        const owner = await as('owner');
+        const user = await freshUser('member');
+        await owner.api.put('/api/v1/members', { id: user.companyUserId, data: { designation: 0 }, userData: { name: '=HYPERLINK("http://example.invalid","Rahul")' } });
+
+        const row = await waitFor(async () => {
+            const res = await owner.api.get('/api/v1/audit-logs', { query: { entityId: user.companyUserId } });
+            return res.body.data[0];
+        });
+        expect(row.actorId).toBe(owner.uid);
+        expect(row.actorName).not.toContain('HYPERLINK');
+
+        const csv = await owner.api.get('/api/v1/audit-logs/export', { query: { entityId: user.companyUserId } });
+        expect(String(csv.body)).not.toMatch(/(^|,)=HYPERLINK/m);
+    });
+});
+
+const SETTINGS_READS = [
+    '/api/v1/setting/designation',
+    '/api/v1/setting/companyUserStatus',
+    '/api/v1/setting/category',
+    '/api/v1/setting/roles',
+    '/api/v1/commonDateFormate',
+    '/api/v1/currency',
+    '/api/v1/taskPriority',
+    '/api/v1/restricted-extensions',
+    '/api/v1/fileExtensions',
+    '/api/v1/milestoneStatus',
+    '/api/v1/milestoneBillingPeriod',
+    '/api/v1/securityPermissions',
+    '/api/v1/project-status-template',
+    '/api/v1/templates/taskType',
+    '/api/v1/templates/taskStatus',
+    '/api/v1/setting/projectStatus',
+    '/api/v1/setting/taskStatus',
+    '/api/v1/setting/taskType',
+    '/api/v1/members',
+];
+
+describe('company settings reads', () => {
+    it.each(ALL_ROLES)('serves every settings catalogue to %s', async (role) => {
+        const { api } = await as(role);
+        for (const path of SETTINGS_READS) {
+            const res = await api.get(path);
+            expect({ path, status: res.status }).toEqual({ path, status: 200 });
+        }
+        const self = await api.get(`/api/v1/members/${state.users[role].userId}`);
+        expect(self.body).toMatchObject({ userId: state.users[role].userId, roleType: state.users[role].roleType });
+        const count = await api.post('/api/v1/members/count', { query: {} });
+        expect(count.body[0].totalCount).toBeGreaterThanOrEqual(4);
+    });
+
+    it('refuses every settings catalogue without a session', async () => {
+        for (const path of SETTINGS_READS) {
+            const res = await anonymousWithCompany.get(path);
+            expect({ path, status: res.status }).toEqual({ path, status: 401 });
+        }
+    });
+
+    it('refuses a member reading another company', async () => {
+        const { api } = await as('member');
+        const res = await api.withCompany(OTHER_COMPANY).get('/api/v1/setting/roles');
+        expect(res.status).toBe(401);
+    });
+
+    it.failing.each([
+        ['/api/v1/milestoneRange'],
+        ['/api/v1/setting/skills'],
+        [`/api/v1/notifications/${state.users.member.userId}`],
+    ])('INS-03/INS-04 refuses %s without a session', async (path) => {
+        const res = await anonymousWithCompany.get(path);
+        expect(res.status).toBe(401);
+    });
+});
+
+describe('company settings writes as the owner', () => {
+    it('creates, renames and deletes a task status template', async () => {
+        const { api } = await as('owner');
+        const name = `[QA instance] status ${uniqueSuffix()}`;
+        const created = await api.post('/api/v1/templates/taskStatus', { updateObject: statusTemplate(name) });
+        expect(created.status).toBe(200);
+        const id = created.body._id;
+        expect(created.body.TemplateName).toBe(name);
+
+        const renamed = await api.put('/api/v1/templates/taskStatus', { type: 'updateOne', key: '$set', id, updateObject: { TemplateName: `${name} renamed` } });
+        expect(renamed.status).toBe(200);
+        const list = await api.get('/api/v1/templates/taskStatus');
+        expect(list.body.find((t) => t._id === id).TemplateName).toBe(`${name} renamed`);
+
+        expect((await api.delete(`/api/v1/templates/taskStatus/${id}`)).status).toBe(200);
+    });
+
+    it('creates, renames and deletes a task type template', async () => {
+        const { api } = await as('owner');
+        const name = `[QA instance] type ${uniqueSuffix()}`;
+        const created = await api.post('/api/v1/templates/taskType', { updateObject: { TemplateName: name, taskTypes: [] } });
+        expect(created.status).toBe(200);
+        const id = created.body._id;
+
+        const renamed = await api.put('/api/v1/templates/taskType', { type: 'updateOne', key: '$set', id, updateObject: { TemplateName: `${name} renamed` } });
+        expect(renamed.status).toBe(200);
+        const list = await api.get('/api/v1/templates/taskType');
+        expect(list.body.find((t) => t._id === id).TemplateName).toBe(`${name} renamed`);
+
+        expect((await api.delete(`/api/v1/templates/taskType/${id}`)).status).toBe(200);
+    });
+
+    it('creates, renames and deletes a project status template', async () => {
+        const { api } = await as('owner');
+        const name = `[QA instance] project status ${uniqueSuffix()}`;
+        const created = await api.post('/api/v1/project-status-template', { TemplateName: name, projectActiveStatus: [], projectCompletedStatus: {}, projectDoneStatus: [] });
+        expect(created.body.status).toBe(true);
+        const id = created.body.data._id;
+
+        const renamed = await api.put('/api/v1/project-status-template', { id, templateName: `${name} renamed` });
+        expect(renamed.status).toBe(200);
+        const list = await api.get('/api/v1/project-status-template');
+        expect(list.body.data.find((t) => t._id === id).TemplateName).toBe(`${name} renamed`);
+
+        const removed = await api.delete(`/api/v1/project-status-template/${id}`);
+        expect(removed.body.status).toBe(true);
+    });
+
+    it('adds a project skill and hides it again', async () => {
+        const { api } = await as('owner');
+        const added = await api.put('/api/v1/setting/skills', { operation: 'add', name: `QA Instance ${uniqueSuffix()}` });
+        expect(added.status).toBe(200);
+        const { key } = added.body.skill;
+        const hidden = await api.put('/api/v1/setting/skills', { operation: 'setActive', key, active: false });
+        expect(hidden.body.skill).toMatchObject({ key, active: false });
+    });
+
+    it('updates the caller notification preferences only for their own document', async () => {
+        const user = await freshUser('member');
+        const other = await freshUser('member');
+        const mine = await user.api.get(`/api/v1/notifications/${user.userId}`);
+        const theirs = await other.api.get(`/api/v1/notifications/${other.userId}`);
+
+        const own = await user.api.put('/api/v1/notifications/preferences', { id: mine.body._id, dailyDigest: true });
+        expect(own.body).toMatchObject({ status: true, data: { dailyDigest: true } });
+
+        const foreign = await user.api.put('/api/v1/notifications/preferences', { id: theirs.body._id, dailyDigest: true });
+        expect(foreign.status).toBe(404);
+    });
+});
+
+describe('company settings role enforcement', () => {
+    it.failing('INS-01 refuses a member promoting themselves to owner through PUT /api/v1/members', async () => {
+        const user = await freshUser('member');
+        const res = await user.api.put('/api/v1/members', { id: user.companyUserId, data: { roleType: 1 } });
+        expect(refused(res)).toBe(true);
+        expect(await roleTypeOf(user.userId)).toBe(user.roleType);
+    });
+
+    it.failing('INS-02 refuses a guest promoting themselves to admin through PUT /api/v1/root-members', async () => {
+        const user = await freshUser('guest');
+        const res = await user.api.put('/api/v1/root-members', { id: user.companyUserId, data: { roleType: 2 }, companyId: state.companyId });
+        expect(refused(res)).toBe(true);
+        expect(await roleTypeOf(user.userId)).toBe(user.roleType);
+    });
+
+    const marker = () => `qa-instance-${uniqueSuffix()}`;
+    it.failing.each([
+        ['PUT /api/v1/setting/roles/update', 'put', '/api/v1/setting/roles/update', () => ({ queryFilter: { name: marker() }, queryObj: { $set: { qaMarker: true } } })],
+        ['PUT /api/v1/setting/designation/update', 'put', '/api/v1/setting/designation/update', () => ({ queryFilter: { name: marker() }, queryObj: { $set: { qaMarker: true } } })],
+        ['PUT /api/v1/commonDateFormate', 'put', '/api/v1/commonDateFormate', () => ({ key: '$set', updateObject: { qaMarker: marker() } })],
+        ['PUT /api/v1/taskPriority', 'put', '/api/v1/taskPriority', () => ({ key: '$set', updateObject: { qaMarker: marker() } })],
+        ['PUT /api/v1/fileExtensions', 'put', '/api/v1/fileExtensions', () => ({ key: '$set', updateObject: { qaMarker: marker() } })],
+        ['PUT /api/v1/milestoneStatus', 'put', '/api/v1/milestoneStatus', () => ({ key: '$set', updateObject: { qaMarker: marker() } })],
+        ['POST /api/v1/templates/taskStatus', 'post', '/api/v1/templates/taskStatus', () => ({ updateObject: statusTemplate(`[QA instance] ${marker()}`) })],
+    ])('INS-06 refuses a guest on %s', async (label, method, path, body) => {
+        const { api } = await as('guest');
+        const res = await api.request(method.toUpperCase(), path, { body: body() });
+        expect(refused(res)).toBe(true);
+    });
+
+    it.failing('INS-06 refuses a guest editing a security permission rule', async () => {
+        const { api } = await as('guest');
+        const rules = await api.get('/api/v1/securityPermissions');
+        const rule = rules.body.find((r) => !r.isParent);
+        const res = await api.put('/api/v1/securityPermissions', { type: 'updateOne', key: '$set', id: rule._id, updateObject: { qaMarker: marker() } });
+        expect(refused(res)).toBe(true);
+    });
+
+    it.failing('INS-05 refuses a currency write aimed at another company', async () => {
+        const { api } = await as('admin');
+        const currencies = await api.get('/api/v1/currency');
+        const [currency] = currencies.body;
+        const res = await api.put(`/api/v1/currency/${OTHER_COMPANY}/${currency._id}`, { key: '$set', updateObject: { qaMarker: true } });
+        expect(refused(res)).toBe(true);
+    });
+
+    it.failing('INS-03 refuses an anonymous change to someone else notification settings', async () => {
+        const user = await freshUser('member');
+        const doc = (await user.api.get(`/api/v1/notifications/${user.userId}`)).body;
+        const item = doc.chat.items[0];
+
+        const res = await anonymousWithCompany.put('/api/v1/notifications', { id: doc._id, key: 'chat', elementKey: item.key, fieldToUpdate: 'email', valueToUpdate: !item.email, userId: user.userId });
+        const after = (await user.api.get(`/api/v1/notifications/${user.userId}`)).body;
+
+        expect(res.status).toBe(401);
+        expect(after.chat.items[0].email).toBe(item.email);
+    });
+
+    it.failing('INS-04 refuses an anonymous project skill write', async () => {
+        const res = await anonymousWithCompany.put('/api/v1/setting/skills', { operation: 'add', name: `QA Anonymous ${uniqueSuffix()}` });
+        expect(res.status).toBe(401);
+    });
+
+    it.failing('INS-11 refuses an anonymous version update flag', async () => {
+        const res = await anonymous.post('/api/v1/versionUpdateNotify', { flag: false });
+        expect(res.status).toBe(401);
+    });
+
+    it.failing('INS-10 refuses a member editing another member private views', async () => {
+        const user = await freshUser('member');
+        const other = await freshUser('member');
+        const res = await user.api.post('/api/v1/members/private-view', { id: other.companyUserId, operation: 'push', data: { id: `qa-${uniqueSuffix()}`, name: '[QA instance] view' } });
+        expect(refused(res)).toBe(true);
+    });
+});
+
+describe('common, admin and api docs', () => {
+    it('serves the time, email templates, logo and brand settings', async () => {
+        const time = await anonymous.get('/api/v1/getTime', { query: { zone: 'UTC' } });
+        expect(time.status).toBe(200);
+        expect(String(time.body)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+        const templates = await anonymous.get('/api/v1/getEmailTemplates');
+        expect(Object.keys(templates.body)).toEqual(expect.arrayContaining(['verifyEmail', 'resetEmail']));
+
+        const logo = await anonymous.get('/api/v1/getlogo');
+        expect(logo.status).toBe(200);
+        expect(logo.headers.get('content-type')).toMatch(/^image\//);
+
+        const brand = await anonymous.get('/api/v1/getBrandSettingsData');
+        expect(brand.body).toEqual(expect.objectContaining({ productName: expect.any(String) }));
+    });
+
+    it('refuses the connections list without the preset key', async () => {
+        const res = await anonymous.get('/connections/not-the-key');
+        expect(res.body).toBe('Unauthorized');
+    });
+
+    it('serves the API docs', async () => {
+        const res = await anonymous.get('/apidocs/');
+        expect(res.status).toBe(200);
+        expect(String(res.body)).toContain('swagger');
+    });
+
+    it.failing('INS-12 answers getTime without a zone with the standard error shape', async () => {
+        const res = await anonymous.get('/api/v1/getTime');
+        expect(res.body).toMatchObject({ status: false });
+    });
+});

--- a/tests/integration/instance.int.test.js
+++ b/tests/integration/instance.int.test.js
@@ -386,7 +386,7 @@ describe('company settings reads', () => {
         expect(res.status).toBe(401);
     });
 
-    it.failing.each([
+    it.each([
         ['/api/v1/milestoneRange'],
         ['/api/v1/setting/skills'],
         [`/api/v1/notifications/${state.users.member.userId}`],
@@ -513,7 +513,7 @@ describe('company settings role enforcement', () => {
         expect(refused(res)).toBe(true);
     });
 
-    it.failing('INS-03 refuses an anonymous change to someone else notification settings', async () => {
+    it('INS-03 refuses an anonymous change to someone else notification settings', async () => {
         const user = await freshUser('member');
         const doc = (await user.api.get(`/api/v1/notifications/${user.userId}`)).body;
         const item = doc.chat.items[0];
@@ -525,12 +525,12 @@ describe('company settings role enforcement', () => {
         expect(after.chat.items[0].email).toBe(item.email);
     });
 
-    it.failing('INS-04 refuses an anonymous project skill write', async () => {
+    it('INS-04 refuses an anonymous project skill write', async () => {
         const res = await anonymousWithCompany.put('/api/v1/setting/skills', { operation: 'add', name: `QA Anonymous ${uniqueSuffix()}` });
         expect(res.status).toBe(401);
     });
 
-    it.failing('INS-11 refuses an anonymous version update flag', async () => {
+    it('INS-11 refuses an anonymous version update flag', async () => {
         const res = await anonymous.post('/api/v1/versionUpdateNotify', { flag: false });
         expect(res.status).toBe(401);
     });


### PR DESCRIPTION
## Summary

QA sweep and permanent suite for the **Instance and administration** area of task 034 (Instance, settings, Admin, Audit, common, Template, swaggerAPI, typesense).

- `Tasks/active/034-end-to-end-qa-programme/findings/instance.md`: coverage table and 12 findings.
- `tests/integration/instance.int.test.js`: 144 tests covering:
  - instance console refusals for admin, member, guest and no session;
  - the owner console in the throwaway harness: settings, maintenance, migrations, logs, backups including a real restore, stats, and the company history CSV;
  - the audit log per role;
  - settings reads per role;
  - owner template and skill writes;
  - common, Admin and swagger availability;
  - one `it.failing` regression test per finding.
- `e2e/specs/instance.spec.js`: the six owner Instance screens and the beta build label on Stats and Upgrade; the workspace settings screens of the area; the audit log with CSV export; nav gating for admin, member and guest; the INS-07 `test.fail`.
- No product code and no `e2e/support` helpers changed.

## Findings

| Id | Severity | Title |
|---|---|---|
| INS-01 | critical | A member can promote themselves to owner through `PUT /api/v1/members` |
| INS-02 | critical | A guest can promote themselves to admin through `PUT /api/v1/root-members` |
| INS-03 | critical | Notification settings are readable and writable without a session (`api/v1/notifications` lacks its leading slash in `setMiddleware`) |
| INS-04 | critical | Project skills can be changed without a session; milestone range readable without one |
| INS-05 | critical | `PUT /api/v1/currency/:cid/:id` writes to the company named in the path |
| INS-06 | high | Company settings writes (roles, designations, date format, priorities, file extensions, milestone status, templates, security permissions) have no role check |
| INS-07 | high | Instance settings cannot be saved from the owner session (`refreshToken` injected into the body fails validation) |
| INS-08 | medium | Audit log CSV export stops at 100 rows |
| INS-09 | medium | Audit rows take the actor name from the request body; CSV cells not neutralised |
| INS-10 | medium | A member can edit another member's private views |
| INS-11 | medium | `POST /api/v1/versionUpdateNotify` works without a session |
| INS-12 | low | `GET /api/v1/getTime` without a zone answers 200 with plain text |

INS-01 to INS-06 share a root cause: `requirePermission` in `Config/permissionGuard.js` only runs for API-token requests, so web sessions skip every route-level permission check.

## Test plan

- [x] `npx jest --selectProjects integration tests/integration/instance.int.test.js` against a throwaway Mongo: 144 passed.
- [x] Each `it.failing` was checked with a temporary copy that has `.failing` removed: all fail on the intended assertion.
- [x] `npx jest tests/conventions`: 94 passed.
- [x] eslint: 0 errors on both spec files.
- [ ] `npx playwright test e2e/specs/instance.spec.js`: see the comment below for the latest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
