### PR TITLE
fix(project): refuse project updates from callers outside the project

### DIFF
--- a/Modules/Project/controller/updateProject.js
+++ b/Modules/Project/controller/updateProject.js
@@ -3,6 +3,7 @@ const { MongoDbCrudOpration,validateObjectId } = require("../../../utils/mongo-h
 const {removeCache} = require('../../../utils/commonFunctions');
 const { resolveProjectSkills } = require('../../settings/ProjectSkills/helper');
 const { PROJECT_SOURCES, normaliseSource, sourceOrDefault, cleanProposalId, numericProposalId, validateProposalId } = require('../helpers/projectSourceRules');
+const { canUpdateProject } = require('../helpers/projectUpdateAccess');
 
 exports.updateProjectInternal = async (companyId, projectId, updateObject, key, arrayFilters) => {
     return new Promise((resolve, reject) => {
@@ -133,6 +134,9 @@ exports.updateProject = async (req, res) => {
         }
         if(!companyId){
             return res.status(400).json({ message: "CompanyId is Required" });
+        }
+        if (!(await canUpdateProject({ companyId, uid: req.uid, projectId, updateObject, key }))) {
+            return res.status(403).json({ status: false, statusText: "You do not have permission to update this project." });
         }
         // Single write path for every client, so `skills` is validated here.
         // $addToSet/$push send a bare value that would land as a nested array

--- a/Modules/Project/helpers/projectUpdateAccess.js
+++ b/Modules/Project/helpers/projectUpdateAccess.js
@@ -1,0 +1,53 @@
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+const { getRoleType, isPrivileged } = require('../../../Config/permissionGuard');
+
+const TEAM_PREFIX = 'tId_';
+const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
+
+// Starring and watching write the caller's own entry on the project document, and the
+// web app offers both on every project a member can see, assigned or not.
+const isOwnPreferenceUpdate = (uid, updateObject, key) => {
+    const fields = Object.keys(updateObject || {});
+    return fields.length > 0 && fields.every((field) => {
+        const value = updateObject[field];
+        if (field === 'favouriteTasks') {
+            return (key === '$addToSet' || key === '$pull')
+                && Boolean(value) && typeof value === 'object'
+                && Object.keys(value).length === 1 && String(value.userId) === uid;
+        }
+        return field === `watchers.${uid}` && (!key || key === '$set' || key === '$unset');
+    });
+};
+
+const isAssigned = async (companyId, uid, assigneeUserId) => {
+    const assignees = (Array.isArray(assigneeUserId) ? assigneeUserId : []).map(String);
+    if (assignees.includes(uid)) return true;
+    const teamIds = assignees
+        .filter((id) => id.startsWith(TEAM_PREFIX))
+        .map((id) => id.slice(TEAM_PREFIX.length))
+        .filter((id) => OBJECT_ID_PATTERN.test(id));
+    if (!teamIds.length) return false;
+    const team = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.TEAMS_MANAGEMENT,
+        data: [{ _id: { $in: teamIds }, assigneeUsersArray: { $in: [uid] } }, { _id: 1 }],
+    }, 'findOne');
+    return Boolean(team);
+};
+
+const canUpdateProject = async ({ companyId, uid, projectId, updateObject, key }) => {
+    if (!uid) return false;
+    const caller = String(uid);
+    const roleType = await getRoleType(companyId, caller);
+    if (roleType === null) return false;
+    if (isPrivileged(roleType)) return true;
+    if (isOwnPreferenceUpdate(caller, updateObject, key)) return true;
+    const project = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.PROJECTS,
+        data: [{ _id: projectId }, { AssigneeUserId: 1 }],
+    }, 'findOne');
+    if (!project) return false;
+    return isAssigned(companyId, caller, project.AssigneeUserId);
+};
+
+module.exports = { canUpdateProject, isOwnPreferenceUpdate };

--- a/tests/integration/smoke.int.test.js
+++ b/tests/integration/smoke.int.test.js
@@ -33,9 +33,7 @@ describe('projects', () => {
         expect(res.body.map((project) => project._id)).toContain(state.projects.shared._id);
     });
 
