### PR TITLE
fix(tasks): allowlist task/find pipelines and the PUT task operation

### DIFF
--- a/Modules/Tasks/helpers/getTasksData.js
+++ b/Modules/Tasks/helpers/getTasksData.js
@@ -2,40 +2,41 @@ const { default: mongoose } = require("mongoose");
 const { SCHEMA_TYPE } = require("../../../Config/schemaType");
 const { MongoDbCrudOpration } = require("../../../utils/mongo-handler/mongoQueries");
 const { replaceObjectKey, relapceUndefinedvals } = require("../../Auth/helper");
+const { tenantOf, TenantError } = require("../../../Config/tenant");
+const { removeCache } = require("../../../utils/commonFunctions.js");
+const socketEmitter = require("../../../event/socketEventEmitter");
+const logger = require("../../../Config/loggerConfig");
+const { QueryRefused, validatePipeline, visibilityStage } = require("./taskQueryGuard");
+const { WriteRefused, parseCascade, assertCanCascade, cascadeFilter } = require("./taskWriteGuard");
 
-exports.getTaskByQyery = async(req,res) => {
+const refuse = (res, statusCode, statusText, message, extra = {}) => res.status(statusCode).json({ status: false, statusText, message, ...extra });
+
+exports.getTaskByQyery = async (req, res) => {
     try {
-        const companyId = req.headers["companyid"];
-        const { findQuery, replaceUndefined=false } = req.body;
-
+        const companyId = tenantOf(req);
+        const { findQuery, replaceUndefined = false } = req.body || {};
         if (!findQuery) {
-            return res.status(400).json({
-                message: "An error occurred while getting the task.",
-                error: "Query is required."
-            });
+            return refuse(res, 400, "Query is required.", "An error occurred while getting the task.");
         }
-        let query;
-        if(replaceUndefined) {
-            let modeQuery =  relapceUndefinedvals(findQuery);
-            query = replaceObjectKey(modeQuery, ["objId","dbDate"]);
-        } else {
-            query = replaceObjectKey(findQuery, ["objId","dbDate"]);
-        }
-        const taskQuery = [query];
-        const taskObj = {
-            type: SCHEMA_TYPE.TASKS,
-            data: [taskQuery]
-        };
-        const response = await MongoDbCrudOpration(companyId, taskObj, 'aggregate');
 
+        const stages = validatePipeline(findQuery);
+        const converted = replaceObjectKey(replaceUndefined ? relapceUndefinedvals(stages) : stages, ["objId", "dbDate"]);
+        const scope = await visibilityStage(companyId, req.uid);
+        const pipeline = scope ? [scope, ...converted] : converted;
+
+        const response = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [pipeline] }, "aggregate");
         return res.status(200).json(response);
     } catch (error) {
-        return res.status(500).json({
-            message: "An error occurred while getting the task.",
-            error: error.message || error
-        });
+        if (error instanceof QueryRefused) {
+            return refuse(res, 400, "Query refused", error.message, { stage: error.stage });
+        }
+        if (error instanceof TenantError) {
+            return refuse(res, error.statusCode, "Forbidden", error.message);
+        }
+        logger.error(`getTaskByQyery error: ${error.message || error}`);
+        return refuse(res, 500, "An error occurred while getting the task.", error.message || String(error));
     }
-}
+};
 
 exports.getTask = async(req,res) => {
     try {
@@ -68,57 +69,46 @@ exports.getTask = async(req,res) => {
     }
 }
 
-const UPDATE_TASK_METHODS = ["updateOne", "updateMany"];
+const ALLOWED_BODY_KEYS = ["firstParameter", "secondParameter", "key", "isConvertFirstParameter", "isConvertSecondParameter", "refreshToken"];
+const SOCKET_FIELDS = { _id: 1, ProjectID: 1, sprintId: 1, ParentTaskId: 1, AssigneeUserId: 1 };
 
 exports.updateTask = async (req, res) => {
     try {
-        const companyId = req.headers["companyid"];
-        const { firstParameter, secondParameter, key, isConvertFirstParameter, isConvertSecondParameter } = req.body;
+        const companyId = tenantOf(req);
+        const body = req.body || {};
 
-        if (!companyId) {
-            return res.status(400).json({
-                message: "An error occurred while updating the task.",
-                error: "Company ID is required."
-            });
-        }
-
-        const requiredFields = { firstParameter,secondParameter,key };
-        const missingField = Object.keys(requiredFields).find(key => !requiredFields[key]);
+        const missingField = ["firstParameter", "secondParameter", "key"].find((field) => !body[field]);
         if (missingField) {
-            return res.status(400).json({ message: `${missingField} is required.` });
+            return refuse(res, 400, `${missingField} is required.`, "An error occurred while updating the task.");
         }
-
-        if (!UPDATE_TASK_METHODS.includes(key)) {
-            return res.status(400).json({ message: `key must be one of: ${UPDATE_TASK_METHODS.join(", ")}.` });
-        }
-
-        const allowedKeys = ["firstParameter","secondParameter","key","isConvertFirstParameter","isConvertSecondParameter","refreshToken"];
-        const invalidKeys = Object.keys(req.body).filter(key => !allowedKeys.includes(key));
+        const invalidKeys = Object.keys(body).filter((key) => !ALLOWED_BODY_KEYS.includes(key));
         if (invalidKeys.length > 0) {
-            return res.status(400).json({
-                message: "Invalid keys provided in the request.",
-                error: `Invalid keys: ${invalidKeys.join(", ")}. Allowed keys: ${allowedKeys.join(", ")}.`
-            });
+            return refuse(res, 400, "Invalid keys provided in the request.", `Invalid keys: ${invalidKeys.join(", ")}.`);
         }
 
-        const convertParameter = (param, shouldConvert) => shouldConvert ? replaceObjectKey(param, "objId") : param;
-        const convertedFirstParameter = convertParameter(firstParameter, isConvertFirstParameter);
-        const convertedSecondParameter = convertParameter(secondParameter, isConvertSecondParameter);
+        const cascade = parseCascade(body);
+        await assertCanCascade(companyId, req.uid, cascade);
 
-        // Query Data
-        const query = {
-            type: SCHEMA_TYPE.TASKS,
-            data: [convertedFirstParameter, convertedSecondParameter]
-        };
+        const filter = cascadeFilter(cascade);
+        const tasks = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [filter, SOCKET_FIELDS] }, "find");
+        const ids = (tasks || []).map((task) => task._id);
+        const result = ids.length
+            ? await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [{ ...filter, _id: { $in: ids } }, { $set: { deletedStatusKey: cascade.to } }] }, "updateMany")
+            : { acknowledged: true, matchedCount: 0, modifiedCount: 0 };
 
