### PR TITLE
test(034): flip the regression tests for findings #600 fixed

### DIFF
--- a/tests/integration/access.int.test.js
+++ b/tests/integration/access.int.test.js
@@ -94,7 +94,7 @@ describe('access — API tokens', () => {
 
 describe('access — regression tests for confirmed findings (flip to it() once fixed)', () => {
     // ACC-01: POST /api/v1/mongoOpration runs arbitrary Mongo with no auth.
-    it.failing('ACC-01 refuses an anonymous arbitrary Mongo operation', async () => {
+    it('ACC-01 refuses an anonymous arbitrary Mongo operation', async () => {
         const res = await anon.post('/api/v1/mongoOpration', {
             dbName: 'global', collection: 'users', methodName: 'countDocuments', dataObj: [{}],
         });
@@ -116,13 +116,13 @@ describe('access — regression tests for confirmed findings (flip to it() once 
         expect(refused(res)).toBe(true);
     });
 
-    it.failing('ACC-03 refuses deleting another user\'s sessions anonymously', async () => {
+    it('ACC-03 refuses deleting another user\'s sessions anonymously', async () => {
         const res = await anon.delete(`/api/v2/session/delete/${randomId()}`);
         expect(res.status).toBe(401);
     });
 
     // ACC-04: /api/v1/settings/oauth reads secrets and rewrites .env with no auth.
-    it.failing('ACC-04 refuses reading OAuth credentials anonymously', async () => {
+    it('ACC-04 refuses reading OAuth credentials anonymously', async () => {
         const res = await anon.get('/api/v1/settings/oauth');
         expect(res.status).toBe(401);
     });
@@ -148,7 +148,7 @@ describe('access — regression tests for confirmed findings (flip to it() once 
     });
 
     // ACC-07: manageTrackerUserPermission is unauthenticated.
-    it.failing('ACC-07 refuses an anonymous tracker-permission change', async () => {
+    it('ACC-07 refuses an anonymous tracker-permission change', async () => {
         const res = await anon.post('/api/v1/manageTrackerUserPermission', {
             CompanyId: state.companyId, DataObj: { ops: true, data: { status: 2, userId: randomId() } },
         });
@@ -156,13 +156,13 @@ describe('access — regression tests for confirmed findings (flip to it() once 
     });
 
     // ACC-08: change-password requires no session (only the old password).
-    it.failing('ACC-08 refuses an anonymous change-password', async () => {
+    it('ACC-08 refuses an anonymous change-password', async () => {
         const res = await anon.patch(`/api/v2/auth/${randomId()}/change-password`, { oldPassword: 'x', newPassword: 'y' });
         expect(res.status).toBe(401);
     });
 
     // ACC-09: checkSendInviatation is an unauthenticated membership oracle.
-    it.failing('ACC-09 refuses an anonymous membership probe', async () => {
+    it('ACC-09 refuses an anonymous membership probe', async () => {
         const res = await anonWithCompany.post('/api/v1/checkSendInviatation', {
             email: state.users.member.email, companyId: state.companyId,
         });

--- a/tests/integration/automations.int.test.js
+++ b/tests/integration/automations.int.test.js
@@ -343,7 +343,7 @@ describe('AI features', () => {
     });
 
     // The handler rewrites <repo>/.env, so the probe only runs where no .env exists (CI, a fresh worktree).
-    (fs.existsSync(path.join(ROOT, '.env')) ? it.skip : it.failing)('AUT-01 refuses an anonymous AI model update', async () => {
+    (fs.existsSync(path.join(ROOT, '.env')) ? it.skip : it)('AUT-01 refuses an anonymous AI model update', async () => {
         const res = await anonymous.post('/api/v1/updateAiModel', { key: 'E2E_PROBE', value: 'x' });
         expect(res.status).toBe(401);
     });

--- a/tests/integration/messages.int.test.js
+++ b/tests/integration/messages.int.test.js
@@ -90,7 +90,7 @@ describe('messages/inbox — general reminders', () => {
 
 describe('messages/inbox — task reminders (MSG-01)', () => {
     // MSG-01 — the /api/v1/reminders prefix is in neither JWT list, so it runs with no session.
-    it.failing('MSG-01 refuses an unauthenticated task-reminder write', async () => {
+    it('MSG-01 refuses an unauthenticated task-reminder write', async () => {
         const res = await anonymous.post('/api/v1/reminders',
             { reminderAt: futureISO(), reminderText: 'x' },
             { headers: { companyid: state.companyId, userid: state.users.member.userId } });

--- a/tests/integration/tasks.int.test.js
+++ b/tests/integration/tasks.int.test.js
@@ -142,7 +142,7 @@ describe('tasks & collaboration — confirmed findings (regressions)', () => {
     });
 
     // TSK-02
-    it.failing('TSK-02: refuses an arbitrary Mongoose operation key on PUT /api/v1/task', async () => {
+    it('TSK-02: refuses an arbitrary Mongoose operation key on PUT /api/v1/task', async () => {
         const member = await loginAs('member');
         const res = await member.api.put('/api/v1/task', {
             firstParameter: {}, secondParameter: { _id: 1 }, key: 'estimatedDocumentCount', isConvertFirstParameter: false,
@@ -151,7 +151,7 @@ describe('tasks & collaboration — confirmed findings (regressions)', () => {
     });
 
     // TSK-04
-    it.failing('TSK-04: requires auth for POST /api/v1/getTaskTypeImage', async () => {
+    it('TSK-04: requires auth for POST /api/v1/getTaskTypeImage', async () => {
         const res = await anon.post('/api/v1/getTaskTypeImage', { companyId: state.companyId, path: 'setting/task_type/task.png' });
         expect(res.status).toBe(401);
     });


### PR DESCRIPTION
The e2e job is red on every open PR (#603, #604, #605 and the fix PRs). The QA sweeps marked each unfixed finding with `it.failing`; #600 fixed ten of them, so those tests pass and jest reports a passing `it.failing` as a failure (CI run 34580761445: 10 failed, 257 passed, every failure one of these).

Flipped to `it` by exact title, leaving the still-open tests that share an id untouched:
- access: ACC-01, ACC-03 (deleting another user's sessions), ACC-04, ACC-07, ACC-08, ACC-09
- automations: AUT-01
- messages: MSG-01 (unauthenticated task-reminder write; the ownership test stays `it.failing`)
- tasks: TSK-02, TSK-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)