-    // Known gap: PUT /api/v1/project/:id checks no project membership for a web session,
-    // so today the member's edit lands. Flip to it() once the route enforces it.
-    it.failing('refuses a member editing a project they are not in', async () => {
+    it('refuses a member editing a project they are not in', async () => {
         const owner = await loginAs('owner');
         const member = await loginAs('member');
         const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid, isPrivate: true });

--- a/tests/project-update-access.test.js
+++ b/tests/project-update-access.test.js
@@ -1,0 +1,127 @@
+const mongoose = require('mongoose');
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(), validateObjectId: jest.fn(() => true) }));
+jest.mock('../Config/permissionGuard', () => ({ getRoleType: jest.fn(), isPrivileged: (roleType) => roleType === 1 || roleType === 2 }));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+jest.mock('../Modules/settings/ProjectSkills/helper', () => ({ resolveProjectSkills: jest.fn() }));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { getRoleType } = require('../Config/permissionGuard');
+const { canUpdateProject, isOwnPreferenceUpdate } = require('../Modules/Project/helpers/projectUpdateAccess');
+const { updateProject } = require('../Modules/Project/controller/updateProject');
+
+const COMPANY = 'c1';
+const UID = new mongoose.Types.ObjectId().toString();
+const OTHER = new mongoose.Types.ObjectId().toString();
+const TEAM = new mongoose.Types.ObjectId().toString();
+const PROJECT = new mongoose.Types.ObjectId().toString();
+
+const rename = { ProjectName: 'Renamed' };
+const access = (over = {}) => canUpdateProject({ companyId: COMPANY, uid: UID, projectId: PROJECT, updateObject: rename, key: '', ...over });
+
+const stubMongo = ({ project = null, team = null } = {}) => {
+    MongoDbCrudOpration.mockImplementation(async (companyId, { type }) => {
+        if (type === 'projects') return project;
+        if (type === 'teams_management') return team;
+        return { _id: PROJECT };
+    });
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    getRoleType.mockResolvedValue(3);
+});
+
+describe('canUpdateProject', () => {
+    test.each([1, 2])('lets roleType %i edit without reading the project', async (roleType) => {
+        getRoleType.mockResolvedValue(roleType);
+        await expect(access()).resolves.toBe(true);
+        expect(MongoDbCrudOpration).not.toHaveBeenCalled();
+    });
+
+    test('refuses a caller who is not in the company', async () => {
+        getRoleType.mockResolvedValue(null);
+        await expect(access()).resolves.toBe(false);
+    });
+
+    test('refuses a request without a user', async () => {
+        await expect(access({ uid: undefined })).resolves.toBe(false);
+        expect(getRoleType).not.toHaveBeenCalled();
+    });
+
+    test('lets a directly assigned member edit', async () => {
+        stubMongo({ project: { AssigneeUserId: [OTHER, UID] } });
+        await expect(access()).resolves.toBe(true);
+    });
+
+    test('refuses a member who is not assigned', async () => {
+        stubMongo({ project: { AssigneeUserId: [OTHER] } });
+        await expect(access()).resolves.toBe(false);
+    });
+
+    test('refuses when the project does not exist', async () => {
+        stubMongo({ project: null });
+        await expect(access()).resolves.toBe(false);
+    });
+
+    test('lets a member of an assigned team edit', async () => {
+        stubMongo({ project: { AssigneeUserId: [OTHER, `tId_${TEAM}`] }, team: { _id: TEAM } });
+        await expect(access()).resolves.toBe(true);
+        const teamCall = MongoDbCrudOpration.mock.calls.find(([, query]) => query.type === 'teams_management');
+        expect(teamCall[1].data[0]).toEqual({ _id: { $in: [TEAM] }, assigneeUsersArray: { $in: [UID] } });
+    });
+
+    test('refuses when no assigned team holds the caller', async () => {
+        stubMongo({ project: { AssigneeUserId: [`tId_${TEAM}`] }, team: null });
+        await expect(access()).resolves.toBe(false);
+    });
+
+    test('lets any member star, unstar and watch for themself', async () => {
+        stubMongo({ project: { AssigneeUserId: [OTHER] } });
+        await expect(access({ updateObject: { favouriteTasks: { userId: UID } }, key: '$addToSet' })).resolves.toBe(true);
+        await expect(access({ updateObject: { favouriteTasks: { userId: UID } }, key: '$pull' })).resolves.toBe(true);
+        await expect(access({ updateObject: { [`watchers.${UID}`]: 'all_activity' } })).resolves.toBe(true);
+        await expect(access({ updateObject: { [`watchers.${UID}`]: 1 }, key: '$unset' })).resolves.toBe(true);
+    });
+});
+
+describe('isOwnPreferenceUpdate', () => {
+    test('rejects entries for another user', () => {
+        expect(isOwnPreferenceUpdate(UID, { favouriteTasks: { userId: OTHER } }, '$addToSet')).toBe(false);
+        expect(isOwnPreferenceUpdate(UID, { [`watchers.${OTHER}`]: 'all_activity' }, '')).toBe(false);
+    });
+
+    test('rejects a preference bundled with a project field', () => {
+        expect(isOwnPreferenceUpdate(UID, { favouriteTasks: { userId: UID }, ProjectName: 'x' }, '$addToSet')).toBe(false);
+        expect(isOwnPreferenceUpdate(UID, { [`watchers.${UID}`]: 'all_activity', ProjectName: 'x' }, '')).toBe(false);
+    });
+
+    test('rejects replacing the whole list or smuggling extra keys', () => {
+        expect(isOwnPreferenceUpdate(UID, { favouriteTasks: { userId: UID } }, '$set')).toBe(false);
+        expect(isOwnPreferenceUpdate(UID, { favouriteTasks: { userId: UID, pinned: true } }, '$addToSet')).toBe(false);
+        expect(isOwnPreferenceUpdate(UID, { watchers: { [UID]: 'all_activity' } }, '')).toBe(false);
+    });
+});
+
+describe('PUT /api/v1/project/:id', () => {
+    const mockRes = () => ({ status: jest.fn().mockReturnThis(), json: jest.fn() });
+    const request = (updateObject) => ({ params: { id: PROJECT }, body: { updateObject }, headers: { companyid: COMPANY }, uid: UID });
+
+    test('answers 403 in the standard shape and writes nothing', async () => {
+        stubMongo({ project: { AssigneeUserId: [OTHER] } });
+        const res = mockRes();
+        await updateProject(request(rename), res);
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({ status: false, statusText: 'You do not have permission to update this project.' });
+        expect(MongoDbCrudOpration.mock.calls.some(([, , op]) => op === 'findOneAndUpdate')).toBe(false);
+    });
+
+    test('lets an assignee through to the write', async () => {
+        stubMongo({ project: { AssigneeUserId: [UID] } });
+        const res = mockRes();
+        await updateProject(request(rename), res);
+        await new Promise(setImmediate);
+        expect(MongoDbCrudOpration.mock.calls.some(([, , op]) => op === 'findOneAndUpdate')).toBe(true);
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+});


### PR DESCRIPTION
## Summary

`PUT /api/v1/project/:id` only checked the JWT and company audience, so any company member could edit any project. On the E2E harness a member (roleType 3) not assigned to a private project renamed it (HTTP 200). The route now refuses such callers with `403 { status: false, statusText }`.

Allowed through:
- owner / admin (roleType 1 / 2);
- a direct assignee (`AssigneeUserId` holds the caller's uid);
- a member of an assigned team (`tId_<teamId>` in `AssigneeUserId`, the same convention as `getProjectList.js`);
- **any company member** when the request touches only their own per-user entry: `favouriteTasks` with `{ userId: <self> }` via `$addToSet` / `$pull` (star / unstar), or `watchers.<self>` via `$set` / `$unset` (watch). The web app offers both on every project a member can see, including public projects they are not assigned to.

Everything else (name, status, close / archive / delete, attachments, views, `viewColumn`, assignees, custom fields, permissions, privacy) requires assignment. `markAsStar` is only written at creation and is not per-user.

The check lives in `Modules/Project/helpers/projectUpdateAccess.js` and reuses `getRoleType` / `isPrivileged` from `Config/permissionGuard.js`. It applies to web sessions and API tokens alike. Internal callers of `updateProjectInternal` (LogTime, Milestone, Trash) are unaffected.

## Type of change

- [x] 🐛 `fix` — Bug fix

## Test plan

- [x] `tests/project-update-access.test.js` (new, unit): role bypass, direct assignee, team assignee, non-member, missing project, own-preference updates, preferences for another user or bundled with a project field, and the controller's 403 shape with no write.
- [x] `npm test` (unit + conventions)
- [x] `npm run e2e:db`, `E2E_MONGODB_URL=mongodb://127.0.0.1:27018`, `npm run test:integration`: `smoke.int.test.js` "refuses a member editing a project they are not in" now runs as `it(...)` and passes.

## Breaking changes

- [x] ⚠️ Yes — a member who is **not assigned** to a **public** project can no longer edit it (rename, status, attachments, list columns, views…) through this route. Before this change the UI allowed that whenever the Security & Permissions matrix did. Starring and watching still work. If non-assigned edits on public projects are meant to be allowed, the guard needs a public-project branch keyed on the permission matrix.

## Notes for reviewers

- Targets `beta` per the current branching practice.
- Project creators are unaffected: `CreateProjectSidebar.vue` always puts the creator in `AssigneeUserId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