-        const response = await MongoDbCrudOpration(companyId, query, key);
-
-        return res.status(200).json(response);
-    } catch (error) {
-        console.error("Error updating task:", error);
-        return res.status(500).json({
-            message: "An error occurred while updating the task.",
-            error: error.message || error
+        const updatedFields = { deletedStatusKey: cascade.to };
+        (tasks || []).forEach((task) => {
+            const plain = typeof task.toObject === "function" ? task.toObject() : task;
+            socketEmitter.emit("update", { type: "update", data: { ...plain, ...updatedFields }, updatedFields, module: "task" });
         });
+        removeCache("UserProjectData:", true);
+
+        return res.status(200).json({ status: true, statusText: "Tasks updated successfully.", data: result });
+    } catch (error) {
+        if (error instanceof WriteRefused || error instanceof TenantError) {
+            return refuse(res, error.statusCode, "Forbidden", error.message);
+        }
+        logger.error(`updateTask error: ${error.message || error}`);
+        return refuse(res, 500, "An error occurred while updating the task.", error.message || String(error));
     }
 };

--- a/Modules/Tasks/helpers/taskQueryGuard.js
+++ b/Modules/Tasks/helpers/taskQueryGuard.js
@@ -1,0 +1,131 @@
+const mongoose = require('mongoose');
+const { dbCollections } = require('../../../Config/collections');
+const { getRoleType, isPrivileged } = require('../../../Config/permissionGuard');
+const { visibleProjectIds } = require('../../Agents/scope');
+
+const MAX_LIMIT = 1000;
+const MAX_STAGES = 40;
+
+const TOP_LEVEL_STAGES = Object.freeze(['$match', '$sort', '$skip', '$limit', '$project', '$addFields', '$count', '$group', '$unwind', '$lookup', '$facet']);
+const SUB_PIPELINE_STAGES = Object.freeze(['$match', '$sort', '$skip', '$limit', '$project', '$addFields', '$count', '$group', '$unwind']);
+
+const FORBIDDEN_OPERATORS = Object.freeze([
+    '$where', '$function', '$accumulator', '$out', '$merge', '$unionWith', '$graphLookup', '$lookup', '$facet',
+    '$documents', '$collStats', '$indexStats', '$currentOp', '$listSessions', '$listLocalSessions', '$planCacheStats',
+]);
+
+const LOOKUP_TARGETS = Object.freeze({
+    [dbCollections.PROJECTS]: Object.freeze({ localField: Object.freeze(['ProjectID']), foreignField: Object.freeze(['_id']) }),
+    [dbCollections.SPRINTS]: Object.freeze({ localField: Object.freeze(['sprintId']), foreignField: Object.freeze(['_id']) }),
+    [dbCollections.FOLDERS]: Object.freeze({ localField: Object.freeze(['folderObjId']), foreignField: Object.freeze(['_id']) }),
+});
+
+class QueryRefused extends Error {
+    constructor(stage, reason) {
+        super(`${stage} is not allowed: ${reason}`);
+        this.name = 'QueryRefused';
+        this.stage = stage;
+        this.reason = reason;
+    }
+}
+
+const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value)
+    && [Object.prototype, null].includes(Object.getPrototypeOf(value));
+
+const findForbiddenOperator = (value) => {
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const hit = findForbiddenOperator(item);
+            if (hit) return hit;
+        }
+        return null;
+    }
+    if (!isPlainObject(value)) return null;
+    for (const [key, inner] of Object.entries(value)) {
+        if (FORBIDDEN_OPERATORS.includes(key)) return key;
+        const hit = findForbiddenOperator(inner);
+        if (hit) return hit;
+    }
+    return null;
+};
+
+const clampLimit = (value) => {
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 1) throw new QueryRefused('$limit', 'it must be a positive integer');
+    return Math.min(n, MAX_LIMIT);
+};
+
+const checkSkip = (value) => {
+    const n = Number(value);
+    if (!Number.isInteger(n) || n < 0) throw new QueryRefused('$skip', 'it must be a non-negative integer');
+    return n;
+};
+
+let validateStages;
+
+const checkLookup = (spec) => {
+    if (!isPlainObject(spec)) throw new QueryRefused('$lookup', 'the stage must be an object');
+    const target = Object.prototype.hasOwnProperty.call(LOOKUP_TARGETS, spec.from) ? LOOKUP_TARGETS[spec.from] : null;
+    if (!target) throw new QueryRefused('$lookup', `collection "${spec.from}" cannot be joined`);
+    if (spec.let !== undefined) throw new QueryRefused('$lookup', 'let is not supported; join on localField and foreignField');
+    if (!target.localField.includes(spec.localField)) throw new QueryRefused('$lookup', `localField "${spec.localField}" cannot join ${spec.from}`);
+    if (!target.foreignField.includes(spec.foreignField)) throw new QueryRefused('$lookup', `foreignField "${spec.foreignField}" cannot join ${spec.from}`);
+    if (typeof spec.as !== 'string' || !spec.as || spec.as.startsWith('$')) throw new QueryRefused('$lookup', 'as must name a field');
+    const extra = Object.keys(spec).filter((k) => !['from', 'localField', 'foreignField', 'as', 'pipeline'].includes(k));
+    if (extra.length) throw new QueryRefused('$lookup', `unsupported option ${extra[0]}`);
+    const out = { from: spec.from, localField: spec.localField, foreignField: spec.foreignField, as: spec.as };
+    if (spec.pipeline !== undefined) out.pipeline = validateStages(spec.pipeline, SUB_PIPELINE_STAGES);
+    return out;
+};
+
+const checkFacet = (spec) => {
+    if (!isPlainObject(spec) || !Object.keys(spec).length) throw new QueryRefused('$facet', 'the stage must name at least one output');
+    return Object.fromEntries(Object.entries(spec).map(([output, stages]) => {
+        if (output.startsWith('$') || output.includes('.')) throw new QueryRefused('$facet', `output "${output}" is not a field name`);
+        return [output, validateStages(stages, SUB_PIPELINE_STAGES)];
+    }));
+};
+
+validateStages = (stages, allowed) => {
+    if (!Array.isArray(stages)) throw new QueryRefused('pipeline', 'a pipeline must be an array of stages');
+    if (stages.length > MAX_STAGES) throw new QueryRefused('pipeline', `at most ${MAX_STAGES} stages are accepted`);
+    return stages.map((stage) => {
+        if (!isPlainObject(stage) || Object.keys(stage).length !== 1) throw new QueryRefused('pipeline', 'each stage must be an object with exactly one operator');
+        const [name, spec] = Object.entries(stage)[0];
+        if (!allowed.includes(name)) throw new QueryRefused(name, 'the stage is outside the task query allowlist');
+        if (name === '$lookup') return { $lookup: checkLookup(spec) };
+        if (name === '$facet') return { $facet: checkFacet(spec) };
+        const forbidden = findForbiddenOperator(spec);
+        if (forbidden) throw new QueryRefused(forbidden, `found inside ${name}`);
+        if (name === '$limit') return { $limit: clampLimit(spec) };
+        if (name === '$skip') return { $skip: checkSkip(spec) };
+        return stage;
+    });
+};
+
+/* Several callers send a lone { $match } object, which Mongoose's aggregate accepts as a one-stage pipeline. */
+const validatePipeline = (pipeline) => validateStages(isPlainObject(pipeline) ? [pipeline] : pipeline, TOP_LEVEL_STAGES);
+
+const toObjectIds = (ids) => (ids || [])
+    .filter((id) => /^[a-f0-9]{24}$/i.test(String(id)))
+    .map((id) => new mongoose.Types.ObjectId(String(id)));
+
+/* Owners and admins keep company-wide task visibility; everyone else sees the projects the sidebar lists for them. */
+const visibilityStage = async (companyId, uid) => {
+    const roleType = await getRoleType(companyId, uid);
+    if (isPrivileged(roleType)) return null;
+    const ids = roleType === null ? [] : await visibleProjectIds(companyId, uid);
+    return { $match: { ProjectID: { $in: toObjectIds(ids) } } };
+};
+
+module.exports = {
+    MAX_LIMIT,
+    TOP_LEVEL_STAGES,
+    SUB_PIPELINE_STAGES,
+    FORBIDDEN_OPERATORS,
+    LOOKUP_TARGETS,
+    QueryRefused,
+    validatePipeline,
+    visibilityStage,
+    toObjectIds,
+};

