### PR TITLE
fix(invitations): drop the stray characters after the verify-invitation link id

### DIFF
--- a/Modules/Auth/controller/sendInvitation.js
+++ b/Modules/Auth/controller/sendInvitation.js
@@ -265,7 +265,7 @@ exports.sendInvitationEmailFun = (bodyData) => {
                                     let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${resp._id}`;
                                     sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),resp);
                                 } else {
-                                    let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${resp._id}&linkId=${token}`)})}`;
+                                    let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${resp._id}&linkId=${token}`)}`;
                                     sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),resp);
                                 }
                             }).catch((error)=>{
@@ -435,7 +435,7 @@ exports.sendInvitationEmail = (req,res) => {
                             let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${re._id}`;
                             sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),re);
                         } else {
-                            let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${re._id}&linkId=${token}`)})}`;
+                            let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${re._id}&linkId=${token}`)}`;
                             sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),re);
                         }
                     }).catch((error) => {
@@ -477,7 +477,7 @@ exports.sendInvitationEmail = (req,res) => {
                             let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${resp._id}`;
                             sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),resp);
                         } else {
-                            let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${resp._id}&linkId=${token}`)})}`;
+                            let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${resp._id}&linkId=${token}`)}`;
                             sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),resp);
                         }
                     }).catch((error)=>{


### PR DESCRIPTION
## Summary

Fixes follow-up 28: three of the four verify-invitation links built in `Modules/Auth/controller/sendInvitation.js` ended with a literal `)}` after the base64 `id`.

- **Cause:** a doubled `)}` closing the template literal in three places.
- **Impact:** cosmetic. `verifyInvitation.js` decodes the id with `Buffer.from(id, 'base64')`, which ignores the trailing characters, so the links worked. They looked malformed in the invitation email.
- **Fix:** the three links now match the fourth.

## Test plan

- [x] `node --check` on the file.
- [x] Full backend unit suite on this base: 246 suites, 3355 tests passed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
