### PR TITLE
fix: send only the account id on verification resend and fix the settings dial code crash

### DIFF
--- a/frontend/src/components/molecules/CountryPhoneNumberDropdown/PhoneCountry.vue
+++ b/frontend/src/components/molecules/CountryPhoneNumberDropdown/PhoneCountry.vue
@@ -89,8 +89,8 @@
     onMounted(() => {
         uniqueId.value = `phoneCountry-${makeUniqueId()}`
         setTimeout(() => {
-            activeCountry.value = findCountry(props.preferredCountries[0])
-            emit("onSelect", activeCountry.value);
+            const [initialCountry] = getCountries(props.preferredCountries);
+            if (initialCountry) selectedComapany(initialCountry);
         }, 10);
     })      
 

--- a/frontend/src/components/molecules/CountryPhoneNumberDropdown/PhoneCountry.vue
+++ b/frontend/src/components/molecules/CountryPhoneNumberDropdown/PhoneCountry.vue
@@ -1,10 +1,10 @@
 <template>
     <DropDown :id="uniqueId" :bodyClass="{'countrycode__dropdown' : true}" @isVisible="checkDropdown">
         <template #button>
-            <div class="dropdown">
+            <div class="dropdown" ref="dropdownButton">
                 <span class="imageCountry text-ellipsis">
                 <div class="vti__flag" :class="activeCountry?.isoCode.toLowerCase()"></div>
-                <span :ref="uniqueId" v-if="enabledCountryCode" class="black activeCountrydialCode">+{{ activeCountry?.dialCode }}</span>
+                <span v-if="enabledCountryCode" class="black activeCountrydialCode">+{{ activeCountry?.dialCode }}</span>
                 </span>
                 <img v-if="enabledArrowIcon" :src="arrow" alt="dropdown-arrow" class="dropdown-arrow">
             </div>
@@ -26,7 +26,7 @@
             <DropDownOption
                 v-for="(country, index) in sortedCountries"
                 :key="'phone'+index"
-                @click="$emit('onSelect', activeCountry),selectedComapany(country),$refs[uniqueId].click(),search = ''"
+                @click="chooseCountry(country)"
                 :highlight="index === highlightIndex"
                 :id="'item'+index"
             >
@@ -42,7 +42,7 @@
 </template>
 
 <script setup>
-    import { defineComponent, onMounted, ref,defineEmits ,defineProps , computed , inject, nextTick, watch} from "vue";
+    import { defineComponent, onMounted, onBeforeUnmount, ref,defineEmits ,defineProps , computed , inject, nextTick, watch} from "vue";
     import DropDown from '@/components/molecules/DropDown/DropDown.vue'
     import DropDownOption from '@/components/molecules/DropDownOption/DropDownOption.vue'
     import InputText from '@/components/atom/InputText/InputText.vue';
@@ -125,6 +125,20 @@
         emit("onSelect", activeCountry.value);
     }
 
+    const dropdownButton = ref(null);
+
+    const chooseCountry = (country) => {
+        if (!country) return;
+        selectedComapany(country);
+        dropdownButton.value?.click();
+        search.value = '';
+        highlightIndex.value = 0;
+    }
+
+    watch(search, () => {
+        highlightIndex.value = 0;
+    })
+
     function startListener() {
         document.addEventListener("keydown", keyListener)
     }
@@ -133,21 +147,18 @@
         document.removeEventListener("keydown", keyListener)
     }
 
