### PR TITLE
fix(auth): stop embedding the refresh token in access tokens and tracker urls

### DIFF
--- a/Config/jwt.js
+++ b/Config/jwt.js
@@ -8,7 +8,7 @@ const {myCache} = require('./config');
 // circular dependency risk. The controller is lazy-required inside
 // verifyApiTokenRequest below.
 const { looksLikeToken, hasScope } = require('../Modules/ApiTokens/helpers/apiTokenRules');
-const { sessionTokenQuery, hashRefreshToken } = require('../Modules/Auth/helpers/refreshTokenRules');
+const { sessionTokenQuery, readAccessSession, sessionCacheKey } = require('../Modules/Auth/helpers/refreshTokenRules');
 
 // Mongo ObjectId pattern — used to reject regex/control characters in the
 // `companyid` request header before any token-membership check.
@@ -220,132 +220,76 @@ const removeCacheAndCookie = (key, cacheKey, res, refreshToken) => {
     }
 }
 
-// An access token minted just before its session's refresh token was rotated:
-// the client already holds the new pair, so it is sent to refresh instead of
-// being logged out (and its fresh cookies are left alone).
-const isRotatedAway = async (uid, refreshToken) => {
-    const rotated = await mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, {
-        type: dbCollections.SESSIONS,
-        data: [{ userId: uid, previousRefreshTokenHash: hashRefreshToken(refreshToken) }]
-    }, "findOne");
-    return Boolean(rotated && rotated._id);
+const SESSION_CACHE_SECONDS = 600;
+
+// The client still holds a usable refresh token (its session was rotated elsewhere, or the
+// access token predates named sessions), so it is sent to refresh instead of being logged out.
+const refuseForRefresh = (res) => res.status(401).json({
+    status: false,
+    error: 'Token has expired',
+    statusText: 'Token has expired',
+    isJwtError: true
+});
+
+const refuseSession = (res, error, statusText = 'Unauthorized') => {
+    res.clearCookie('accessToken');
+    res.clearCookie('refreshToken');
+    return res.status(401).json({
+        status: false,
+        error,
+        statusText,
+        isJwtError: true,
+        isRefreshTokenError: true,
+        isLogout: true
+    });
 };
 
