### PR TITLE
fix(storage): bind bucket routes and signed urls to the caller's company

### DIFF
--- a/Modules/storage/bucketAccess.js
+++ b/Modules/storage/bucketAccess.js
@@ -1,0 +1,53 @@
+const { verifyCompanyMembership } = require('../../Config/jwt');
+const { safeRelativePath } = require('../../utils/uploadConfig');
+
+const OBJECT_ID = /^[a-f0-9]{24}$/i;
+const USER_PROFILES_BUCKET = 'USER_PROFILES';
+
+const refuse = (res, code, statusText) => res.status(code).json({ status: false, statusText, message: statusText });
+
+const inAudience = (aud, companyId) => {
+    if (!aud) return false;
+    const list = Array.isArray(aud) ? aud : String(aud).split(',');
+    return list.some((entry) => String(entry).trim() === companyId);
+};
+
+/* A company's bucket id is the company _id. The JWT audience is frozen at login,
+ * so the live membership check is what locks out a user removed since then. */
+async function belongsToCompany(req, companyId) {
+    const id = String(companyId || '');
+    if (!req.uid || !OBJECT_ID.test(id) || !inAudience(req.aud, id)) return false;
+    return verifyCompanyMembership(String(req.uid), id);
+}
+
+function requireOwnBucket(pickBucketId, { allowUserProfiles = false } = {}) {
+    return async (req, res, next) => {
+        if (!req.uid) return refuse(res, 401, 'Unauthorized');
+        const bucketId = String(pickBucketId(req) || '');
+        if (allowUserProfiles && bucketId === USER_PROFILES_BUCKET) return next();
+        try {
+            if (await belongsToCompany(req, bucketId)) return next();
+        } catch (error) {
+            return refuse(res, 500, error.message);
+        }
+        return refuse(res, 403, 'You do not have access to this bucket');
+    };
+}
+
+function requireSafeObjectPath(pickPath) {
+    return (req, res, next) => (safeRelativePath(pickPath(req)) ? next() : refuse(res, 400, 'Invalid path'));
+}
+
+const bucketIdParam = (req) => req.params && req.params.bucketId;
+const bodyField = (key) => (req) => req.body && req.body[key];
+const queryField = (key) => (req) => req.query && req.query[key];
+
+module.exports = {
+    USER_PROFILES_BUCKET,
+    belongsToCompany,
+    requireOwnBucket,
+    requireSafeObjectPath,
+    bucketIdParam,
+    bodyField,
+    queryField,
+};

--- a/Modules/storage/server/controller.js
+++ b/Modules/storage/server/controller.js
@@ -53,49 +53,16 @@ exports.createBucketOnStorage = async(req, res) => {
 }
 
 
