### PR TITLE
fix(company): limit company updates to owners and admins and send verification only to the account

### DIFF
--- a/Modules/Auth/controller/sendInvitation.js
+++ b/Modules/Auth/controller/sendInvitation.js
@@ -13,6 +13,7 @@ const { getUserByQueyFun } = require("../../Users/controller.js");
 const { updateMemberFunction } = require('../../settings/Members/controller.js');
 const logger = require("../../../Config/loggerConfig.js");
 const { emitListener } = require("../../Company/eventController.js");
+const { newLinkToken } = require("../helpers/linkToken");
 
 
 async function batchUpdate(arr, eventId) {
@@ -294,12 +295,7 @@ exports.sendInvitationEmailFun = (bodyData) => {
                 try {
                     if (resp.length > 0) {
                         const response = resp[0];
-                        let temp = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-                        let token = '';
-                        for ( let i = 0; i < 8; i++ ) {
-                            token += temp.charAt(Math.floor(Math.random() * temp.length));
-                        }
-        
+                        const token = newLinkToken();
                         let userId = response._id;
                         sendCheckRequest(email, userId, token)
                     } else {
@@ -504,12 +500,7 @@ exports.sendInvitationEmail = (req,res) => {
         getUserByQueyFun(query).then((resp)=>{
             if (resp.length > 0) {
                 const response = resp[0];
-                let temp = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-                let token = '';
-                for ( let i = 0; i < 8; i++ ) {
-                    token += temp.charAt(Math.floor(Math.random() * temp.length));
-                }
-
+                const token = newLinkToken();
                 let userId = response._id;
                 sendCheckRequest(email, userId, token)
             } else {

--- a/Modules/Auth/controller/sendVerificationMail.js
+++ b/Modules/Auth/controller/sendVerificationMail.js
@@ -1,9 +1,11 @@
 const mongoRef = require('../../../utils/mongo-handler/mongoQueries');
-const senVerificationMailTemplate = require("../../Template/sendEmailVerification.js")
+const verificationMailTemplate = require("../../Template/sendEmailVerification.js");
 const sendMail = require("../../service.js");
 const config = require("../../../Config/config");
 const { dbCollections } = require('../../../Config/collections');
+const { newLinkToken } = require('../helpers/linkToken');
 
+const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
 
 /**
  * Send Verification Email
@@ -13,30 +15,27 @@ const { dbCollections } = require('../../../Config/collections');
  */
 exports.sendVerificationEmailPromise = (userId,email) => {
     return new Promise((resolve, reject) => {
+        const failed = (error) => reject({
+            status: false,
+            statusText: `Error sending verification email for user ${userId} : ${error && error.message ? error.message : error}`
+        });
         try {
-            let temp = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-            let token = '';
-            for ( let i = 0; i < 8; i++ ) {
-                token += temp.charAt(Math.floor(Math.random() * temp.length));
-            }
-            let uid = userId;
-            let userEmail = (email).toLowerCase();
-            let obj = {
+            const token = newLinkToken();
+            const userEmail = String(email).toLowerCase();
+            const obj = {
                 type: dbCollections.USERS,
                 data: [
+                    { _id: userId },
                     {
-                        _id: userId
-                    },
-                    { 
                         verificationToken: token,
                         verificationTokenTime: new Date(),
                     }
                 ]
-            }
+            };
             mongoRef.MongoDbCrudOpration('global', obj, "updateOne").then(()=>{
-                let verificationLink = `${config.WEBURL}/#/verify-email/${uid}/${token}`
-                let mail = require("../../Template/sendEmailVerification.js")(verificationLink,config.WEBURL);
-                sendMail.SendEmail(mail.subject,mail.mail, userEmail, true, (result) => {
+                const verificationLink = `${config.WEBURL}/#/verify-email/${userId}/${token}`;
+                const mail = verificationMailTemplate(verificationLink, config.WEBURL);
+                sendMail.SendEmail(mail.subject, mail.mail, userEmail, true, (result) => {
                     if(result.status) {
                         resolve({
                             status: true,
@@ -49,76 +48,37 @@ exports.sendVerificationEmailPromise = (userId,email) => {
                         });
                     }
                 });
-            }).catch((error)=>{
-                reject({
-                    status: false, 
-                    statusText:`Error sending verification email for user ${email} : ${error.message ? error.message : error}`
-                })
-            })
-    
+            }).catch(failed);
         } catch (error) {
-            reject({
-                status: false, 
-                statusText:`Error sending verification email for user ${email} : ${error.message ? error.message : error}`
-            })
+            failed(error);
         }
-    })
-}
-
+    });
+};
 
 /**
- * Send Verification Mail
+ * Resend the verification link. The address always comes from the account, never from the request.
  * @param {Objcet} req
  * @param {Object} res
  * @returns
  */
-exports.sendVerificationEmail = (req,res) => {
-    try {
-        if(!req.body.uid || req.body.uid === '') {
-            res.send({
-                status: false,
-                statusText: "Userid is required."
-            });
-            return;
-        }
-        if (!req.body.email || req.body.email === '') {
-            res.send({
-                status: false,
-                statusText: "email is required."
-            })
-        }
-        let obj = {
-            type: dbCollections.USERS,
-            data: [
-                {
-                    _id: req.body.uid
-                },
-            ]
-        }
-        mongoRef.MongoDbCrudOpration("global",obj,"findOne").then((response)=>{
-            if (response.isEmailVerified === true) {
-                res.send({
-                    status: false,
-                    statusText: `Your Email is already verified`
-                })
-                return;
-            } else {
-                exports.sendVerificationEmailPromise(req.body.uid,req.body.email).then((response)=>{
-                    res.send(response)
-                }).catch((error)=>{
-                    res.send(error)
-                })
-            }
-        }).catch((error)=>{
-            res.send({
-                status: false,
-                statusText: error
-            })
-        })
-    } catch (error) {
-        res.send({
-            status: false,
-            statusText: `Error: ${error}`
-        })
+exports.sendVerificationEmail = async (req,res) => {
+    const uid = String((req.body && req.body.uid) || '');
+    if (!OBJECT_ID_PATTERN.test(uid)) {
+        return res.send({ status: false, statusText: "Userid is required." });
     }
-}
+    try {
+        const account = await mongoRef.MongoDbCrudOpration("global", {
+            type: dbCollections.USERS,
+            data: [{ _id: uid }, { Employee_Email: 1, isEmailVerified: 1 }]
+        }, "findOne");
+        if (!account || !account.Employee_Email) {
+            return res.send({ status: false, statusText: "Couldn’t find your Account" });
+        }
+        if (account.isEmailVerified === true) {
+            return res.send({ status: false, statusText: "Your Email is already verified" });
+        }
+        return res.send(await exports.sendVerificationEmailPromise(uid, account.Employee_Email));
+    } catch (error) {
+        return res.send({ status: false, statusText: (error && error.statusText) || "Could not send the verification email." });
+    }
+};

--- a/Modules/Auth/helpers/linkToken.js
+++ b/Modules/Auth/helpers/linkToken.js
@@ -1,0 +1,5 @@
+const crypto = require('crypto');
+
+const newLinkToken = () => crypto.randomBytes(32).toString('hex');
+
+module.exports = { newLinkToken };

--- a/Modules/Company/controller/updateCompany.js
+++ b/Modules/Company/controller/updateCompany.js
@@ -6,7 +6,18 @@ const { default: mongoose } = require("mongoose");
 const { replaceObjectKey } = require("../../Auth/helper");
 const socketEmitter = require("../../../event/socketEventEmitter");
 const { isInstanceOwner } = require("../../Instance/guard");
-const { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline } = require("../helpers/companyAccessRules");
+const { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, memberCompanyUpdate } = require("../helpers/companyAccessRules");
+const { getRoleType, evaluatePermission, isPrivileged, isWritable } = require("../../../Config/permissionGuard");
+
+const mayUpdateCompany = async (companyId, req) => {
+    const roleType = await getRoleType(companyId, req.uid);
+    if (roleType === null) return false;
+    if (isPrivileged(roleType)) return true;
+    const kind = memberCompanyUpdate(req.body);
+    if (kind === 'projectType') return true;
+    if (kind !== 'seatRelease') return false;
+    return isWritable(await evaluatePermission(companyId, req.uid, 'settings.settings_member_list').catch(() => null));
+};
 
 const loadOwnCompanyIds = async (uid) => {
     const user = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
@@ -29,6 +40,10 @@ exports.updateCompany = async(req,res) => {
 
         if (!(req.body && req.body.updateObject)) {
             return res.status(400).json({message: 'Update Object is Required'});
+        }
+
+        if (!(await mayUpdateCompany(companyId, req))) {
+            return res.status(403).json({ status: false, message: 'Only an owner or an admin can change the company.' });
         }
 
         let key;

--- a/Modules/Company/helpers/companyAccessRules.js
+++ b/Modules/Company/helpers/companyAccessRules.js
@@ -33,4 +33,26 @@ const scopeCompanyPipeline = (findQuery, own) => {
     return { ok: true, pipeline: [{ $match: { _id: { $in: own } } }, ...stages] };
 };
 
-module.exports = { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline };
+const PROJECT_TYPE_FIELDS = ['projectCount.privateCount', 'projectCount.publicCount'];
+const SEAT_FIELD = 'companyData.$[elementIndex].users';
+const SEAT_ARRAY_FILTERS = JSON.stringify([{ 'elementIndex.users': { $exists: true } }]);
+
+// The only company writes the app sends for someone who is not an owner or admin: moving a
+// project between the private and public counts, and releasing a seat after removing a member.
+const memberCompanyUpdate = (body) => {
+    const { key, updateObject, arrayFilters } = body || {};
+    if (key !== '$inc' || !isPlainContainer(updateObject) || Array.isArray(updateObject)) return null;
+    const entries = Object.entries(updateObject);
+    const hasArrayFilters = Array.isArray(arrayFilters) && arrayFilters.length > 0;
+    const fields = entries.map(([field]) => field).sort();
+    if (!hasArrayFilters && entries.length === 2 && fields.join() === [...PROJECT_TYPE_FIELDS].sort().join()
+        && entries.every(([, step]) => step === 1 || step === -1) && entries[0][1] + entries[1][1] === 0) {
+        return 'projectType';
+    }
+    if (entries.length !== 1 || entries[0][1] !== -1) return null;
+    if (fields[0] === 'trackerUsers' && !hasArrayFilters) return 'seatRelease';
+    if (fields[0] === SEAT_FIELD && JSON.stringify(arrayFilters) === SEAT_ARRAY_FILTERS) return 'seatRelease';
+    return null;
+};
+
+module.exports = { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, memberCompanyUpdate };

--- a/tests/company-access.test.js
+++ b/tests/company-access.test.js
@@ -1,20 +1,30 @@
 jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
 jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(async () => null) }));
 jest.mock('../event/socketEventEmitter', () => ({}));
+jest.mock('../Config/permissionGuard', () => ({
+    ...jest.requireActual('../Config/permissionGuard'),
+    getRoleType: jest.fn(async () => null),
+    evaluatePermission: jest.fn(async () => null),
+}));
 
 const mongoose = require('mongoose');
 const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
 const { myCache } = require('../Config/config');
 const { SCHEMA_TYPE } = require('../Config/schemaType');
 const { setMiddlewareV2 } = require('../Config/setMiddleware');
+const { getRoleType, evaluatePermission } = require('../Config/permissionGuard');
 const { signSession, startApp } = require('./fixtures/sessionApp');
-const { scopeCompanyPipeline, allowedCompanyIds } = require('../Modules/Company/helpers/companyAccessRules');
+const { scopeCompanyPipeline, allowedCompanyIds, memberCompanyUpdate } = require('../Modules/Company/helpers/companyAccessRules');
 const ctrl = require('../Modules/Company/controller/updateCompany');
 
 const COMPANY = '6f0000000000000000000c01';
 const OTHER_COMPANY = '6f0000000000000000000c02';
 const OWNER = '6f0000000000000000000001';
+const ADMIN = '6f0000000000000000000002';
+const MEMBER = '6f0000000000000000000003';
 const GUEST = '6f0000000000000000000004';
+const OUTSIDER = '6f0000000000000000000005';
+const ROLE_OF = { [OWNER]: 1, [ADMIN]: 2, [MEMBER]: 3, [GUEST]: 0 };
 
 const callsOf = (method) => MongoDbCrudOpration.mock.calls.filter((call) => call[2] === method);
 
@@ -26,12 +36,17 @@ beforeAll(async () => {
         server.post('/api/v1/admin/company', ctrl.getCompany);
         server.post('/api/v1/admin/company/find', ctrl.getCompanyByAggregate);
         server.put('/api/v1/admin/company', ctrl.updateCompany);
+        server.put('/api/v1/company-invitation', ctrl.updateCompany);
     });
 });
 afterAll(() => app.close());
 
 beforeEach(() => {
     myCache.flushAll();
+    getRoleType.mockReset();
+    getRoleType.mockImplementation(async (companyId, uid) => (companyId === COMPANY && uid in ROLE_OF ? ROLE_OF[uid] : null));
+    evaluatePermission.mockReset();
+    evaluatePermission.mockImplementation(async () => null);
     MongoDbCrudOpration.mockReset();
     MongoDbCrudOpration.mockImplementation(async (db, obj, method) => {
         const filter = (obj.data && obj.data[0]) || {};
@@ -39,6 +54,7 @@ beforeEach(() => {
         if (obj.type === SCHEMA_TYPE.USERS) return { AssignCompany: String(filter._id) === OWNER ? [COMPANY, OTHER_COMPANY] : [COMPANY] };
         if (method === 'find') return filter._id ? filter._id.$in.map((id) => ({ _id: String(id) })) : [{ _id: COMPANY }, { _id: OTHER_COMPANY }];
         if (method === 'aggregate') return [];
+        if (method === 'findOneAndUpdate') return { _id: COMPANY };
         return null;
     });
 });
@@ -113,6 +129,82 @@ describe('PUT /api/v1/admin/company', () => {
     it('refuses an update that names no company', async () => {
         const res = await app.call('PUT', '/api/v1/admin/company', { token: signSession(GUEST, [COMPANY]), body: { updateObject: { Cst_CompanyName: 'x' } } });
         expect(res.status).toBe(400);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+});
+
+const SWAP_TO_PRIVATE = { key: '$inc', updateObject: { 'projectCount.privateCount': 1, 'projectCount.publicCount': -1 } };
+const SEAT_RELEASE = { key: '$inc', updateObject: { 'companyData.$[elementIndex].users': -1 }, arrayFilters: [{ 'elementIndex.users': { $exists: true } }] };
+const TRACKER_SEAT_RELEASE = { key: '$inc', updateObject: { trackerUsers: -1 } };
+const RENAME = { updateObject: { Cst_CompanyName: 'Taken over' } };
+
+describe('memberCompanyUpdate', () => {
+    it('recognises the project type swap in both directions', () => {
+        expect(memberCompanyUpdate(SWAP_TO_PRIVATE)).toBe('projectType');
+        expect(memberCompanyUpdate({ key: '$inc', updateObject: { 'projectCount.publicCount': 1, 'projectCount.privateCount': -1 } })).toBe('projectType');
+    });
+
+    it('recognises the seat releases the members page sends', () => {
+        expect(memberCompanyUpdate(SEAT_RELEASE)).toBe('seatRelease');
+        expect(memberCompanyUpdate(TRACKER_SEAT_RELEASE)).toBe('seatRelease');
+    });
+
+    it.each([
+        [RENAME],
+        [{ key: '$set', updateObject: SWAP_TO_PRIVATE.updateObject }],
+        [{ key: '$inc', updateObject: { 'projectCount.privateCount': 5, 'projectCount.publicCount': -5 } }],
+        [{ key: '$inc', updateObject: { 'projectCount.privateCount': 1, 'projectCount.publicCount': 1 } }],
+        [{ key: '$inc', updateObject: { 'projectCount.privateCount': 1 } }],
+        [{ key: '$inc', updateObject: { ...SWAP_TO_PRIVATE.updateObject, planId: 1 } }],
+        [{ ...SWAP_TO_PRIVATE, arrayFilters: [{ x: 1 }] }],
+        [{ key: '$inc', updateObject: { 'companyData.$[elementIndex].users': 1 }, arrayFilters: SEAT_RELEASE.arrayFilters }],
+        [{ key: '$inc', updateObject: SEAT_RELEASE.updateObject, arrayFilters: [{ 'elementIndex.users': { $gt: 0 } }] }],
+        [{ key: '$inc', updateObject: { trackerUsers: -10 } }],
+        [{ key: '$inc', updateObject: { 'projectCount.privateCount': '1', 'projectCount.publicCount': '-1' } }],
+    ])('rejects %j', (body) => {
+        expect(memberCompanyUpdate(body)).toBe(null);
+    });
+});
+
+describe('PUT company update is for owners and admins', () => {
+    const put = (path, uid, body) => app.call('PUT', path, { token: signSession(uid, [COMPANY]), companyId: COMPANY, body });
+
+    it.each(['/api/v1/admin/company', '/api/v1/company-invitation'])('refuses a member renaming the company through %s', async (path) => {
+        const res = await put(path, MEMBER, RENAME);
+        expect(res.status).toBe(403);
+        expect(res.body).toEqual({ status: false, message: expect.any(String) });
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it('refuses a guest and a caller outside the company', async () => {
+        expect((await put('/api/v1/admin/company', GUEST, RENAME)).status).toBe(403);
+        expect((await put('/api/v1/admin/company', OUTSIDER, SWAP_TO_PRIVATE)).status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it.each([[OWNER], [ADMIN]])('lets %s rename the company', async (uid) => {
+        const res = await put('/api/v1/admin/company', uid, RENAME);
+        expect(res.status).toBe(200);
+        expect(callsOf('findOneAndUpdate')[0][1].data[1]).toEqual({ $set: RENAME.updateObject });
+    });
+
+    it('lets a member swap a project between private and public', async () => {
+        const res = await put('/api/v1/admin/company', MEMBER, SWAP_TO_PRIVATE);
+        expect(res.status).toBe(200);
+        expect(callsOf('findOneAndUpdate')[0][1].data[1]).toEqual({ $inc: SWAP_TO_PRIVATE.updateObject });
+    });
+
+    it('lets a member who manages the member list release a seat', async () => {
+        evaluatePermission.mockImplementation(async (companyId, uid, key) => (key === 'settings.settings_member_list' ? true : null));
+        expect((await put('/api/v1/admin/company', MEMBER, SEAT_RELEASE)).status).toBe(200);
+        expect((await put('/api/v1/admin/company', MEMBER, TRACKER_SEAT_RELEASE)).status).toBe(200);
+        expect(evaluatePermission).toHaveBeenCalledWith(COMPANY, MEMBER, 'settings.settings_member_list');
+    });
+
+    it('refuses a seat release from a member without member-list write access', async () => {
+        evaluatePermission.mockImplementation(async () => false);
+        const res = await put('/api/v1/admin/company', MEMBER, SEAT_RELEASE);
+        expect(res.status).toBe(403);
         expect(callsOf('findOneAndUpdate')).toHaveLength(0);
     });
 });

--- a/tests/integration/access.int.test.js
+++ b/tests/integration/access.int.test.js
@@ -295,6 +295,51 @@ describe('access — company reads are the caller\'s own companies', () => {
     });
 });
 
+describe('access — only owners and admins change the company', () => {
+    const readCompany = async (session) => (await session.api.post('/api/v1/admin/company', { companyIds: [state.companyId] })).body[0];
+
+    it.each([
+        ['member', '/api/v1/company'],
+        ['member', '/api/v1/admin/company'],
+        ['guest', '/api/v1/company-invitation'],
+    ])('refuses a %s renaming the company through %s', async (role, path) => {
+        const session = await loginAs(role);
+        const before = await readCompany(session);
+        const res = await session.api.put(path, { updateObject: { Cst_CompanyName: `Taken ${uniqueSuffix()}` }, companyId: state.companyId });
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect((await readCompany(session)).Cst_CompanyName).toBe(before.Cst_CompanyName);
+    });
+
+    it('lets an admin save the company details', async () => {
+        const admin = await loginAs('admin');
+        const before = await readCompany(admin);
+        const res = await admin.api.put('/api/v1/company', { updateObject: { Cst_CompanyName: before.Cst_CompanyName } });
+        expect(res.status).toBe(200);
+        expect(res.body.Cst_CompanyName).toBe(before.Cst_CompanyName);
+    });
+
+    it('lets a member switch a project between private and public', async () => {
+        const member = await loginAs('member');
+        const swap = (toPrivate) => member.api.put('/api/v1/company', {
+            key: '$inc',
+            updateObject: { 'projectCount.privateCount': toPrivate ? 1 : -1, 'projectCount.publicCount': toPrivate ? -1 : 1 },
+        });
+        expect((await swap(true)).status).toBe(200);
+        expect((await swap(false)).status).toBe(200);
+    });
+
+    it('refuses a guest releasing a seat', async () => {
+        const guest = await loginAs('guest');
+        const res = await guest.api.put('/api/v1/company', {
+            key: '$inc',
+            updateObject: { 'companyData.$[elementIndex].users': -1 },
+            arrayFilters: [{ 'elementIndex.users': { $exists: true } }],
+        });
+        expect(res.status).toBe(403);
+    });
+});
+
 describe('access — the invitation check stays inside the signed-in company', () => {
     it('refuses probing another company', async () => {
         const admin = await loginAs('admin');

--- a/tests/integration/public-routes.int.test.js
+++ b/tests/integration/public-routes.int.test.js
@@ -167,4 +167,34 @@ describe('invitations', () => {
         expect(res.body.statusText.AssignCompany).toEqual([]);
         expect(res.body.statusText.isEmailVerified).toBe(false);
     });
+
+    it('gives an existing account a 256-bit invitation link token', async () => {
+        const email = `link-token-${uniqueSuffix()}@e2e.alianhub.test`;
+        const created = await anonymous.post('/api/v2/createUser', { firstName: 'Link', lastName: 'Token', email, password: 'Str0ng!pass' });
+        expect(created.body.status).toBe(true);
+        const { api } = await loginAs('owner');
+        const invite = await api.post('/api/v2/sendInvitationEmail', { email, companyId: state.companyId, companyName: 'E2E', role: 3, designation: 0 });
+        expect(invite.body.data.linkId).toMatch(/^[0-9a-f]{64}$/);
+    });
+});
+
+describe('verification email', () => {
+    const newAccount = async () => {
+        const email = `verify-${uniqueSuffix()}@e2e.alianhub.test`;
+        const created = await anonymous.post('/api/v2/createUser', { firstName: 'Verify', lastName: 'Me', email, password: 'Str0ng!pass' });
+        expect(created.body.status).toBe(true);
+        return String(created.body.statusText._id);
+    };
+
+    it('resends to the account address without taking one from the request', async () => {
+        const uid = await newAccount();
+        const res = await anonymous.post('/api/v2/sendVerificationEmail', { uid });
+        expect(res.status).toBe(200);
+        expect(res.body.statusText).not.toBe('email is required.');
+    });
+
+    it('refuses an account id that does not exist', async () => {
+        const res = await anonymous.post('/api/v2/sendVerificationEmail', { uid: '000000000000000000000000', email: `someone-${uniqueSuffix()}@e2e.alianhub.test` });
+        expect(res.body.status).toBe(false);
+    });
 });

--- a/tests/verification-email-recipient.test.js
+++ b/tests/verification-email-recipient.test.js
@@ -1,0 +1,87 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
+jest.mock('../Modules/service.js', () => ({ SendEmail: jest.fn((subject, html, to, isHtml, cb) => cb({ status: true })) }));
+
+const fs = require('fs');
+const path = require('path');
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { SendEmail } = require('../Modules/service.js');
+const { newLinkToken } = require('../Modules/Auth/helpers/linkToken');
+const ctrl = require('../Modules/Auth/controller/sendVerificationMail');
+
+const UID = '6f0000000000000000000a01';
+const STORED_EMAIL = 'account.owner@example.test';
+
+const callController = (body) => new Promise((resolve) => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.send = jest.fn((payload) => resolve(payload));
+    res.json = res.send;
+    ctrl.sendVerificationEmail({ body }, res);
+});
+
+let account;
+
+beforeEach(() => {
+    SendEmail.mockClear();
+    account = { _id: UID, Employee_Email: STORED_EMAIL, isEmailVerified: false };
+    MongoDbCrudOpration.mockReset();
+    MongoDbCrudOpration.mockImplementation(async (db, obj, method) => (method === 'findOne' ? account : { acknowledged: true }));
+});
+
+describe('sendVerificationEmail', () => {
+    it('sends the link to the stored address, not the one in the request', async () => {
+        const payload = await callController({ uid: UID, email: 'attacker@evil.test' });
+        expect(payload.status).toBe(true);
+        expect(SendEmail).toHaveBeenCalledTimes(1);
+        expect(SendEmail.mock.calls[0][2]).toBe(STORED_EMAIL);
+    });
+
+    it('does not need an email in the request', async () => {
+        const payload = await callController({ uid: UID });
+        expect(payload.status).toBe(true);
+        expect(SendEmail.mock.calls[0][2]).toBe(STORED_EMAIL);
+    });
+
+    it('stores a 256-bit token and puts it in the link', async () => {
+        await callController({ uid: UID, email: STORED_EMAIL });
+        const update = MongoDbCrudOpration.mock.calls.find((call) => call[2] === 'updateOne');
+        const token = update[1].data[1].verificationToken;
+        expect(token).toMatch(/^[0-9a-f]{64}$/);
+        expect(SendEmail.mock.calls[0][1]).toContain(`/verify-email/${UID}/${token}`);
+    });
+
+    it.each([[{}], [{ uid: 'not-an-id', email: 'attacker@evil.test' }]])('refuses %j without sending', async (body) => {
+        const payload = await callController(body);
+        expect(payload.status).toBe(false);
+        expect(SendEmail).not.toHaveBeenCalled();
+    });
+
+    it('refuses an unknown account without sending', async () => {
+        account = null;
+        const payload = await callController({ uid: UID, email: 'attacker@evil.test' });
+        expect(payload.status).toBe(false);
+        expect(SendEmail).not.toHaveBeenCalled();
+    });
+
+    it('refuses an account that is already verified', async () => {
+        account.isEmailVerified = true;
+        const payload = await callController({ uid: UID });
+        expect(payload.status).toBe(false);
+        expect(SendEmail).not.toHaveBeenCalled();
+    });
+});
+
+describe('invite and verification link tokens', () => {
+    it('are 32 random bytes, hex encoded', () => {
+        const tokens = new Set(Array.from({ length: 50 }, newLinkToken));
+        expect(tokens.size).toBe(50);
+        tokens.forEach((token) => expect(token).toMatch(/^[0-9a-f]{64}$/));
+    });
+
+    it.each(['sendInvitation.js', 'sendVerificationMail.js'])('%s no longer builds tokens with Math.random', (file) => {
+        const source = fs.readFileSync(path.join(__dirname, '../Modules/Auth/controller', file), 'utf8');
+        expect(source).not.toMatch(/Math\.random/);
+        expect(source).toMatch(/newLinkToken\(\)/);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes QA follow-ups 1 and 12 from `Tasks/active/034-end-to-end-qa-programme/followups.md`.

| Finding | Route | Fix | Test |
|---|---|---|---|
| 1. Any company member can update the company document | `PUT /api/v1/company`, `PUT /api/v1/admin/company`, and `PUT /api/v1/company-invitation` (same controller) | `updateCompany` checks the caller's role with `getRoleType`. Owners and admins (roleType 1 or 2) can make any update. Everyone else gets 403 `{ status: false, message }` unless the body matches one of two allowlisted shapes (see Notes). | `tests/company-access.test.js` (`memberCompanyUpdate`, "PUT company update is for owners and admins"); `tests/integration/access.int.test.js` ("access — only owners and admins change the company") |
| 12a. `sendVerificationEmail` sends the link to any email in the request | `POST /api/v2/sendVerificationEmail` | The handler looks up the account by `uid` and sends only to its stored `Employee_Email`; the request's `email` is ignored. It refuses a malformed uid, an unknown account, or an account that is already verified, and sends nothing in those cases. Error text no longer includes the address. | `tests/verification-email-recipient.test.js`; `tests/integration/public-routes.int.test.js` ("verification email") |
| 12b. Invite and verification tokens are 8 `Math.random` characters | `sendInvitationEmail` (both paths), verification email | New `Modules/Auth/helpers/linkToken.js`: `crypto.randomBytes(32).toString('hex')`, which gives 64 hex characters | `tests/verification-email-recipient.test.js`; `tests/integration/public-routes.int.test.js` ("gives an existing account a 256-bit invitation link token") |

## Notes

**Callers checked for the company route**
- `SettingCompanyDetails.vue` (company details): admin-only screen, so nothing changes.
- `ProjectsListingSetting.vue` `updateProjectType`: sends `$inc { projectCount.privateCount: ±1, projectCount.publicCount: ∓1 }`, and members can do this. It stays allowed for any company member, but only as that exact net-zero swap: two fields, steps of ±1, sum 0, no `arrayFilters`.
- `Members.vue` remove member and cancel invitation: send `$inc { "companyData.$[elementIndex].users": -1 }` with the exact `arrayFilters`, and `$inc { trackerUsers: -1 }`. Owners and admins pass anyway. A member passes only when `settings.settings_member_list` is writable for them, which is the same permission the Members screen and `PUT /api/v1/members` use.
- `Invitation.vue`: calls `PUT /api/v1/company-invitation` only when the accepted invite is for the owner role. That call runs after `PUT /api/v1/root-members` has linked the row, and `rootUpdateMember` already calls `invalidateRoleCache`, so the new owner passes the gate.
- Server-side count updates (invites via `sendInvitation`, project create/delete, setup, storage, and others) call `updateCompanyFun` directly, not this route, so they are unaffected. Invite seat increments happen server-side.
- The time-tracker app only reads through `/api/v1/admin/company/find`.

**Tokens and pending links**
- Invite `linkId` and `verificationToken` are still compared by exact string equality against the stored value (`verifyInvitation.js`, `verifyEmail.js`). Nothing checks their length, so invite and verification links issued before this change keep working until they expire.
- `Login.vue` and `VerifyEmail.vue` still send `email` in the resend request. The server now ignores it, so no frontend change is needed.

**Upgrade impact**
- Scripts or integrations that used a member's session to write the company document now get 403 and must use an owner or admin account.
- The resend endpoint now always mails the address stored on the account.
- No migration is needed.

**Left out**
- Owners and admins can still write any field through this route, including plan or subscription fields. Tightening that is a separate change.
- The members allowlist relies on `getRoleType`, which does not look at `isDelete` or `status`. Removed members are already stopped by the membership check in the JWT middleware.

## Test plan

- [x] Failing first: before the fix, `tests/company-access.test.js` and `tests/verification-email-recipient.test.js` gave 18 failed, 17 passed (the verification suite could not load its helper yet). The integration cases were added with the fix and were not run against the old code.
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 244 suites, 3339 tests passed
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed (tenant-scoping baseline unchanged)
- [x] `E2E_MONGODB_URL=mongodb://127.0.0.1:27171 npx jest --selectProjects integration --runInBand tests/integration/access.int.test.js tests/integration/public-routes.int.test.js`: 2 suites, 114 tests passed, on a throwaway `mongo:7` container that was removed afterwards
- [x] `npm run i18n:check`: no missing keys (no user-visible strings changed)
- [x] eslint on the touched files: 0 errors. There are 2 warnings for `async` Promise executors in `updateCompany.js`, on lines this PR does not touch.
- [x] CI: branch name, commitlint, PR title, backend (1m32s), frontend (4m59s) and e2e (6m48s) all passed; CodeRabbit skipped (reviews disabled for `beta`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