+    onBeforeUnmount(stopListener)
+
     function keyListener(event) {
         if(event.keyCode === 13) { // Enter
-            emit('onSelect', activeCountry.value),
-            selectedComapany(sortedCountries.value[highlightIndex.value])
-            let timeZoneInput = document.getElementById('item'+highlightIndex.value)
-            timeZoneInput?.click();
-            search.value= ''
-            highlightIndex.value = 0;
+            chooseCountry(sortedCountries.value[highlightIndex.value]);
         } else if(event.keyCode === 38){ // UP
             highlightIndex.value = highlightIndex.value > 0 ? highlightIndex.value-1 : 0;
             nextTick(() => {
                 document.getElementById('item'+highlightIndex.value)?.scrollIntoView({behavior: "smooth", block: 'end'})
             })
         } else if (event.keyCode === 40){ // DOWN
-            highlightIndex.value = highlightIndex.value < sortedCountries.value.length-1 ? highlightIndex.value+1 : sortedCountries.value.length-1;
+            highlightIndex.value = Math.max(0, Math.min(highlightIndex.value + 1, sortedCountries.value.length - 1));
             nextTick(() => {
                 document.getElementById('item'+highlightIndex.value)?.scrollIntoView({behavior: "smooth", block: 'nearest', inline: 'start'})
             })

--- a/frontend/src/views/Authentication/Login/Login.vue
+++ b/frontend/src/views/Authentication/Login/Login.vue
@@ -388,7 +388,7 @@ const backToLogin = () => {
 const handleSubmitResend = () => {
     if (!userData.value?._id) { $toast.error(t("Toast.something_went_wrong"), { position: "top-right" }); return; }
     busy.value = true;
-    axios.post(env.API_URI + env.SEND_VARIFICATION_EMAIL, { uid: userData.value._id, email: userData.value.Employee_Email || form.email }).then((result) => {
+    axios.post(env.API_URI + env.SEND_VARIFICATION_EMAIL, { uid: userData.value._id }).then((result) => {
         if (result.data.status === true) { resendWait.value = 60; $toast.success(t("Toast.Verification_mail_has_been_send_successfully"), { position: "top-right" }); }
         else $toast.error(result.data.statusText, { position: "top-right" });
     }).catch(() => $toast.error(t("Toast.something_went_wrong"), { position: "top-right" })).finally(() => { busy.value = false; });

--- a/frontend/src/views/Authentication/VerifyEmail/VerifyEmail.vue
+++ b/frontend/src/views/Authentication/VerifyEmail/VerifyEmail.vue
@@ -96,7 +96,7 @@ const resend = async () => {
     busy.value = true;
     resendError.value = "";
     try {
-        const result = await axios.post(env.API_URI + env.SEND_VARIFICATION_EMAIL, { uid: route.params.id, email: email.value });
+        const result = await axios.post(env.API_URI + env.SEND_VARIFICATION_EMAIL, { uid: route.params.id });
         if (result.data.status === true) stage.value = "resent";
         else resendError.value = result.data.statusText || t("Auth.server_error");
     } catch {

--- a/frontend/tests/unit/phoneCountry.spec.js
+++ b/frontend/tests/unit/phoneCountry.spec.js
@@ -1,0 +1,102 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+
+vi.mock('@/composable', () => ({ useCustomComposable: () => ({ makeUniqueId: () => 'id', debounce: (fn) => fn }) }));
+
+import PhoneCountry from '@/components/molecules/CountryPhoneNumberDropdown/PhoneCountry.vue';
+import allCountries from '@/components/molecules/CountryPhoneNumberDropdown/allCountry.js';
+
+const ENTER = 13;
+const DOWN = 40;
+
+const press = async (keyCode, times = 1) => {
+    for (let i = 0; i < times; i++) {
+        const event = new KeyboardEvent('keydown', { bubbles: true });
+        Object.defineProperty(event, 'keyCode', { value: keyCode });
+        document.dispatchEvent(event);
+        await nextTick();
+    }
+    await flushPromises();
+};
+
+const typeSearch = async (text) => {
+    const input = document.querySelector('.countrycode__dropdown input');
+    input.value = text;
+    input.dispatchEvent(new Event('input'));
+    await flushPromises();
+};
+
+let wrapper;
+
+const openDropdown = async () => {
+    wrapper = mount(PhoneCountry, { props: { preferredCountries: ['US'], enabledCountryCode: true } });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await wrapper.find('.dropdown').trigger('click');
+    await flushPromises();
+    expect(wrapper.emitted('onSelect')).toHaveLength(1);
+    return {
+        selections: () => (wrapper.emitted('onSelect') || []).slice(1).map(([country]) => country),
+        dialCode: () => wrapper.find('.activeCountrydialCode').text()
+    };
+};
+
+describe('PhoneCountry keyboard selection', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+        const target = document.createElement('div');
+        target.id = 'my-dropdown';
+        document.body.appendChild(target);
+    });
+
+    afterEach(() => { wrapper?.unmount(); wrapper = undefined; });
+
+    it('selects the first match, never undefined, when Enter follows a search that shrank the list below the highlight', async () => {
+        const { selections, dialCode } = await openDropdown();
+        await press(DOWN, 5);
+        await typeSearch('ind');
+        const matches = allCountries.filter((country) => country.name.toLowerCase().includes('ind'));
+        expect(matches.length).toBeLessThan(6);
+
+        await press(ENTER);
+
+        expect(selections()).toEqual([matches[0]]);
+        expect(dialCode()).toBe(`+${matches[0].dialCode}`);
+    });
+
+    it('highlights the first match after the search changes', async () => {
+        await openDropdown();
+        await press(DOWN, 5);
+        await typeSearch('ind');
+
+        expect(document.querySelector('#item0').classList).toContain('bg-blue');
+    });
+
+    it('keeps the current country when Enter finds no match', async () => {
+        const { selections, dialCode } = await openDropdown();
+        await typeSearch('zzzz');
+
+        await press(ENTER);
+
+        expect(selections()).toEqual([]);
+        expect(dialCode()).toBe('+1');
+    });
+
+    it('reports only the highlighted country, once, on Enter', async () => {
+        const { selections } = await openDropdown();
+        await press(DOWN, 2);
+
+        await press(ENTER);
+
+        expect(selections()).toEqual([allCountries[1]]);
+    });
+
+    it('reports only the clicked country, once, on click', async () => {
+        const { selections } = await openDropdown();
+
+        document.querySelector('#item3').click();
+        await flushPromises();
+
+        expect(selections()).toEqual([allCountries[2]]);
+    });
+});

--- a/frontend/tests/unit/settingCompanyDetails.spec.js
+++ b/frontend/tests/unit/settingCompanyDetails.spec.js
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+
+const { apiRequest, getters, stub } = vi.hoisted(() => ({
+    apiRequest: vi.fn(),
+    getters: {},
+    stub: (name) => ({ default: { name, render: () => null } })
+}));
+
+vi.mock('@/services', () => ({ apiRequest, apiRequestWithoutCompnay: vi.fn() }));
+vi.mock('vuex', () => ({ useStore: () => ({ getters, commit: vi.fn() }) }));
+vi.mock('@/composable', () => ({ useCustomComposable: () => ({ makeUniqueId: () => 'id', debounce: (fn) => fn }) }));
+vi.mock('@/locales/main', () => ({ i18n: { global: { t: (key) => key } } }));
+vi.mock('@/composable/Validation.js', () => ({ useValidation: () => ({ checkErrors: vi.fn(), checkAllFields: vi.fn(async () => true) }) }));
+vi.mock('@/components/atom/WasabiIamgeCompp/WasabiIamgeCompp.vue', () => stub('WasabiImage'));
+vi.mock('@/components/atom/CroppingTool/CroppingTool.vue', () => stub('CroppingTool'));
+vi.mock('@/components/molecules/Sidebar/Sidebar.vue', () => stub('Sidebar'));
+
+import SettingCompanyDetails from '@/components/molecules/Setting/SettingCompanyDetails.vue';
+
+const COMPANY_ID = 'company-1';
+
+// The shapes Modules/Setup/createCompany.js and Modules/Company/controller.js store before anyone opens Settings.
+const fromSetupWizard = {
+    _id: COMPANY_ID, Cst_CompanyName: 'Acme', Cst_Phone: 'N/A', Cst_Country: 'N/A', Cst_City: '', Cst_State: '',
+    Cst_DialCode: { name: '', dialCode: '', code: '' }, Cst_LogTimeDays: '8'
+};
+const fromCreateCompany = {
+    _id: COMPANY_ID, Cst_CompanyName: 'Acme', Cst_Phone: '', Cst_Country: '', Cst_City: '', Cst_State: '',
+    Cst_DialCode: {}, Cst_countryCode: '', Cst_stateCode: ''
+};
+
+const open = async (company) => {
+    getters['settings/companies'] = [company];
+    getters['settings/companyDateFormat'] = { dateFormat: 'DD/MM/YYYY' };
+    const errors = [];
+    const wrapper = mount(SettingCompanyDetails, {
+        props: { editPermission: true },
+        global: { provide: { customerUpdate: () => {} }, config: { errorHandler: (error) => errors.push(error) } }
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await flushPromises();
+    return { wrapper, errors };
+};
+
+describe('Settings > General company details on a fresh company', () => {
+    beforeEach(() => { apiRequest.mockReset(); });
+
+    it.each([['the setup wizard', fromSetupWizard], ['the create-company screen', fromCreateCompany]])(
+        'opens a company made by %s with a real dial code country selected',
+        async (_source, company) => {
+            const { wrapper, errors } = await open(company);
+            expect(errors.map(String)).toEqual([]);
+            expect(wrapper.find('.activeCountrydialCode').text()).toBe('+1');
+            expect(wrapper.find('.vti__flag').classes()).toContain('us');
+            wrapper.unmount();
+        }
+    );
+
+    it('saves a fresh company with the dial code country it shows', async () => {
+        const { wrapper, errors } = await open(fromSetupWizard);
+        apiRequest.mockResolvedValue({ status: 200, data: { _id: COMPANY_ID } });
+
+        const phoneInput = wrapper.find('input[placeholder="eg. 000-000-0000"]');
+        await phoneInput.setValue('4155552671');
+        await phoneInput.trigger('keyup');
+        await wrapper.find('#blue-btn-savecompany').trigger('click');
+        await flushPromises();
+
+        expect(errors.map(String)).toEqual([]);
+        expect(apiRequest).toHaveBeenCalled();
+        const [method, , body] = apiRequest.mock.calls[0];
+        expect(method).toBe('put');
+        expect(body.updateObject.Cst_Phone).toBe('4155552671');
+        expect(body.updateObject.Cst_DialCode).toMatchObject({ isoCode: 'US', dialCode: '1' });
+        wrapper.unmount();
+    });
+});

--- a/frontend/tests/unit/settingCompanyDetails.spec.js
+++ b/frontend/tests/unit/settingCompanyDetails.spec.js
@@ -17,6 +17,7 @@ vi.mock('@/components/atom/CroppingTool/CroppingTool.vue', () => stub('CroppingT
 vi.mock('@/components/molecules/Sidebar/Sidebar.vue', () => stub('Sidebar'));
 
 import SettingCompanyDetails from '@/components/molecules/Setting/SettingCompanyDetails.vue';
+import allCountries from '@/components/molecules/CountryPhoneNumberDropdown/allCountry.js';
 
 const COMPANY_ID = 'company-1';
 
@@ -73,6 +74,37 @@ describe('Settings > General company details on a fresh company', () => {
         expect(method).toBe('put');
         expect(body.updateObject.Cst_Phone).toBe('4155552671');
         expect(body.updateObject.Cst_DialCode).toMatchObject({ isoCode: 'US', dialCode: '1' });
+        wrapper.unmount();
+    });
+
+    it('keeps a real dial code country when Enter is pressed after a search shrinks the list below the highlight', async () => {
+        Element.prototype.scrollIntoView = vi.fn();
+        if (!document.getElementById('my-dropdown')) {
+            const target = document.createElement('div');
+            target.id = 'my-dropdown';
+            document.body.appendChild(target);
+        }
+        const press = (keyCode) => {
+            const event = new KeyboardEvent('keydown', { bubbles: true });
+            Object.defineProperty(event, 'keyCode', { value: keyCode });
+            document.dispatchEvent(event);
+            return flushPromises();
+        };
+        const { wrapper, errors } = await open(fromSetupWizard);
+        apiRequest.mockResolvedValue({ status: 200, data: { _id: COMPANY_ID } });
+
+        await wrapper.find('.phone .dropdown').trigger('click');
+        await flushPromises();
+        for (let i = 0; i < 5; i++) await press(40);
+        const search = document.querySelector('.countrycode__dropdown input');
+        search.value = 'ind';
+        search.dispatchEvent(new Event('input'));
+        await flushPromises();
+        await press(13);
+
+        const [firstMatch] = allCountries.filter((country) => country.name.toLowerCase().includes('ind'));
+        expect(errors.map(String)).toEqual([]);
+        expect(wrapper.find('.phone .activeCountrydialCode').text()).toBe(`+${firstMatch.dialCode}`);
         wrapper.unmount();
     });
 });

--- a/frontend/tests/unit/verificationResend.spec.js
+++ b/frontend/tests/unit/verificationResend.spec.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { h } from 'vue';
+
+const { apiRequestWithoutSecure, route, stub } = vi.hoisted(() => ({
+    apiRequestWithoutSecure: vi.fn(),
+    route: { params: {}, query: {} },
+    stub: (name) => ({ default: { name, render: () => null } })
+}));
+
+vi.mock('@/services', () => ({ apiRequestWithoutSecure, apiRequestWithoutCompnay: vi.fn(), getAuth: vi.fn() }));
+vi.mock('vue-router', () => ({
+    useRoute: () => route,
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn(), hasRoute: () => false })
+}));
+vi.mock('vuex', () => ({ useStore: () => ({ getters: {} }) }));
+vi.mock('@/config/publicConfig', () => ({ publicConfig: { auth: { sso: false } }, enabledProviders: () => [] }));
+vi.mock('@/components/templates/AuthShell/AuthShell.vue', () => ({
+    default: { name: 'AuthShell', render() { return h('div', this.$slots.default && this.$slots.default()); } }
+}));
+vi.mock('@/plugins/oauth/ProviderButton.vue', () => stub('ProviderButton'));
+vi.mock('@/components/organisms/Shell/ShellIcon.vue', () => stub('ShellIcon'));
+
+import Login from '@/views/Authentication/Login/Login.vue';
+import VerifyEmail from '@/views/Authentication/VerifyEmail/VerifyEmail.vue';
+import * as env from '@/config/env';
+
+const UID = '6f0000000000000000000b01';
+const RESEND_URL = env.API_URI + env.SEND_VARIFICATION_EMAIL;
+
+const open = (component, post) => mount(component, {
+    global: { provide: { $axios: { post } }, stubs: { 'router-link': true, RouterLink: true } }
+});
+
+const button = (wrapper, label) => wrapper.findAll('button').find((b) => b.text().includes(label));
+
+describe('resending the verification email', () => {
+    beforeEach(() => {
+        apiRequestWithoutSecure.mockReset();
+        route.params = {};
+        route.query = {};
+    });
+
+    it('sends only the account id from an unverified login on the login screen', async () => {
+        apiRequestWithoutSecure.mockRejectedValue({
+            response: {
+                status: 400,
+                data: {
+                    status: false,
+                    isLogout: true,
+                    isEmailVerified: false,
+                    userData: { _id: UID, Employee_Email: 'stored.address@example.test', isEmailVerified: false },
+                    message: 'Email is not verified.'
+                }
+            }
+        });
+        const post = vi.fn().mockResolvedValue({ data: { status: true } });
+        const wrapper = open(Login, post);
+
+        await wrapper.find('#email').setValue('typed.address@example.test');
+        await wrapper.find('#password').setValue('Str0ng!pass');
+        await wrapper.find('form').trigger('submit');
+        await flushPromises();
+
+        const resend = button(wrapper, 'Auth.resend_email');
+        expect(resend).toBeTruthy();
+        await resend.trigger('click');
+        await flushPromises();
+
+        expect(post).toHaveBeenCalledTimes(1);
+        expect(post).toHaveBeenCalledWith(RESEND_URL, { uid: UID });
+        wrapper.unmount();
+    });
+
+    it('sends only the account id from the link on the verify-email screen', async () => {
+        route.params = { id: UID, token: 'a'.repeat(64) };
+        const post = vi.fn()
+            .mockResolvedValueOnce({ data: { status: false, email: 'stored.address@example.test', statusText: 'This link is expired', showResendVerification: true } })
+            .mockResolvedValueOnce({ data: { status: true } });
+        const wrapper = open(VerifyEmail, post);
+        await flushPromises();
+
+        const resend = button(wrapper, 'Auth.resend_email');
+        expect(resend).toBeTruthy();
+        await resend.trigger('click');
+        await flushPromises();
+
+        expect(post).toHaveBeenNthCalledWith(1, env.API_URI + env.VERIFY_EMAIL, { uid: UID, token: route.params.token });
+        expect(post).toHaveBeenNthCalledWith(2, RESEND_URL, { uid: UID });
+        expect(wrapper.text()).toContain('Auth.magic_sent_title');
+    });
+});

--- a/tests/integration/public-routes.int.test.js
+++ b/tests/integration/public-routes.int.test.js
@@ -179,18 +179,34 @@ describe('invitations', () => {
 });
 
 describe('verification email', () => {
+    const password = 'Str0ng!pass';
     const newAccount = async () => {
         const email = `verify-${uniqueSuffix()}@e2e.alianhub.test`;
-        const created = await anonymous.post('/api/v2/createUser', { firstName: 'Verify', lastName: 'Me', email, password: 'Str0ng!pass' });
+        const created = await anonymous.post('/api/v2/createUser', { firstName: 'Verify', lastName: 'Me', email, password });
         expect(created.body.status).toBe(true);
-        return String(created.body.statusText._id);
+        return { email, uid: String(created.body.statusText._id) };
     };
 
-    it('resends to the account address without taking one from the request', async () => {
-        const uid = await newAccount();
-        const res = await anonymous.post('/api/v2/sendVerificationEmail', { uid });
+    // The harness points mail at a closed port, so a resend the server accepts fails at delivery, after every refusal check.
+    const expectDeliveryAttempted = (res) => {
         expect(res.status).toBe(200);
-        expect(res.body.statusText).not.toBe('email is required.');
+        expect(res.body.statusText).toMatch(/ECONNREFUSED/);
+    };
+
+    it('resends with only the account id the login screen gets from an unverified login', async () => {
+        const { email, uid } = await newAccount();
+        const login = await anonymous.post('/api/v2/auth/login', { email, password, isLoginType: 'frontend' });
+        expect(login.status).toBe(400);
+        expect(login.body.isEmailVerified).toBe(false);
+        expect(String(login.body.userData._id)).toBe(uid);
+        expectDeliveryAttempted(await anonymous.post('/api/v2/sendVerificationEmail', { uid: login.body.userData._id }));
+    });
+
+    it('resends with only the account id the verify-email screen reads from the link', async () => {
+        const { uid } = await newAccount();
+        const verify = await anonymous.post('/api/v2/verifyEmail', { uid, token: 'f'.repeat(64) });
+        expect(verify.body.showResendVerification).toBe(true);
+        expectDeliveryAttempted(await anonymous.post('/api/v2/sendVerificationEmail', { uid }));
     });
 
     it('refuses an account id that does not exist', async () => {


### PR DESCRIPTION
## Summary

| Finding | Where | Fix | Test |
|---|---|---|---|
| Follow-up 31: since #633 `POST /api/v2/sendVerificationEmail` mails only the stored address of the account named by `uid`, but both resend screens still sent an `email`. Checked first whether resend still works: it does. The login screen takes the id from the unverified-login response (`userData._id`); the verify-email screen takes it from the link (`/verify-email/:id/:token`). | `frontend/src/views/Authentication/Login/Login.vue`, `frontend/src/views/Authentication/VerifyEmail/VerifyEmail.vue` | Both send only `{ uid }` | `frontend/tests/unit/verificationResend.spec.js` pins each screen's request body (fails on beta: `email` in both). `tests/integration/public-routes.int.test.js` › verification email: the `userData._id` from a real unverified login, and the link id after a failed verify, each resend with only `{ uid }` and get as far as delivery |
| Follow-up 33: Settings > General logs `TypeError: Cannot read properties of undefined (reading 'isoCode')` | `frontend/src/components/molecules/CountryPhoneNumberDropdown/PhoneCountry.vue` (only used by `SettingCompanyDetails.vue`) | Start on the first preferred country that exists, and never emit `undefined` | `frontend/tests/unit/settingCompanyDetails.spec.js` mounts the form with a fresh company in the shape the setup wizard stores and in the shape the create-company screen stores. It checks for no errors, a real country (+1, US flag), and a save that sends that dial code. Fails on beta with the TypeError above |

### Root cause of 33

A fresh company's `Cst_DialCode` has no `isoCode`:

- the setup wizard stores `{ name: '', dialCode: '', code: '' }` (`Modules/Setup/createCompany.js`);
- the create-company screen stores `{}`.

The settings screen passes `[Cst_DialCode.isoCode, 'US']` as the preferred countries. PhoneCountry looked only at the first entry, found nothing, and emitted `onSelect(undefined)`. `SettingCompanyDetails` then did three things with that value:

- stored it as the dial code;
- read `.isoCode` from it in `phoneValidation`, which is the logged error;
- left the selector showing a bare `+`.

`SaveChangeToDb` also reads `countryCodeObj.value.name` from the same value. The fix gives the form a real default instead of guarding the reads, because `'US'` was already the intended fallback.

**Review fixes:** the `isoCode` crash was still reachable from the keyboard: after pressing Down a few times and typing `ind`, Enter emitted `onSelect(undefined)` because the highlight pointed past the filtered list. `PhoneCountry.vue` now handles Enter and click in one `chooseCountry` path that ignores a missing country. It also drops the stale pre-selection emit (the only caller, `SettingCompanyDetails`, just stores the latest value), resets the highlight when the search changes, and removes its keydown listener on unmount. New `frontend/tests/unit/phoneCountry.spec.js` (5 tests) and a keyboard case in `settingCompanyDetails.spec.js` reproduce it; before the fix all 6 failed, the page case with the TypeError. After merging beta: vitest 34 files / 253 tests, `jest tests/conventions` 94 passed, `i18n:check` and eslint clean.

## Notes

- **Upgrade impact:** none. No API, schema or stored-data change. Companies whose dial code was never chosen now open with United States (+1) selected, and store it when the owner saves. Companies with a stored dial code open as before.
- A setup-wizard company stores its phone as `N/A`. Now that phone validation runs on load instead of throwing, that field shows the existing "Please enter valid number" message straight away. The message is a pre-existing script string without an i18n key. It is left as is so this PR stays out of the locale files other open PRs are changing.
- The login screen reads the account id from the unverified-login response. That response is built in `Modules/Auth/controller/authHelpers.js` and `loginSession.js`, which #638 is changing, so its shape is not touched here. The new integration test fails if the response stops carrying `userData._id`, which is what resend depends on.
- The server controller is unchanged: it already ignores any address in the request.

## Test plan

- [x] Before the fix, `cd frontend && npx vitest run tests/unit/verificationResend.spec.js tests/unit/settingCompanyDetails.spec.js`: 5 of 5 failed (both screens sent `email`; the fresh-company tests captured `TypeError: Cannot read properties of undefined (reading 'isoCode')`)
- [x] After the fix, the same two files: 5 passed
- [x] `cd frontend && npx vitest run`: 34 files, 253 tests passed (after the review fixes and the beta merge)
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 246 suites, 3355 tests passed
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed
- [x] `E2E_MONGODB_URL=mongodb://127.0.0.1:<port> npx jest --selectProjects integration --runInBand tests/integration/public-routes.int.test.js` on a throwaway mongo:7: 69 passed, including all 3 in the verification email block
- [x] `npm run i18n:check`: pass
- [x] eslint on every touched file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