--- a/Modules/Tasks/helpers/taskWriteGuard.js
+++ b/Modules/Tasks/helpers/taskWriteGuard.js
@@ -1,0 +1,72 @@
+const mongoose = require('mongoose');
+const { getRoleType, isPrivileged, evaluatePermission, isWritable } = require('../../../Config/permissionGuard');
+const { visibleProjectIds } = require('../../Agents/scope');
+
+const OBJECT_ID = /^[a-f0-9]{24}$/i;
+
+const CASCADE_OPERATION = 'updateMany';
+const ALLOWED_OPERATIONS = Object.freeze([CASCADE_OPERATION]);
+
+/* A project close, archive, delete or restore moves its tasks between these keys (frontend useProjectLifecycle);
+   each transition needs the permission the project menu checks before offering that action. */
+const CASCADE_PERMISSIONS = Object.freeze({
+    '0>8': 'project.project_close',
+    '0>7': 'project.project_delete',
+    '0>1': 'project.project_delete',
+    '7>0': 'project.project_list',
+    '8>0': 'project.project_list',
+});
+
+class WriteRefused extends Error {
+    constructor(statusCode, message) {
+        super(message);
+        this.name = 'WriteRefused';
+        this.statusCode = statusCode;
+    }
+}
+
+const isPlainObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const onlyKeys = (value, keys) => isPlainObject(value) && Object.keys(value).every((k) => keys.includes(k));
+
+const parseCascade = ({ key, firstParameter, secondParameter }) => {
+    if (!ALLOWED_OPERATIONS.includes(key)) throw new WriteRefused(403, `Operation "${key}" is not allowed on tasks.`);
+    if (!onlyKeys(firstParameter, ['objId', 'ProjectID', 'deletedStatusKey'])) {
+        throw new WriteRefused(403, 'The filter may only name ProjectID and deletedStatusKey.');
+    }
+    const objId = firstParameter.objId === undefined ? {} : firstParameter.objId;
+    if (!onlyKeys(objId, ['ProjectID'])) throw new WriteRefused(403, 'The filter may only name ProjectID and deletedStatusKey.');
+    const projectId = String(objId.ProjectID || firstParameter.ProjectID || '');
+    if (!OBJECT_ID.test(projectId)) throw new WriteRefused(403, 'The filter must name one valid ProjectID.');
+    if (!onlyKeys(secondParameter, ['$set']) || !onlyKeys(secondParameter.$set, ['deletedStatusKey'])) {
+        throw new WriteRefused(403, 'The update may only $set deletedStatusKey.');
+    }
+    const from = firstParameter.deletedStatusKey;
+    const to = secondParameter.$set.deletedStatusKey;
+    const permissionKey = CASCADE_PERMISSIONS[`${from}>${to}`];
+    if (!Number.isInteger(from) || !Number.isInteger(to) || !permissionKey) {
+        throw new WriteRefused(403, `Moving tasks from deletedStatusKey ${from} to ${to} is not allowed.`);
+    }
+    return { projectId, from, to, permissionKey };
+};
+
+const assertCanCascade = async (companyId, uid, { projectId, permissionKey }) => {
+    const roleType = await getRoleType(companyId, uid);
+    if (roleType === null) throw new WriteRefused(403, 'You are not a member of this company.');
+    if (!isPrivileged(roleType)) {
+        const visible = await visibleProjectIds(companyId, uid);
+        if (!visible.includes(projectId)) throw new WriteRefused(403, 'You do not have access to this project.');
+    }
+    const permission = await evaluatePermission(companyId, uid, permissionKey, { projectId });
+    if (!isWritable(permission)) throw new WriteRefused(403, 'You do not have permission to perform this action.');
+};
+
+const cascadeFilter = ({ projectId, from }) => ({ ProjectID: new mongoose.Types.ObjectId(projectId), deletedStatusKey: from });
+
+module.exports = {
+    ALLOWED_OPERATIONS,
+    CASCADE_PERMISSIONS,
+    WriteRefused,
+    parseCascade,
+    assertCanCascade,
+    cascadeFilter,
+};