-const checkToken = (isValid, req, res, next) => {
-    if (isValid) {
-        const { uid, refreshToken,aud } = isValid;
-        req.uid = uid;
-        req.aud = aud;
-        req.refreshToken = refreshToken;
-        if (typeof refreshToken !== 'string' || !refreshToken) {
-            res.clearCookie('accessToken');
-            return res.status(401).json({
-                status: false,
-                error: "Your session is expired",
-                statusText: 'Unauthorized',
-                isJwtError: true,
-                isRefreshTokenError: true,
-                isLogout: true
-            });
-        }
-        const cacheKey = `session:${uid}:${refreshToken}`;
-        const value = myCache.get(cacheKey);
-        try {
-            if (value) {
-                const isRefreshTokenValid = jwt.verify(refreshToken, process.env.JWT_SECRET);
-                if (isRefreshTokenValid) {
-                    req.uid = uid;
-                    next();
-                } else {
-                    removeCacheAndCookie("", cacheKey, res, refreshToken);
-                    // Access Denied
-                    return res.status(401).json({
-                        status: false,
-                        error: 'Refresh Token has expired',
-                        statusText: 'Refresh Token has expired',
-                        isRefreshTokenError: true,
-                        isJwtError: true,
-                        isLogout: true
-                    });
-                }
-            } else {
-                let obj = {
-                    type: dbCollections.SESSIONS,
-                    data: [{
-                        userId: uid,
-                        ...sessionTokenQuery(refreshToken),
-                    }]
-                }
-                mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, obj, "findOne").then(async (resData)=>{
-                    if (!(resData && resData._id)) {
-                        if (await isRotatedAway(uid, refreshToken)) {
-                            return res.status(401).json({
-                                status: false,
-                                error: 'Token has expired',
-                                statusText: 'Token has expired',
-                                isJwtError: true
-                            });
-                        }
-                        removeCacheAndCookie("", cacheKey, res, refreshToken);
-                        return res.status(401).json({
-                            status: false,
-                            error: "Your session is expired",
-                            statusText: 'Unauthorized',
-                            isJwtError: true,
-                            isRefreshTokenError: true,
-                            isLogout: true
-                        });
-                    }
-                    const isRefreshTokenValid = jwt.verify(refreshToken, process.env.JWT_SECRET);
-                    if (isRefreshTokenValid) {
-                        myCache.set(cacheKey, JSON.stringify({_id: resData._id, userId: uid, refreshToken: refreshToken}), 600);
-                        req.uid = uid;
-                        next();
-                    } else {
-                        removeCacheAndCookie("", cacheKey, res, refreshToken);
-                        // Access Denied
-                        return res.status(401).json({
-                            status: false,
-                            error: 'Refresh Token has expired',
-                            statusText: 'Refresh Token has expired',
-                            isRefreshTokenError: true,
-                            isJwtError: true,
-                            isLogout: true
-                        });
-                    }
-                }).catch((error)=>{
-                    removeCacheAndCookie("", cacheKey, res, refreshToken);
-                    return res.status(401).json({
-                        status: false,
-                        error: error.message,
-                        statusText: 'Unauthorized',
-                        isJwtError: true,
-                        isRefreshTokenError: true,
-                        isLogout: true
-                    });
-                })
-            }
-        } catch (error) {
-            removeCacheAndCookie("", cacheKey, res, refreshToken);
-            return res.status(401).json({
-                status: false,
-                error: error.message,
-                statusText: 'Unauthorized',
-                isJwtError: true,
-                isRefreshTokenError: true,
-                isLogout: true
-            });
-        }
-    } else {
+const sessionsQuery = (uid, sid, method) => mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, {
+    type: dbCollections.SESSIONS,
+    data: [{ _id: new mongoose.Types.ObjectId(sid), userId: uid }]
+}, method);
+
+const checkToken = async (isValid, req, res, next) => {
+    if (!isValid) {
         removeCacheAndCookie("accessToken", "", res);
-        // Access Denied
+        return refuseForRefresh(res);
+    }
+    req.uid = isValid.uid;
+    req.aud = isValid.aud;
+    const access = readAccessSession(isValid);
+    if (access.kind === 'legacy') return refuseForRefresh(res);
+    if (access.kind !== 'session') {
+        res.clearCookie('accessToken');
         return res.status(401).json({
             status: false,
-            error: 'Token has expired',
-            statusText: 'Token has expired',
-            isJwtError: true
+            error: "Your session is expired",
+            statusText: 'Unauthorized',
+            isJwtError: true,
+            isRefreshTokenError: true,
+            isLogout: true
         });
     }
+    const { uid, sid, rti, sexp } = access;
+    req.sessionId = sid;
+    const cacheKey = sessionCacheKey(uid, sid, rti);
+    if (sexp * 1000 <= Date.now()) {
+        myCache.del(cacheKey);
+        sessionsQuery(uid, sid, "deleteMany").catch((error) => logger.error(`Expired session remove error ${error.message || error}`));
+        return refuseSession(res, 'Refresh Token has expired', 'Refresh Token has expired');
+    }
+    if (!myCache.get(cacheKey)) {
+        let session;
+        try {
+            session = await sessionsQuery(uid, sid, "findOne");
+        } catch (error) {
+            logger.error(`Session lookup error ${error.message || error}`);
+            return refuseSession(res, "Your session is expired");
+        }
+        if (!(session && session._id)) return refuseSession(res, "Your session is expired");
+        if (session.refreshTokenJti !== rti) return refuseForRefresh(res);
+        myCache.set(cacheKey, JSON.stringify({ _id: session._id, userId: uid }), SESSION_CACHE_SECONDS);
+    }
+    return next();
 }
 
 /**

--- a/Config/setMiddleware.js
+++ b/Config/setMiddleware.js
@@ -365,6 +365,7 @@ const verifyJWTToken = [
     "/api/v1/user",
     "/api/v2/users/sessions",
     "/api/v2/session/update",
+    "/api/v2/auth/tracker-code",
     "/api/v1/userAndCompanyCheck",
     "/api/v1/admin/wasabi/retriveObject",
     "/api/v1/admin/getInvoiceAndCreditNotes",

--- a/Modules/Auth/controller/authHelpers.js
+++ b/Modules/Auth/controller/authHelpers.js
@@ -6,6 +6,7 @@ const logger = require("../../../Config/loggerConfig");
 const serviceCtr = require("../../serviceFunction.js")
 const sendMail = require("../../service.js");
 const { generateToken, verifyToken, generateJWTToken, removeCacheAndCookie } = require("../../../Config/jwt.js");
+const { accessClaimsFor } = require("../helpers/refreshTokenRules");
 const helperCtr = require("../helper.js");
 const sesstionCtr = require("../session.js");
 const mongoose = require("mongoose");
@@ -56,6 +57,15 @@ exports.addAndRemoveUserInMongodbNotificationCount = (companyId,userId,type) => 
 
 exports.generateTokenV2Fun = (uid, refreshToken, cb) => {
     try {
+        const sessionClaims = accessClaimsFor(refreshToken);
+        if (!sessionClaims) {
+            cb({
+                status: false,
+                isLogout: true,
+                message: 'Your session is expired',
+            });
+            return;
+        }
         let object = {
             type: dbCollections.USERS,
             data: [
@@ -84,7 +94,7 @@ exports.generateTokenV2Fun = (uid, refreshToken, cb) => {
                 return;
             }
             const companyIds = response.AssignCompany && response.AssignCompany.length ? response.AssignCompany : [];
-            const token = await generateJWTToken({uid: uid, companyIds: companyIds, refreshToken});
+            const token = await generateJWTToken({uid: uid, companyIds: companyIds, ...sessionClaims});
             cb({
                 status: true,
                 message: "Jwt token generate successfully.",

--- a/Modules/Auth/controller/loginSession.js
+++ b/Modules/Auth/controller/loginSession.js
@@ -9,6 +9,7 @@ const { removeCacheAndCookie } = require("../../../Config/jwt.js");
 const helperCtr = require("../helper.js");
 const sesstionCtr = require("../session.js");
 const refreshSession = require("../helpers/refreshSession");
+const trackerCode = require("../helpers/trackerCode");
 const mongoose = require("mongoose");
 const { removeCache } = require("../../../utils/commonFunctions.js");
 const { updateUserFun } = require("../../Users/controller.js");
@@ -159,19 +160,26 @@ exports.loginAuth = (req, res, next) => {
     }
 };
 
-/**
- * Tracker login Auth
- * @param {Object} req 
- * @param {Object} res 
- */
+exports.issueTrackerCode = async (req, res) => {
+    const refuse = (statusCode, message) => res.status(statusCode).json({ status: false, statusText: message, message });
+    try {
+        if (!(req.uid && req.sessionId)) return refuse(401, 'Sign in to connect the desktop tracker.');
+        const issued = await trackerCode.issueTrackerCode({ userId: req.uid, sessionId: req.sessionId });
+        if (!issued) return refuse(401, 'Your session is expired');
+        return res.status(200).json({ status: true, statusText: 'OK', data: { code: issued.code, expiresAt: issued.expiresAt } });
+    } catch (error) {
+        logger.error(`issueTrackerCode: ${error.message || error}`);
+        return refuse(400, 'Could not create a tracker sign-in code.');
+    }
+};
 
 exports.loginAuthTracker = async (req, res) => {
-    const invalid = () => res.status(400).json({message: 'Invalid Refresh Token'});
+    const invalid = () => res.status(400).json({message: 'Invalid or expired tracker sign-in code'});
     try {
-        const { refreshToken, userId } = req.body || {};
-        const resolved = await refreshSession.resolveRefreshSession(refreshToken, userId);
-        if (!resolved.ok) return invalid();
-        const sessionUserId = String(resolved.session.userId);
+        const { code, refreshToken, userId } = req.body || {};
+        // Tracker builds released before one-time codes post the deep-link value as `refreshToken`.
+        const sessionUserId = await trackerCode.redeemTrackerCode(code || refreshToken);
+        if (!sessionUserId) return invalid();
         if (userId && String(userId) !== sessionUserId) return invalid();
 
         const forwarded = req?.headers['x-forwarded-for'] || req.ip;
@@ -273,7 +281,7 @@ exports.generateTokenV2 = async (req, res) => {
 
         generateTokenV2Fun(rotated.userId, rotated.refreshToken, (gData) => {
             if (!(gData && gData.status)) {
-                removeCacheAndCookie("", `session:${rotated.userId}:${rotated.refreshToken}`, res, rotated.refreshToken);
+                removeCacheAndCookie("", "", res, rotated.refreshToken);
                 res.status(400).json(gData);
                 return;
             }

--- a/Modules/Auth/helpers/refreshSession.js
+++ b/Modules/Auth/helpers/refreshSession.js
@@ -14,10 +14,11 @@ const issuedFields = ({ token, jti }) => ({
     tokenTail: rules.tokenTailOf(token),
 });
 
-const dropSessionCache = (userId) => {
-    const prefix = `session:${userId}:`;
+const dropCachedPrefix = (prefix) => {
     myCache.keys().filter((key) => key.startsWith(prefix)).forEach((key) => myCache.del(key));
 };
+
+const dropSessionCache = (userId) => dropCachedPrefix(`session:${userId}:`);
 
 const revokeSessions = async (filter, userIds) => {
     await sessionsCrud([filter], 'deleteMany');
@@ -82,7 +83,7 @@ const rotateRefreshSession = async ({ session, legacy, token, payload, hash }) =
     if (legacy) update.$unset = { refreshToken: '' };
     const updated = await sessionsCrud([filter, update, { new: true }], 'findOneAndUpdate');
     if (!updated) return refusal('rotated');
-    myCache.del(`session:${session.userId}:${token}`);
+    dropCachedPrefix(`session:${session.userId}:${session._id}:`);
     return { ok: true, userId: String(session.userId), refreshToken: issued.token, expiresAt: issued.exp };
 };
 

--- a/Modules/Auth/helpers/refreshTokenRules.js
+++ b/Modules/Auth/helpers/refreshTokenRules.js
@@ -57,6 +57,28 @@ const sessionTokenQuery = (token) => ({
     $or: [{ refreshTokenHash: hashRefreshToken(token) }, { refreshToken: String(token) }],
 });
 
+const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
+
+const accessClaimsFor = (refreshToken) => {
+    const read = readRefreshToken(refreshToken);
+    if (!read.valid || read.legacy) return null;
+    return { sid: read.payload.sid, rti: read.payload.jti, sexp: read.payload.exp };
+};
+
+// Access tokens minted before sessions were named carried the plaintext refresh token instead.
+const readAccessSession = (payload) => {
+    if (!payload || typeof payload !== 'object' || payload.typ === REFRESH_TOKEN_TYPE) return { kind: 'invalid' };
+    const { uid, sid, rti, sexp } = payload;
+    if (typeof uid !== 'string' || !uid) return { kind: 'invalid' };
+    if (typeof sid === 'string' && OBJECT_ID_PATTERN.test(sid) && typeof rti === 'string' && rti && Number.isFinite(sexp)) {
+        return { kind: 'session', uid, sid, rti, sexp };
+    }
+    if (typeof payload.refreshToken === 'string' && payload.refreshToken) return { kind: 'legacy', uid };
+    return { kind: 'invalid' };
+};
+
+const sessionCacheKey = (uid, sid, rti) => `session:${uid}:${sid}:${rti}`;
+
 module.exports = {
     REFRESH_TOKEN_TYPE,
     hashRefreshToken,
@@ -66,4 +88,7 @@ module.exports = {
     reuseGraceSeconds,
     sessionLifetimeSeconds,
     sessionTokenQuery,
+    accessClaimsFor,
+    readAccessSession,
+    sessionCacheKey,
 };

--- a/Modules/Auth/helpers/trackerCode.js
+++ b/Modules/Auth/helpers/trackerCode.js
@@ -1,0 +1,35 @@
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const mongoC = require('../../../utils/mongo-handler/mongoQueries');
+const { dbCollections } = require('../../../Config/collections');
+
+const TRACKER_CODE_TTL_MS = 2 * 60 * 1000;
+const TRACKER_CODE_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+const sessionsCrud = (data, method) => mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, { type: dbCollections.SESSIONS, data }, method);
+
+const hashTrackerCode = (code) => crypto.createHash('sha256').update(String(code)).digest('hex');
+
+// The code lives on the browser session that asked for it, so signing that session out drops it.
+const issueTrackerCode = async ({ userId, sessionId }) => {
+    if (!userId || !mongoose.Types.ObjectId.isValid(sessionId)) return null;
+    const code = crypto.randomBytes(32).toString('base64url');
+    const expiresAt = new Date(Date.now() + TRACKER_CODE_TTL_MS);
+    const updated = await sessionsCrud([
+        { _id: new mongoose.Types.ObjectId(sessionId), userId: String(userId) },
+        { $set: { trackerCodeHash: hashTrackerCode(code), trackerCodeExpiresAt: expiresAt } },
+        { new: true },
+    ], 'findOneAndUpdate');
+    return updated ? { code, expiresAt } : null;
+};
+
+const redeemTrackerCode = async (code) => {
+    if (typeof code !== 'string' || !TRACKER_CODE_PATTERN.test(code)) return null;
+    const session = await sessionsCrud([
+        { trackerCodeHash: hashTrackerCode(code), trackerCodeExpiresAt: { $gt: new Date(Date.now()) } },
+        { $unset: { trackerCodeHash: '', trackerCodeExpiresAt: '' } },
+    ], 'findOneAndUpdate');
+    return session && session.userId ? String(session.userId) : null;
+};
+
+module.exports = { issueTrackerCode, redeemTrackerCode, TRACKER_CODE_TTL_MS };

--- a/Modules/Auth/routes.js
+++ b/Modules/Auth/routes.js
@@ -64,6 +64,7 @@ exports.init = (app) => {
      */
     app.post("/api/v2/auth/login", ctrl.loginAuth, ctrl.manageAttempt)
     app.post("/api/v1/auth/loginAuthTracker", ctrl.loginAuthTracker)
+    app.post("/api/v2/auth/tracker-code", ctrl.issueTrackerCode)
 
     // Two-factor auth (TOTP) — Phase 1, password login only.
     // setup/verify/disable require a logged-in session (gated by

--- a/Modules/Auth/session.js
+++ b/Modules/Auth/session.js
@@ -1,10 +1,11 @@
+const mongoose = require("mongoose");
 const mongoC = require("../../utils/mongo-handler/mongoQueries")
 const { myCache } = require('../../Config/config');
 const serviceCtr = require("../serviceFunction.js")
 const { removeCache } = require('../../utils/commonFunctions');
 const { dbCollections } = require("../../Config/collections.js");
 const { newSessionCredentials } = require("./helpers/refreshSession");
-const { sessionTokenQuery } = require("./helpers/refreshTokenRules");
+const { sessionCacheKey } = require("./helpers/refreshTokenRules");
 
 
 /**
@@ -34,7 +35,7 @@ exports.insertSessionFun = async (reqData, userAgent, ip, cb) => {
             }
         }
         mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, obj, "save").then((res)=>{
-            const cacheKey = `session:${reqData.userId}:${credentials.refreshToken}`;
+            const cacheKey = sessionCacheKey(String(reqData.userId), String(res._id), credentials.fields.refreshTokenJti);
             myCache.set(cacheKey, JSON.stringify({_id: res._id, userId: reqData.userId}), 600);
             cb({
                 status: true,
@@ -55,12 +56,21 @@ exports.insertSessionFun = async (reqData, userAgent, ip, cb) => {
 };
 
 
-/**
- * Update Session Function
- * @param {Object} reqData 
- * @param {*} cb 
- * @returns 
- */
+const SESSION_UPDATABLE_FIELDS = {
+    webToken: (value) => typeof value === 'string',
+    lastActive: (value) => (typeof value === 'string' || typeof value === 'number') && !Number.isNaN(new Date(value).getTime()),
+};
+
+// The body used to be handed to Mongo as the update itself, which let a caller rewrite
+// the owner or token fields of their own session row.
+const sessionUpdateOf = (updateObject) => {
+    if (!updateObject || typeof updateObject !== 'object' || Array.isArray(updateObject)) return null;
+    const entries = Object.entries(updateObject);
+    const allowed = entries.length && entries.every(([field, value]) => Object.hasOwn(SESSION_UPDATABLE_FIELDS, field) && SESSION_UPDATABLE_FIELDS[field](value));
+    if (!allowed) return null;
+    return { $set: Object.fromEntries(entries.map(([field, value]) => [field, field === 'lastActive' ? new Date(value) : value])) };
+};
+
 exports.updateSessionFun = async (reqData, cb) => {
     try {
         if (!(reqData && reqData.userId)) {
@@ -70,27 +80,33 @@ exports.updateSessionFun = async (reqData, cb) => {
             });
             return;
         }
-        if (!(reqData && reqData.refreshToken)) {
+        if (!(reqData.sessionId && mongoose.Types.ObjectId.isValid(reqData.sessionId))) {
             cb({
                 status: false,
-                message: "Refresh Token is require"
+                message: "Session id is required"
+            });
+            return;
+        }
+        const update = sessionUpdateOf(reqData.updateObject);
+        if (!update) {
+            cb({
+                status: false,
+                message: "Only webToken and lastActive can be updated"
             });
             return;
         }
         let obj = {
             type: dbCollections.SESSIONS,
             data: [
-                { userId: reqData.userId, ...sessionTokenQuery(reqData.refreshToken) },
-                reqData.updateObject
+                { _id: new mongoose.Types.ObjectId(reqData.sessionId), userId: String(reqData.userId) },
+                update
             ]
         }
 
-        mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, obj, "findOneAndUpdate").then((res)=>{
-            const cacheKey = `session:${reqData.userId}:${reqData.refreshToken}`;
-            removeCache(cacheKey, true);
+        mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, obj, "findOneAndUpdate").then(()=>{
             cb({
                 status: true,
-                data: {userId: reqData.userId, refreshToken: reqData.refreshToken}
+                data: {userId: reqData.userId, _id: reqData.sessionId}
             })
         }).catch((error)=>{
             cb({
@@ -109,7 +125,7 @@ exports.updateSessionFun = async (reqData, cb) => {
 
 exports.updateSession = (req, res) => {
     try {
-        exports.updateSessionFun({ ...req.body, refreshToken: req.refreshToken || req.body.refreshToken }, (resData) => {
+        exports.updateSessionFun({ userId: req.uid, sessionId: req.sessionId, updateObject: req.body && req.body.updateObject }, (resData) => {
             if (!(resData && resData.status)) {
                 res.status(400).json({message: resData.message});
                 return;
@@ -247,17 +263,21 @@ exports.deleteUserSpecificSession = async (req, res) => {
 
 exports.removeSession = (req, cb) => {
     try {
-        const bodyData = req.body;
+        // Treat "no session found" as success — the user is already logged out.
+        // Only propagate failures if the DB operation itself throws (handled in .catch).
+        if (!(req.uid && req.sessionId && mongoose.Types.ObjectId.isValid(req.sessionId))) {
+            cb({ status: true, data: { deletedCount: 0 } });
+            return;
+        }
         let obj = {
             type: dbCollections.SESSIONS,
             data: [{
-                userId: bodyData.id,
-                ...sessionTokenQuery(req.refreshToken || bodyData.refreshToken)
+                _id: new mongoose.Types.ObjectId(req.sessionId),
+                userId: String(req.uid)
             }]
         }
         mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, obj, "deleteMany").then((resData)=>{
-            // Treat "no session found" as success — the user is already logged out.
-            // Only propagate failures if the DB operation itself throws (handled in .catch).
+            removeCache(`session:${req.uid}:${req.sessionId}:`, true);
             cb({
                 status: true,
                 data: resData,

--- a/frontend/src/config/env.js
+++ b/frontend/src/config/env.js
@@ -69,6 +69,7 @@ module.exports.CALL_NOTES = '/api/v2/calls/notes';
 module.exports.FOLDER = '/api/v1/folder';
 module.exports.REMOVE_USER_NOTIFICATION = '/api/v1/removeUserNotification';
 module.exports.GENERATETOKEN_V2 = '/api/v2/generateToken';
+module.exports.TRACKER_CODE = '/api/v2/auth/tracker-code';
 module.exports.UPDATE_UNREADREAD_COMMENTS_COUNT = '/api/v1/updateunreadcommentscount';
 module.exports.UNSET_COMMENTS_COUNT = '/api/v1/unsetCommentCounts';
 module.exports.V2_TASKS = '/api/v2/tasks';

--- a/frontend/src/locales/ar.js
+++ b/frontend/src/locales/ar.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/ar.pending.json
+++ b/frontend/src/locales/ar.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ar",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.255Z",
+  "updatedAt": "2026-09-11T12:39:00.825Z",
   "keys": {
     "Scrum.stranded_head": "These {count} will stay in this sprint",
     "Scrum.stranded_hint": "They are unfinished, but their parent task is done — and a subtask moves with its parent. Finish them, or reopen the parent task, before completing the sprint.",
@@ -7578,6 +7578,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/ch.js
+++ b/frontend/src/locales/ch.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/ch.pending.json
+++ b/frontend/src/locales/ch.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ch",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.281Z",
+  "updatedAt": "2026-09-11T12:39:00.852Z",
   "keys": {
     "errorPage.card_name": "card name",
     "Auth.welcome_back": "Welcome back",
@@ -5436,6 +5436,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -507,6 +507,7 @@ export default {
         tracker_title: "Authorize the desktop tracker",
         tracker_body: "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         tracker_continue: "Continue",
+        tracker_code_failed: "Couldn't start the tracker sign-in. Refresh this page and try again.",
         new_project: "New project",
         search_templates: "Search templates",
         for_focus: "For {focus}",

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/fr.pending.json
+++ b/frontend/src/locales/fr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "fr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.305Z",
+  "updatedAt": "2026-09-11T12:39:00.877Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5445,6 +5445,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/ge.js
+++ b/frontend/src/locales/ge.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/ge.pending.json
+++ b/frontend/src/locales/ge.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ge",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.328Z",
+  "updatedAt": "2026-09-11T12:39:00.903Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5517,6 +5517,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/gr.js
+++ b/frontend/src/locales/gr.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/gr.pending.json
+++ b/frontend/src/locales/gr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.355Z",
+  "updatedAt": "2026-09-11T12:39:00.933Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5438,6 +5438,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/gu.js
+++ b/frontend/src/locales/gu.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/gu.pending.json
+++ b/frontend/src/locales/gu.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gu",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.380Z",
+  "updatedAt": "2026-09-11T12:39:00.959Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5436,6 +5436,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/hi.pending.json
+++ b/frontend/src/locales/hi.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "hi",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.404Z",
+  "updatedAt": "2026-09-11T12:39:00.985Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5437,6 +5437,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/it.pending.json
+++ b/frontend/src/locales/it.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "it",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.426Z",
+  "updatedAt": "2026-09-11T12:39:01.009Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5436,6 +5436,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/ru.pending.json
+++ b/frontend/src/locales/ru.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ru",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.450Z",
+  "updatedAt": "2026-09-11T12:39:01.036Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5435,6 +5435,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/locales/spa.js
+++ b/frontend/src/locales/spa.js
@@ -485,6 +485,7 @@ export default {
         "tracker_title": "Authorize the desktop tracker",
         "tracker_body": "Opening the desktop tracker on this computer. If nothing happens, click Continue.",
         "tracker_continue": "Continue",
+        "tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again.",
         "new_project": "New project",
         "search_templates": "Search templates",
         "for_focus": "For {focus}",

--- a/frontend/src/locales/spa.pending.json
+++ b/frontend/src/locales/spa.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "spa",
   "machineTranslated": false,
-  "updatedAt": "2026-09-11T09:38:28.474Z",
+  "updatedAt": "2026-09-11T12:39:01.061Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5435,6 +5435,7 @@
     "AiAlerts.notice_resolved_cost_forecast": "Resolved: spend is back under its forecast threshold.",
     "AiAlerts.notice_resolved_queue_age": "Resolved: the run queue is moving again.",
     "dashboardCard.dashboard_updated": "Dashboard updated successfully",
-    "Time.variance_own_only": "Showing only the time you logged"
+    "Time.variance_own_only": "Showing only the time you logged",
+    "Auth.tracker_code_failed": "Couldn't start the tracker sign-in. Refresh this page and try again."
   }
 }

--- a/frontend/src/services/index.js
+++ b/frontend/src/services/index.js
@@ -343,10 +343,7 @@ export function useAuth() {
     
             if (userId && refreshToken && data?.islogOut === true) {
                 try {
-                    await apiRequestWithoutCompnay("post", env.LOGOUT, {
-                        id: userId,
-                        refreshToken: refreshToken,
-                    });                    
+                    await apiRequestWithoutCompnay("post", env.LOGOUT, { id: userId });
                 } catch (error) {
                     console.error('Error in logout', error);
                     cleanup(data);

--- a/frontend/src/views/Authentication/TrackerLogin/TrackerLogin.vue
+++ b/frontend/src/views/Authentication/TrackerLogin/TrackerLogin.vue
@@ -4,24 +4,40 @@
             <div class="auth__glyph auth__glyph--brand"><ShellIcon name="time" :size="15" /></div>
             <h2 class="auth__h">{{ $t('Auth.tracker_title') }}</h2>
             <p class="auth__p">{{ $t('Auth.tracker_body') }}</p>
-            <button type="button" class="ah-btn ah-btn--primary ah-btn--block ah-btn--lg" @click="redirect">{{ $t('Auth.tracker_continue') }}</button>
+            <p v-if="failed" class="auth__p" role="alert" data-test="tracker-code-error">{{ $t('Auth.tracker_code_failed') }}</p>
+            <button type="button" class="ah-btn ah-btn--primary ah-btn--block ah-btn--lg" :disabled="opening" @click="redirect">{{ $t('Auth.tracker_continue') }}</button>
         </div>
     </AuthShell>
 </template>
 
 <script setup>
-import { inject, onMounted } from "vue";
-
-defineOptions({ name: "TrackerLoginPage" });
-import Cookies from "js-cookie";
+import { inject, onMounted, ref } from "vue";
 import AuthShell from "@/components/templates/AuthShell/AuthShell.vue";
 import ShellIcon from "@/components/organisms/Shell/ShellIcon.vue";
+import { apiRequestWithoutCompnay } from "@/services";
+import * as env from "@/config/env";
+
+defineOptions({ name: "TrackerLoginPage" });
 
 const userId = inject("$userId");
-const refreshToken = Cookies.get("refreshToken") || "";
+const opening = ref(false);
+const failed = ref(false);
 
-const redirect = () => {
-    window.location.href = `myapp://authorize?client_id=${userId.value}&client_secret=${refreshToken}`;
+// Each code works once, so every attempt to open the tracker asks for a fresh one.
+const redirect = async () => {
+    if (opening.value) return;
+    opening.value = true;
+    failed.value = false;
+    try {
+        const response = await apiRequestWithoutCompnay("post", env.TRACKER_CODE, {});
+        const code = response?.data?.data?.code;
+        if (!code) throw new Error("No tracker sign-in code");
+        window.location.href = `myapp://authorize?client_id=${encodeURIComponent(userId.value)}&code=${encodeURIComponent(code)}`;
+    } catch {
+        failed.value = true;
+    } finally {
+        opening.value = false;
+    }
 };
 onMounted(redirect);
 </script>

--- a/frontend/tests/unit/trackerLogin.spec.js
+++ b/frontend/tests/unit/trackerLogin.spec.js
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+
+const { apiRequestWithoutCompnay } = vi.hoisted(() => ({ apiRequestWithoutCompnay: vi.fn() }));
+
+vi.mock('@/services', () => ({ apiRequestWithoutCompnay }));
+vi.mock('js-cookie', () => ({ default: { get: () => 'refresh.token.value' } }));
+vi.mock('@/components/organisms/Shell/ShellIcon.vue', () => ({ default: { name: 'ShellIcon', render: () => null } }));
+vi.mock('@/components/templates/AuthShell/AuthShell.vue', () => ({ default: { name: 'AuthShell', template: '<div><slot /></div>' } }));
+
+import TrackerLogin from '@/views/Authentication/TrackerLogin/TrackerLogin.vue';
+
+const CODE = 'Q2l0eS1jb2RlLWZvci10aGUtdHJhY2tlci1zaWduLWlu';
+const originalLocation = window.location;
+
+describe('TrackerLogin', () => {
+    beforeEach(() => {
+        apiRequestWithoutCompnay.mockReset();
+        Object.defineProperty(window, 'location', { configurable: true, value: { href: '' } });
+    });
+    afterEach(() => {
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    });
+
+    it('opens the tracker with a one-time code and never the refresh token', async () => {
+        apiRequestWithoutCompnay.mockResolvedValue({ data: { status: true, data: { code: CODE } } });
+        mount(TrackerLogin);
+        await flushPromises();
+
+        expect(apiRequestWithoutCompnay).toHaveBeenCalledWith('post', '/api/v2/auth/tracker-code', {});
+        expect(window.location.href).toBe(`myapp://authorize?client_id=user-1&code=${CODE}`);
+        expect(window.location.href).not.toContain('refresh.token.value');
+    });
+
+    it('asks for a fresh code each time Continue is clicked', async () => {
+        apiRequestWithoutCompnay.mockResolvedValue({ data: { status: true, data: { code: CODE } } });
+        const wrapper = mount(TrackerLogin);
+        await flushPromises();
+        await wrapper.find('button').trigger('click');
+        await flushPromises();
+        expect(apiRequestWithoutCompnay).toHaveBeenCalledTimes(2);
+    });
+
+    it('shows an error and does not open the tracker when no code comes back', async () => {
+        apiRequestWithoutCompnay.mockRejectedValue(new Error('offline'));
+        const wrapper = mount(TrackerLogin);
+        await flushPromises();
+        expect(window.location.href).toBe('');
+        expect(wrapper.find('[data-test="tracker-code-error"]').exists()).toBe(true);
+    });
+});

--- a/tests/access-token-session.test.js
+++ b/tests/access-token-session.test.js
@@ -1,0 +1,284 @@
+process.env.JWT_SECRET = 'access-token-session-secret';
+process.env.JWT_ALGORITHM = 'HS256';
+process.env.JWT_EXP = '24h';
+
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+
+const jwt = require('jsonwebtoken');
+const { dbCollections } = require('../Config/collections');
+const { myCache } = require('../Config/config');
+const sessionCtr = require('../Modules/Auth/session');
+const loginSession = require('../Modules/Auth/controller/loginSession');
+const { generateTokenV2Fun } = require('../Modules/Auth/controller/authHelpers');
+const { generateToken, verifyJWTTokenV2, verifyJWTTokenWithCV2 } = require('../Config/jwt');
+
+const USER_A = '6f00000000000000000000a1';
+const USER_B = '6f00000000000000000000b1';
+const COMPANY = '6f0000000000000000000c01';
+const NOW = Date.UTC(2026, 8, 11, 12, 0, 0);
+
+const sessions = () => mockDb.store[dbCollections.SESSIONS] || [];
+const sessionsOf = (userId) => sessions().filter((s) => String(s.userId) === userId);
+
+const response = () => {
+    const res = { statusCode: 200, body: undefined, cookies: {} };
+    res.done = new Promise((resolve) => { res.finish = resolve; });
+    res.status = (code) => { res.statusCode = code; return res; };
+    res.json = (body) => { res.body = body; res.finish(body); return res; };
+    res.cookie = (name, value) => { res.cookies[name] = value; return res; };
+    res.clearCookie = (name) => { res.cookies[name] = null; return res; };
+    return res;
+};
+
+const issueSession = (userId) => new Promise((resolve, reject) => {
+    sessionCtr.insertSessionFun({ userId }, 'jest', '127.0.0.1', (out) => (out.status ? resolve(out.data) : reject(new Error(out.message))));
+});
+
+const accessTokenFor = (userId, refreshToken) => new Promise((resolve, reject) => {
+    generateTokenV2Fun(userId, refreshToken, (out) => (out.status ? resolve(out.token) : reject(new Error(out.message))));
+});
+
+const signIn = async (userId) => {
+    const { refreshToken, _id } = await issueSession(userId);
+    return { refreshToken, sessionId: String(_id), accessToken: await accessTokenFor(userId, refreshToken) };
+};
+
+const throughMiddleware = (accessToken, { verifier = verifyJWTTokenV2, headers = {}, body = {} } = {}) => new Promise((resolve) => {
+    const req = { headers: { authorization: `Bearer ${accessToken}`, ...headers }, body };
+    const res = response();
+    res.done.then((out) => resolve({ passed: false, status: res.statusCode, body: out, cookies: res.cookies, req }));
+    verifier(req, res, () => resolve({ passed: true, req }));
+});
+
+const call = async (handler, req) => {
+    const res = response();
+    handler({ headers: { 'user-agent': 'tracker' }, ip: '127.0.0.1', body: {}, ...req }, res);
+    await res.done;
+    return res;
+};
+
+const refused = (res) => res.statusCode >= 400 || Boolean(res.body && res.body.status === false);
+const clockAt = (ms) => jest.spyOn(Date, 'now').mockReturnValue(ms);
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    myCache.flushAll();
+    jest.restoreAllMocks();
+    clockAt(NOW);
+    mockDb.seed(dbCollections.USERS, { _id: USER_A, isEmailVerified: true, AssignCompany: [COMPANY] });
+    mockDb.seed(dbCollections.USERS, { _id: USER_B, isEmailVerified: true, AssignCompany: [COMPANY] });
+});
+
+describe('the access token', () => {
+    it('names its session and never carries the refresh token', async () => {
+        const { refreshToken, sessionId, accessToken } = await signIn(USER_A);
+        const claims = jwt.decode(accessToken);
+        const refreshClaims = jwt.decode(refreshToken);
+        expect(claims.refreshToken).toBeUndefined();
+        expect(Object.values(claims)).not.toContain(refreshToken);
+        expect(accessToken).not.toContain(refreshToken);
+        expect(claims).toMatchObject({ uid: USER_A, sid: sessionId, rti: refreshClaims.jti, sexp: refreshClaims.exp, aud: COMPANY });
+    });
+
+    it('is not minted from a token that is not a current refresh token', async () => {
+        await expect(accessTokenFor(USER_A, jwt.sign({}, process.env.JWT_SECRET, { expiresIn: 60 }))).rejects.toThrow();
+    });
+});
+
+describe.each([
+    ['verifyJWTTokenV2', verifyJWTTokenV2, {}],
+    ['verifyJWTTokenWithCV2', verifyJWTTokenWithCV2, { companyid: COMPANY }],
+])('%s', (name, verifier, headers) => {
+    beforeEach(() => { myCache.set(`membership:${USER_A}:${COMPANY}`, true, 600); });
+
+    it('lets a live session through and names it on the request', async () => {
+        const { sessionId, accessToken } = await signIn(USER_A);
+        const out = await throughMiddleware(accessToken, { verifier, headers });
+        expect(out.passed).toBe(true);
+        expect(out.req.uid).toBe(USER_A);
+        expect(out.req.sessionId).toBe(sessionId);
+        expect(out.req.refreshToken).toBeUndefined();
+    });
+
+    it('checks the session store when the cache is cold', async () => {
+        const { accessToken } = await signIn(USER_A);
+        myCache.keys().filter((key) => key.startsWith('session:')).forEach((key) => myCache.del(key));
+        expect((await throughMiddleware(accessToken, { verifier, headers })).passed).toBe(true);
+    });
+
+    it('sends an access token issued before this change to refresh, without logging out', async () => {
+        const { refreshToken } = await signIn(USER_A);
+        const legacy = jwt.sign({ uid: USER_A, refreshToken }, process.env.JWT_SECRET, { audience: COMPANY, expiresIn: '1h' });
+        const out = await throughMiddleware(legacy, { verifier, headers });
+        expect(out.passed).toBe(false);
+        expect(out.status).toBe(401);
+        expect(out.body.isJwtError).toBe(true);
+        expect(out.body.isLogout).toBeUndefined();
+        expect(out.cookies.refreshToken).toBeUndefined();
+        expect(sessionsOf(USER_A)).toHaveLength(1);
+    });
+
+    it('logs out an access token whose session was signed out', async () => {
+        const { accessToken } = await signIn(USER_A);
+        await new Promise((resolve) => sessionCtr.deleteSessionFun(USER_A, resolve));
+        myCache.flushAll();
+        myCache.set(`membership:${USER_A}:${COMPANY}`, true, 600);
+        const out = await throughMiddleware(accessToken, { verifier, headers });
+        expect(out.passed).toBe(false);
+        expect(out.status).toBe(401);
+        expect(out.body.isLogout).toBe(true);
+    });
+
+    it('logs out and removes the session once the refresh token lifetime is over', async () => {
+        process.env.SESSIONEXPIREDTIME = '60';
+        try {
+            const { accessToken } = await signIn(USER_A);
+            clockAt(NOW + 120 * 1000);
+            const out = await throughMiddleware(accessToken, { verifier, headers });
+            expect(out.passed).toBe(false);
+            expect(out.body.isLogout).toBe(true);
+            await new Promise(setImmediate);
+            expect(sessionsOf(USER_A)).toHaveLength(0);
+        } finally {
+            delete process.env.SESSIONEXPIREDTIME;
+        }
+    });
+
+    it('refuses a refresh token presented as the access token', async () => {
+        const { refreshToken } = await signIn(USER_A);
+        const out = await throughMiddleware(refreshToken, { verifier, headers });
+        expect(out.passed).toBe(false);
+        expect(out.status).toBe(401);
+    });
+});
+
+describe('verifyJWTTokenV2 and tokens that name no session', () => {
+    it('refuses a signed token with an empty payload, as before', async () => {
+        const out = await throughMiddleware(generateToken(600));
+        expect(out.passed).toBe(false);
+        expect(out.status).toBe(401);
+        expect(out.body.isLogout).toBe(true);
+    });
+});
+
+describe('session routes use the verified session id', () => {
+    it('logs out only the session the access token names, whatever the body says', async () => {
+        const a1 = await signIn(USER_A);
+        const a2 = await signIn(USER_A);
+        const b = await signIn(USER_B);
+        const { req } = await throughMiddleware(a1.accessToken, { body: { id: USER_A, refreshToken: b.refreshToken } });
+        const done = await new Promise((resolve) => sessionCtr.removeSession(req, resolve));
+        expect(done.status).toBe(true);
+        expect(sessions().map((s) => String(s._id)).sort()).toEqual([a2.sessionId, b.sessionId].sort());
+    });
+
+    it('updates the web push token and last activity of the calling session only', async () => {
+        const a1 = await signIn(USER_A);
+        const a2 = await signIn(USER_A);
+        const { req } = await throughMiddleware(a1.accessToken, { body: { userId: USER_B, updateObject: { webToken: 'fcm-1', lastActive: new Date(NOW).toISOString() } } });
+        const res = await call(sessionCtr.updateSession, req);
+        expect(res.statusCode).toBe(200);
+        const [row1] = sessions().filter((s) => String(s._id) === a1.sessionId);
+        const [row2] = sessions().filter((s) => String(s._id) === a2.sessionId);
+        expect(row1.webToken).toBe('fcm-1');
+        expect(row2.webToken).toBeUndefined();
+    });
+
+    it.each([
+        [{ userId: USER_B }],
+        [{ $set: { refreshToken: 'x' } }],
+        [{ trackerCodeHash: 'x' }],
+        [{ webToken: { $gt: '' } }],
+    ])('refuses a session update that touches anything else: %j', async (updateObject) => {
+        const a1 = await signIn(USER_A);
+        const { req } = await throughMiddleware(a1.accessToken, { body: { updateObject } });
+        const res = await call(sessionCtr.updateSession, req);
+        expect(res.statusCode).toBe(400);
+        const [row] = sessionsOf(USER_A);
+        expect(row.userId).toBe(USER_A);
+        expect(row.refreshToken).toBeUndefined();
+        expect(row.trackerCodeHash).toBeUndefined();
+    });
+});
+
+describe('tracker sign-in with a one-time code', () => {
+    const issueCode = async (accessToken) => {
+        const { passed, req } = await throughMiddleware(accessToken);
+        expect(passed).toBe(true);
+        return call(loginSession.issueTrackerCode, req);
+    };
+
+    it('issues a short random code, stores only its hash, and exchanges it once for a new session', async () => {
+        const browser = await signIn(USER_A);
+        const issued = await issueCode(browser.accessToken);
+        expect(issued.statusCode).toBe(200);
+        const { code } = issued.body.data;
+        expect(code).toMatch(/^[A-Za-z0-9_-]{43}$/);
+        expect(JSON.stringify(sessions())).not.toContain(code);
+
+        const tracker = await call(loginSession.loginAuthTracker, { body: { code, userId: USER_A } });
+        expect(refused(tracker)).toBe(false);
+        expect(tracker.body.uid).toBe(USER_A);
+        expect(jwt.decode(tracker.body.accessToken)).toMatchObject({ uid: USER_A });
+        expect(jwt.decode(tracker.body.accessToken).refreshToken).toBeUndefined();
+        expect(jwt.decode(tracker.body.refreshToken)).toMatchObject({ sub: USER_A, typ: 'refresh' });
+        expect(sessionsOf(USER_A)).toHaveLength(2);
+        expect((await throughMiddleware(tracker.body.accessToken)).passed).toBe(true);
+
+        const again = await call(loginSession.loginAuthTracker, { body: { code, userId: USER_A } });
+        expect(refused(again)).toBe(true);
+        expect(again.body.accessToken).toBeUndefined();
+        expect(sessionsOf(USER_A)).toHaveLength(2);
+    });
+
+    it('accepts the code in the field older tracker builds send the deep-link value in', async () => {
+        const browser = await signIn(USER_A);
+        const { code } = (await issueCode(browser.accessToken)).body.data;
+        const tracker = await call(loginSession.loginAuthTracker, { body: { refreshToken: code, userId: USER_A } });
+        expect(refused(tracker)).toBe(false);
+        expect(tracker.body.uid).toBe(USER_A);
+    });
+
+    it('refuses an expired code', async () => {
+        const browser = await signIn(USER_A);
+        const { code } = (await issueCode(browser.accessToken)).body.data;
+        clockAt(NOW + 10 * 60 * 1000);
+        expect(refused(await call(loginSession.loginAuthTracker, { body: { code } }))).toBe(true);
+    });
+
+    it("refuses a code presented with another user's id", async () => {
+        const browser = await signIn(USER_A);
+        const { code } = (await issueCode(browser.accessToken)).body.data;
+        const res = await call(loginSession.loginAuthTracker, { body: { code, userId: USER_B } });
+        expect(refused(res)).toBe(true);
+        expect(res.body.accessToken).toBeUndefined();
+    });
+
+    it('refuses a refresh token in place of a code', async () => {
+        const browser = await signIn(USER_A);
+        const res = await call(loginSession.loginAuthTracker, { body: { refreshToken: browser.refreshToken, userId: USER_A } });
+        expect(refused(res)).toBe(true);
+        expect(sessionsOf(USER_A)).toHaveLength(1);
+    });
+
+    it('drops an unused code when the browser session that issued it signs out', async () => {
+        const browser = await signIn(USER_A);
+        const { code } = (await issueCode(browser.accessToken)).body.data;
+        const { req } = await throughMiddleware(browser.accessToken, { body: { id: USER_A } });
+        await new Promise((resolve) => sessionCtr.removeSession(req, resolve));
+        expect(refused(await call(loginSession.loginAuthTracker, { body: { code } }))).toBe(true);
+    });
+
+    it('refuses to issue a code without a verified session', async () => {
+        const res = await call(loginSession.issueTrackerCode, { uid: USER_A });
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('declares the code fields, so the strict sessions schema keeps them', () => {
+        const { sessionsSchema } = require('../utils/mongo-handler/createSchema');
+        ['trackerCodeHash', 'trackerCodeExpiresAt'].forEach((field) => expect(sessionsSchema.path(field)).toBeDefined());
+    });
+});

--- a/tests/fixtures/sessionApp.js
+++ b/tests/fixtures/sessionApp.js
@@ -1,9 +1,12 @@
 // Spins up an express app behind the real JWT middleware lists, and signs web sessions the
 // way login does, with the session row and company membership pre-seeded in the cache so the
 // middleware never needs a database.
+const crypto = require('crypto');
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const mongoose = require('mongoose');
 const { myCache } = require('../../Config/config');
+const { sessionCacheKey } = require('../../Modules/Auth/helpers/refreshTokenRules');
 
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'unit-test-secret';
 process.env.JWT_ALGORITHM = process.env.JWT_ALGORITHM || 'HS256';
@@ -11,9 +14,11 @@ process.env.JWT_EXP = process.env.JWT_EXP || '1h';
 
 function signSession(uid, companyIds = []) {
     const options = { algorithm: 'HS256', expiresIn: '1h' };
-    const refreshToken = jwt.sign({}, process.env.JWT_SECRET, options);
-    const token = jwt.sign({ uid, refreshToken }, process.env.JWT_SECRET, companyIds.length ? { ...options, audience: companyIds.join(',') } : options);
-    myCache.set(`session:${uid}:${refreshToken}`, JSON.stringify({ userId: uid, refreshToken }), 600);
+    const sid = new mongoose.Types.ObjectId().toHexString();
+    const rti = crypto.randomUUID();
+    const sexp = Math.floor(Date.now() / 1000) + 3600;
+    const token = jwt.sign({ uid, sid, rti, sexp }, process.env.JWT_SECRET, companyIds.length ? { ...options, audience: companyIds.join(',') } : options);
+    myCache.set(sessionCacheKey(uid, sid, rti), JSON.stringify({ _id: sid, userId: uid }), 600);
     companyIds.forEach((companyId) => myCache.set(`membership:${uid}:${companyId}`, true, 600));
     return token;
 }

--- a/tests/integration/refresh-token.int.test.js
+++ b/tests/integration/refresh-token.int.test.js
@@ -54,10 +54,107 @@ describe('refresh tokens', () => {
         expect(claimsOf(next.body.token).uid).toBe(owner.uid);
     });
 
-    it("refuses tracker login with another user's id", async () => {
+});
+
+describe('access tokens', () => {
+    it('name the session and never carry the refresh token', async () => {
+        const owner = await loginAs('owner');
+        const claims = claimsOf(owner.accessToken);
+        expect(claims.refreshToken).toBeUndefined();
+        expect(Object.values(claims)).not.toContain(owner.refreshToken);
+        expect(owner.accessToken).not.toContain(owner.refreshToken);
+        expect(claims.uid).toBe(owner.uid);
+        expect(claims.sid).toMatch(/^[a-f0-9]{24}$/);
+    });
+
+    it('carry a session through login, refresh and logout', async () => {
+        const owner = await loginAs('owner');
+        const signedIn = createApiClient({ baseURL: state.baseURL, accessToken: owner.accessToken });
+        expect((await signedIn.get('/api/v2/users/sessions')).status).toBe(200);
+
+        const refreshed = await refresh(owner.refreshToken, owner.uid);
+        expect(refreshed.status).toBe(200);
+        expect(claimsOf(refreshed.body.token).refreshToken).toBeUndefined();
+        expect(claimsOf(refreshed.body.token).sid).toBe(claimsOf(owner.accessToken).sid);
+
+        const stale = await signedIn.get('/api/v2/users/sessions');
+        expect(stale.status).toBe(401);
+        expect(stale.body.isJwtError).toBe(true);
+        expect(stale.body.isLogout).toBeUndefined();
+
+        const current = createApiClient({ baseURL: state.baseURL, accessToken: refreshed.body.token });
+        expect((await current.get('/api/v2/users/sessions')).status).toBe(200);
+
+        const loggedOut = await current.post('/api/v2/logout', { id: owner.uid });
+        expect(loggedOut.status).toBe(200);
+
+        const afterLogout = await current.get('/api/v2/users/sessions');
+        expect(afterLogout.status).toBe(401);
+        expect(afterLogout.body.isLogout).toBe(true);
+        expect(refused(await refresh(refreshed.body.refreshToken, owner.uid))).toBe(true);
+    });
+
+    it('log out only the session they name', async () => {
+        const [first, second] = await Promise.all([loginAs('member'), loginAs('member')]);
+        const firstApi = createApiClient({ baseURL: state.baseURL, accessToken: first.accessToken });
+        expect((await firstApi.post('/api/v2/logout', { id: first.uid })).status).toBe(200);
+        expect((await createApiClient({ baseURL: state.baseURL, accessToken: second.accessToken }).get('/api/v2/users/sessions')).status).toBe(200);
+    });
+});
+
+describe('tracker sign-in', () => {
+    const trackerLogin = (body) => anonymous.post('/api/v1/auth/loginAuthTracker', body);
+    const issueCode = async (accessToken) => {
+        const res = await createApiClient({ baseURL: state.baseURL, accessToken }).post('/api/v2/auth/tracker-code', {});
+        expect(res.status).toBe(200);
+        return res.body.data.code;
+    };
+
+    it('exchanges a one-time code from the signed-in browser for a tracker session', async () => {
+        const owner = await loginAs('owner');
+        const code = await issueCode(owner.accessToken);
+        expect(code).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+        const tracker = await trackerLogin({ code, userId: owner.uid });
+        expect(tracker.status).toBe(200);
+        expect(tracker.body.uid).toBe(owner.uid);
+        expect(claimsOf(tracker.body.accessToken).refreshToken).toBeUndefined();
+        const trackerApi = createApiClient({ baseURL: state.baseURL, accessToken: tracker.body.accessToken });
+        expect((await trackerApi.get('/api/v2/users/sessions')).status).toBe(200);
+
+        const trackerRefresh = await refresh(tracker.body.refreshToken, owner.uid);
+        expect(trackerRefresh.status).toBe(200);
+        expect(claimsOf(trackerRefresh.body.token).uid).toBe(owner.uid);
+
+        const reused = await trackerLogin({ code, userId: owner.uid });
+        expect(refused(reused)).toBe(true);
+        expect(reused.body.accessToken).toBeUndefined();
+    });
+
+    it('accepts the code the way older tracker builds send the deep-link value', async () => {
+        const owner = await loginAs('owner');
+        const code = await issueCode(owner.accessToken);
+        const tracker = await trackerLogin({ refreshToken: code, userId: owner.uid });
+        expect(tracker.status).toBe(200);
+        expect(tracker.body.uid).toBe(owner.uid);
+    });
+
+    it("refuses a code presented with another user's id", async () => {
         const [owner, member] = await Promise.all([loginAs('owner'), loginAs('member')]);
-        const res = await anonymous.post('/api/v1/auth/loginAuthTracker', { refreshToken: owner.refreshToken, userId: member.uid });
+        const res = await trackerLogin({ code: await issueCode(owner.accessToken), userId: member.uid });
         expect(refused(res)).toBe(true);
         expect(res.body.accessToken).toBeUndefined();
+    });
+
+    it('refuses a refresh token in place of a code', async () => {
+        const owner = await loginAs('owner');
+        const res = await trackerLogin({ refreshToken: owner.refreshToken, userId: owner.uid });
+        expect(refused(res)).toBe(true);
+        expect(res.body.accessToken).toBeUndefined();
+    });
+
+    it('refuses to issue a code without a session', async () => {
+        const res = await anonymous.post('/api/v2/auth/tracker-code', {});
+        expect(res.status).toBe(401);
     });
 });

--- a/tests/mongo-gateway.test.js
+++ b/tests/mongo-gateway.test.js
@@ -39,10 +39,12 @@ const resetStore = () => {
     mockDb.seed(dbCollections.TIMESHEET, { TicketID: 'task-2', LogTimeDuration: 99 });
 };
 
+const SESSION = '6f00000000000000000005e1';
+
 const signIn = () => {
-    const refreshToken = jsonwebtoken.sign({}, process.env.JWT_SECRET, { expiresIn: '1h' });
-    mockDb.seed(dbCollections.SESSIONS, { userId: USER, refreshToken });
-    return jsonwebtoken.sign({ uid: USER, refreshToken }, process.env.JWT_SECRET, { audience: COMPANY, expiresIn: '1h' });
+    mockDb.seed(dbCollections.SESSIONS, { _id: SESSION, userId: USER, refreshTokenJti: 'refresh-jti' });
+    const sexp = Math.floor(Date.now() / 1000) + 3600;
+    return jsonwebtoken.sign({ uid: USER, sid: SESSION, rti: 'refresh-jti', sexp }, process.env.JWT_SECRET, { audience: COMPANY, expiresIn: '1h' });
 };
 
 describe('POST /api/v1/mongoOpration', () => {

--- a/tests/refresh-token-uniqueness.test.js
+++ b/tests/refresh-token-uniqueness.test.js
@@ -182,13 +182,12 @@ describe('POST /api/v2/generateToken', () => {
 });
 
 describe('POST /api/v1/auth/loginAuthTracker', () => {
-    it("resolves A's token to A even when B's session was issued first in the same second", async () => {
-        await issueSession(USER_B);
+    it("no longer turns a user's refresh token into a second session", async () => {
         const tokenA = await issueSession(USER_A);
         const res = await trackerLogin({ refreshToken: tokenA, userId: USER_A });
-        expect(refused(res)).toBe(false);
-        expect(String(res.body.uid)).toBe(USER_A);
-        expect(jwt.decode(res.body.accessToken).uid).toBe(USER_A);
+        expect(refused(res)).toBe(true);
+        expect(res.body.accessToken).toBeUndefined();
+        expect(sessionsOf(USER_A)).toHaveLength(1);
     });
 
     it("refuses a token presented with another user's id", async () => {

--- a/tests/session-refresh-token.test.js
+++ b/tests/session-refresh-token.test.js
@@ -9,14 +9,14 @@ const jsonwebtoken = require('jsonwebtoken');
 const { verifyJWTTokenV2 } = require('../Config/jwt');
 const { validateSettings } = require('../Modules/Instance/settingsCatalog');
 const session = require('../Modules/Auth/session');
-const { sessionTokenQuery } = require('../Modules/Auth/helpers/refreshTokenRules');
 
 const UID = '6f0000000000000000000001';
+const SID = '6f00000000000000000005e1';
 
 const signedRequest = (body) => {
-    const refreshToken = jsonwebtoken.sign({ kind: 'refresh' }, process.env.JWT_SECRET, { expiresIn: '1h' });
-    const accessToken = jsonwebtoken.sign({ uid: UID, refreshToken }, process.env.JWT_SECRET, { expiresIn: '1h' });
-    return { refreshToken, req: { headers: { authorization: `Bearer ${accessToken}` }, body } };
+    const sexp = Math.floor(Date.now() / 1000) + 3600;
+    const accessToken = jsonwebtoken.sign({ uid: UID, sid: SID, rti: 'refresh-jti', sexp }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    return { req: { headers: { authorization: `Bearer ${accessToken}` }, body } };
 };
 
 const res = () => {
@@ -26,38 +26,41 @@ const res = () => {
     return r;
 };
 
+const passThrough = (req) => new Promise((resolve) => verifyJWTTokenV2(req, res(), resolve));
+
 beforeEach(() => mockCrud.mockClear());
 
 describe('INS-07 the session middleware and the request body', () => {
-    it('keeps the refresh token out of the body so strict validators accept it', async () => {
-        const { refreshToken, req } = signedRequest({ APP_NAME: 'Renamed' });
-        const next = jest.fn();
-        verifyJWTTokenV2(req, res(), next);
-        expect(next).toHaveBeenCalled();
+    it('keeps session details out of the body so strict validators accept it', async () => {
+        const { req } = signedRequest({ APP_NAME: 'Renamed' });
+        await passThrough(req);
         expect(req.body).toEqual({ APP_NAME: 'Renamed' });
-        expect(req.refreshToken).toBe(refreshToken);
+        expect(req.sessionId).toBe(SID);
+        expect(req.refreshToken).toBeUndefined();
         expect(validateSettings(req.body)).toMatchObject({ valid: true, values: { APP_NAME: 'Renamed' } });
     });
 
     it('updates the session named by the verified token, not the body', async () => {
-        const { refreshToken, req } = signedRequest({ userId: UID, refreshToken: 'someone-else', updateObject: { $set: { lastActive: 1 } } });
-        verifyJWTTokenV2(req, res(), () => {});
+        const { req } = signedRequest({ userId: '6f0000000000000000000002', refreshToken: 'someone-else', updateObject: { lastActive: new Date().toISOString() } });
+        await passThrough(req);
         const out = res();
         session.updateSession(req, out);
         await new Promise(setImmediate);
         const [, query] = mockCrud.mock.calls.find(([, q, method]) => q.type === 'sessions' && method === 'findOneAndUpdate');
-        expect(query.data[0]).toEqual({ userId: UID, ...sessionTokenQuery(refreshToken) });
+        expect(String(query.data[0]._id)).toBe(SID);
+        expect(query.data[0].userId).toBe(UID);
         expect(out.code).toBe(200);
     });
 
     it('logs out the session named by the verified token', async () => {
-        const { refreshToken, req } = signedRequest({ id: UID });
-        verifyJWTTokenV2(req, res(), () => {});
+        const { req } = signedRequest({ id: UID, refreshToken: 'someone-else' });
+        await passThrough(req);
         const done = jest.fn();
         session.removeSession(req, done);
         await new Promise(setImmediate);
         const [, query] = mockCrud.mock.calls.find(([, q, method]) => q.type === 'sessions' && method === 'deleteMany');
-        expect(query.data[0]).toEqual({ userId: UID, ...sessionTokenQuery(refreshToken) });
+        expect(String(query.data[0]._id)).toBe(SID);
+        expect(query.data[0].userId).toBe(UID);
         expect(done).toHaveBeenCalledWith(expect.objectContaining({ status: true }));
     });
 });

--- a/time-tracker-app/renderer/components/Login/Login.jsx
+++ b/time-tracker-app/renderer/components/Login/Login.jsx
@@ -14,10 +14,10 @@ const Login = () => {
   const dispatch = useDispatch();
   const router = useRouter();
 
-  const loginAPI = (refreshToken, userId) => {
+  const loginAPI = (code, userId) => {
     return new Promise((resolve, reject) => {
       try {
-        apiRequestWithoutSecure("post", `/api/v1/auth/loginAuthTracker`, {refreshToken, userId}).then((ele) => {
+        apiRequestWithoutSecure("post", `/api/v1/auth/loginAuthTracker`, {code, userId}).then((ele) => {
           resolve(ele?.data)
         }).catch((error)=>{
           reject(error);
@@ -35,12 +35,11 @@ const Login = () => {
       if (isProcessing) return; // Prevent multiple executions
       isProcessing = true;
       
-      let refreshToken = url.url.split("?")[1].split("&")[1].split("=")[1]
-      let userId = url.url.split("?")[1].split("&")[0].split("=")[1]
-      loginAPI(refreshToken, userId).then((ele)=>{
+      const params = new URLSearchParams(url.url.split("?").slice(1).join("?"))
+      loginAPI(params.get("code"), params.get("client_id")).then((ele)=>{
         localStorage.setItem('refreshToken', ele.refreshToken)
         localStorage.setItem('token', ele.accessToken)
-        localStorage.setItem("userId", userId);
+        localStorage.setItem("userId", ele.uid);
         getUserData(dispatch).then(() => {
           dispatch(login());
           getAssignCompanyData().then(() => {

--- a/time-tracker-app/renderer/controller/user/user.js
+++ b/time-tracker-app/renderer/controller/user/user.js
@@ -41,11 +41,7 @@ export const logoutFunction = async () => {
         } else {
             try {
                 const userId = localStorage.getItem("userId");
-                const refreshToken = localStorage.getItem("refreshToken");
-                await apiRequestWithoutCompnay("post", '/api/v2/logout', {
-                    id: userId,
-                    refreshToken: refreshToken,
-                });                    
+                await apiRequestWithoutCompnay("post", '/api/v2/logout', { id: userId });
                 store.dispatch(logout());
             } catch (error) {
                 console.error('Error in logout', error);

--- a/utils/mongo-handler/createSchema.js
+++ b/utils/mongo-handler/createSchema.js
@@ -317,9 +317,10 @@ userAuthSchema.index({ email: 1 });
 // companyUsers: lookup by userId + invitation status.
 companyUserSchema.index({ userId: 1 });
 
-// sessions: refresh-token lookup is what `Config/jwt.js` does.
+// sessions: the refresh endpoint finds a session by token hash, tracker sign-in by code hash.
 sessionsSchema.index({ refreshToken: 1 });
 sessionsSchema.index({ refreshTokenHash: 1 });
+sessionsSchema.index({ trackerCodeHash: 1 }, { sparse: true });
 sessionsSchema.index({ userId: 1 });
 
 // resetAttempt: keyed by IP.

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -3796,6 +3796,14 @@ const schema = {
             type: Date,
             required: false
         },
+        trackerCodeHash: {
+            type: String,
+            required: false
+        },
+        trackerCodeExpiresAt: {
+            type: Date,
+            required: false
+        },
         lastActive: {
             type: Date,
             default: new Date()


### PR DESCRIPTION
## Summary

Fixes QA follow-ups 8 and 9 from `Tasks/active/034-end-to-end-qa-programme/followups.md` and documents 10.

| Finding | Where | Fix | Test |
|---|---|---|---|
| 8. The access token payload embeds the plaintext refresh token | `Modules/Auth/controller/authHelpers.js` (`generateTokenV2Fun`), `Config/jwt.js` (`checkToken`, behind `verifyJWTTokenV2` and `verifyJWTTokenWithCV2`) | Access tokens carry `sid` (session id), `rti` (current refresh token jti) and `sexp` (session expiry) instead. The guard finds the session by `_id` + `uid`, sends an older `rti` to refresh with a non-logout 401 (what the rotated-away check did), ends the session once `sexp` passes, and sets `req.sessionId` instead of `req.refreshToken`. A refresh token presented as a bearer token is refused. | `tests/access-token-session.test.js`, `tests/refresh-token-uniqueness.test.js`, `tests/integration/refresh-token.int.test.js` |
| 8. Logout named the session with the embedded refresh token (or the body) | `Modules/Auth/session.js` `removeSession` (`POST /api/v2/logout`) | Deletes `{ _id: req.sessionId, userId: req.uid }` and drops that session's cache entry, so the logged-out access token is refused at once. The web app and the tracker no longer send the refresh token in the body. | `tests/access-token-session.test.js`, `tests/session-refresh-token.test.js`, integration |
| 8. Session update named the session with the embedded refresh token, and passed the body to Mongo as the update | `Modules/Auth/session.js` `updateSession` (`PUT /api/v2/session/update`) | Targets the verified session and sets only `webToken` (string) and `lastActive` (date), the two fields `App.vue` sends. Anything else is a 400. Before, a caller could `$set` `userId` or `refreshToken` on their own session row. | `tests/access-token-session.test.js`, `tests/session-refresh-token.test.js` |
| 9. `TrackerLogin.vue` put the refresh token in `myapp://authorize?...&client_secret=` | `frontend/src/views/Authentication/TrackerLogin/TrackerLogin.vue`, new `POST /api/v2/auth/tracker-code`, `loginAuthTracker`, `Modules/Auth/helpers/trackerCode.js` | The page asks for a one-time code: 256 random bits, only its SHA-256 stored on the browser session, valid for 2 minutes, single use, dropped if that session signs out. It opens `myapp://authorize?client_id=<uid>&code=<code>`, and the tracker exchanges the code over POST for its own session. `loginAuthTracker` no longer accepts refresh tokens. | `frontend/tests/unit/trackerLogin.spec.js`, `tests/access-token-session.test.js`, integration |
| 9. The Electron tracker parsed the refresh token out of the deep link | `time-tracker-app/renderer/components/Login/Login.jsx`, `time-tracker-app/renderer/controller/user/user.js` | Reads `code` and `client_id` with `URLSearchParams`, posts `{ code, userId }` and stores the `uid` the server returns. Logout no longer sends the refresh token. `main/background.js` is unchanged: it already forwards the whole `myapp://` URL to the renderer. | Syntax-checked with esbuild (no test runner or lint config covers the tracker) |
| 10. Old tracker builds that don't send `userId` | `loginAuthTracker`, `generateTokenV2` | Documented below. New-format behaviour is kept. | `tests/refresh-token-uniqueness.test.js` (unchanged legacy cases) |

**Every reader of the embedded token, and what replaced it**
- `Config/jwt.js` `checkToken`: the only code that took `refreshToken` out of a decoded access token. It now reads `sid`/`rti`/`sexp` and looks the session up by id.
- `req.refreshToken`, which `checkToken` set, was read by `Modules/Auth/session.js` `updateSession` and `removeSession`. Both now use `req.sessionId` and `req.uid`.
- `generateTokenV2Fun`, used by login, 2FA, magic link, setup, SSO, tracker sign-in and refresh, now signs the session claims.
- Checked and not readers: the socket handshake (`socket/socketinit.js` verifies the JWT, and `socket/controller/callSocket.js` reads only `uid`/`aud`), `verifyJWTToken`/`verifyJWTTokenWithC` (only `uid`), storage signed URLs, and the "this device" marker in My Settings (it reads the refresh cookie, not the access token).

## Notes

**Upgrade impact: web sessions**
- An access token issued before this deploy still verifies but names no session. The guards answer it with `401 { isJwtError: true }` and no `isLogout`, the same reply an expired access token gets. The web client already refreshes and retries on that reply using the refresh cookie, so signed-in users get a new access token on their next request and nobody is signed out.
- Refresh tokens and session rows are unchanged. No migration and no env var change.
- Scripts that hold a raw access token and never refresh get 401 until they sign in again. Personal API tokens (`ahp_…`) are not affected.
- New `sessions` fields `trackerCodeHash` and `trackerCodeExpiresAt` are declared in the strict schema, with a sparse index on the hash.

**Upgrade impact: tracker builds**
- Builds from before this PR keep signing in. They post the second deep-link value as `refreshToken`. The page now puts the one-time code there, and `loginAuthTracker` accepts the code in either `code` or `refreshToken`. Refresh keeps working as before.
- Builds from this PR need a server with this PR, because an older server ignores `code`.
- Posting a refresh token to `loginAuthTracker` is now refused. Only the removed URL flow did that, and accepting it let anyone holding a refresh token mint a second session that outlives revocation of the first.
- Item 10: builds from before #609 posted `{ refreshToken }` without `userId`, and #609 refused that for legacy-format tokens. Sign-in no longer involves a refresh token, and `userId` is optional (checked only when sent), so those builds can sign in again. Refreshing a legacy-format refresh token still requires `uid` in the body, as #609 left it. Every tracker build sends it from `requestAuth`, and a client that doesn't gets `400 The user id is required.` and must sign in again. New-format refresh tokens don't need it.

**Smaller behaviour changes**
- Logout drops the session's cache entry, so a logged-out access token no longer passes for up to 10 minutes on a warm cache.
- A database error during the session lookup still logs the user out, but no longer echoes the error message.
- An access token more than one rotation old is now sent to refresh (non-logout 401). Before, it logged the user out.

**Left out**
- Socket handshakes still check only the JWT signature, not that the session is live. That is unchanged, and they never read the refresh token.
- Auth cookies stay non-httpOnly (P1-SEC-09).
- The stray `"refreshToken"` entries in a few body allowlists (Milestone, task update, settings templates, notification settings) date from before #624. They are harmless and left alone.

## Test plan

- [x] Tests written first: before the fix, 47 backend unit tests and all 3 new frontend specs failed.
- [x] `npx jest --selectProjects unit conventions --maxWorkers=2`: 252 suites, 3431 tests passed.
- [x] `E2E_MONGODB_URL=mongodb://127.0.0.1:27175 npm run test:integration` against `mongo:7`: 663 tests passed. This includes the new login → refresh → logout, single-session logout and tracker-code cases.
- [x] `cd frontend && npx vitest run`: 32 files, 245 tests passed.
- [x] `npm run i18n:backfill` then `npm run i18n:check`: exit 0.
- [x] `node scripts/env-doc.js --check`: in sync.
- [x] eslint on the touched backend and test files: 0 errors (the warnings are unused imports already there). `vue-cli-service lint` on the touched frontend files: no errors.
- [x] `npx commitlint --from origin/beta --to HEAD`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