-/**
- * @description Get a bucket with the specified bucket id.
- * @param {*} req 
- * @param {*} res
- */
-exports.getBucketOnStorage = (req,res) => {
-    const {bucketId} = req.params;
-
-    if(!bucketId) {
-        return res.status(400).json({
-            success: false,
-            statusText: 'bucketId is required'
-        })
-    }
-
-    const object = {
-        type: dbCollections.BUCKETS,
-        data: [{id : bucketId}]
-    }
-
+exports.getBucketOnStorage = async (req, res) => {
+    const { bucketId } = req.params;
     try {
-        MongoDbCrudOpration("global", object, "find")
-        .then(result => {
-            if(result.length > 0){
-                return res.status(200).json(result)
-            } else {
-                return res.status(400).json({
-                    success: false,
-                    statusText: 'Bucket not found'
-                })
-            }
-        })
-        .catch(err => {
-            return res.status(400).json({
-                success: false,
-                statusText: err
-            })
-        })
+        const bucket = await MongoDbCrudOpration("global", { type: dbCollections.BUCKETS, data: [{ id: bucketId }] }, "findOne");
+        if (!bucket) {
+            return res.status(404).json({ status: false, statusText: 'Bucket not found', message: 'Bucket not found' });
+        }
+        return res.status(200).json({ status: true, statusText: 'Bucket found', data: bucket });
     } catch (error) {
-        return res.status(400).json({
-            success: false,
-            statusText: error
-        })
+        return res.status(400).json({ status: false, statusText: 'Bucket lookup failed', message: error.message });
     }
 }
 
@@ -157,92 +124,30 @@ exports.updateBucketOnStorage = (req,res) => {
 }
 
 
-/**
- * @description This is remove bucket from the database as well as from storage.
- * @param {*} req
- * @param {*} res
- */
-exports.removeBucketOnStorage = (req, res) => {
-    const {bucketId} = req.params;
-    if(!bucketId) {
-        return res.status(400).json({
-            success: false,
-            statusText: 'bucketId is required'
-        })
-    }
-
-    const object = {
-        type: dbCollections.BUCKETS,
-        data: [
-            {
-                id : bucketId
-            }
-        ]
-    }
+exports.removeBucketOnStorage = async (req, res) => {
+    const { bucketId } = req.params;
     try {
-        MongoDbCrudOpration("global", object, "findOneAndDelete")
-       .then(result => {
-            if(result!== null){
-                const bucketDir = path.join(__dirname, '../../../storage', bucketId);
-                if (fs.existsSync(bucketDir)) {
-                    fs.rmdirSync(bucketDir, { recursive: true });
-                    return res.status(200).json({
-                        success: true,
-                        data: result
-                    })
-                } else {
-                    return res.status(400).json({
-                        success: false,
-                        statusText: 'Bucket not found'
-                    })
-                }
-
-            } else {
-                return res.status(400).json({
-                    success: false,
-                    statusText: 'Bucket not found'
-                })
-            }
-        })
-       .catch(err => {
-            return res.status(400).json({
-                success: false,
-                statusText: err
-            })
-        })
+        const removed = await MongoDbCrudOpration("global", { type: dbCollections.BUCKETS, data: [{ id: bucketId }] }, "findOneAndDelete");
+        if (!removed) {
+            return res.status(404).json({ status: false, statusText: 'Bucket not found', message: 'Bucket not found' });
+        }
+        await fs.promises.rm(path.join(__dirname, '../../../storage', bucketId), { recursive: true, force: true });
+        return res.status(200).json({ status: true, statusText: 'Bucket removed', data: removed });
     } catch (error) {
-        return res.status(400).json({
-            success: false,
-            statusText: error
-        })
+        return res.status(400).json({ status: false, statusText: 'Bucket removal failed', message: error.message });
     }
 }
 
 
-/**
- * @description Get Bucket size with Bucket id in server storage derectory.
- * @param {*} req
- * @param {*} res
- */
-exports.getBucketSizeOnStorage = (req,res) =>{
-    const {bucketId} = req.params;
-    const {unit = ''} = req.query;
-
-    if(!bucketId) {
-        return res.status(400).json({
-            success: false,
-            statusText: 'bucketId is required'
-        })
+exports.getBucketSizeOnStorage = async (req, res) => {
+    const { bucketId } = req.params;
+    const { unit = '' } = req.query;
+    try {
+        const size = await getBucketSizeCompanyWiseStorage(bucketId, unit);
+        return res.status(200).json({ status: true, statusText: 'Bucket size', data: size });
+    } catch (error) {
+        return res.status(400).json({ status: false, statusText: 'Bucket size failed', message: error.message || String(error.statusText || error) });
     }
-
-    getBucketSizeCompanyWiseStorage(bucketId, unit).then((res)=>{
-        return res.status(200).json({...res})
-    }).catch((err)=>{
-        return res.status(400).json({
-            success: false,
-            statusText: err
-        })
-    })
 }
 
 /**

--- a/Modules/storage/server/routes.js
+++ b/Modules/storage/server/routes.js
@@ -1,29 +1,26 @@
 const { handleProfileGetForUser, handleTaskTypeImageGet } = require(`../../../common-storage/common-${process.env.STORAGE_TYPE}.js`);
 const ctrl = require('./controller');
 const { upload, validatePath } = require('./helpers/bucket.helper');
+const { requireInstanceAdmin } = require('../../Instance/guard');
+const { requireOwnBucket, requireSafeObjectPath, bucketIdParam, bodyField, queryField } = require('../bucketAccess');
 
 exports.init = (app) => {
-    //Create Bucket Route
-    app.post('/api/v1/createBucket', ctrl.createBucketOnStorage);
-    //Update Bucket Route
-    app.patch('/api/v1/updateBucket/:bucketId', ctrl.updateBucketOnStorage);
-    //Get Bucket Route
-    app.get('/api/v1/getBucket/:bucketId', ctrl.getBucketOnStorage);
-    //Remove Bucket Route
-    app.delete('/api/v1/removeBucket/:bucketId', ctrl.removeBucketOnStorage);
-    //Get Bucket Size with bucket Id
-    app.get('/api/v1/getBucketSize/:bucketId', ctrl.getBucketSizeOnStorage);
+    const ownBucket = requireOwnBucket(bucketIdParam);
+    const ownOrProfileBucket = requireOwnBucket(bucketIdParam, { allowUserProfiles: true });
 
-    //Create Bucket Route
-    app.post('/api/v1/storage/uploadFile',upload.single("file"),validatePath, ctrl.uploadFileOnStorage);
-    //Generate Signed or public url
-    app.get('/api/v1/generateSignedUrl/:bucketId', ctrl.getSignedUrlFile);
-    //Download File Route
+    // No app screen manages buckets: a company's bucket is created with the company.
+    app.post('/api/v1/createBucket', requireInstanceAdmin, requireOwnBucket(bodyField('bucketId')), ctrl.createBucketOnStorage);
+    app.patch('/api/v1/updateBucket/:bucketId', requireInstanceAdmin, ownBucket, ctrl.updateBucketOnStorage);
+    app.get('/api/v1/getBucket/:bucketId', ownBucket, ctrl.getBucketOnStorage);
+    app.delete('/api/v1/removeBucket/:bucketId', requireInstanceAdmin, ownBucket, ctrl.removeBucketOnStorage);
+    app.get('/api/v1/getBucketSize/:bucketId', ownBucket, ctrl.getBucketSizeOnStorage);
+
+    app.post('/api/v1/storage/uploadFile', upload.single("file"), validatePath, ctrl.uploadFileOnStorage);
+    app.get('/api/v1/generateSignedUrl/:bucketId', ownOrProfileBucket, requireSafeObjectPath(queryField('filepath')), ctrl.getSignedUrlFile);
     app.get('/api/v1/download/:bucketId/*', ctrl.handleFileRequest);
-    //Remove file from storage]
-    app.delete('/api/v1/storage/removeFile/:bucketId', ctrl.removeFileFromStorage);
+    app.delete('/api/v1/storage/removeFile/:bucketId', ownOrProfileBucket, requireSafeObjectPath(queryField('filepath')), ctrl.removeFileFromStorage);
 
-    app.post("/api/v1/getUserProfile", handleProfileGetForUser);
-    app.post("/api/v1/getTaskTypeImage", handleTaskTypeImageGet);
-    app.post('/api/v1/storage/uploadFileBase64',ctrl.uploadBase64FileOnServerStorage);
+    app.post("/api/v1/getUserProfile", requireSafeObjectPath(bodyField('path')), handleProfileGetForUser);
+    app.post("/api/v1/getTaskTypeImage", requireOwnBucket(bodyField('companyId')), requireSafeObjectPath(bodyField('path')), handleTaskTypeImageGet);
+    app.post('/api/v1/storage/uploadFileBase64', requireOwnBucket(bodyField('companyId'), { allowUserProfiles: true }), requireSafeObjectPath(bodyField('path')), ctrl.uploadBase64FileOnServerStorage);
 }

--- a/Modules/storage/wasabi/routes.js
+++ b/Modules/storage/wasabi/routes.js
@@ -2,6 +2,7 @@ const { handleProfileGetForUser, handleTaskTypeImageGet } = require(`../../../co
 const ctrl = require('./controller');
 const multer = require("multer");
 const { DEFAULT_LIMITS, safeFileFilter } = require('../../../utils/uploadConfig');
+const { requireOwnBucket, bodyField } = require('../bucketAccess');
 
 
 const upload = multer({
@@ -219,5 +220,5 @@ exports.init = (app) => {
      */
 	app.post("/api/v1/wasabi/deleteFile", ctrl.deleteFileWasabi);
     app.post("/api/v1/getUserProfile", handleProfileGetForUser);
-    app.post("/api/v1/getTaskTypeImage", handleTaskTypeImageGet);
+    app.post("/api/v1/getTaskTypeImage", requireOwnBucket(bodyField("companyId")), handleTaskTypeImageGet);
 }

--- a/tests/integration/storage-tenant.int.test.js
+++ b/tests/integration/storage-tenant.int.test.js
@@ -1,0 +1,121 @@
+const crypto = require('node:crypto');
+const { createApiClient } = require('../../e2e/support/api');
+const { loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anon = createApiClient({ baseURL: state.baseURL });
+const COMPANY_A = state.companyId;
+const TASK_TYPE_IMAGE = 'setting/task_type/task.png';
+
+/* The harness seeds one company and no pre-provisioned ones, so /api/v2/company/create
+ * answers "Predefine company not found". Company B is an id outside every fixture
+ * user's token; tests/storage-bucket-access.test.js covers two real memberships. */
+const COMPANY_B = crypto.randomBytes(12).toString('hex');
+
+describe('anonymous callers', () => {
+    it.each([
+        ['GET', `/api/v1/getBucket/${COMPANY_A}`],
+        ['GET', `/api/v1/getBucketSize/${COMPANY_A}`],
+        ['DELETE', `/api/v1/removeBucket/${COMPANY_A}`],
+        ['GET', `/api/v1/generateSignedUrl/${COMPANY_A}?filepath=${TASK_TYPE_IMAGE}`],
+    ])('get 401 from %s %s', async (method, url) => {
+        const res = await anon.request(method, url);
+        expect(res.status).toBe(401);
+    });
+
+    it('get 401 from POST /api/v1/getTaskTypeImage (TSK-04)', async () => {
+        const res = await anon.post('/api/v1/getTaskTypeImage', { companyId: COMPANY_A, path: TASK_TYPE_IMAGE });
+        expect(res.status).toBe(401);
+        expect(JSON.stringify(res.body)).not.toContain('token=');
+    });
+
+    it('get 401 from POST /api/v1/getUserProfile (TSK-04)', async () => {
+        const res = await anon.post('/api/v1/getUserProfile', { path: 'avatar.png' });
+        expect(res.status).toBe(401);
+        expect(JSON.stringify(res.body)).not.toContain('token=');
+    });
+});
+
+describe('a user of company A asking for company B (TSK-03)', () => {
+    it.each(['owner', 'admin', 'member', 'guest'])('%s is refused every read of company B', async (role) => {
+        const { api } = await loginAs(role);
+        expect((await api.get(`/api/v1/getBucket/${COMPANY_B}`)).status).toBe(403);
+        expect((await api.get(`/api/v1/getBucketSize/${COMPANY_B}`)).status).toBe(403);
+        expect((await api.get(`/api/v1/generateSignedUrl/${COMPANY_B}`, { query: { filepath: TASK_TYPE_IMAGE } })).status).toBe(403);
+        expect((await api.withCompany(COMPANY_B).get(`/api/v1/getBucket/${COMPANY_B}`)).status).toBe(403);
+    });
+
+    it('member cannot mint a signed URL for company B through getTaskTypeImage', async () => {
+        const { api } = await loginAs('member');
+        const res = await api.post('/api/v1/getTaskTypeImage', { companyId: COMPANY_B, path: TASK_TYPE_IMAGE });
+        expect(res.status).toBe(403);
+        expect(JSON.stringify(res.body)).not.toContain('token=');
+    });
+
+    it.each(['owner', 'member'])('%s cannot change, delete from or remove company B', async (role) => {
+        const { api } = await loginAs(role);
+        expect((await api.patch(`/api/v1/updateBucket/${COMPANY_B}`, { rule: { isPrivate: false } })).status).toBe(403);
+        expect((await api.delete(`/api/v1/storage/removeFile/${COMPANY_B}`, { query: { filepath: TASK_TYPE_IMAGE } })).status).toBe(403);
+        expect((await api.delete(`/api/v1/removeBucket/${COMPANY_B}`)).status).toBe(403);
+    });
+
+    it('member cannot climb out of their own bucket with a relative path', async () => {
+        const { api } = await loginAs('member');
+        const escape = `../${COMPANY_B}/${TASK_TYPE_IMAGE}`;
+        expect((await api.get(`/api/v1/generateSignedUrl/${COMPANY_A}`, { query: { filepath: escape } })).status).toBe(400);
+        expect((await api.delete(`/api/v1/storage/removeFile/${COMPANY_A}`, { query: { filepath: escape } })).status).toBe(400);
+        expect((await api.post('/api/v1/getTaskTypeImage', { companyId: COMPANY_A, path: escape })).status).toBe(400);
+        expect((await api.post('/api/v1/getUserProfile', { path: escape })).status).toBe(400);
+    });
+});
+
+describe('changing or removing the own company bucket', () => {
+    it.each(['admin', 'member', 'guest'])('is refused to a company %s', async (role) => {
+        const owner = await loginAs('owner');
+        const { api } = await loginAs(role);
+        expect((await api.patch(`/api/v1/updateBucket/${COMPANY_A}`, { rule: { isPrivate: false } })).status).toBe(403);
+        expect((await api.delete(`/api/v1/removeBucket/${COMPANY_A}`)).status).toBe(403);
+
+        const after = await owner.api.get(`/api/v1/getBucket/${COMPANY_A}`);
+        expect(after.status).toBe(200);
+        expect(after.body.data.rule.isPrivate).toBe(true);
+    });
+});
+
+describe('own-company flows still work', () => {
+    it('owner reads their bucket and its size', async () => {
+        const { api } = await loginAs('owner');
+        const bucket = await api.get(`/api/v1/getBucket/${COMPANY_A}`);
+        expect(bucket.status).toBe(200);
+        expect(bucket.body).toMatchObject({ status: true, data: { id: COMPANY_A } });
+
+        const size = await api.get(`/api/v1/getBucketSize/${COMPANY_A}`, { query: { unit: 'MB' } });
+        expect(size.status).toBe(200);
+        expect(size.body).toMatchObject({ status: true, data: { unit: 'MB' } });
+    });
+
+    it('member mints a signed URL for their company image and downloads it', async () => {
+        const { api } = await loginAs('member');
+        const res = await api.get(`/api/v1/generateSignedUrl/${COMPANY_A}`, { query: { filepath: TASK_TYPE_IMAGE, domainUrl: state.baseURL } });
+        expect(res.status).toBe(200);
+        const file = await fetch(res.body.url);
+        expect(file.status).toBe(200);
+    });
+
+    it('member gets a task type image URL for their own company and downloads it', async () => {
+        const { api } = await loginAs('member');
+        const res = await api.post('/api/v1/getTaskTypeImage', { companyId: COMPANY_A, path: TASK_TYPE_IMAGE });
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(true);
+        const file = await fetch(res.body.statusText);
+        expect(file.status).toBe(200);
+    });
+
+    it('a signed-in user without a company header gets a profile image URL', async () => {
+        const member = await loginAs('member');
+        const noCompany = createApiClient({ baseURL: state.baseURL, accessToken: member.accessToken });
+        const res = await noCompany.post('/api/v1/getUserProfile', { path: 'avatar.png' });
+        expect(res.status).toBe(200);
+        expect(res.body.statusText).toContain('/api/v1/download/USER_PROFILES/avatar.png?token=');
+    });
+});

--- a/tests/integration/tasks.int.test.js
+++ b/tests/integration/tasks.int.test.js
@@ -151,7 +151,7 @@ describe('tasks & collaboration — confirmed findings (regressions)', () => {
     });
 
     // TSK-04
-    it.failing('TSK-04: requires auth for POST /api/v1/getTaskTypeImage', async () => {
+    it('TSK-04: requires auth for POST /api/v1/getTaskTypeImage', async () => {
         const res = await anon.post('/api/v1/getTaskTypeImage', { companyId: state.companyId, path: 'setting/task_type/task.png' });
         expect(res.status).toBe(401);
     });

--- a/tests/storage-bucket-access.test.js
+++ b/tests/storage-bucket-access.test.js
@@ -1,0 +1,82 @@
+jest.mock('../Config/jwt', () => ({ verifyCompanyMembership: jest.fn() }));
+
+const { verifyCompanyMembership } = require('../Config/jwt');
+const { requireOwnBucket, requireSafeObjectPath, bucketIdParam, bodyField, queryField } = require('../Modules/storage/bucketAccess');
+
+const COMPANY_A = '64b1f0c2a1b2c3d4e5f60718';
+const COMPANY_B = '64b1f0c2a1b2c3d4e5f60719';
+const USER_OF_A = '64b1f0c2a1b2c3d4e5f607aa';
+
+const members = { [USER_OF_A]: [COMPANY_A] };
+
+function run(middleware, req) {
+    return new Promise((resolve) => {
+        const res = {
+            statusCode: 200,
+            status(code) { this.statusCode = code; return this; },
+            json(body) { resolve({ nextCalled: false, status: this.statusCode, body }); return this; },
+        };
+        Promise.resolve(middleware(req, res, () => resolve({ nextCalled: true }))).catch((error) => resolve({ error }));
+    });
+}
+
+beforeEach(() => {
+    verifyCompanyMembership.mockReset();
+    verifyCompanyMembership.mockImplementation(async (uid, companyId) => (members[uid] || []).includes(companyId));
+});
+
+describe('requireOwnBucket', () => {
+    const ownBucket = requireOwnBucket(bucketIdParam);
+
+    it('answers 401 when no session was verified', async () => {
+        const out = await run(ownBucket, { params: { bucketId: COMPANY_A } });
+        expect(out).toMatchObject({ nextCalled: false, status: 401, body: { status: false } });
+    });
+
+    it('lets a member reach their own company bucket', async () => {
+        const out = await run(ownBucket, { uid: USER_OF_A, aud: COMPANY_A, params: { bucketId: COMPANY_A } });
+        expect(out.nextCalled).toBe(true);
+    });
+
+    it('refuses company A asking for company B', async () => {
+        const out = await run(ownBucket, { uid: USER_OF_A, aud: COMPANY_A, params: { bucketId: COMPANY_B } });
+        expect(out).toMatchObject({ nextCalled: false, status: 403, body: { status: false } });
+        expect(verifyCompanyMembership).not.toHaveBeenCalled();
+    });
+
+    it('refuses a company still in a stale token audience once membership is gone', async () => {
+        const out = await run(ownBucket, { uid: USER_OF_A, aud: `${COMPANY_A},${COMPANY_B}`, params: { bucketId: COMPANY_B } });
+        expect(out.status).toBe(403);
+        expect(verifyCompanyMembership).toHaveBeenCalledWith(USER_OF_A, COMPANY_B);
+    });
+
+    it.each(['USER_PROFILES', '.*', '', `../${COMPANY_A}`, `${COMPANY_A},${COMPANY_B}`])('refuses %p as a company bucket', async (bucketId) => {
+        const out = await run(ownBucket, { uid: USER_OF_A, aud: `${COMPANY_A},${COMPANY_B}`, params: { bucketId } });
+        expect(out.status).toBe(403);
+    });
+
+    it('lets USER_PROFILES through only where the route allows the shared profile bucket', async () => {
+        const profiles = requireOwnBucket(bucketIdParam, { allowUserProfiles: true });
+        expect((await run(profiles, { uid: USER_OF_A, aud: COMPANY_A, params: { bucketId: 'USER_PROFILES' } })).nextCalled).toBe(true);
+        expect((await run(profiles, { uid: USER_OF_A, aud: COMPANY_A, params: { bucketId: COMPANY_B } })).status).toBe(403);
+    });
+
+    it('reads the company from the body for the signing routes', async () => {
+        const fromBody = requireOwnBucket(bodyField('companyId'));
+        expect((await run(fromBody, { uid: USER_OF_A, aud: COMPANY_A, body: { companyId: COMPANY_A } })).nextCalled).toBe(true);
+        expect((await run(fromBody, { uid: USER_OF_A, aud: COMPANY_A, body: { companyId: COMPANY_B } })).status).toBe(403);
+    });
+});
+
+describe('requireSafeObjectPath', () => {
+    const safePath = requireSafeObjectPath(queryField('filepath'));
+
+    it('accepts a path inside the bucket', async () => {
+        expect((await run(safePath, { query: { filepath: 'setting/task_type/task.png' } })).nextCalled).toBe(true);
+    });
+
+    it.each([`../${COMPANY_B}/secret.png`, 'a/../../b', '/etc/passwd', '\\share', '', undefined])('refuses %p', async (filepath) => {
+        const out = await run(safePath, { query: { filepath } });
+        expect(out).toMatchObject({ nextCalled: false, status: 400 });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two HIGH findings from QA task 034 (`Tasks/active/034-end-to-end-qa-programme/findings/tasks.md`).

- **TSK-03:** storage bucket routes had no tenant binding. `getBucket`, `getBucketSize` and `removeBucket` acted on any `:bucketId`, and `requireCompanyAud` never looked at that path param.
- **TSK-04:** `POST /api/v1/getUserProfile` and `POST /api/v1/getTaskTypeImage` were in neither JWT list, so anyone could mint a valid signed download URL for any company.

#600 (`fix/unauthenticated-v1-routes`) has since merged and already puts both TSK-04 routes behind a session, and it keeps downloads and `removeFile` inside their bucket with `resolveBucketFile`. This PR builds on that: it binds every bucket route and both signing routes to the caller's own company, which #600 does not do, and it flips the TSK-04 `it.failing` case in `tests/integration/tasks.int.test.js` to `it`.

## How a bucket maps to a company

A company's bucket id is the company `_id`. It is created with the company (`createCompanyDataStorage` → `createBucketHelper`), recorded in the global `buckets` collection as `{ id, rule }`, and stored on disk under `storage/<companyId>`. The only other bucket is the shared `USER_PROFILES` bucket for profile pictures.

## The fix

New `Modules/storage/bucketAccess.js`:

- `requireOwnBucket` lets a request through only when the bucket id is a company id listed in the caller's login token **and** the caller is still a member of that company right now (`verifyCompanyMembership`), so a user removed since login is locked out too. Otherwise it answers 403, or 401 with no session.
- `requireSafeObjectPath` rejects object paths that could climb out of the bucket (`..`, leading `/` or `\`). Without it, a caller could reach company B's files through their own bucket with `filepath=../<B>/...`.

| Route | Before | After | Caller impact |
|---|---|---|---|
| `GET /api/v1/getBucket/:bucketId` | any logged-in user, any bucket | own company only; standard response shape | none (no app caller) |
| `GET /api/v1/getBucketSize/:bucketId` | any bucket; never answered (a variable named `res` hid the response) | own company only; answers `{ status, data: { size, unit } }` | none (no app caller) |
| `DELETE /api/v1/removeBucket/:bucketId` | any user deleted any bucket and its folder | instance owner **and** a member of that company | none (no app caller, so no confirmation parameter) |
| `PATCH /api/v1/updateBucket/:bucketId` | any user could make another company's bucket public | instance owner and a member of that company | none (no app caller) |
| `POST /api/v1/createBucket` | any bucket name | instance owner, own company id only | none (company creation calls the helper directly) |
| `GET /api/v1/generateSignedUrl/:bucketId` | signed any bucket | own company or `USER_PROFILES`; safe path | web image loading, always the viewer's own company, so no change |
| `DELETE /api/v1/storage/removeFile/:bucketId` | any bucket | own company or `USER_PROFILES`; safe path | company logo and profile photo replace, unchanged |
| `POST /api/v1/storage/uploadFileBase64` | companyId checked against the token only; path unchecked | live membership as well; safe path | profile photo upload, unchanged |
| `GET /api/v1/download/:bucketId/*` | unchanged here (#600 contains it with `resolveBucketFile`) | unchanged | none |
| `POST /api/v1/getUserProfile` | logged in since #600, any path | also refuses paths that climb out of `USER_PROFILES` | desktop tracker `getUserImage` already sends a Bearer token |
| `POST /api/v1/getTaskTypeImage` (server and wasabi) | logged in since #600, but it still signed any body `companyId` | the caller must be a member of that company; safe path | none (no app caller) |

No page loads these images without a session. Emails use signed URLs created on the server (`getWasabiImageUrl` calls the wasabi signer directly, not over HTTP), so nothing had to move to server-side signing.

## Tests

- `tests/storage-bucket-access.test.js` (unit, two companies), 18 tests: anonymous 401; company A asking for company B 403; a stale token audience refused once membership is gone; non-company bucket ids refused; `USER_PROFILES` allowed only where the route permits it; path escapes refused.
- `tests/integration/storage-tenant.int.test.js`:
  - anonymous callers get 401 on every route, and the two TSK-04 routes return no signed URL;
  - owner, admin, member and guest of company A are refused company B's bucket reads, `generateSignedUrl` (also with a `companyid` header for B), and `getTaskTypeImage`;
  - the owner (even as instance owner) and a member are refused `updateBucket`, `removeFile` and `removeBucket` on company B;
  - relative-path escapes out of the caller's own bucket are refused;
  - admin, member and guest cannot make their own company's bucket public or remove it, and the bucket stays private;
  - own-company flows still work: bucket read and size, signed URL plus download, task type image URL plus download, and a profile image URL without a company header.

  The harness seeds one company and no spare companies (those come only from `setPresetCompany` with a random key the tests never see), so `/api/v2/company/create` cannot make a second one there. Company B in the integration test is an id outside every fixture user's token. The case of a user who really belongs to two companies is covered in the unit test.

Gates, run on this branch rebased onto beta (with #598, #600, #601 and #602 merged):

- `npx jest --selectProjects unit`: 186 suites, 2327 tests passed.
- `npx jest --selectProjects conventions`: 8 suites, 94 tests passed.
- `npm run test:integration` (local Mongo 7): 9 suites, 260 tests: 240 passed, 20 failed. None of the failures are in `storage-tenant.int.test.js`, and none touch a storage route; they are listed below.
- `tests/integration/storage-tenant.int.test.js` run alone: 21 of 21 passed.
- eslint on the touched files: 0 errors.
- Frontend not touched, so no vitest run.

Two notes on the integration suite, neither caused by this PR:

- Some `it.failing` cases now fail because other merged PRs fixed their bugs, and those files belong to other fix branches:
  - `AUT-01` in `automations.int.test.js` (#600 guarded `Modules/AI/routes.js`);
  - `TSK-02` in `tasks.int.test.js` (probably #600's change to `Modules/Tasks/helpers/getTasksData.js`; #606, the dedicated fix, is still open);
  - `MSG-01` in `messages.int.test.js` (source not confirmed);
  - `ACC-01`, `ACC-03`, `ACC-04`, `ACC-07`, `ACC-08` and `ACC-09` in `access.int.test.js` (anonymous routes #600 put behind a session).

  They need flipping to `it` in those areas.
- The local run also had 5-second timeouts in automations, messages and tasks happy-path tests. The machine was running at load 60–118 on 8 CPUs.

`tests/integration/tasks.int.test.js` (from #598): the TSK-04 case is flipped from `it.failing` to `it`, since #600 plus this PR make it pass.

## Not in this PR

- No integration test covers the instance owner successfully removing a bucket: the only harness bucket is the shared fixture company's, and deleting it would break every other test in the run. The route order (`requireInstanceAdmin`, then `requireOwnBucket`) and the refusals are tested.
- `POST /api/v1/storage/uploadFile` (multer) still writes the file before `validatePath` runs, and `validatePath` checks the token audience only, not live membership.
- `USER_PROFILES` is one shared bucket: any logged-in user can still remove or overwrite any profile image path in it. Binding profile paths to their owner needs a path layout that includes the user id.
- `getBucketSizeCompanyWiseStorage` in `bucket.helper.js` has `then(` without a leading dot on its `isUpdate` (cron) branch, so the company `bucketSize` update throws. It is not on a route and is left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