--- a/Modules/Tasks/routes.js
+++ b/Modules/Tasks/routes.js
@@ -159,7 +159,7 @@ exports.init = (app) => {
 
     app.post('/api/v1/task/find', getTaskCtrl.getTaskByQyery);
 
-    app.put('/api/v1/task',getTaskCtrl.updateTask);
+    app.put('/api/v1/task', getTaskCtrl.updateTask);
 
     app.get('/task-import/events/:id', (req, res) => {
         res.setHeader('Content-Type', 'text/event-stream');

--- a/tests/integration/public-routes.int.test.js
+++ b/tests/integration/public-routes.int.test.js
@@ -119,10 +119,10 @@ describe('the same routes with a session', () => {
         expect(res.status).toBe(403);
     });
 
-    it('refuses anything but an update on PUT /api/v1/task', async () => {
+    it('refuses anything but the project cascade on PUT /api/v1/task', async () => {
         const { api } = await loginAs('member');
         const res = await api.put('/api/v1/task', { firstParameter: { _id: state.tasks[0]._id }, secondParameter: {}, key: 'deleteMany' });
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(403);
     });
 
     it('imports notification settings only for the caller', async () => {

--- a/tests/integration/task-query.int.test.js
+++ b/tests/integration/task-query.int.test.js
@@ -1,0 +1,124 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { createProject, createTask, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anon = createApiClient({ baseURL: state.baseURL });
+
+const findById = (api, id) => api.post('/api/v1/task/find', { findQuery: [{ $match: { _id: { objId: { $in: [id] } } } }] });
+
+async function projectWithTask(owner, { assigneeIds, isPrivate = false }) {
+    const project = await createProject(owner.api, { name: `TQ ${uniqueSuffix()}`, assigneeIds, createdBy: owner.uid, isPrivate });
+    const task = await createTask(owner.api, { project, name: `TQ Task ${uniqueSuffix()}`, user: state.users.owner, companyOwnerId: owner.uid });
+    return { project, task };
+}
+
+describe('TSK-01 — POST /api/v1/task/find', () => {
+    it('refuses a member $lookup into company_users', async () => {
+        const member = await loginAs('member');
+        const res = await member.api.post('/api/v1/task/find', {
+            findQuery: [
+                { $limit: 1 },
+                { $lookup: { from: 'company_users', pipeline: [{ $project: { roleType: 1 } }], as: 'x' } },
+                { $project: { n: { $size: '$x' } } },
+            ],
+        });
+        expect(res.status).toBe(400);
+        expect(res.body).toMatchObject({ status: false, stage: '$lookup' });
+    });
+
+    it('refuses $unionWith and $out by stage name', async () => {
+        const member = await loginAs('member');
+        const union = await member.api.post('/api/v1/task/find', { findQuery: [{ $unionWith: 'users' }] });
+        expect(union.status).toBe(400);
+        expect(union.body.stage).toBe('$unionWith');
+        const out = await member.api.post('/api/v1/task/find', { findQuery: [{ $match: {} }, { $out: 'stolen' }] });
+        expect(out.status).toBe(400);
+        expect(out.body.stage).toBe('$out');
+    });
+
+    it('hides a task in a private owner-only project from a member, but not from the owner', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const { task } = await projectWithTask(owner, { assigneeIds: [owner.uid], isPrivate: true });
+
+        const asMember = await findById(member.api, task._id);
+        expect(asMember.status).toBe(200);
+        expect(asMember.body).toEqual([]);
+
+        const asOwner = await findById(owner.api, task._id);
+        expect(asOwner.body.map((t) => String(t._id))).toEqual([String(task._id)]);
+    });
+
+    it('still answers the board, facet and lookup shapes for a member in a shared project', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const { project, task } = await projectWithTask(owner, { assigneeIds: [owner.uid, member.uid] });
+
+        const board = await member.api.post('/api/v1/task/find', {
+            findQuery: [
+                { $match: { objId: { sprintId: task.sprintId, ProjectID: project._id }, deletedStatusKey: 0 } },
+                { $sort: { createdAt: 1, _id: 1 } },
+                { $facet: { result: [{ $skip: 0 }, { $limit: 35 }], count: [{ $count: 'count' }] } },
+            ],
+        });
+        expect(board.status).toBe(200);
+        expect(board.body[0].result.map((t) => String(t._id))).toContain(String(task._id));
+
+        const withNames = await member.api.post('/api/v1/task/find', {
+            findQuery: [
+                { $match: { objId: { _id: task._id } } },
+                { $lookup: { from: 'projects', localField: 'ProjectID', foreignField: '_id', as: 'projectArr', pipeline: [{ $project: { ProjectName: 1 } }] } },
+                { $unwind: { path: '$projectArr', preserveNullAndEmptyArrays: true } },
+                { $lookup: { from: 'sprints', localField: 'sprintId', foreignField: '_id', as: 'sprintArr', pipeline: [{ $project: { name: 1 } }] } },
+                { $unwind: { path: '$sprintArr', preserveNullAndEmptyArrays: true } },
+            ],
+        });
+        expect(withNames.status).toBe(200);
+        expect(withNames.body[0].projectArr.ProjectName).toBe(project.ProjectName);
+    });
+});
+
+describe('TSK-02 — PUT /api/v1/task', () => {
+    it('refuses an arbitrary Mongoose operation key', async () => {
+        const member = await loginAs('member');
+        const res = await member.api.put('/api/v1/task', {
+            firstParameter: {}, secondParameter: { _id: 1 }, key: 'estimatedDocumentCount', isConvertFirstParameter: false,
+        });
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+    });
+
+    it('refuses deleteMany and leaves the tasks in place', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const { task } = await projectWithTask(owner, { assigneeIds: [owner.uid, member.uid] });
+
+        const res = await member.api.put('/api/v1/task', { firstParameter: { deletedStatusKey: 0 }, secondParameter: {}, key: 'deleteMany' });
+        expect(res.status).toBe(403);
+        expect((await findById(owner.api, task._id)).body).toHaveLength(1);
+    });
+
+    it('refuses an anonymous caller', async () => {
+        const res = await anon.put('/api/v1/task', {
+            firstParameter: {}, secondParameter: { _id: 1 }, key: 'estimatedDocumentCount',
+        }, { headers: { companyid: state.companyId } });
+        expect(res.status).toBe(401);
+    });
+
+    it('still cascades a project close to its tasks for the owner', async () => {
+        const owner = await loginAs('owner');
+        const { project, task } = await projectWithTask(owner, { assigneeIds: [owner.uid] });
+
+        const res = await owner.api.put('/api/v1/task', {
+            firstParameter: { objId: { ProjectID: project._id }, deletedStatusKey: 0 },
+            secondParameter: { $set: { deletedStatusKey: 8 } },
+            key: 'updateMany',
+            isConvertFirstParameter: true,
+            isConvertSecondParameter: false,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(true);
+        const [after] = (await findById(owner.api, task._id)).body;
+        expect(after.deletedStatusKey).toBe(8);
+    });
+});

--- a/tests/integration/tasks.int.test.js
+++ b/tests/integration/tasks.int.test.js
@@ -128,7 +128,7 @@ describe('tasks & collaboration — auth refusals that work', () => {
 
 describe('tasks & collaboration — confirmed findings (regressions)', () => {
     // TSK-01
-    it.failing('TSK-01: refuses a client-supplied aggregation pipeline on POST /api/v1/task/find', async () => {
+    it('TSK-01: refuses a client-supplied aggregation pipeline on POST /api/v1/task/find', async () => {
         const member = await loginAs('member');
         const res = await member.api.post('/api/v1/task/find', {
             findQuery: [

--- a/tests/public-route-handlers.test.js
+++ b/tests/public-route-handlers.test.js
@@ -1,7 +1,7 @@
 jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
 jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
 jest.mock('../utils/data', () => ({ importUserNotifications: jest.fn(async () => undefined) }));
-jest.mock('../Config/permissionGuard', () => ({ getRoleType: jest.fn(), isPrivileged: (roleType) => roleType === 1 || roleType === 2 }));
+jest.mock('../Config/permissionGuard', () => ({ getRoleType: jest.fn(), isPrivileged: (roleType) => roleType === 1 || roleType === 2, evaluatePermission: jest.fn(), isWritable: (permission) => permission === true }));
 jest.mock('../Modules/Company/controller/updateCompany', () => ({ updateCompanyFun: jest.fn() }));
 jest.mock('../Modules/settings/Members/controller', () => ({ updateMemberFunction: jest.fn() }));
 jest.mock('../Modules/Users/controller', () => ({ updateUserFun: jest.fn(), getUserByQueyFun: jest.fn() }));
@@ -12,7 +12,7 @@ jest.mock('../Modules/storage/server/helpers/bucket.helper.js', () => ({}));
 const path = require('path');
 const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
 const { importUserNotifications } = require('../utils/data');
-const { getRoleType } = require('../Config/permissionGuard');
+const { getRoleType, evaluatePermission } = require('../Config/permissionGuard');
 const { mongoOperation } = require('../Modules/Auth/controller/mongoOperation');
 const { updateTask } = require('../Modules/Tasks/helpers/getTasksData');
 const { resolveBucketFile } = require('../Modules/storage/server/controller');
@@ -81,19 +81,32 @@ describe('mongoOperation reads only the caller company', () => {
     });
 });
 
-describe('PUT /api/v1/task only updates', () => {
+describe('PUT /api/v1/task only runs the project lifecycle cascade', () => {
+    const PROJECT = '6f00000000000000000000b1';
     const body = (key) => ({ firstParameter: { _id: 't1' }, secondParameter: { $set: { a: 1 } }, key });
+    const closeProject = { firstParameter: { objId: { ProjectID: PROJECT }, deletedStatusKey: 0 }, secondParameter: { $set: { deletedStatusKey: 8 } }, key: 'updateMany' };
 
-    it.each(['deleteMany', 'find', 'aggregate', 'findOneAndDelete'])('refuses %s', async (key) => {
+    it.each(['deleteMany', 'find', 'aggregate', 'findOneAndDelete', 'updateOne'])('refuses %s', async (key) => {
         const res = response();
         await updateTask(request({ body: body(key) }), res);
-        expect(res.statusCode).toBe(400);
+        expect(res.statusCode).toBe(403);
         expect(MongoDbCrudOpration).not.toHaveBeenCalled();
     });
 
-    it('runs updateMany', async () => {
+    it('refuses an updateMany that is not a cascade', async () => {
         const res = response();
         await updateTask(request({ body: body('updateMany') }), res);
+        expect(res.statusCode).toBe(403);
+        expect(MongoDbCrudOpration).not.toHaveBeenCalled();
+    });
+
+    it('runs the cascade updateMany for a caller allowed to close the project', async () => {
+        getRoleType.mockResolvedValue(1);
+        evaluatePermission.mockResolvedValue(true);
+        MongoDbCrudOpration.mockResolvedValueOnce([{ _id: 't1', ProjectID: PROJECT }]);
+        const res = response();
+        await updateTask(request({ body: closeProject }), res);
+        expect(res.statusCode).toBe(200);
         expect(MongoDbCrudOpration).toHaveBeenCalledWith(COMPANY, expect.anything(), 'updateMany');
     });
 });

--- a/tests/public-route-handlers.test.js
+++ b/tests/public-route-handlers.test.js
@@ -41,6 +41,8 @@ const settle = () => new Promise((resolve) => setImmediate(resolve));
 
 beforeEach(() => {
     jest.clearAllMocks();
+    getRoleType.mockReset();
+    evaluatePermission.mockReset();
     MongoDbCrudOpration.mockResolvedValue([]);
 });
 

--- a/tests/task-query-guard.test.js
+++ b/tests/task-query-guard.test.js
@@ -1,0 +1,301 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+/* fakeMongo compares ids as strings; the handlers build real ObjectIds. */
+const mockPlain = (value) => {
+    if (Array.isArray(value)) return value.map(mockPlain);
+    if (value && value._bsontype === 'ObjectId') return value.toHexString();
+    if (value instanceof Date || value instanceof RegExp) return value;
+    if (value && typeof value === 'object') return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, mockPlain(v)]));
+    return value;
+};
+const mockRawCalls = [];
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({
+    MongoDbCrudOpration: (companyId, query, method) => {
+        mockRawCalls.push({ companyId, query, method });
+        return mockDb.crud(companyId, mockPlain(query), method);
+    },
+}));
+jest.mock('../Config/permissionGuard', () => ({
+    getRoleType: jest.fn(),
+    isPrivileged: (roleType) => roleType === 1 || roleType === 2,
+    evaluatePermission: jest.fn(),
+    isWritable: (permission) => permission === true || permission === 1 || permission === 2,
+}));
+jest.mock('../Modules/Agents/scope', () => ({ visibleProjectIds: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn() }));
+jest.mock('../utils/commonFunctions.js', () => ({ removeCache: jest.fn() }));
+jest.mock('../Modules/service.js', () => ({}));
+jest.mock('../Modules/serviceFunction.js', () => ({}));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { getRoleType, evaluatePermission } = require('../Config/permissionGuard');
+const { visibleProjectIds } = require('../Modules/Agents/scope');
+const { removeCache } = require('../utils/commonFunctions.js');
+const socketEmitter = require('../event/socketEventEmitter');
+const { MAX_LIMIT, validatePipeline, QueryRefused } = require('../Modules/Tasks/helpers/taskQueryGuard');
+const { getTaskByQyery, updateTask } = require('../Modules/Tasks/helpers/getTasksData');
+
+const C = '6f0000000000000000000c01';
+const OTHER_COMPANY = '6f0000000000000000000c02';
+const ME = '6f0000000000000000000001';
+const MY_PROJECT = '6f0000000000000000000a01';
+const HIDDEN_PROJECT = '6f0000000000000000000a02';
+const SPRINT = '6f0000000000000000000b01';
+
+const request = (body, over = {}) => ({ headers: { companyid: C }, uid: ME, aud: C, body, ...over });
+const response = () => {
+    const res = { statusCode: 200, body: undefined };
+    res.status = jest.fn((code) => { res.statusCode = code; return res; });
+    res.json = jest.fn((body) => { res.body = body; return res; });
+    return res;
+};
+const run = async (handler, body, over) => {
+    const res = response();
+    await handler(request(body, over), res);
+    return res;
+};
+
+const task = (over) => mockDb.seed(SCHEMA_TYPE.TASKS, { TaskName: 'task', deletedStatusKey: 0, AssigneeUserId: [ME], sprintId: SPRINT, ...over });
+const tasks = () => mockDb.store[SCHEMA_TYPE.TASKS] || [];
+const writes = () => mockDb.calls.filter((c) => !['find', 'findOne', 'aggregate', 'countDocuments'].includes(c.method));
+const asRole = (roleType) => getRoleType.mockResolvedValue(roleType);
+
+const QA_LOOKUP_PAYLOAD = [
+    { $limit: 1 },
+    { $lookup: { from: 'company_users', pipeline: [{ $project: { roleType: 1 } }], as: 'x' } },
+    { $project: { n: { $size: '$x' } } },
+];
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    mockDb.calls.length = 0;
+    mockRawCalls.length = 0;
+    jest.clearAllMocks();
+    asRole(3);
+    visibleProjectIds.mockResolvedValue([MY_PROJECT]);
+    evaluatePermission.mockResolvedValue(true);
+});
+
+describe('TSK-01 — the task query pipeline allowlist', () => {
+    const refusal = (pipeline) => {
+        try {
+            validatePipeline(pipeline);
+        } catch (error) {
+            if (error instanceof QueryRefused) return error;
+            throw error;
+        }
+        return null;
+    };
+
+    it('refuses the member $lookup into company_users with 400 and runs nothing', async () => {
+        const res = await run(getTaskByQyery, { findQuery: QA_LOOKUP_PAYLOAD });
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toMatchObject({ status: false, stage: '$lookup' });
+        expect(res.body.message).toContain('company_users');
+        expect(mockDb.calls.filter((c) => c.method === 'aggregate')).toHaveLength(0);
+    });
+
+    it.each(['company_users', 'users', 'userAuth', 'sessions', 'apiTokens', 'rules', 'companies', 'tasks', 'timesheets'])(
+        'refuses a $lookup into %s',
+        (from) => {
+            expect(refusal([{ $lookup: { from, localField: 'ProjectID', foreignField: '_id', as: 'x' } }])).toMatchObject({ stage: '$lookup' });
+        },
+    );
+
+    it.each(['$out', '$merge', '$unionWith', '$graphLookup', '$documents', '$collStats', '$currentOp', '$indexStats', '$set', '$replaceRoot', '$sample'])(
+        'refuses the %s stage by name',
+        (stage) => {
+            expect(refusal([{ $match: {} }, { [stage]: 'x' }])).toMatchObject({ stage });
+        },
+    );
+
+    it.each([
+        ['$where', [{ $match: { $where: 'sleep(1000)' } }]],
+        ['$function', [{ $match: { $expr: { $function: { body: 'function() { return true }', args: [], lang: 'js' } } } }]],
+        ['$accumulator', [{ $group: { _id: null, x: { $accumulator: { init: 'function() {}', lang: 'js' } } } }]],
+        ['$lookup', [{ $facet: { leak: [{ $lookup: { from: 'users', pipeline: [], as: 'u' } }] } }]],
+        ['$lookup', [{ $lookup: { from: 'projects', localField: 'ProjectID', foreignField: '_id', as: 'p', pipeline: [{ $lookup: { from: 'users', pipeline: [], as: 'u' } }] } }]],
+        ['$unionWith', [{ $facet: { leak: [{ $unionWith: 'users' }] } }]],
+    ])('refuses %s wherever it is nested', (stage, pipeline) => {
+        expect(refusal(pipeline)).toMatchObject({ stage });
+    });
+
+    it.each([
+        ['a let join', { from: 'projects', let: { p: '$ProjectID' }, pipeline: [], as: 'p' }],
+        ['a join with no localField', { from: 'projects', pipeline: [{ $project: { ProjectName: 1 } }], as: 'p' }],
+        ['a join on another field', { from: 'projects', localField: 'AssigneeUserId', foreignField: '_id', as: 'p' }],
+        ['a join into another foreign field', { from: 'sprints', localField: 'sprintId', foreignField: 'AssigneeUserId', as: 's' }],
+    ])('refuses %s', (_, spec) => {
+        expect(refusal([{ $lookup: spec }])).toMatchObject({ stage: '$lookup' });
+    });
+
+    it('caps $limit and refuses a non-positive one', () => {
+        expect(validatePipeline([{ $limit: 1e9 }])).toEqual([{ $limit: MAX_LIMIT }]);
+        expect(refusal([{ $limit: -1 }])).toMatchObject({ stage: '$limit' });
+        expect(refusal([{ $skip: -5 }])).toMatchObject({ stage: '$skip' });
+    });
+
+    const lookups = [
+        { $lookup: { from: 'projects', localField: 'ProjectID', foreignField: '_id', as: 'projectArr', pipeline: [{ $project: { ProjectName: 1 } }] } },
+        { $unwind: { path: '$projectArr', preserveNullAndEmptyArrays: true } },
+        { $lookup: { from: 'folders', localField: 'folderObjId', foreignField: '_id', as: 'folderArr', pipeline: [{ $project: { name: 1 } }] } },
+        { $unwind: { path: '$folderArr', preserveNullAndEmptyArrays: true } },
+        { $lookup: { from: 'sprints', localField: 'sprintId', foreignField: '_id', as: 'sprintArr', pipeline: [{ $project: { name: 1, folderId: 1 } }] } },
+        { $unwind: '$sprintArr' },
+    ];
+    const INVENTORY = [
+        ['desktop deep-link start', [{ $match: { objId: { _id: MY_PROJECT, CompanyId: C } } }, ...lookups]],
+        ['desktop task search', [{ $match: { objId: { CompanyId: C }, AssigneeUserId: { $in: [ME] }, statusType: { $in: ['active'] }, deletedStatusKey: 0, TaskName: { $regex: 'a\\.b', $options: 'i' } } }, { $sort: { _id: -1 } }, { $skip: 20 }, { $limit: 20 }, ...lookups]],
+        ['desktop home list', [{ $match: { $and: [{ objId: { CompanyId: C } }, { ProjectID: { objId: { $in: [MY_PROJECT] } } }], $or: [{ startDate: { dbDate: { $gte: 1, $lte: 2 } } }, { $and: [{ DueDate: { dbDate: { $gte: 1 } } }] }] } }, ...lookups, { $sort: { DueDate: -1, _id: 1 } }]],
+        ['dashboard queue card facet', [{ $facet: { results: [{ $match: { $and: [{ AssigneeUserId: { $in: [ME] } }, { deletedStatusKey: 0 }] } }, { $skip: 0 }, { $limit: 10 }], count: [{ $match: { deletedStatusKey: 0 } }, { $count: 'count' }] } }]],
+        ['tasks per sprint count', [{ $match: { objId: { sprintId: SPRINT }, deletedStatusKey: { $in: [0, 2, null] } } }, { $count: 'count' }]],
+        ['home my work (bare object)', { $match: { mainChat: { $ne: true }, statusType: { $nin: ['done', 'close'] }, $or: [{ AssigneeUserId: ME }, { Task_Leader: ME }] } }],
+        ['subtask estimate sum', [{ $match: { ParentTaskId: 'p' } }, { $group: { _id: null, estimate: { $sum: { $ifNull: ['$estimatedTime', 0] } } } }]],
+        ['subtask progress', [{ $match: { ParentTaskId: 'p', deletedStatusKey: { $in: [0, null] } } }, { $group: { _id: null, total: { $sum: 1 }, completed: { $sum: { $cond: [{ $eq: ['$statusType', 'close'] }, 1, 0] } } } }]],
+        ['page block task list', [{ $match: { ProjectID: { objId: { $in: [MY_PROJECT] } }, 'status.type': { $ne: 'close' } } }, { $project: { TaskName: 1, TaskKey: 1 } }, { $sort: { updatedAt: -1 } }, { $limit: 30 }]],
+        ['dashboard pie by assignee', [{ $unwind: '$AssigneeUserId' }, { $match: { deletedStatusKey: { $in: [0] }, customField: { $elemMatch: { value: { $in: ['x'] } } } } }, { $group: { _id: '$AssigneeUserId', count: { $sum: 1 } } }, { $sort: { count: -1 } }, { $match: { _id: ME } }]],
+        ['people directory', [{ $match: { statusType: { $ne: 'close' } } }, { $unwind: '$AssigneeUserId' }, { $group: { _id: '$AssigneeUserId', tasks: { $sum: 1 }, projects: { $addToSet: '$ProjectID' } } }, { $project: { tasks: 1, projects: { $size: '$projects' } } }]],
+        ['sprints with matches', [{ $match: { legacyId: { $exists: false }, TaskName: { $regex: 'x', $options: 'i' } } }, { $group: { _id: '$sprintId' } }]],
+        ['paginated board group', [{ $match: { objId: { sprintId: SPRINT, ProjectID: MY_PROJECT }, deletedStatusKey: 0, statusKey: { $eq: 1 } } }, { $sort: { groupByStatusIndex: 1, createdAt: 1, _id: 1 } }, { $facet: { result: [{ $skip: 0 }, { $limit: 35 }], count: [{ $count: 'count' }] } }]],
+        ['log-time picker', [{ $match: { AssigneeUserId: { $in: [ME] } } }, { $sort: { updatedAt: -1 } }, { $limit: 30 }, { $project: { TaskName: 1 } }]],
+    ];
+
+    it.each(INVENTORY)('still accepts the %s pipeline unchanged', (_, pipeline) => {
+        const stages = Array.isArray(pipeline) ? pipeline : [pipeline];
+        expect(validatePipeline(pipeline)).toEqual(stages);
+    });
+});
+
+describe('TSK-01 — tasks are bound to the projects the caller can see', () => {
+    beforeEach(() => {
+        task({ TaskName: 'mine', ProjectID: MY_PROJECT });
+        task({ TaskName: 'hidden', ProjectID: HIDDEN_PROJECT });
+    });
+    const names = (res) => res.body.map((t) => t.TaskName).sort();
+
+    it('a member sees only tasks in projects they belong to, with the scope as the first stage', async () => {
+        const res = await run(getTaskByQyery, { findQuery: [{ $match: { deletedStatusKey: 0 } }] });
+        expect(res.statusCode).toBe(200);
+        expect(names(res)).toEqual(['mine']);
+        expect(visibleProjectIds).toHaveBeenCalledWith(C, ME);
+        const [pipeline] = mockRawCalls.find((c) => c.method === 'aggregate').query.data;
+        expect(pipeline[0]).toEqual({ $match: { ProjectID: { $in: [expect.objectContaining({ _bsontype: 'ObjectId' })] } } });
+        expect(String(pipeline[0].$match.ProjectID.$in[0])).toBe(MY_PROJECT);
+    });
+
+    it('a member cannot read a hidden task by id', async () => {
+        const hidden = tasks().find((t) => t.TaskName === 'hidden');
+        const res = await run(getTaskByQyery, { findQuery: { $match: { _id: hidden._id } } });
+        expect(res.body).toEqual([]);
+    });
+
+    it.each([[1, 'owner'], [2, 'admin']])('roleType %s (%s) keeps full company visibility', async (roleType) => {
+        asRole(roleType);
+        const res = await run(getTaskByQyery, { findQuery: [{ $match: { deletedStatusKey: 0 } }] });
+        expect(names(res)).toEqual(['hidden', 'mine']);
+        expect(visibleProjectIds).not.toHaveBeenCalled();
+    });
+
+    it('someone who is not a member of the company sees nothing', async () => {
+        asRole(null);
+        const res = await run(getTaskByQyery, { findQuery: [{ $match: {} }] });
+        expect(res.body).toEqual([]);
+    });
+
+    it('refuses a company outside the token audience', async () => {
+        const res = await run(getTaskByQyery, { findQuery: [{ $match: {} }] }, { headers: { companyid: OTHER_COMPANY } });
+        expect(res.statusCode).toBe(403);
+        expect(res.body.status).toBe(false);
+    });
+});
+
+describe('TSK-02 — PUT /api/v1/task only runs the project lifecycle cascade', () => {
+    const cascade = (over = {}) => ({
+        firstParameter: { objId: { ProjectID: MY_PROJECT }, deletedStatusKey: 0 },
+        secondParameter: { $set: { deletedStatusKey: 8 } },
+        key: 'updateMany',
+        isConvertFirstParameter: true,
+        isConvertSecondParameter: false,
+        ...over,
+    });
+
+    beforeEach(() => {
+        task({ TaskName: 'open', ProjectID: MY_PROJECT });
+        task({ TaskName: 'already trashed', ProjectID: MY_PROJECT, deletedStatusKey: 1 });
+        task({ TaskName: 'elsewhere', ProjectID: HIDDEN_PROJECT });
+    });
+
+    it.each(['deleteMany', 'deleteOne', 'findOneAndDelete', 'estimatedDocumentCount', 'drop', 'bulkWrite', 'updateOne', 'replaceOne', 'aggregate'])(
+        'refuses key %s with 403 and touches nothing',
+        async (key) => {
+            const res = await run(updateTask, { firstParameter: {}, secondParameter: { _id: 1 }, key, isConvertFirstParameter: false });
+            expect(res.statusCode).toBe(403);
+            expect(res.body.status).toBe(false);
+            expect(mockDb.calls).toHaveLength(0);
+            expect(tasks()).toHaveLength(3);
+        },
+    );
+
+    it.each([
+        ['an empty filter', { firstParameter: {} }],
+        ['an extra filter field', { firstParameter: { objId: { ProjectID: MY_PROJECT }, deletedStatusKey: 0, AssigneeUserId: ME } }],
+        ['an operator in the filter', { firstParameter: { objId: { ProjectID: MY_PROJECT }, deletedStatusKey: { $ne: 5 } } }],
+        ['a different update', { secondParameter: { $set: { TaskName: 'owned' } } }],
+        ['an unsupported transition', { secondParameter: { $set: { deletedStatusKey: 2 } } }],
+    ])('refuses updateMany with %s', async (_, over) => {
+        const res = await run(updateTask, cascade(over));
+        expect(res.statusCode).toBe(403);
+        expect(writes()).toHaveLength(0);
+    });
+
+    it('runs a permitted cascade, scoped to the project and prior key, and emits each task', async () => {
+        const emit = jest.spyOn(socketEmitter, 'emit');
+        const res = await run(updateTask, cascade());
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject({ status: true, data: { modifiedCount: 1 } });
+        expect(evaluatePermission).toHaveBeenCalledWith(C, ME, 'project.project_close', { projectId: MY_PROJECT });
+        expect(Object.fromEntries(tasks().map((t) => [t.TaskName, t.deletedStatusKey]))).toEqual({ open: 8, 'already trashed': 1, elsewhere: 0 });
+        const events = emit.mock.calls.filter(([name]) => name === 'update');
+        expect(events).toHaveLength(1);
+        expect(events[0][1]).toMatchObject({ type: 'update', module: 'task', updatedFields: { deletedStatusKey: 8 }, data: { deletedStatusKey: 8 } });
+        expect(removeCache).toHaveBeenCalledWith('UserProjectData:', true);
+        emit.mockRestore();
+    });
+
+    it.each([[8, 0, 'project.project_list'], [0, 1, 'project.project_delete'], [0, 7, 'project.project_delete']])(
+        'checks the matching permission for %s → %s',
+        async (from, to, key) => {
+            await run(updateTask, cascade({ firstParameter: { objId: { ProjectID: MY_PROJECT }, deletedStatusKey: from }, secondParameter: { $set: { deletedStatusKey: to } } }));
+            expect(evaluatePermission).toHaveBeenCalledWith(C, ME, key, { projectId: MY_PROJECT });
+        },
+    );
+
+    it('refuses a member without the permission', async () => {
+        evaluatePermission.mockResolvedValue(false);
+        const res = await run(updateTask, cascade());
+        expect(res.statusCode).toBe(403);
+        expect(writes()).toHaveLength(0);
+    });
+
+    it('refuses a member cascading a project they cannot see', async () => {
+        const res = await run(updateTask, cascade({ firstParameter: { objId: { ProjectID: HIDDEN_PROJECT }, deletedStatusKey: 0 } }));
+        expect(res.statusCode).toBe(403);
+        expect(writes()).toHaveLength(0);
+        expect(tasks().find((t) => t.TaskName === 'elsewhere').deletedStatusKey).toBe(0);
+    });
+
+    it('lets an owner cascade any project', async () => {
+        asRole(1);
+        const res = await run(updateTask, cascade({ firstParameter: { objId: { ProjectID: HIDDEN_PROJECT }, deletedStatusKey: 0 } }));
+        expect(res.statusCode).toBe(200);
+        expect(visibleProjectIds).not.toHaveBeenCalled();
+        expect(tasks().find((t) => t.TaskName === 'elsewhere').deletedStatusKey).toBe(8);
+    });
+
+    it('refuses a company outside the token audience', async () => {
+        const res = await run(updateTask, cascade(), { headers: { companyid: OTHER_COMPANY } });
+        expect(res.statusCode).toBe(403);
+        expect(mockDb.calls).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Rebased over #600

Rebased onto `beta` after #600 (`2954eb91`, "guard the routes that answered without a session"). It conflicted in `Modules/Tasks/helpers/getTasksData.js`.

- **From #606:** `updateTask` and `getTaskByQyery` take this branch's side. #600's `UPDATE_TASK_METHODS` check (updateOne or updateMany, 400) is removed, because `taskWriteGuard.parseCascade` is stricter: only `updateMany`, only the project lifecycle cascade, 403 otherwise. #600's hunk also referenced a `key` variable that this branch's handler no longer declares.
- **From #600:** the session requirement stays in `Config/setMiddleware.js`. Its `/api/v1/task` prefix entry guards both `PUT /api/v1/task` and `POST /api/v1/task/find`, and it runs before the module routes load. The route-level `verifyJWTTokenWithCV2` this PR had added to `PUT /api/v1/task` would have run the same check a second time, so it was dropped. Nothing else #600 changed is touched.
- **Test updates.** #600's unit block in `tests/public-route-handlers.test.js` now expects the stricter behaviour: 403 for the other keys and for a free-form `updateMany`, and a permitted cascade runs. `TSK-01` in `tests/integration/tasks.int.test.js` is flipped from `it.failing` to `it`. `TSK-02` was already flipped by #607 and passes.
- **Gates after the rebase (Node 20):**
  - `task-query-guard`: 74/74
  - unit project: 2385/2385 (186 suites)
  - conventions: 94/94
  - integration `tasks` + `task-query` + `access` on its own mongo:7: 47/47
  - eslint on touched files: 0 errors

Fixes the two critical task API findings from QA task 034 (`Tasks/active/034-end-to-end-qa-programme/findings/tasks.md`).

## TSK-01: `POST /api/v1/task/find` ran a client-supplied aggregation pipeline

The pipeline is now validated against a frozen allowlist (`Modules/Tasks/helpers/taskQueryGuard.js`) before it runs. A refused pipeline answers `400 { status:false, statusText:"Query refused", message, stage }` with the offending stage or operator named.

**Allowed top-level stages:** `$match`, `$sort`, `$skip`, `$limit`, `$project`, `$addFields`, `$count`, `$group`, `$unwind`, `$lookup`, `$facet`.
**Inside `$lookup.pipeline` and `$facet` outputs:** the same set minus `$lookup` and `$facet`.
**`$lookup`** is limited to these joins, written as `localField`/`foreignField`, with an optional sub-pipeline. `let` is refused.

| from | localField | foreignField |
|---|---|---|
| `projects` | `ProjectID` | `_id` |
| `sprints` | `sprintId` | `_id` |
| `folders` | `folderObjId` | `_id` |

**Refused anywhere in the pipeline, at any depth:** `$where`, `$function`, `$accumulator`, `$out`, `$merge`, `$unionWith`, `$graphLookup`, `$documents`, `$collStats`, `$indexStats`, `$currentOp`, `$listSessions`, `$listLocalSessions`, `$planCacheStats`. Any stage not on the allowlist is also refused, for example `$set`, `$replaceRoot` or `$sample`. So is any `$lookup` into another collection (`company_users`, `users`, `userAuth`, `sessions`, `apiTokens`, `rules`, `companies`, `tasks`, `timesheets` and the rest), and a nested `$lookup` or `$facet`.

**Limits:**
- `$limit` must be a positive integer and is capped at 1000. The largest value any caller sends is 35.
- `$skip` must be a non-negative integer.
- A pipeline may have at most 40 stages.

**Visibility:** a `$match` on `ProjectID` is prepended to every pipeline. It is built from `Modules/Agents/scope.js` `visibleProjectIds`, the same rules as the sidebar project list. Owners and admins (roleType 1/2) get no injected stage, so they keep company-wide visibility. A caller who is not a company member matches nothing. The company comes from `tenantOf(req)`, so a header outside the token audience gets 403.

## TSK-02: `PUT /api/v1/task` dispatched any Mongoose method named in `key`

It was worse than the finding described: `PUT /api/v1/task` was in **neither** JWT middleware list. `app.use('/api/v1/task/:id')` does not match the bare path, so anyone with a company id could call it. #600 has since added `/api/v1/task` to the session-guarded prefixes in `Config/setMiddleware.js`, and that entry now provides the session requirement.

**Operation allowlist: `updateMany` only**, because the inventory found exactly one real caller. That caller is the project lifecycle cascade in `frontend/src/views/Projects/composables/useProjectLifecycle.js`. It is a bulk caller, so it is kept but pinned down (`Modules/Tasks/helpers/taskWriteGuard.js`):

- The filter may name only `ProjectID` (one valid id) and `deletedStatusKey`, and the update may only `$set` `deletedStatusKey`. Any other filter field, operator or update gets 403.
- Only the transitions the UI performs are accepted. Each requires the permission the project menu checks before it offers that action. The check uses `evaluatePermission`, which honours project-level rules:

  | from → to | action | permission |
  |---|---|---|
  | 0 → 8 | close | `project.project_close` |
  | 0 → 7 | archive | `project.project_delete` |
  | 0 → 1 | delete | `project.project_delete` |
  | 7/8 → 0 | restore | `project.project_list` |

- A non-privileged caller must also be able to see the project (`visibleProjectIds`).
- The server builds the filter itself: `{ ProjectID: ObjectId, deletedStatusKey: from }`, restricted to the `_id`s it matched.
- Afterwards it emits `socketEmitter.emit('update', { module: 'task', ... })` for each affected task and runs `removeCache('UserProjectData:', true)`, as `PUT /api/v1/project/:id` does. Before this PR the route did neither.

**Refused with 403:** every other `key`, for example `deleteMany`, `deleteOne`, `findOneAndDelete`, `updateOne`, `replaceOne`, `estimatedDocumentCount`, `drop`, `bulkWrite` and `aggregate`.

Responses now use the standard envelope. The success body changed from the raw Mongoose result to `{ status:true, statusText, data: <result> }`; the only caller ignores it.

## Caller inventory

### `POST /api/v1/task/find`: 47 web call sites and 7 desktop call sites

Every shape below still passes the guard. A representative pipeline for each group is asserted unchanged in `tests/task-query-guard.test.js`.

| Group | Call sites | Stages | `$lookup` | Match operators and helper keys |
|---|---|---|---|---|
| Project board / list / table (`store/ProjectData/actions.js` getPaginatedTasks, setTableTasksFromTypesense, searchTask, getAllTask) | 4 + backfill | `$match`, `$sort`, `$skip`, `$limit`, `$facet{result,count}` | none | `objId`, `$in`, `$and`, `$or`, `$regex`, `$eq`, `dbDate` |
| Tasklist dashboard (`DashBoardList.vue` ×3) | 3 | `$match`, `$skip`, `$limit`, `$group{_id:$sprintId}` | none | `$and`, `$in`, `$nin`, `$exists`, `$elemMatch`, `$regex`, `dbDate` |
| Dashboard cards (Queue, Calendar, Pie, Bar, StackBar, TotalTask) | 7 | `$match`, `$facet`, `$lookup`, `$unwind`, `$sort`, `$skip`, `$limit`, `$group`, `$count` | `folders` folderObjId→_id, `sprints` sprintId→_id (with `$project` sub-pipeline) | `$and`, `$or`, `$in`, `dbDate` `$gte/$lte` |
| Home my work / personal list | 3 | bare `{ $match }` object | none | `$ne`, `$nin`, `$or`, `dbDate` |
| Subtasks (SubTasks, TaskDetailPanel, Task.vue badge, EstimatedTimeInput, ConvertTo*) | 7 | `$match`, `$sort`, `$skip`, `$limit`, `$group` (`$sum`, `$cond`, `$eq`, `$ifNull`) | none | `ParentTaskId`, `$in` |
| Settings / templates "in use" checks (TaskStatusForm, ProjectTaskTypeForm, ProjectSettingSidebar, SettingTaskPriority) | 6 | bare `{ $match }`, `$match`+`$count` | none | `$and`, `$in`, `$nin`, `objId` |
| Pages / chips / linked tasks / log-time picker | 5 | `$match`, `$project`, `$sort`, `$limit` | none | `$in`, `$or`, `$regex`, `'status.type'` |
| Timesheets / people directory | 7 | `$match`, `$unwind`, `$group` (`$addToSet`), `$project` (`$size`) | none | `_id objId $in`, `$ne` |
| Misc (export plugin, calendar views, sidebar pickers, plan-limit count) | 5 | `$match`, `$facet`, `$count` | none | `objId`, `$in`, `$ne` |
| Desktop tracker (estimateLimit, useDeepLinkStart, TrackerSelection ×3, logentry, home) | 7 | `$match`, `$lookup`, `$unwind`, `$sort`, `$skip`, `$limit` | `projects` ProjectID→_id, `folders` folderObjId→_id, `sprints` sprintId→_id (each with `$project` sub-pipeline) | `objId`, `$in`, `$regex`, `$and`, `$or`, `dbDate` |

No caller sends `$expr`, `$function`, `$where`, `$unionWith`, `$graphLookup`, `$out`, `$merge` or `let` lookups, so **nothing needed widening**.

### `PUT /api/v1/task`

| Caller | key | filter | update |
|---|---|---|---|
| `useProjectLifecycle.js:58` `updateChildTasks` (close / archive / delete / restore project) | `updateMany` | `{ objId:{ ProjectID }, deletedStatusKey }` | `{ $set:{ deletedStatusKey } }` |

No desktop, MCP, script or backend callers. The offline replay queue (`frontend/src/offline`) replays this same body unchanged.

## Tests

- **Unit:** `tests/task-query-guard.test.js`, jest with fakeMongo, 74 tests. It covers:
  - the QA `$lookup` into `company_users` → 400 and nothing runs;
  - lookups into other collections, forbidden stages and nested operators refused;
  - `$limit` capped;
  - 14 inventoried shapes accepted unchanged;
  - a member sees only visible-project tasks, and the scope is the first stage;
  - owner and admin keep full visibility;
  - a non-member sees nothing;
  - out-of-audience company → 403;
  - `deleteMany`, `updateMany` with a free filter or update, and 7 other keys → 403 with nothing touched;
  - the permitted cascade updates only the named project and prior key, emits, and clears the cache;
  - permission key per transition, missing permission, invisible project, and owner override.
- **Integration:** `tests/integration/task-query.int.test.js`. `tests/integration/task-query.int.test.js` carries these assertions:
  - TSK-01: `$lookup` into `company_users` → 400; `$unionWith` / `$out` → 400;
  - a member cannot read a private owner-only project's task, the owner can;
  - board facet and lookup shapes still answer for a member;
  - TSK-02: `estimatedDocumentCount` → 403; `deleteMany` → 403 and the task survives; anonymous PUT → 401;
  - the owner's close cascade still sets `deletedStatusKey: 8`.

## Gates (local, Node 20)

The machine was heavily loaded during this run (load average ~100 from parallel agents), so several suites hit jest/vitest default 5s timeouts. Every timed-out file was rerun with a longer timeout and passed. None of them touch this change.

| Gate | Result |
|---|---|
| `npx jest --selectProjects unit` | 2228 / 2238 passed. The 10 failures were all "Exceeded timeout of 5000 ms" in `agent-*` and `twofactor-rules` files. Rerunning those 10 files with `--testTimeout=120000` gave **115 / 115 passed**. New file: **74 / 74**. |
| `npx jest tests/conventions` | **94 / 94 passed** (8 suites) |
| `npm run test:integration` (own mongo:7 on :27123) | **24 / 24 passed** (smoke, member-permissions, task-query), run with `--testTimeout=180000`. The first run hit 5s timeouts in the setup-heavy tests, including the untouched member-permissions suite. |
| `cd frontend && npx vitest run` | 180 / 188 passed. The 8 failures were 5s timeouts in `aiProjectCreator`, `projectMemoryCard`, `useAppVersion`, `agentPreferences` and `agentRunDetail`. Rerunning those 5 files with `--testTimeout=60000` gave **50 / 50 passed**. No frontend file changed. |
| eslint on touched files | **0 errors, 0 warnings** |
| Playwright smoke + tasks specs | **7 / 7 passed** with `--workers=1`: smoke, plus the tasks spec from `test/qa-tasks` copied in locally. That covers sign-in to Home, Trash, the Personal List and the task detail overlay; the TSK-05 `test.fail` still fails, as expected. In the first parallel run, the overlay test failed in the `createTask` fixture ("project has no sprint to hold a task"), before any page loaded. That is a sprint-creation race under load, and it passed serially. |

## Follow-ups (not widened here)

- **Private sprints.** Visibility is enforced per project. Tasks in a private sprint of a project the member can see are still returned, as they were before; `getProjectList` has the same gap.
- **Sprint and folder names.** Sprint and folder lookups join only the task's own sprint and folder, so names come from inside visible projects. There is no sprint-privacy filter on the joined name.
- **Unscoped per-user queries.** `PieChartCardComponent` and its siblings send no project clause when the project list is empty, and `useMyWork` queries cross-project. For members these are now scoped by the injected match, which is a behaviour change only for tasks outside their visible projects.
- **`GET /api/v1/task/:id` needs a visibility follow-up.** `getTask` is behind JWT but still reads any task in the company by id, with no project-visibility check. It would need the same `visibilityStage` binding.
- **The project update itself.** `PUT /api/v1/project/:id`, which runs before the cascade, is `fix/project-edit-membership`'s area and is not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
