### PR TITLE
fix(access): scope user, company, session and oauth routes (acc-02 to acc-09)

### DIFF
--- a/Config/setMiddleware.js
+++ b/Config/setMiddleware.js
@@ -343,7 +343,7 @@ const verifyJWTToken = [
     "/api/v1/getUserProfile",
     "/api/v1/getTaskTypeImage",
     "/api/v2/auth/:id/change-password",
-    "/api/v2/session/delete/:id",
+    "/api/v2/session/delete",
     "/api/v1/wasabi/retriveUserProfile/:companyId/:path",
     "/api/v1/wasabi/uploadFile",
     "/api/v1/createPaymentPlan",

--- a/Modules/Auth/controller/createUser.js
+++ b/Modules/Auth/controller/createUser.js
@@ -1,7 +1,6 @@
 const logger = require("../../../Config/loggerConfig");
 const mongoRef = require('../../../utils/mongo-handler/mongoQueries');
 const sendMailRef = require("./sendVerificationMail")
-const {generateJWTToken} = require('../../../Config/jwt');
 const { dbCollections } = require('../../../Config/collections');
 const ctr = require("../controller");
 const { SCHEMA_TYPE } = require("../../../Config/schemaType");
@@ -158,57 +157,6 @@ exports.createUserV2 = (req,res) => {
         })
     }
 }
