### PR TITLE
test(034): give the two-factor and change-password screens a page load each

### DIFF
--- a/e2e/specs/access.spec.js
+++ b/e2e/specs/access.spec.js
@@ -26,9 +26,13 @@ test.describe('access screens as the owner', () => {
         await expect(page.getByText('Teams', { exact: true }).first()).toBeVisible();
     });
 
-    test('Two-factor and change-password screens render', async ({ page, state }) => {
+    test('Two-factor screen renders', async ({ page, state }) => {
         await page.goto(`/#/${state.companyId}/settings/two-factor-auth`);
         await expect(page).toHaveTitle(/Two-Factor/i);
+    });
+
+    // The router sets the title only after it fetches the user, so a second hash-only goto in one test can be checked before that lands.
+    test('Change-password screen renders', async ({ page, state }) => {
         await page.goto(`/#/${state.companyId}/settings/change-password`);
         await expect(page).toHaveTitle(/Change Password/i);
     });


### PR DESCRIPTION
## Summary

Fixes the flaky "Two-factor and change-password screens render" test (follow-up 27 in `Tasks/active/034-end-to-end-qa-programme/followups.md`). It failed on #626 twice and on #630 while passing on other PRs.

- **Cause:** the global router guard in `frontend/src/router/index.js` fetches the user before it sets the page title. The test opened the two-factor screen, then changed only the hash to the change-password screen in the same page. When that fetch or a late navigation from the first screen was slow, the title was still "Two-Factor Authentication".
- **Fix:** one test per screen, each starting with its own page load, as every other access spec does. What is checked is unchanged: each screen renders with its own title.
- **Product:** no change. Both screens render correctly; only the test's timing was wrong.

## Test plan

- [x] `node --check` and eslint on `e2e/specs/access.spec.js`.
- [ ] CI `e2e` job green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