-
-/**
- * Generate JWT Token Function
- * @param {Object} req 
- * @param {Object} res 
- */
-exports.generateToken = async (req, res) => {
-    try {
-
-        if (!(req.body && req.body.uid)) {
-            res.status(400).json({
-                status: false,
-                statusText: "The user id is required."
-            });
-            return;
-        }
-
-        const {uid} = req.body;
-        let object = {
-            type: dbCollections.USERS,
-            data: [
-                {
-                    _id: uid
-                }
-            ]
-        }
-        mongoRef.MongoDbCrudOpration('global', object, "findOne").then(async (response) => {
-            const companyIds = response.AssignCompany && response.AssignCompany.length ? response.AssignCompany : [];
-            const token = await generateJWTToken({uid: uid, companyIds: companyIds});
-            res.json({
-                status: true,
-                statusText: "Jwt token generate successfully.",
-                token: token
-            });
-        }).catch((error) => {
-            logger.error(`Generate Jwt Token Error: ${error}`);
-            res.status(400).json({
-                status: false, 
-                error,
-                statusText: 'User not found.',
-            });
-        })
-    } catch (error) {
-        logger.error(`Generate Jwt Token Error: ${error}`);
-        res.status(400).json({
-            status: false,
-            statusText: "Authentication failed!"
-        });
-    }
-};
-
 
 exports.verifyToken = (req, res) => {
     res.json({

--- a/Modules/Auth/controller/sendInvitation.js
+++ b/Modules/Auth/controller/sendInvitation.js
@@ -542,10 +542,15 @@ exports.checkSendInviatation = (req,res) => {
             res.send({ status: false, statusText: 'email is required' });
             return;
         }
-        if (!(req.body && req.body.companyId)) {
+        const bodyCompanyId = req.body.companyId;
+        const companyId = String(req.headers['companyid'] || bodyCompanyId || '');
+        if (!companyId) {
             res.send({ status: false, statusText: 'companyId is required' });
             return;
-        } 
+        }
+        if (req.headers['companyid'] && bodyCompanyId && String(bodyCompanyId) !== companyId) {
+            return res.status(403).send({ status: false, statusText: 'You do not have access to this company' });
+        }
         let obj = {
             type: dbCollections.COMPANY_USERS,
             data: [
@@ -554,7 +559,7 @@ exports.checkSendInviatation = (req,res) => {
                 },
             ]
         }
-        mongoRef.MongoDbCrudOpration(req.body.companyId, obj, "findOne").then((resp)=>{
+        mongoRef.MongoDbCrudOpration(companyId, obj, "findOne").then((resp)=>{
             if (resp === null || resp?.status === 3) {
                 res.send({
                     status: true,

--- a/Modules/Auth/routes.js
+++ b/Modules/Auth/routes.js
@@ -261,7 +261,7 @@ exports.init = (app) => {
      *          "200":
      *              description: status:true, message:message
      */
-    app.delete('/api/v2/session/delete', requireInstanceAdmin, sessionCtr.deleteAllSession);
+    app.delete('/api/v2/session/delete', sessionCtr.deleteAllSession);
 
 
     /**
@@ -337,7 +337,6 @@ const verifyInvitationCtrl = require("./controller/verifyInvitation");
 const { removeCacheHandler } = require('./controller/removeCache');
 const { mongoOperation } = require('./controller/mongoOperation');
 const { invitationPreview } = require('./controller/invitationPreview');
-const { requireInstanceAdmin } = require('../Instance/guard');
 const { handleEvents } = require('../Company/eventController');
 function initSignup(app) {
     app.post("/api/v2/createUser", createUserCtrl.createUserV2);

--- a/Modules/Auth/session.js
+++ b/Modules/Auth/session.js
@@ -118,28 +118,6 @@ exports.updateSession = (req, res) => {
         res.status(400).json({message: error.message ? error.message : error});
     }
 }
-/**
- * Register Sesstion
- * @param {Object} req 
- * @param {Object} res 
- */
-exports.registerSesstion = (req, res) => {
-    try {
-        const forwarded = req?.headers['x-forwarded-for'] || req.ip;
-        const clientIp = forwarded ? forwarded?.split(',')[0] : req?.connection?.remoteAddress;
-        exports.insertSessionFun(req.body, req.headers['user-agent'] || "", clientIp, (iSessionRes) => {
-            if (iSessionRes.status) {
-                res.status(200).json(iSessionRes)
-                return;
-            }
-            res.status(400).json({message: iSessionRes.message});
-        });
-    } catch (error) {
-        res.status(400).json({message: error.message ? error.message : error});
-    }
-};
-
-
 exports.getSessionwithRefreshTokenFun = (data, cb) => {
     try {
         let obj = {
@@ -176,15 +154,16 @@ exports.getSessionwithRefreshTokenFun = (data, cb) => {
 };
 
 
+// An empty filter here would sign out every user on the instance.
 exports.deleteSessionFun = (id, cb) => {
     try {
+        if (!id) {
+            cb({ status: false, message: "User id is required" });
+            return;
+        }
         let obj = {
             type: dbCollections.SESSIONS,
-            data: [{
-            }]
-        }
-        if (id) {
-            obj.data[0].userId = id;
+            data: [{ userId: String(id) }]
         }
         mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, obj, "deleteMany").then((resData)=>{
             if (!(resData && resData.deletedCount)) {
@@ -210,54 +189,56 @@ exports.deleteSessionFun = (id, cb) => {
     }
 };
 
+const respondDeleted = (res, userId) => (resData) => {
+    if (!(resData && resData.status)) {
+        res.status(400).json({status: false, message: resData.message});
+        return;
+    }
+    removeCache(`session:${userId}:`, true);
+    res.status(200).json(resData);
+};
 
-/**
- * Delete All Session
- * @param {Object} req 
- * @param {Object} res 
- */
 exports.deleteAllSession = (req, res) => {
     try {
-        exports.deleteSessionFun("", (resData) => {
-            if (!(resData && resData.status)) {
-                res.status(400).json({message: resData.message});
-                return;
-            }
-            removeCache(`session:`, true);
-            res.status(200).json(resData);
-        });
+        if (!req.uid) {
+            return res.status(401).json({ status: false, message: "Unauthorized" });
+        }
+        exports.deleteSessionFun(String(req.uid), respondDeleted(res, String(req.uid)));
     } catch (error) {
-        res.status(400).json({message: error.message ? error.message : error});
+        res.status(400).json({status: false, message: error.message ? error.message : error});
     }
 };
 
+const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
 
-/**
- * Delete User Specific Session
- * @param {Object} req 
- * @param {Object} res 
- * @returns 
- */
-exports.deleteUserSpecificSession = (req, res) => {
+exports.canManageUserSessions = async (uid, targetId, companyId) => {
+    if (String(uid) === String(targetId)) return true;
+    if (!OBJECT_ID_PATTERN.test(String(targetId || '')) || !OBJECT_ID_PATTERN.test(String(companyId || ''))) return false;
+    const { getRoleType, isPrivileged, ROLE_OWNER } = require("../../Config/permissionGuard");
+    const callerRole = await getRoleType(companyId, uid);
+    if (!isPrivileged(callerRole)) return false;
+    const targetRole = await getRoleType(companyId, targetId);
+    if (targetRole === null) return false;
+    return callerRole === ROLE_OWNER || targetRole !== ROLE_OWNER;
+};
+
+exports.deleteUserSpecificSession = async (req, res) => {
     try {
+        if (!req.uid) {
+            return res.status(401).json({ status: false, message: "Unauthorized" });
+        }
         if (!(req.params && req.params.id)) {
-            res.status(400).json({message: "User id is required"});
+            res.status(400).json({status: false, message: "User id is required"});
             return;
         }
-        if (String(req.params.id) !== String(req.uid)) {
-            res.status(403).json({message: "You can only end your own sessions."});
-            return;
+        const targetId = String(req.params.id);
+        const allowed = await exports.canManageUserSessions(String(req.uid), targetId, req.headers['companyid']);
+        if (!allowed) {
+            return res.status(403).json({ status: false, message: "You can only sign out your own sessions, or a member of a company you administer." });
         }
-        exports.deleteSessionFun(req.params.id, (resData) => {
-            if (!(resData && resData.status)) {                
-                res.status(400).json({message: resData.message});
-                return;
-            }
-            removeCache(`session:${req.params.id}`, true);
-            res.status(200).json(resData);
-        });
+        exports.deleteSessionFun(targetId, respondDeleted(res, targetId));
     } catch (error) {
-        res.status(400).json({message: error.message ? error.message : error});
+        res.status(400).json({status: false, message: error.message ? error.message : error});
     }
 };
 

--- a/Modules/Company/controller/updateCompany.js
+++ b/Modules/Company/controller/updateCompany.js
@@ -5,11 +5,27 @@ const { MongoDbCrudOpration } = require("../../../utils/mongo-handler/mongoQueri
 const { default: mongoose } = require("mongoose");
 const { replaceObjectKey } = require("../../Auth/helper");
 const socketEmitter = require("../../../event/socketEventEmitter");
+const { isInstanceOwner } = require("../../Instance/guard");
+const { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline } = require("../helpers/companyAccessRules");
+
+const loadOwnCompanyIds = async (uid) => {
+    const user = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+        type: SCHEMA_TYPE.USERS,
+        data: [{ _id: new mongoose.Types.ObjectId(String(uid)) }, { AssignCompany: 1 }]
+    }, 'findOne');
+    return ownCompanyIds(user);
+};
+
+const isInstanceAdminRequest = async (req) => !req.apiToken && isInstanceOwner(req.uid);
+const hasSession = (req) => OBJECT_ID_PATTERN.test(String(req.uid || ''));
 
 exports.updateCompany = async(req,res) => {
     try {
 
         const companyId = req.headers['companyid'] || req.body.companyId;
+        if (!OBJECT_ID_PATTERN.test(String(companyId || ''))) {
+            return res.status(400).json({ status: false, message: 'A valid company id is required' });
+        }
 
         if (!(req.body && req.body.updateObject)) {
             return res.status(400).json({message: 'Update Object is Required'});
@@ -63,12 +79,20 @@ exports.updateCompany = async(req,res) => {
     }
 }
 
-exports.getCompany = (req,res) => {
-    exports.getCompanyDataFun(req.body.companyIds,req.body.fetchAllCompany,req.body.condition).then((data) => {
-        res.json(data);
-    }).catch((error) => {
-        res.json(error);
-    })
+exports.getCompany = async (req,res) => {
+    try {
+        if (!hasSession(req)) return res.status(401).json({ status: false, message: 'Unauthorized' });
+        if (await isInstanceAdminRequest(req)) {
+            return res.json(await exports.getCompanyDataFun(req.body.companyIds, req.body.fetchAllCompany));
+        }
+        if (req.body.fetchAllCompany) {
+            return res.status(403).json({ status: false, message: 'Only the instance owner can list every company.' });
+        }
+        const allowed = allowedCompanyIds(req.body.companyIds, await loadOwnCompanyIds(req.uid));
+        return res.json(await exports.getCompanyDataFun(allowed));
+    } catch (error) {
+        return res.status(500).json({ status: false, message: "An error occurred while getting the company" });
+    }
 }
 
 exports.getCompanyDataFun = async(companyIds,fetchAllCompany = false) => {
@@ -153,26 +177,34 @@ exports.updateCompanyFun = (type,companyObj,method,companyId = "",isSocketUpdate
 
 exports.getCompanyByAggregate = async(req,res) => {
     try {
+        if (!hasSession(req)) return res.status(401).json({ status: false, message: 'Unauthorized' });
         const { findQuery } = req.body;
 
         if (!findQuery) {
             return res.status(400).json({
+                status: false,
                 message: "An error occurred while getting the task.",
                 error: "Query is required."
             });
         }
         const query = replaceObjectKey(findQuery, ["objId"])
-        const cQuery = [query];
+        let pipeline = [query];
+        if (!(await isInstanceAdminRequest(req))) {
+            const own = (await loadOwnCompanyIds(req.uid)).map((id) => new mongoose.Types.ObjectId(id));
+            const scoped = scopeCompanyPipeline(query, own);
+            if (!scoped.ok) return res.status(403).json({ status: false, message: scoped.error });
+            pipeline = scoped.pipeline;
+        }
         const companyObj = {
             type: SCHEMA_TYPE.COMPANIES,
-            data: [cQuery]
+            data: [pipeline]
         };
 
         const response = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL,companyObj, 'aggregate');
 
         return res.status(200).json(response);
     } catch (error) {
-        return res.status(500).json({ message: "An error occurred while fetching the company",error:error });
+        return res.status(500).json({ status: false, message: "An error occurred while fetching the company" });
     }
 }
 

--- a/Modules/Company/helpers/companyAccessRules.js
+++ b/Modules/Company/helpers/companyAccessRules.js
@@ -1,0 +1,36 @@
+const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
+
+const MEMBER_STAGES = ['$match', '$project', '$sort', '$limit', '$skip', '$addFields', '$set', '$unset', '$count'];
+const FORBIDDEN_OPERATORS = ['$where', '$function', '$accumulator', '$lookup', '$graphLookup', '$unionWith', '$out', '$merge'];
+
+const isPlainContainer = (value) => Array.isArray(value)
+    || (value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype);
+
+const containsForbidden = (value) => {
+    if (!isPlainContainer(value)) return false;
+    if (Array.isArray(value)) return value.some(containsForbidden);
+    return Object.entries(value).some(([key, inner]) => FORBIDDEN_OPERATORS.includes(key) || containsForbidden(inner));
+};
+
+const ownCompanyIds = (user) => ((user && user.AssignCompany) || []).map(String).filter((id) => OBJECT_ID_PATTERN.test(id));
+
+const allowedCompanyIds = (requested, own) => {
+    const mine = (own || []).map(String);
+    return [...new Set((Array.isArray(requested) ? requested : []).map(String))].filter((id) => mine.includes(id));
+};
+
+// A member may only shape documents of their own companies: the pipeline is pinned to
+// those ids and may not reach other collections or run server-side JavaScript.
+const scopeCompanyPipeline = (findQuery, own) => {
+    const stages = Array.isArray(findQuery) ? findQuery : [findQuery];
+    for (const stage of stages) {
+        const keys = stage && typeof stage === 'object' ? Object.keys(stage) : [];
+        if (keys.length !== 1 || !MEMBER_STAGES.includes(keys[0])) {
+            return { ok: false, error: `Pipeline stage ${keys.join(',') || String(stage)} is not allowed.` };
+        }
+        if (containsForbidden(stage)) return { ok: false, error: 'The pipeline uses an operator that is not allowed.' };
+    }
+    return { ok: true, pipeline: [{ $match: { _id: { $in: own } } }, ...stages] };
+};
+
+module.exports = { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline };

--- a/Modules/OAuth/controller.js
+++ b/Modules/OAuth/controller.js
@@ -1,54 +1,29 @@
 const logger = require("../../Config/loggerConfig");
 const { updateEnvVariablesUtil, getEnvVariablesUtil } = require("../../utils/envUpdater");
+const { validateOAuthUpdate, maskOAuthCred } = require("./helpers/oauthSettingsRules");
 
-/**
- * Get OAuth credentails
- */
 exports.getOAuthCred = async (req, res) => {
     try {
-        // Use our new utility to fetch all frontend env variables
-        // If need specific variable value then call like - await getEnvVariablesUtil("frontend", "VUE_APP_GOOGLE_CLIENT_ID")
-        const envVars = await getEnvVariablesUtil("frontend");
-        const backendEnvVars = await getEnvVariablesUtil("root");
-
-        return res.json({
-            status: true,
-            data: {
-                clientId: backendEnvVars.GOOGLE_CLIENT_ID || "",
-                clientSecret: backendEnvVars.GOOGLE_CLIENT_SECRET || "",
-                isGoogleLogin: envVars.VUE_APP_IS_GOOGLE_LOGIN === "true",
-                githubClientId: backendEnvVars.GITHUB_CLIENT_ID || '',
-                githubClientSecret: backendEnvVars.GITHUB_CLIENT_SECRET || '',
-                isGithubLogin: envVars.VUE_APP_IS_GITHUB_LOGIN === "true",
-                gitlabClientId: backendEnvVars.GITLAB_CLIENT_ID || '',
-                gitlabClientSecret: backendEnvVars.GITLAB_CLIENT_SECRET || '',
-                isGitlabLogin: envVars.VUE_APP_IS_GITLAB_LOGIN === "true",
-            },
-        });
+        const frontendEnv = await getEnvVariablesUtil("frontend").catch(() => ({}));
+        const backendEnv = await getEnvVariablesUtil("root").catch(() => ({}));
+        return res.json({ status: true, statusText: "OK", data: maskOAuthCred(backendEnv, frontendEnv) });
     } catch (error) {
-        logger.error("Error reading .env file in getOAuthCred:", error);
-        return res.status(500).json({
-            status: false,
-            statusText: "Failed to read .env file",
-            error: error.message,
-        });
+        logger.error(`Error reading .env file in getOAuthCred: ${error.message || error}`);
+        return res.status(500).json({ status: false, statusText: "Failed to read OAuth settings", message: "Failed to read OAuth settings" });
     }
 };
 
-/**
- * Update OAuth credentails
- */
-exports.updateOAuthCred = (req, res) => {
+exports.updateOAuthCred = async (req, res) => {
     try {
-        const { pathType, variables } = req.body;
-        const message = updateEnvVariablesUtil(pathType, variables);
-        res.json({ status: true, statusText: message });
+        const { pathType, variables } = req.body || {};
+        const checked = validateOAuthUpdate(pathType, variables);
+        if (!checked.ok) {
+            return res.status(400).json({ status: false, statusText: checked.error, message: checked.error });
+        }
+        const message = await updateEnvVariablesUtil(pathType, checked.variables);
+        return res.json({ status: true, statusText: message });
     } catch (error) {
-        logger.error("Unexpected error in updateOAuthCred:", error);
-        res.status(500).json({
-            status: false,
-            statusText: "Unexpected server error",
-            error: error.message,
-        });
+        logger.error(`Unexpected error in updateOAuthCred: ${error.message || error}`);
+        return res.status(500).json({ status: false, statusText: "Unexpected server error", message: "Unexpected server error" });
     }
 };

--- a/Modules/OAuth/helpers/oauthSettingsRules.js
+++ b/Modules/OAuth/helpers/oauthSettingsRules.js
@@ -1,0 +1,55 @@
+const WRITABLE_KEYS = {
+    root: ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET', 'GITLAB_CLIENT_ID', 'GITLAB_CLIENT_SECRET'],
+    frontend: ['VUE_APP_GOOGLE_CLIENT_ID', 'VUE_APP_GITHUB_CLIENT_ID', 'VUE_APP_GITLAB_CLIENT_ID', 'VUE_APP_IS_GOOGLE_LOGIN', 'VUE_APP_IS_GITHUB_LOGIN', 'VUE_APP_IS_GITLAB_LOGIN'],
+};
+const BOOLEAN_KEYS = ['VUE_APP_IS_GOOGLE_LOGIN', 'VUE_APP_IS_GITHUB_LOGIN', 'VUE_APP_IS_GITLAB_LOGIN'];
+const MAX_VALUE_LENGTH = 512;
+// The value is written inside double quotes in a .env file: a quote, backslash, `$`,
+// whitespace or newline would let a caller close the value and inject another variable.
+const SAFE_VALUE = /^[A-Za-z0-9._~+/=:@-]*$/;
+
+const fail = (error) => ({ ok: false, error });
+
+function validateOAuthUpdate(pathType, variables) {
+    const allowed = WRITABLE_KEYS[pathType];
+    if (!allowed) return fail(`pathType must be one of: ${Object.keys(WRITABLE_KEYS).join(', ')}.`);
+    if (!Array.isArray(variables) || variables.length === 0) return fail('variables must be a non-empty array.');
+    if (variables.length > allowed.length) return fail('Too many variables.');
+
+    const seen = new Set();
+    const clean = [];
+    for (const entry of variables) {
+        const name = entry && entry.variableName;
+        if (typeof name !== 'string' || !allowed.includes(name)) return fail(`${String(name)} cannot be changed here.`);
+        if (seen.has(name)) return fail(`${name} is listed twice.`);
+        seen.add(name);
+
+        let value = entry.variableValue;
+        if (BOOLEAN_KEYS.includes(name)) {
+            if (value === true || value === 'true') value = 'true';
+            else if (value === false || value === 'false') value = 'false';
+            else return fail(`${name} must be true or false.`);
+        }
+        if (typeof value !== 'string') return fail(`${name} must be a string.`);
+        if (value.length > MAX_VALUE_LENGTH) return fail(`${name} is too long.`);
+        if (!SAFE_VALUE.test(value)) return fail(`${name} contains characters that are not allowed.`);
+        clean.push({ variableName: name, variableValue: value });
+    }
+    return { ok: true, variables: clean };
+}
+
+function maskOAuthCred(backendEnv = {}, frontendEnv = {}) {
+    return {
+        clientId: backendEnv.GOOGLE_CLIENT_ID || '',
+        clientSecretSet: Boolean(backendEnv.GOOGLE_CLIENT_SECRET),
+        isGoogleLogin: frontendEnv.VUE_APP_IS_GOOGLE_LOGIN === 'true',
+        githubClientId: backendEnv.GITHUB_CLIENT_ID || '',
+        githubClientSecretSet: Boolean(backendEnv.GITHUB_CLIENT_SECRET),
+        isGithubLogin: frontendEnv.VUE_APP_IS_GITHUB_LOGIN === 'true',
+        gitlabClientId: backendEnv.GITLAB_CLIENT_ID || '',
+        gitlabClientSecretSet: Boolean(backendEnv.GITLAB_CLIENT_SECRET),
+        isGitlabLogin: frontendEnv.VUE_APP_IS_GITLAB_LOGIN === 'true',
+    };
+}
+
+module.exports = { WRITABLE_KEYS, validateOAuthUpdate, maskOAuthCred };

--- a/Modules/Users/controller.js
+++ b/Modules/Users/controller.js
@@ -5,53 +5,69 @@ const { SCHEMA_TYPE } = require("../../Config/schemaType.js");
 const { removeCache } = require("../../utils/commonFunctions.js");
 const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries.js");
 const mongoose = require("mongoose")
+const {
+    isObjectId, toSelfView, toMemberView, sharedCompanies, sanitizeUserQuery, scopeQueryToCompany,
+    sanitizeSelfUpdate, companyRemovalOf, sanitizeUpdateOptions,
+} = require("./helpers/userAccessRules.js");
 
-exports.updateUserStatus = (req,res) => {
-    const { userId, updateObject,newObj} = req.body;
+const refuse = (res, code, message) => res.status(code).json({ status: false, statusText: message, message });
 
-    if(!userId) {
-        res.send({status: false, message: 'userId is required'});
-        return;
-    }
-    if(!updateObject) {
-        res.send({status: false, message: 'userId is required'});
-        return;
-    }
+const loadGlobalUser = (id) => MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+    type: SCHEMA_TYPE.USERS,
+    data: [{ _id: new mongoose.Types.ObjectId(String(id)) }]
+}, 'findOne');
 
-    let data =  [
-        { _id: new mongoose.Types.ObjectId(req.body.userId) }, 
-        updateObject,
-        newObj
-    ]
-
-    let obj = {
-        type: dbCollections.USERS,
-        data: data
-    }
+exports.updateUserStatus = async (req, res) => {
+    const { userId, updateObject, newObj } = req.body || {};
+    if (!req.uid) return refuse(res, 401, 'Unauthorized');
+    if (!isObjectId(userId)) return refuse(res, 400, 'userId is required');
+    if (!updateObject) return refuse(res, 400, 'updateObject is required');
 
     try {
-        const cacheKey = `UserData:${req.body.userId}`;
-        MongoDbCrudOpration('global', obj, "findOneAndUpdate").then((response)=>{
-            removeCache(cacheKey)
-            removeCache('UserAllData:',true)
-            res.send({
-                status: true,
-                statusText: "User Status Updated",
-                data:response
-            });
-        }).catch((error)=>{
-            res.send({
-                status: false,
-                statusText: "User Status Not Updated"
-            });
-            logger.error('USER STATUS UPDATE ERROR updateUserStatus: ',error);
-        })
-    } catch (error) {
-        res.send({
-            status: false,
-            statusText: "User Status Not Updated"
+        let update;
+        let view;
+        let afterUpdate = () => {};
+        if (String(userId) === String(req.uid)) {
+            const checked = sanitizeSelfUpdate(updateObject);
+            if (!checked.ok) return refuse(res, 403, checked.error);
+            const selected = checked.update.$set.lastSelectedCompany;
+            if (selected !== undefined) {
+                const me = await loadGlobalUser(req.uid);
+                if (!sharedCompanies(me, { AssignCompany: [selected] }).length) return refuse(res, 403, 'You are not a member of that company.');
+            }
+            update = checked.update;
+            view = toSelfView;
+        } else {
+            const companyId = companyRemovalOf(updateObject);
+            if (!companyId || req.apiToken) return refuse(res, 403, 'You can only update your own profile.');
+            const { getRoleType, isPrivileged, ROLE_OWNER } = require("../../Config/permissionGuard.js");
+            const callerRole = await getRoleType(companyId, req.uid);
+            const targetRole = await getRoleType(companyId, userId);
+            if (!isPrivileged(callerRole) || targetRole === null || targetRole === ROLE_OWNER) {
+                return refuse(res, 403, 'Only an owner or admin of that company can remove this member.');
+            }
+            const me = await loadGlobalUser(req.uid);
+            update = { $pull: { AssignCompany: companyId } };
+            view = (doc) => toMemberView(doc, (me && me.AssignCompany) || []);
+            afterUpdate = () => require("../../Config/jwt.js").invalidateMembershipCache(String(userId), companyId);
+        }
+
+        const obj = {
+            type: dbCollections.USERS,
+            data: [{ _id: new mongoose.Types.ObjectId(String(userId)) }, update, sanitizeUpdateOptions(newObj)]
+        };
+        const response = await MongoDbCrudOpration('global', obj, "findOneAndUpdate");
+        removeCache(`UserData:${userId}`);
+        removeCache('UserAllData:', true);
+        afterUpdate();
+        return res.send({
+            status: true,
+            statusText: "User Status Updated",
+            data: response ? view(response) : response
         });
-        logger.error('USER STATUS UPDATE ERROR updateUserStatus: ',error);
+    } catch (error) {
+        logger.error(`USER STATUS UPDATE ERROR updateUserStatus: ${error.message || error}`);
+        return refuse(res, 400, "User Status Not Updated");
     }
 }
 
@@ -173,9 +189,10 @@ exports.checkUserAndCompany = (req, res) => {
 
 exports.getUserById = async(req, res) => {
     try {
+        if (!req.uid) return refuse(res, 401, 'Unauthorized');
         let { id } = req.params;
         const { query } = req.query;
-        
+
         if(!id) {
             return res.status(400).json({
                 status: false,
@@ -185,69 +202,82 @@ exports.getUserById = async(req, res) => {
 
         const customerCacheKey = `customerId:${id}`;
         let key = '_id';
-        
+
         if (query === 'customerId') {
             const cachedCustomerId = myCache.get(customerCacheKey);
-            if (cachedCustomerId) {                
+            if (cachedCustomerId) {
                 id = cachedCustomerId;
             } else {
                 key = 'customerId';
             }
         }
-        const cacheKey = `UserData:${id}`;
-
-        const value = myCache.get(cacheKey);
-        
-        if (value) {
-            res.set({
-                'FromCache': 'true',
-                'cacheExpireTime': myCache.getTtl(cacheKey)
-            });
-            return res.status(200).json(JSON.parse(value));
+        if (key === '_id' && !isObjectId(id)) {
+            return res.status(404).json({ status: false, message: "user not found" });
         }
-        
-        const userObj = {
-            type: SCHEMA_TYPE.USERS,
-            data: [
-                {[key] : id}
-            ]
-        };
-        const users = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, userObj, 'findOne');
 
-        if (!users) {
-            return res.status(404).json({ message: "user not found" });
-        }
-        const userId = users._id;
-        const userData = JSON.stringify(users);
+        const cached = myCache.get(`UserData:${id}`);
+        let user = cached ? JSON.parse(cached) : null;
 
-        if (query === 'customerId') {
-            myCache.set(customerCacheKey, userId);
-            myCache.set(`UserData:${userId}`, userData, 604800);
-        } else {
-            if (users?.customerIds && users?.customerIds?.length) {
-                for (let i = 0; i < users?.customerIds?.length; i += 1) {
-                    myCache.set(`customerId:${users?.customerIds[i]}`, userId);
-                }
+        if (!user) {
+            const userObj = {
+                type: SCHEMA_TYPE.USERS,
+                data: [
+                    {[key] : id}
+                ]
+            };
+            user = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, userObj, 'findOne');
+            if (!user) {
+                return res.status(404).json({ status: false, message: "user not found" });
             }
-
-            // if (users?.customerId) {
-            //     myCache.set(`customerId:${users.customerId}`, userId);
-            // }
-            myCache.set(cacheKey, userData, 604800);
+            const userId = user._id;
+            const userData = JSON.stringify(user);
+            if (query === 'customerId') {
+                myCache.set(customerCacheKey, userId);
+                myCache.set(`UserData:${userId}`, userData, 604800);
+            } else {
+                (user?.customerIds || []).forEach((customerId) => myCache.set(`customerId:${customerId}`, userId));
+                myCache.set(`UserData:${id}`, userData, 604800);
+            }
         }
-        return res.status(200).json(users);
+
+        if (String(user._id) === String(req.uid)) {
+            return res.status(200).json(toSelfView(user));
+        }
+        const shared = sharedCompanies(await loadGlobalUser(req.uid), user);
+        if (!shared.length) {
+            return res.status(404).json({ status: false, message: "user not found" });
+        }
+        return res.status(200).json(toMemberView(user, shared));
     } catch (error) {
-        res.status(500).json({ message: "An error occurred while getting the user",error: error });
+        logger.error(`getUserById: ${error.message || error}`);
+        res.status(500).json({ status: false, message: "An error occurred while getting the user" });
     }
 }
 
 exports.getUserByQuey = async(req, res) => {
-    exports.getUserByQueyFun(req.body.query,req.body.companyId,req.body.fetchFromCache).then((data) => {
-        res.json(data);
-    }).
-    catch((error) => {
-        res.json(error);
-    })
+    try {
+        if (!req.uid) return refuse(res, 401, 'Unauthorized');
+        const headerCompany = req.headers['companyid'];
+        const bodyCompany = req.body.companyId;
+        const companyId = String(headerCompany || bodyCompany || '');
+        if (!isObjectId(companyId)) return refuse(res, 400, 'companyId is required');
+        if (headerCompany && bodyCompany && String(bodyCompany) !== companyId) {
+            return refuse(res, 403, 'You do not have access to this company');
+        }
+        const { verifyCompanyMembership } = require("../../Config/jwt.js");
+        if (!(await verifyCompanyMembership(String(req.uid), companyId))) {
+            return refuse(res, 403, 'You do not have access to this company');
+        }
+        const checked = sanitizeUserQuery(req.body.query);
+        if (!checked.ok) return refuse(res, 400, checked.error);
+
+        const users = await exports.getUserByQueyFun(scopeQueryToCompany(checked.query, companyId), companyId, false);
+        const list = Array.isArray(users) ? users : [];
+        return res.json(list.map((user) => (String(user._id) === String(req.uid) ? toSelfView(user) : toMemberView(user, [companyId]))));
+    } catch (error) {
+        logger.error(`getUserByQuey: ${error.message || error}`);
+        return refuse(res, 400, 'An error occurred while getting the users');
+    }
 }
 
 exports.getUserByQueyFun = async(query = {},companyId = '',fetchFromCache = false, preAggregate = false) => {

--- a/Modules/Users/helpers/userAccessRules.js
+++ b/Modules/Users/helpers/userAccessRules.js
@@ -1,0 +1,133 @@
+const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
+
+const MEMBER_FIELDS = [
+    '_id', 'Employee_Email', 'Employee_FName', 'Employee_LName', 'Employee_Name',
+    'Employee_profileImage', 'Employee_profileImageURL', 'Time_Format', 'Time_Zone',
+    'isActive', 'isOnline', 'lastActive', 'AssignCompany', 'languageCode', 'workingHours',
+    'presence', 'isVesionUpdate', 'createdAt', 'updatedAt',
+];
+const SELF_FIELDS = [
+    ...MEMBER_FIELDS,
+    'isEmailVerified', 'isProductOwner', 'tour', 'lastSelectedCompany', 'customerId', 'customerIds',
+    'homeChecklist', 'localePreferences', 'agentAccount', 'demo',
+];
+const SELF_WRITABLE = [
+    'isOnline', 'lastActive', 'lastSelectedCompany', 'tour', 'homeChecklist', 'presence', 'languageCode',
+    'localePreferences', 'updatedAt', 'Employee_FName', 'Employee_LName', 'Employee_Name',
+    'Employee_profileImage', 'Employee_profileImageURL', 'Time_Format', 'Time_Zone', 'workingHours',
+];
+const FILTER_FIELDS = ['_id', 'isActive', 'AssignCompany', 'Employee_Email', 'Employee_Name', 'Employee_FName', 'Employee_LName', 'isOnline'];
+const FILTER_OPERATORS = ['$in', '$nin', '$eq', '$ne', '$exists'];
+const LOGICAL_OPERATORS = ['$and', '$or', '$nor'];
+
+const isObjectId = (value) => OBJECT_ID_PATTERN.test(String(value || ''));
+const plain = (doc) => (doc ? JSON.parse(JSON.stringify(doc)) : doc);
+
+const pick = (doc, fields) => {
+    const source = plain(doc) || {};
+    return fields.reduce((out, field) => {
+        if (source[field] !== undefined) out[field] = source[field];
+        return out;
+    }, {});
+};
+
+const toSelfView = (doc) => pick(doc, SELF_FIELDS);
+
+const toMemberView = (doc, sharedCompanyIds) => {
+    const view = pick(doc, MEMBER_FIELDS);
+    const shared = (sharedCompanyIds || []).map(String);
+    view.AssignCompany = (view.AssignCompany || []).map(String).filter((id) => shared.includes(id));
+    return view;
+};
+
+const sharedCompanies = (a, b) => {
+    const left = ((a && a.AssignCompany) || []).map(String);
+    return ((b && b.AssignCompany) || []).map(String).filter((id) => left.includes(id));
+};
+
+const isScalar = (value) => value === null || ['string', 'number', 'boolean'].includes(typeof value);
+
+const cleanCondition = (condition) => {
+    if (isScalar(condition)) return true;
+    if (Array.isArray(condition)) return condition.every(isScalar);
+    if (typeof condition !== 'object') return false;
+    return Object.entries(condition).every(([op, arg]) => {
+        if (!FILTER_OPERATORS.includes(op)) return false;
+        if (op === '$in' || op === '$nin') return Array.isArray(arg) && arg.every(isScalar);
+        return isScalar(arg);
+    });
+};
+
+// The client used to send a raw $match. Only simple equality/membership filters on
+// non-secret fields survive, so a caller cannot probe reset tokens with $regex or run $expr.
+const sanitizeUserQuery = (query) => {
+    if (query === undefined || query === null) return { ok: true, query: {} };
+    if (typeof query !== 'object' || Array.isArray(query)) return { ok: false, error: 'query must be an object.' };
+    for (const [key, value] of Object.entries(query)) {
+        if (LOGICAL_OPERATORS.includes(key)) {
+            if (!Array.isArray(value) || !value.every((part) => sanitizeUserQuery(part).ok)) {
+                return { ok: false, error: `${key} must be a list of simple filters.` };
+            }
+            continue;
+        }
+        if (!FILTER_FIELDS.includes(key)) return { ok: false, error: `Filtering on ${key} is not allowed.` };
+        if (!cleanCondition(value)) return { ok: false, error: `The filter on ${key} is not allowed.` };
+    }
+    return { ok: true, query };
+};
+
+const scopeQueryToCompany = (query, companyId) => ({ $and: [query || {}, { AssignCompany: String(companyId) }] });
+
+const writableKey = (key) => {
+    if (typeof key !== 'string' || key.includes('$')) return false;
+    return SELF_WRITABLE.includes(key.split('.')[0]);
+};
+
+const sanitizeSelfUpdate = (updateObject) => {
+    if (!updateObject || typeof updateObject !== 'object' || Array.isArray(updateObject)) {
+        return { ok: false, error: 'updateObject must be an object.' };
+    }
+    const keys = Object.keys(updateObject);
+    if (!keys.length) return { ok: false, error: 'updateObject is empty.' };
+    const operatorKeys = keys.filter((key) => key.startsWith('$'));
+    let fields;
+    if (!operatorKeys.length) {
+        fields = updateObject;
+    } else if (keys.length === 1 && keys[0] === '$set' && updateObject.$set && typeof updateObject.$set === 'object' && !Array.isArray(updateObject.$set)) {
+        fields = updateObject.$set;
+    } else {
+        return { ok: false, error: 'Only $set is allowed when updating your own profile.' };
+    }
+    const refused = Object.keys(fields).filter((key) => !writableKey(key));
+    if (refused.length) return { ok: false, error: `These fields cannot be changed here: ${refused.join(', ')}.` };
+    if (!Object.keys(fields).length) return { ok: false, error: 'updateObject is empty.' };
+    return { ok: true, update: { $set: fields } };
+};
+
+// The one cross-user write the app makes: an owner or admin removing a member from their company.
+const companyRemovalOf = (updateObject) => {
+    if (!updateObject || typeof updateObject !== 'object') return null;
+    const keys = Object.keys(updateObject);
+    if (keys.length !== 1 || keys[0] !== '$pull') return null;
+    const pull = updateObject.$pull;
+    if (!pull || typeof pull !== 'object' || Object.keys(pull).length !== 1) return null;
+    const companyId = pull.AssignCompany;
+    return typeof companyId === 'string' && isObjectId(companyId) ? companyId : null;
+};
+
+const sanitizeUpdateOptions = (options) => (options && options.returnDocument === 'after' ? { returnDocument: 'after' } : undefined);
+
+module.exports = {
+    MEMBER_FIELDS,
+    SELF_FIELDS,
+    SELF_WRITABLE,
+    isObjectId,
+    toSelfView,
+    toMemberView,
+    sharedCompanies,
+    sanitizeUserQuery,
+    scopeQueryToCompany,
+    sanitizeSelfUpdate,
+    companyRemovalOf,
+    sanitizeUpdateOptions,
+};

--- a/frontend/src/config/env.js
+++ b/frontend/src/config/env.js
@@ -68,7 +68,6 @@ module.exports.CALL_ICE_CONFIG = '/api/v2/calls/ice-config';
 module.exports.CALL_NOTES = '/api/v2/calls/notes';
 module.exports.FOLDER = '/api/v1/folder';
 module.exports.REMOVE_USER_NOTIFICATION = '/api/v1/removeUserNotification';
-module.exports.GENERATETOKEN = '/api/v1/generateToken';
 module.exports.GENERATETOKEN_V2 = '/api/v2/generateToken';
 module.exports.UPDATE_UNREADREAD_COMMENTS_COUNT = '/api/v1/updateunreadcommentscount';
 module.exports.UNSET_COMMENTS_COUNT = '/api/v1/unsetCommentCounts';

--- a/tests/company-access.test.js
+++ b/tests/company-access.test.js
@@ -1,0 +1,118 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(async () => null) }));
+jest.mock('../event/socketEventEmitter', () => ({}));
+
+const mongoose = require('mongoose');
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { myCache } = require('../Config/config');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { setMiddlewareV2 } = require('../Config/setMiddleware');
+const { signSession, startApp } = require('./fixtures/sessionApp');
+const { scopeCompanyPipeline, allowedCompanyIds } = require('../Modules/Company/helpers/companyAccessRules');
+const ctrl = require('../Modules/Company/controller/updateCompany');
+
+const COMPANY = '6f0000000000000000000c01';
+const OTHER_COMPANY = '6f0000000000000000000c02';
+const OWNER = '6f0000000000000000000001';
+const GUEST = '6f0000000000000000000004';
+
+const callsOf = (method) => MongoDbCrudOpration.mock.calls.filter((call) => call[2] === method);
+
+let app;
+
+beforeAll(async () => {
+    app = await startApp((server) => {
+        setMiddlewareV2(server);
+        server.post('/api/v1/admin/company', ctrl.getCompany);
+        server.post('/api/v1/admin/company/find', ctrl.getCompanyByAggregate);
+        server.put('/api/v1/admin/company', ctrl.updateCompany);
+    });
+});
+afterAll(() => app.close());
+
+beforeEach(() => {
+    myCache.flushAll();
+    MongoDbCrudOpration.mockReset();
+    MongoDbCrudOpration.mockImplementation(async (db, obj, method) => {
+        const filter = (obj.data && obj.data[0]) || {};
+        if (obj.type === SCHEMA_TYPE.USERS && obj.data[1] === 'isProductOwner') return { isProductOwner: String(filter._id) === OWNER };
+        if (obj.type === SCHEMA_TYPE.USERS) return { AssignCompany: String(filter._id) === OWNER ? [COMPANY, OTHER_COMPANY] : [COMPANY] };
+        if (method === 'find') return filter._id ? filter._id.$in.map((id) => ({ _id: String(id) })) : [{ _id: COMPANY }, { _id: OTHER_COMPANY }];
+        if (method === 'aggregate') return [];
+        return null;
+    });
+});
+
+describe('companyAccessRules', () => {
+    it('keeps only the caller\'s own company ids', () => {
+        expect(allowedCompanyIds([COMPANY, OTHER_COMPANY, COMPANY], [COMPANY])).toEqual([COMPANY]);
+    });
+
+    it.each([
+        [[{ $lookup: { from: 'users', localField: 'userId', foreignField: '_id', as: 'u' } }]],
+        [[{ $unionWith: 'users' }]],
+        [[{ $match: { $where: 'true' } }]],
+        [[{ $project: { x: { $function: { body: 'function(){}', args: [], lang: 'js' } } } }]],
+        [[{ $match: {}, $limit: 1 }]],
+    ])('refuses the pipeline %j', (pipeline) => {
+        expect(scopeCompanyPipeline(pipeline, []).ok).toBe(false);
+    });
+});
+
+describe('ACC-06 POST /api/v1/admin/company', () => {
+    it('refuses an anonymous caller', async () => {
+        const res = await app.call('POST', '/api/v1/admin/company', { body: { fetchAllCompany: true } });
+        expect(res.status).toBe(401);
+    });
+
+    it('refuses a guest listing every company', async () => {
+        const res = await app.call('POST', '/api/v1/admin/company', { token: signSession(GUEST, [COMPANY]), body: { fetchAllCompany: true, companyIds: [] } });
+        expect(res.status).toBe(403);
+        expect(callsOf('find')).toHaveLength(0);
+    });
+
+    it('returns a member only their own companies', async () => {
+        const res = await app.call('POST', '/api/v1/admin/company', { token: signSession(GUEST, [COMPANY]), body: { companyIds: [COMPANY, OTHER_COMPANY] } });
+        expect(res.status).toBe(200);
+        expect(res.body.map((company) => company._id)).toEqual([COMPANY]);
+    });
+
+    it('lets the instance owner list every company', async () => {
+        const res = await app.call('POST', '/api/v1/admin/company', { token: signSession(OWNER, [COMPANY]), body: { fetchAllCompany: true, companyIds: [] } });
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveLength(2);
+    });
+});
+
+describe('ACC-06 POST /api/v1/admin/company/find', () => {
+    it('pins a member\'s pipeline to their own companies', async () => {
+        const findQuery = [{ $match: { _id: { objId: { $in: [COMPANY] } } } }];
+        const res = await app.call('POST', '/api/v1/admin/company/find', { token: signSession(GUEST, [COMPANY]), body: { findQuery } });
+        expect(res.status).toBe(200);
+        const pipeline = callsOf('aggregate')[0][1].data[0];
+        expect(pipeline[0]).toEqual({ $match: { _id: { $in: [new mongoose.Types.ObjectId(COMPANY)] } } });
+        expect(pipeline).toHaveLength(2);
+    });
+
+    it('refuses a member joining another collection', async () => {
+        const findQuery = [{ $lookup: { from: 'users', pipeline: [], as: 'users' } }];
+        const res = await app.call('POST', '/api/v1/admin/company/find', { token: signSession(GUEST, [COMPANY]), body: { findQuery } });
+        expect(res.status).toBe(403);
+        expect(callsOf('aggregate')).toHaveLength(0);
+    });
+
+    it('leaves the instance owner\'s pipeline unscoped', async () => {
+        const findQuery = [{ $match: {} }];
+        const res = await app.call('POST', '/api/v1/admin/company/find', { token: signSession(OWNER, [COMPANY]), body: { findQuery } });
+        expect(res.status).toBe(200);
+        expect(callsOf('aggregate')[0][1].data[0]).toEqual([findQuery]);
+    });
+});
+
+describe('PUT /api/v1/admin/company', () => {
+    it('refuses an update that names no company', async () => {
+        const res = await app.call('PUT', '/api/v1/admin/company', { token: signSession(GUEST, [COMPANY]), body: { updateObject: { Cst_CompanyName: 'x' } } });
+        expect(res.status).toBe(400);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+});

--- a/tests/conventions/tenant-scoping.baseline.json
+++ b/tests/conventions/tenant-scoping.baseline.json
@@ -6,7 +6,7 @@
   "Audit/controller.js": 1,
   "Audit/recorder.js": 1,
   "Auth/controller/loginSession.js": 2,
-  "Auth/controller/sendInvitation.js": 3,
+  "Auth/controller/sendInvitation.js": 2,
   "Automations/controller.js": 2,
   "Calendar/controller.js": 2,
   "CapacityPlanning/controller.js": 1,

--- a/tests/fixtures/sessionApp.js
+++ b/tests/fixtures/sessionApp.js
@@ -1,0 +1,49 @@
+// Spins up an express app behind the real JWT middleware lists, and signs web sessions the
+// way login does, with the session row and company membership pre-seeded in the cache so the
+// middleware never needs a database.
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const { myCache } = require('../../Config/config');
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'unit-test-secret';
+process.env.JWT_ALGORITHM = process.env.JWT_ALGORITHM || 'HS256';
+process.env.JWT_EXP = process.env.JWT_EXP || '1h';
+
+function signSession(uid, companyIds = []) {
+    const options = { algorithm: 'HS256', expiresIn: '1h' };
+    const refreshToken = jwt.sign({}, process.env.JWT_SECRET, options);
+    const token = jwt.sign({ uid, refreshToken }, process.env.JWT_SECRET, companyIds.length ? { ...options, audience: companyIds.join(',') } : options);
+    myCache.set(`session:${uid}:${refreshToken}`, JSON.stringify({ userId: uid, refreshToken }), 600);
+    companyIds.forEach((companyId) => myCache.set(`membership:${uid}:${companyId}`, true, 600));
+    return token;
+}
+
+async function startApp(configure) {
+    const app = express();
+    app.use(express.json());
+    configure(app);
+    const server = await new Promise((resolve) => {
+        const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+    });
+    // fetch reuses keep-alive sockets; on a loaded runner the default 5s idle close races it into ECONNRESET.
+    server.keepAliveTimeout = 60000;
+    const baseURL = `http://127.0.0.1:${server.address().port}`;
+
+    const call = async (method, path, { token, companyId, body } = {}) => {
+        const headers = {};
+        if (token) headers.authorization = `Bearer ${token}`;
+        if (companyId) headers.companyid = companyId;
+        if (body !== undefined) headers['content-type'] = 'application/json';
+        const res = await fetch(baseURL + path, { method, headers, body: body === undefined ? undefined : JSON.stringify(body) });
+        const text = await res.text();
+        let parsed = text;
+        try {
+            parsed = text ? JSON.parse(text) : null;
+        } catch {}
+        return { status: res.status, body: parsed };
+    };
+
+    return { call, close: () => new Promise((resolve) => server.close(resolve)) };
+}
+
+module.exports = { signSession, startApp };

--- a/tests/integration/access.int.test.js
+++ b/tests/integration/access.int.test.js
@@ -6,6 +6,8 @@ const anon = createApiClient({ baseURL: state.baseURL });
 const anonWithCompany = createApiClient({ baseURL: state.baseURL, companyId: state.companyId });
 const refused = (res) => res.status === 401 || res.status === 403 || (res.body && res.body.status === false);
 const randomId = () => uniqueSuffix() + uniqueSuffix() + uniqueSuffix() + uniqueSuffix();
+const SECRET_FIELDS = ['webTokens', 'verificationToken', 'verificationTokenTime', 'forgotPasswordToken', 'forgotPasswordTokenTime', 'passwordHash'];
+const exposesSecret = (doc) => SECRET_FIELDS.some((field) => doc && Object.prototype.hasOwnProperty.call(doc, field));
 
 describe('access — authentication happy paths', () => {
     it('logs in every role', async () => {
@@ -101,19 +103,18 @@ describe('access — regression tests for confirmed findings (flip to it() once 
         expect(res.status).toBe(401);
     });
 
-    // ACC-02: POST /api/v1/generateToken mints a JWT for any uid with no password.
-    it.failing('ACC-02 refuses minting a token for an arbitrary user id', async () => {
+    it('ACC-02 refuses minting a token for an arbitrary user id', async () => {
         const owner = await loginAs('owner');
         const res = await anon.post('/api/v1/generateToken', { uid: owner.uid });
-        expect(refused(res)).toBe(true);
+        expect([401, 403, 404]).toContain(res.status);
         expect(res.body && res.body.token).toBeFalsy();
     });
 
-    // ACC-03: /api/v2/session/* is unauthenticated (forge a session; wipe sessions).
-    it.failing('ACC-03 refuses registering a session anonymously', async () => {
+    it('ACC-03 refuses registering a session anonymously', async () => {
         const owner = await loginAs('owner');
         const res = await anon.post('/api/v2/session/register', { userId: owner.uid });
-        expect(refused(res)).toBe(true);
+        expect([401, 403, 404]).toContain(res.status);
+        expect(res.body && res.body.data && res.body.data.refreshToken).toBeFalsy();
     });
 
     it('ACC-03 refuses deleting another user\'s sessions anonymously', async () => {
@@ -127,21 +128,23 @@ describe('access — regression tests for confirmed findings (flip to it() once 
         expect(res.status).toBe(401);
     });
 
-    // ACC-05: user routes are jwt-only, unscoped — any role reads/edits any user.
-    it.failing('ACC-05 refuses a guest reading another user by id', async () => {
+    // A teammate's public profile stays readable because the member list needs it;
+    // secrets and users of other companies do not.
+    it('ACC-05 gives a guest only the public profile of another user', async () => {
         const guest = await loginAs('guest');
         const res = await guest.api.get(`/api/v1/user/${state.users.owner.userId}`);
-        expect(refused(res)).toBe(true);
+        expect(res.status).toBe(200);
+        expect(exposesSecret(res.body)).toBe(false);
+        expect(res.body.isProductOwner).toBeUndefined();
     });
 
-    it.failing('ACC-05 refuses a guest updating an arbitrary user', async () => {
+    it('ACC-05 refuses a guest updating an arbitrary user', async () => {
         const guest = await loginAs('guest');
         const res = await guest.api.put('/api/v1/user', { userId: randomId(), updateObject: { isActive: true } });
         expect(refused(res)).toBe(true);
     });
 
-    // ACC-06: admin company routes let any member/guest enumerate companies.
-    it.failing('ACC-06 refuses a guest listing all companies via the admin route', async () => {
+    it('ACC-06 refuses a guest listing all companies via the admin route', async () => {
         const guest = await loginAs('guest');
         const res = await guest.api.post('/api/v1/admin/company', { fetchAllCompany: true, companyIds: [] });
         expect(refused(res)).toBe(true);
@@ -167,5 +170,135 @@ describe('access — regression tests for confirmed findings (flip to it() once 
             email: state.users.member.email, companyId: state.companyId,
         });
         expect(res.status).toBe(401);
+    });
+});
+
+describe('access — sessions are the caller\'s own', () => {
+    it('refuses deleting every session anonymously', async () => {
+        expect((await anon.delete('/api/v2/session/delete')).status).toBe(401);
+    });
+
+    it('refuses a member signing out the admin', async () => {
+        const member = await loginAs('member');
+        expect((await member.api.delete(`/api/v2/session/delete/${state.users.admin.userId}`)).status).toBe(403);
+    });
+
+    it('lets a user sign out their own sessions, as change-password does', async () => {
+        const guest = await loginAs('guest');
+        expect((await guest.api.delete(`/api/v2/session/delete/${guest.uid}`)).status).toBe(200);
+        expect((await guest.api.get('/api/v2/users/sessions')).status).toBe(401);
+    });
+});
+
+describe('access — OAuth settings mask secrets and accept only OAuth keys', () => {
+    it('refuses a company admin who is not the instance owner', async () => {
+        const admin = await loginAs('admin');
+        expect((await admin.api.get('/api/v1/settings/oauth')).status).toBe(403);
+    });
+
+    it('shows the instance owner whether secrets are set, never their values', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.get('/api/v1/settings/oauth');
+        expect(res.status).toBe(200);
+        expect(res.body.data).not.toHaveProperty('clientSecret');
+        expect(res.body.data).not.toHaveProperty('githubClientSecret');
+        expect(res.body.data).toHaveProperty('clientSecretSet');
+    });
+
+    it('refuses the instance owner writing a key outside the OAuth allowlist', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.post('/api/v1/settings/oauth', { pathType: 'root', variables: [{ variableName: 'JWT_SECRET', variableValue: 'x' }] });
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('access — user routes are scoped to shared companies', () => {
+    it('returns the owner their own profile without secrets', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.get(`/api/v1/user/${owner.uid}`);
+        expect(res.status).toBe(200);
+        expect(res.body.isProductOwner).toBe(true);
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+
+    it('does not reveal an unknown user id', async () => {
+        const guest = await loginAs('guest');
+        expect((await guest.api.get(`/api/v1/user/${randomId()}`)).status).toBe(404);
+    });
+
+    it('lists only the caller company members, without secrets', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.post('/api/v1/user/find', { query: { isActive: true }, companyId: state.companyId });
+        expect(res.status).toBe(200);
+        expect(res.body.length).toBeGreaterThanOrEqual(4);
+        expect(res.body.every((user) => user.AssignCompany.includes(state.companyId) && !exposesSecret(user))).toBe(true);
+    });
+
+    it('refuses listing users of another company', async () => {
+        const guest = await loginAs('guest');
+        expect((await guest.api.post('/api/v1/user/find', { query: {}, companyId: randomId() })).status).toBe(403);
+    });
+
+    it('refuses a filter that probes a secret field', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.post('/api/v1/user/find', { query: { forgotPasswordToken: { $exists: true } }, companyId: state.companyId });
+        expect(res.status).toBe(400);
+    });
+
+    it('refuses a guest deactivating the owner', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.put('/api/v1/user', { userId: state.users.owner.userId, updateObject: { $set: { isActive: false } } });
+        expect(res.status).toBe(403);
+    });
+
+    it('refuses a guest making themself instance owner', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.put('/api/v1/user', { userId: guest.uid, updateObject: { $set: { isProductOwner: true } } });
+        expect(res.status).toBe(403);
+    });
+
+    it('lets a user save their own profile preferences', async () => {
+        const member = await loginAs('member');
+        const res = await member.api.put('/api/v1/user', { userId: member.uid, updateObject: { $set: { Time_Format: '24' } }, newObj: { returnDocument: 'after' } });
+        expect(res.status).toBe(200);
+        expect(res.body.data.Time_Format).toBe('24');
+        expect(exposesSecret(res.body.data)).toBe(false);
+    });
+});
+
+describe('access — company reads are the caller\'s own companies', () => {
+    it('returns a guest only their own company', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.post('/api/v1/admin/company', { companyIds: [state.companyId, randomId()] });
+        expect(res.status).toBe(200);
+        expect(res.body.map((company) => String(company._id))).toEqual([state.companyId]);
+    });
+
+    it('scopes the aggregate route the desktop tracker uses', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.post('/api/v1/admin/company/find', { findQuery: [{ $match: {} }] });
+        expect(res.status).toBe(200);
+        expect(res.body.map((company) => String(company._id))).toEqual([state.companyId]);
+    });
+
+    it('refuses a guest joining another collection through the aggregate route', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.post('/api/v1/admin/company/find', { findQuery: [{ $lookup: { from: 'users', pipeline: [], as: 'users' } }] });
+        expect(res.status).toBe(403);
+    });
+
+    it('lets the instance owner list every company', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.post('/api/v1/admin/company', { fetchAllCompany: true, companyIds: [] });
+        expect(res.status).toBe(200);
+        expect(res.body.some((company) => String(company._id) === state.companyId)).toBe(true);
+    });
+});
+
+describe('access — the invitation check stays inside the signed-in company', () => {
+    it('refuses probing another company', async () => {
+        const admin = await loginAs('admin');
+        const res = await admin.api.post('/api/v1/checkSendInviatation', { email: state.users.member.email, companyId: randomId() });
+        expect(res.status).toBe(403);
     });
 });

--- a/tests/invitation-check-access.test.js
+++ b/tests/invitation-check-access.test.js
@@ -1,0 +1,55 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(async () => null) }));
+jest.mock('../Modules/service.js', () => ({}));
+jest.mock('../Modules/Company/eventController.js', () => ({ emitListener: jest.fn() }));
+jest.mock('../Modules/Company/controller/updateCompany.js', () => ({ updateCompanyFun: jest.fn() }));
+jest.mock('../Modules/settings/Members/controller.js', () => ({ updateMemberFunction: jest.fn() }));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { myCache } = require('../Config/config');
+const { setMiddlewareWithCV2 } = require('../Config/setMiddleware');
+const { signSession, startApp } = require('./fixtures/sessionApp');
+const invitation = require('../Modules/Auth/controller/sendInvitation');
+
+const COMPANY = '6f0000000000000000000c01';
+const OTHER_COMPANY = '6f0000000000000000000c02';
+const MEMBER = '6f0000000000000000000003';
+
+let app;
+
+beforeAll(async () => {
+    app = await startApp((server) => {
+        setMiddlewareWithCV2(server);
+        server.post('/api/v1/checkSendInviatation', invitation.checkSendInviatation);
+    });
+});
+afterAll(() => app.close());
+
+beforeEach(() => {
+    myCache.flushAll();
+    MongoDbCrudOpration.mockReset();
+    MongoDbCrudOpration.mockImplementation(async () => ({ status: 2, isDelete: false }));
+});
+
+describe('ACC-09 POST /api/v1/checkSendInviatation', () => {
+    const check = (options) => app.call('POST', '/api/v1/checkSendInviatation', options);
+
+    it('refuses an anonymous membership probe', async () => {
+        const res = await check({ companyId: COMPANY, body: { email: 'someone@example.com', companyId: COMPANY } });
+        expect(res.status).toBe(401);
+        expect(MongoDbCrudOpration).not.toHaveBeenCalled();
+    });
+
+    it('refuses probing a company other than the signed-in one', async () => {
+        const res = await check({ token: signSession(MEMBER, [COMPANY]), companyId: COMPANY, body: { email: 'someone@example.com', companyId: OTHER_COMPANY } });
+        expect(res.status).toBe(403);
+        expect(MongoDbCrudOpration).not.toHaveBeenCalled();
+    });
+
+    it('answers a signed-in member for their own company', async () => {
+        const res = await check({ token: signSession(MEMBER, [COMPANY]), companyId: COMPANY, body: { email: 'someone@example.com', companyId: COMPANY } });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ status: true, furtherProceed: false });
+        expect(MongoDbCrudOpration.mock.calls[0][0]).toBe(COMPANY);
+    });
+});

--- a/tests/oauth-settings-access.test.js
+++ b/tests/oauth-settings-access.test.js
@@ -1,0 +1,112 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(async () => null) }));
+jest.mock('../utils/envUpdater', () => ({
+    getEnvVariablesUtil: jest.fn(),
+    updateEnvVariablesUtil: jest.fn(async () => 'Updated'),
+}));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { getEnvVariablesUtil, updateEnvVariablesUtil } = require('../utils/envUpdater');
+const { myCache } = require('../Config/config');
+const { signSession, startApp } = require('./fixtures/sessionApp');
+const { validateOAuthUpdate, maskOAuthCred } = require('../Modules/OAuth/helpers/oauthSettingsRules');
+const oauthRoutes = require('../Modules/OAuth/routes');
+
+const COMPANY = '6f0000000000000000000c01';
+const OWNER = '6f0000000000000000000001';
+const MEMBER = '6f0000000000000000000003';
+
+describe('validateOAuthUpdate', () => {
+    it('accepts the OAuth client keys', () => {
+        const result = validateOAuthUpdate('root', [
+            { variableName: 'GOOGLE_CLIENT_ID', variableValue: '123-abc.apps.googleusercontent.com' },
+            { variableName: 'GOOGLE_CLIENT_SECRET', variableValue: 'GOCSPX-abc_DEF' },
+        ]);
+        expect(result.ok).toBe(true);
+    });
+
+    it('normalises the login flags to true/false strings', () => {
+        const result = validateOAuthUpdate('frontend', [{ variableName: 'VUE_APP_IS_GITHUB_LOGIN', variableValue: true }]);
+        expect(result.variables).toEqual([{ variableName: 'VUE_APP_IS_GITHUB_LOGIN', variableValue: 'true' }]);
+    });
+
+    it.each([
+        ['an arbitrary key', 'root', [{ variableName: 'JWT_SECRET', variableValue: 'x' }]],
+        ['a key from the other file', 'frontend', [{ variableName: 'GOOGLE_CLIENT_SECRET', variableValue: 'x' }]],
+        ['the admin file', 'admin', [{ variableName: 'GOOGLE_CLIENT_ID', variableValue: 'x' }]],
+        ['a newline that injects a variable', 'root', [{ variableName: 'GOOGLE_CLIENT_ID', variableValue: 'x"\nJWT_SECRET="owned' }]],
+        ['a quote', 'root', [{ variableName: 'GOOGLE_CLIENT_ID', variableValue: 'x"' }]],
+        ['a non-boolean login flag', 'frontend', [{ variableName: 'VUE_APP_IS_GOOGLE_LOGIN', variableValue: 'yes' }]],
+        ['a duplicate key', 'root', [{ variableName: 'GITHUB_CLIENT_ID', variableValue: 'a' }, { variableName: 'GITHUB_CLIENT_ID', variableValue: 'b' }]],
+        ['an empty list', 'root', []],
+    ])('refuses %s', (label, pathType, variables) => {
+        expect(validateOAuthUpdate(pathType, variables).ok).toBe(false);
+    });
+});
+
+describe('maskOAuthCred', () => {
+    it('reports whether each secret is set without returning it', () => {
+        const masked = maskOAuthCred({ GOOGLE_CLIENT_SECRET: 's1', GITLAB_CLIENT_SECRET: '' }, {});
+        expect(JSON.stringify(masked)).not.toContain('s1');
+        expect(masked).toMatchObject({ clientSecretSet: true, githubClientSecretSet: false, gitlabClientSecretSet: false });
+    });
+});
+
+describe('ACC-04 /api/v1/settings/oauth', () => {
+    let app;
+
+    beforeAll(async () => {
+        app = await startApp((server) => oauthRoutes.init(server));
+    });
+    afterAll(() => app.close());
+
+    beforeEach(() => {
+        myCache.flushAll();
+        updateEnvVariablesUtil.mockClear();
+        getEnvVariablesUtil.mockImplementation(async (pathType) => (pathType === 'root'
+            ? { GOOGLE_CLIENT_ID: 'client-id', GOOGLE_CLIENT_SECRET: 'super-secret', GITHUB_CLIENT_SECRET: 'gh-secret' }
+            : { VUE_APP_IS_GOOGLE_LOGIN: 'true' }));
+        MongoDbCrudOpration.mockImplementation(async (db, obj) => ({ isProductOwner: String(obj.data[0]._id) === OWNER }));
+    });
+
+    it('refuses an anonymous read', async () => {
+        const res = await app.call('GET', '/api/v1/settings/oauth');
+        expect(res.status).toBe(401);
+        expect(JSON.stringify(res.body)).not.toContain('super-secret');
+    });
+
+    it('refuses an anonymous write', async () => {
+        const res = await app.call('POST', '/api/v1/settings/oauth', { body: { pathType: 'root', variables: [{ variableName: 'GOOGLE_CLIENT_ID', variableValue: 'x' }] } });
+        expect(res.status).toBe(401);
+        expect(updateEnvVariablesUtil).not.toHaveBeenCalled();
+    });
+
+    it('refuses a company member who is not the instance owner', async () => {
+        const res = await app.call('GET', '/api/v1/settings/oauth', { token: signSession(MEMBER, [COMPANY]) });
+        expect(res.status).toBe(403);
+    });
+
+    it('shows the instance owner which secrets are set, never their values', async () => {
+        const res = await app.call('GET', '/api/v1/settings/oauth', { token: signSession(OWNER, [COMPANY]) });
+        expect(res.status).toBe(200);
+        expect(JSON.stringify(res.body)).not.toMatch(/super-secret|gh-secret/);
+        expect(res.body.data).toMatchObject({ clientId: 'client-id', clientSecretSet: true, githubClientSecretSet: true, gitlabClientSecretSet: false, isGoogleLogin: true });
+    });
+
+    it('refuses the instance owner writing a key outside the OAuth allowlist', async () => {
+        const res = await app.call('POST', '/api/v1/settings/oauth', {
+            token: signSession(OWNER, [COMPANY]),
+            body: { pathType: 'root', variables: [{ variableName: 'MONGODB_URL', variableValue: 'mongodb://evil' }] },
+        });
+        expect(res.status).toBe(400);
+        expect(updateEnvVariablesUtil).not.toHaveBeenCalled();
+    });
+
+    it('writes validated OAuth keys for the instance owner', async () => {
+        const variables = [{ variableName: 'GITHUB_CLIENT_ID', variableValue: 'Iv1.abc123' }];
+        const res = await app.call('POST', '/api/v1/settings/oauth', { token: signSession(OWNER, [COMPANY]), body: { pathType: 'root', variables } });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ status: true, statusText: 'Updated' });
+        expect(updateEnvVariablesUtil).toHaveBeenCalledWith('root', variables);
+    });
+});

--- a/tests/public-route-handlers.test.js
+++ b/tests/public-route-handlers.test.js
@@ -145,9 +145,9 @@ describe('a session acts only on its own account', () => {
         expect(MongoDbCrudOpration).not.toHaveBeenCalled();
     });
 
-    it("refuses ending another user's sessions", () => {
+    it("refuses ending another user's sessions", async () => {
         const res = response();
-        deleteUserSpecificSession(request({ params: { id: OTHER_USER } }), res);
+        await deleteUserSpecificSession(request({ params: { id: OTHER_USER } }), res);
         expect(res.statusCode).toBe(403);
         expect(MongoDbCrudOpration).not.toHaveBeenCalled();
     });

--- a/tests/session-token-access.test.js
+++ b/tests/session-token-access.test.js
@@ -1,0 +1,107 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(async () => null) }));
+jest.mock('../utils/data', () => ({ importUserNotifications: jest.fn() }));
+jest.mock('../Modules/Auth/controller', () => ({ addAndRemoveUserInMongodbNotificationCount: jest.fn() }));
+jest.mock('../Modules/Auth/controller/sendVerificationMail', () => ({}));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { myCache } = require('../Config/config');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { setMiddlewareV2 } = require('../Config/setMiddleware');
+const { signSession, startApp } = require('./fixtures/sessionApp');
+const session = require('../Modules/Auth/session');
+
+const COMPANY = '6f0000000000000000000c01';
+const OWNER = '6f0000000000000000000001';
+const ADMIN = '6f0000000000000000000002';
+const MEMBER = '6f0000000000000000000003';
+const ROLES = { [OWNER]: 1, [ADMIN]: 2, [MEMBER]: 3 };
+
+const callsOf = (method) => MongoDbCrudOpration.mock.calls.filter((call) => call[2] === method);
+
+let app;
+
+beforeAll(async () => {
+    app = await startApp((server) => {
+        setMiddlewareV2(server);
+        server.delete('/api/v2/session/delete', session.deleteAllSession);
+        server.delete('/api/v2/session/delete/:id', session.deleteUserSpecificSession);
+    });
+});
+afterAll(() => app.close());
+
+beforeEach(() => {
+    myCache.flushAll();
+    MongoDbCrudOpration.mockReset();
+    MongoDbCrudOpration.mockImplementation(async (db, obj, method) => {
+        const filter = (obj.data && obj.data[0]) || {};
+        if (obj.type === SCHEMA_TYPE.COMPANY_USERS) return ROLES[filter.userId] !== undefined ? { roleType: ROLES[filter.userId] } : null;
+        if (method === 'deleteMany') return { deletedCount: 1 };
+        return null;
+    });
+});
+
+describe('ACC-02 and ACC-03 token and session minting', () => {
+    it('no longer exposes a handler that mints a token or session from a bare user id', () => {
+        expect(require('../Modules/Auth/controller/createUser').generateToken).toBeUndefined();
+        expect(session.registerSesstion).toBeUndefined();
+    });
+});
+
+describe('ACC-03 /api/v2/session/delete', () => {
+    it('refuses deleting every session anonymously', async () => {
+        const res = await app.call('DELETE', '/api/v2/session/delete');
+        expect(res.status).toBe(401);
+        expect(callsOf('deleteMany')).toHaveLength(0);
+    });
+
+    it('deletes only the caller\'s sessions when asked to delete all', async () => {
+        const token = signSession(MEMBER, [COMPANY]);
+        const res = await app.call('DELETE', '/api/v2/session/delete', { token });
+        expect(res.status).toBe(200);
+        expect(callsOf('deleteMany').map((call) => call[1].data[0])).toEqual([{ userId: MEMBER }]);
+    });
+
+    it('never issues an unfiltered deleteMany', async () => {
+        const result = await new Promise((resolve) => session.deleteSessionFun('', resolve));
+        expect(result.status).toBe(false);
+        expect(MongoDbCrudOpration).not.toHaveBeenCalled();
+    });
+
+    it('refuses deleting a user\'s sessions anonymously', async () => {
+        const res = await app.call('DELETE', `/api/v2/session/delete/${OWNER}`);
+        expect(res.status).toBe(401);
+    });
+
+    it('lets a user delete their own sessions by id', async () => {
+        const token = signSession(MEMBER, [COMPANY]);
+        const res = await app.call('DELETE', `/api/v2/session/delete/${MEMBER}`, { token, companyId: COMPANY });
+        expect(res.status).toBe(200);
+    });
+
+    it('refuses a member signing out another member', async () => {
+        const token = signSession(MEMBER, [COMPANY]);
+        const res = await app.call('DELETE', `/api/v2/session/delete/${ADMIN}`, { token, companyId: COMPANY });
+        expect(res.status).toBe(403);
+        expect(callsOf('deleteMany')).toHaveLength(0);
+    });
+
+    it('lets an admin sign out a member of their company', async () => {
+        const token = signSession(ADMIN, [COMPANY]);
+        const res = await app.call('DELETE', `/api/v2/session/delete/${MEMBER}`, { token, companyId: COMPANY });
+        expect(res.status).toBe(200);
+        expect(callsOf('deleteMany')[0][1].data[0]).toEqual({ userId: MEMBER });
+    });
+
+    it('refuses an admin signing out the owner', async () => {
+        const token = signSession(ADMIN, [COMPANY]);
+        const res = await app.call('DELETE', `/api/v2/session/delete/${OWNER}`, { token, companyId: COMPANY });
+        expect(res.status).toBe(403);
+    });
+
+    it('refuses an admin acting without a company', async () => {
+        const token = signSession(ADMIN, [COMPANY]);
+        const res = await app.call('DELETE', `/api/v2/session/delete/${MEMBER}`, { token });
+        expect(res.status).toBe(403);
+    });
+});

--- a/tests/user-access.test.js
+++ b/tests/user-access.test.js
@@ -1,0 +1,216 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(async () => null) }));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { myCache } = require('../Config/config');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { setMiddlewareV2 } = require('../Config/setMiddleware');
+const { signSession, startApp } = require('./fixtures/sessionApp');
+const rules = require('../Modules/Users/helpers/userAccessRules');
+const ctrl = require('../Modules/Users/controller');
+
+const COMPANY = '6f0000000000000000000c01';
+const OTHER_COMPANY = '6f0000000000000000000c02';
+const OWNER = '6f0000000000000000000001';
+const ADMIN = '6f0000000000000000000002';
+const MEMBER = '6f0000000000000000000003';
+const GUEST = '6f0000000000000000000004';
+const STRANGER = '6f0000000000000000000005';
+
+const SECRETS = { webTokens: ['push-token'], verificationToken: 'verify-secret', forgotPasswordToken: 'reset-secret', forgotPasswordTokenTime: 1 };
+const USERS = {
+    [OWNER]: { _id: OWNER, Employee_Name: 'Owner', AssignCompany: [COMPANY, OTHER_COMPANY], isProductOwner: true, customerId: 'cus_1', ...SECRETS },
+    [ADMIN]: { _id: ADMIN, Employee_Name: 'Admin', AssignCompany: [COMPANY], ...SECRETS },
+    [MEMBER]: { _id: MEMBER, Employee_Name: 'Member', AssignCompany: [COMPANY], ...SECRETS },
+    [GUEST]: { _id: GUEST, Employee_Name: 'Guest', AssignCompany: [COMPANY], ...SECRETS },
+    [STRANGER]: { _id: STRANGER, Employee_Name: 'Stranger', AssignCompany: [OTHER_COMPANY], ...SECRETS },
+};
+const ROLES = { [OWNER]: 1, [ADMIN]: 2, [MEMBER]: 3, [GUEST]: 0 };
+
+const callsOf = (method) => MongoDbCrudOpration.mock.calls.filter((call) => call[2] === method);
+const leaksSecret = (body) => /push-token|verify-secret|reset-secret/.test(JSON.stringify(body));
+
+let app;
+
+beforeAll(async () => {
+    app = await startApp((server) => {
+        setMiddlewareV2(server);
+        server.put('/api/v1/user', ctrl.updateUserStatus);
+        server.get('/api/v1/user/:id', ctrl.getUserById);
+        server.post('/api/v1/user/find', ctrl.getUserByQuey);
+    });
+});
+afterAll(() => app.close());
+
+beforeEach(() => {
+    myCache.flushAll();
+    MongoDbCrudOpration.mockReset();
+    MongoDbCrudOpration.mockImplementation(async (db, obj, method) => {
+        const filter = (obj.data && obj.data[0]) || {};
+        if (obj.type === SCHEMA_TYPE.COMPANY_USERS) return db === COMPANY && ROLES[filter.userId] !== undefined ? { roleType: ROLES[filter.userId] } : null;
+        if (method === 'findOne') return USERS[String(filter._id)] || null;
+        if (method === 'aggregate') return [USERS[OWNER], USERS[GUEST]];
+        if (method === 'findOneAndUpdate') return { ...USERS[String(filter._id)], ...((obj.data[1] && obj.data[1].$set) || {}) };
+        return null;
+    });
+});
+
+describe('userAccessRules', () => {
+    it('keeps secrets out of both views', () => {
+        expect(leaksSecret(rules.toSelfView(USERS[OWNER]))).toBe(false);
+        expect(leaksSecret(rules.toMemberView(USERS[OWNER], [COMPANY]))).toBe(false);
+    });
+
+    it('shows only the companies the caller shares', () => {
+        expect(rules.toMemberView(USERS[OWNER], [COMPANY]).AssignCompany).toEqual([COMPANY]);
+    });
+
+    it.each([
+        [{ forgotPasswordToken: { $regex: '^a' } }],
+        [{ Employee_Name: { $regex: 'a' } }],
+        [{ $expr: { $eq: ['$isActive', true] } }],
+        [{ $or: [{ webTokens: 'x' }] }],
+    ])('refuses the filter %j', (query) => {
+        expect(rules.sanitizeUserQuery(query).ok).toBe(false);
+    });
+
+    it('accepts the filter the members store sends', () => {
+        expect(rules.sanitizeUserQuery({ isActive: true, AssignCompany: { $in: [COMPANY] } }).ok).toBe(true);
+    });
+
+    it.each([
+        [{ $set: { isProductOwner: true } }],
+        [{ AssignCompany: [OTHER_COMPANY] }],
+        [{ $push: { AssignCompany: OTHER_COMPANY } }],
+        [{ $set: { 'webTokens.0': 'x' } }],
+        [{ $set: { tour: {} }, $unset: { isActive: 1 } }],
+    ])('refuses the self update %j', (update) => {
+        expect(rules.sanitizeSelfUpdate(update).ok).toBe(false);
+    });
+
+    it('turns a plain profile update into $set', () => {
+        expect(rules.sanitizeSelfUpdate({ isOnline: true }).update).toEqual({ $set: { isOnline: true } });
+    });
+});
+
+describe('ACC-05 GET /api/v1/user/:id', () => {
+    it('refuses an anonymous read', async () => {
+        const res = await app.call('GET', `/api/v1/user/${OWNER}`);
+        expect(res.status).toBe(401);
+    });
+
+    it('returns the caller their own profile without secrets', async () => {
+        const res = await app.call('GET', `/api/v1/user/${OWNER}`, { token: signSession(OWNER, [COMPANY]) });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ _id: OWNER, isProductOwner: true, AssignCompany: [COMPANY, OTHER_COMPANY] });
+        expect(leaksSecret(res.body)).toBe(false);
+    });
+
+    it('gives a guest only the public profile of a teammate', async () => {
+        const res = await app.call('GET', `/api/v1/user/${OWNER}`, { token: signSession(GUEST, [COMPANY]) });
+        expect(res.status).toBe(200);
+        expect(leaksSecret(res.body)).toBe(false);
+        expect(res.body.isProductOwner).toBeUndefined();
+        expect(res.body.customerId).toBeUndefined();
+        expect(res.body.AssignCompany).toEqual([COMPANY]);
+    });
+
+    it('does not reveal a user who shares no company with the caller', async () => {
+        const res = await app.call('GET', `/api/v1/user/${STRANGER}`, { token: signSession(GUEST, [COMPANY]) });
+        expect(res.status).toBe(404);
+        expect(res.body.Employee_Name).toBeUndefined();
+    });
+});
+
+describe('ACC-05 POST /api/v1/user/find', () => {
+    it('refuses a company the caller is not a member of', async () => {
+        const token = signSession(GUEST, [COMPANY, OTHER_COMPANY]);
+        myCache.set(`membership:${GUEST}:${OTHER_COMPANY}`, false);
+        const res = await app.call('POST', '/api/v1/user/find', { token, body: { query: {}, companyId: OTHER_COMPANY } });
+        expect(res.status).toBe(403);
+        expect(callsOf('aggregate')).toHaveLength(0);
+    });
+
+    it('refuses a company outside the caller\'s token', async () => {
+        const res = await app.call('POST', '/api/v1/user/find', { token: signSession(GUEST, [COMPANY]), body: { query: {}, companyId: OTHER_COMPANY } });
+        expect(res.status).toBe(403);
+    });
+
+    it('pins the query to the caller\'s company and strips secrets', async () => {
+        const query = { isActive: true, AssignCompany: { $in: [COMPANY] } };
+        const res = await app.call('POST', '/api/v1/user/find', { token: signSession(GUEST, [COMPANY]), body: { query, companyId: COMPANY } });
+        expect(res.status).toBe(200);
+        expect(callsOf('aggregate')[0][1].data[0]).toEqual([{ $match: { $and: [query, { AssignCompany: COMPANY }] } }]);
+        expect(leaksSecret(res.body)).toBe(false);
+        expect(res.body.find((u) => u._id === OWNER).isProductOwner).toBeUndefined();
+    });
+
+    it('refuses a probing filter on a secret field', async () => {
+        const res = await app.call('POST', '/api/v1/user/find', {
+            token: signSession(GUEST, [COMPANY]),
+            body: { query: { forgotPasswordToken: { $regex: '^a' } }, companyId: COMPANY },
+        });
+        expect(res.status).toBe(400);
+        expect(callsOf('aggregate')).toHaveLength(0);
+    });
+});
+
+describe('ACC-05 PUT /api/v1/user', () => {
+    const put = (uid, body) => app.call('PUT', '/api/v1/user', { token: signSession(uid, [COMPANY]), body });
+
+    it('refuses an anonymous write', async () => {
+        const res = await app.call('PUT', '/api/v1/user', { body: { userId: OWNER, updateObject: { isActive: false } } });
+        expect(res.status).toBe(401);
+    });
+
+    it('refuses a guest writing to another user', async () => {
+        const res = await put(GUEST, { userId: OWNER, updateObject: { $set: { isActive: false } } });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it('refuses a user promoting themself', async () => {
+        const res = await put(GUEST, { userId: GUEST, updateObject: { $set: { isProductOwner: true } } });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it('refuses a user adding a company to themself', async () => {
+        const res = await put(GUEST, { userId: GUEST, updateObject: { $push: { AssignCompany: OTHER_COMPANY } } });
+        expect(res.status).toBe(403);
+    });
+
+    it('lets a user update their own presence and returns no secrets', async () => {
+        const res = await put(GUEST, { userId: GUEST, updateObject: { isOnline: true }, newObj: { returnDocument: 'after', upsert: true } });
+        expect(res.status).toBe(200);
+        expect(callsOf('findOneAndUpdate')[0][1].data).toEqual([expect.anything(), { $set: { isOnline: true } }, { returnDocument: 'after' }]);
+        expect(leaksSecret(res.body)).toBe(false);
+    });
+
+    it('refuses selecting a company the user is not in', async () => {
+        const res = await put(GUEST, { userId: GUEST, updateObject: { $set: { lastSelectedCompany: OTHER_COMPANY } } });
+        expect(res.status).toBe(403);
+    });
+
+    it('refuses a member removing a teammate from the company', async () => {
+        const res = await put(MEMBER, { userId: GUEST, updateObject: { $pull: { AssignCompany: COMPANY } } });
+        expect(res.status).toBe(403);
+    });
+
+    it('lets an admin remove a member from their company', async () => {
+        const res = await put(ADMIN, { userId: GUEST, updateObject: { $pull: { AssignCompany: COMPANY } }, newObj: { returnDocument: 'after' } });
+        expect(res.status).toBe(200);
+        expect(callsOf('findOneAndUpdate')[0][1].data[1]).toEqual({ $pull: { AssignCompany: COMPANY } });
+        expect(leaksSecret(res.body)).toBe(false);
+    });
+
+    it('refuses an admin removing the owner', async () => {
+        const res = await put(ADMIN, { userId: OWNER, updateObject: { $pull: { AssignCompany: COMPANY } } });
+        expect(res.status).toBe(403);
+    });
+
+    it('refuses an admin removing a member from a company they do not administer', async () => {
+        const res = await put(ADMIN, { userId: STRANGER, updateObject: { $pull: { AssignCompany: OTHER_COMPANY } } });
+        expect(res.status).toBe(403);
+    });
+});


### PR DESCRIPTION
Fixes the access-area findings ACC-02 to ACC-09 from task 034 (`Tasks/active/034-end-to-end-qa-programme/findings/access.md`). #600 had already closed the unauthenticated entry points for several of them; this PR builds on it and closes the parts it left open. One commit per finding group.

| Finding | Route | State after #600 | This PR | Caller impact | Tests |
|---|---|---|---|---|---|
| ACC-02 | `POST /api/v1/generateToken` | Route removed | Deletes the still-exported handler and the unused `GENERATETOKEN` frontend constant | None: no caller. Web app and tracker refresh through `POST /api/v2/generateToken`, which needs a valid refresh token | Regression test flipped (404 or refusal, no token). Unit test: handler gone |
| ACC-03 | `POST /api/v2/session/register` | Route removed | Deletes the handler | None: no caller | Regression test flipped |
| ACC-03 | `DELETE /api/v2/session/delete` | Instance owner only, still `deleteMany({})` | Session required. Deletes only the caller's own sessions. `deleteSessionFun` refuses an empty id | None: no caller | Unit tests: 401 anonymous, own rows only, never an unfiltered delete. Integration: 401 anonymous |
| ACC-03 | `DELETE /api/v2/session/delete/:id` | Own id only | Own id, or an owner or admin of the `companyid` company signing out a member of it. An admin cannot sign out the owner | Change Password still sends its own id after changing the password | Unit tests: member 403, admin 200, admin→owner 403, no company 403. Integration: own sign-out works and the old session is then refused |
| ACC-04 | `GET/POST /api/v1/settings/oauth` | Instance owner only | GET returns `clientSecretSet` / `githubClientSecretSet` / `gitlabClientSecretSet` flags, never the values. POST accepts only the Google, GitHub and GitLab client keys and login flags. Values are validated (no quotes, whitespace or newlines, so no `.env` injection). The write is awaited | No frontend caller today. An admin UI would read the `*Set` flags | Unit tests: rules, 401, 403 for a non-owner, masking, allowlist. Integration: admin 403, owner sees flags only, `JWT_SECRET` write 400 |
| ACC-05 | `GET /api/v1/user/:id` | JWT only, full document | Own profile: safe self view. Another user: public profile only if they share a company, else 404. No `webTokens`, verification or reset tokens | App.vue, the router, CreateCompany and the tracker read their own id: unchanged fields minus secrets | Regression test rewritten: a guest gets the teammate's public profile, no secrets. Unit and integration: stranger 404 |
| ACC-05 | `POST /api/v1/user/find` | JWT only, raw `$match` | Requires membership of the requested company, pins the match to it, and allows only equality or membership filters on non-secret fields | The Users store's `{ isActive, AssignCompany: { $in: [cid] } }` query is unchanged | Unit and integration: other company 403, secret-field filter 400, results carry no secrets |
| ACC-05 | `PUT /api/v1/user` | JWT only, any user, any operator | Self: `$set` of profile, presence, tour, checklist, language and working-hours fields only (never `isProductOwner`, `AssignCompany` or tokens); `lastSelectedCompany` must be one of the user's own companies. Another user: only an owner or admin `$pull`ing a non-owner member from their own company. Options limited to `returnDocument` | Login and OAuth presence, tours, My Settings, Language and the home checklist are unchanged. Members removal is unchanged | Regression test flipped. Unit and integration: 403 for another user, self-promotion and adding a company; own preferences save |
| ACC-06 | `POST /api/v1/admin/company` (also `POST /api/v1/company`) | JWT only | `fetchAllCompany` for the instance owner only. `companyIds` filtered to the caller's own companies | Settings store and socket refresh request their own companies: unchanged | Regression test flipped. Unit and integration: only own company returned; owner lists all |
| ACC-06 | `POST /api/v1/admin/company/find` | JWT only, arbitrary pipeline | Non-owners get a leading `$match` on their own companies. `$lookup`, `$unionWith`, `$out`, `$merge`, `$where`, `$function` and similar are refused | The desktop tracker's `$match _id in AssignCompany` query is unchanged | Unit and integration: pinned to own company, `$lookup` 403 |
| ACC-06 | `PUT /api/v1/admin/company` | JWT only | Refuses an update without a valid company id, which used to hit whichever company matched `{}` | Callers always send the company | Unit test |
| ACC-07 | `POST /api/v1/manageTrackerUserPermission` | Session, owner or admin, session company | No change | — | Regression test was already flipped |
| ACC-08 | `PATCH /api/v2/auth/:id/change-password` | Session, own id, current password | No change | — | Regression test was already flipped |
| ACC-09 | `POST /api/v1/checkSendInviatation` | Session required, but the body company was queried | Uses the `companyid` company. A body naming another company gets 403 | Members invite pre-check sends both, and they match | Unit tests. Integration: other company 403, own company still answers |

## Gates

- `npx jest --selectProjects unit conventions`: 198 suites, 2478 tests pass. The tenant-scoping baseline for `sendInvitation.js` is lowered from 3 to 2.
- `npm run test:integration` against a private `mongo:7`: all suites pass. `tasks.int.test.js` failed once while creating its fixtures ("project has no sprint") on a heavily loaded machine, then passed alone. On that machine the integration run also needed `--testTimeout 60000`, because the project-level `testTimeout` is not applied and logins exceed 5 s under load.
- `cd frontend && npx vitest run`: 25 files, 188 tests pass.
- eslint: 0 errors on touched files. Warnings are only on lines this PR did not add.
- Playwright smoke spec: not run locally, because `@playwright/test` is not installed in the shared `node_modules`. Left to CI.

## Not in this PR

- `PUT /api/v1/admin/company` and `PUT /api/v1/company` still let any member of a company update that company's document. Gating them by role touches the member-count and tracker-count writes in Members and needs its own change.
- `PUT /api/v2/session/update` still takes `userId` from the body. The refresh token it matches comes from the session, which limits it to the caller's own row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
