### PR TITLE
fix(automations): handle rejected rule dispatches and log them with the task and company ids

### DIFF
--- a/Modules/Automations/engine/formEvent.js
+++ b/Modules/Automations/engine/formEvent.js
@@ -80,7 +80,8 @@ const publishFormSubmitted = (input) => {
         domainEventBus.bus.emit(EVENT_TYPE, envelope);
         return envelope;
     } catch (error) {
-        logger.error(`${LOG_PREFIX} could not publish ${EVENT_TYPE}: ${error.message}`);
+        const { companyId, form, task } = input || {};
+        logger.error(`${LOG_PREFIX} could not publish ${EVENT_TYPE} for form ${form && form._id} on task ${task && task._id} in company ${companyId}: ${domainEventBus.failureText(error)}`);
         return null;
     }
 };

--- a/Modules/Automations/engine/index.js
+++ b/Modules/Automations/engine/index.js
@@ -43,25 +43,40 @@ const defineRecurring = (name, intervalMs, handler) => {
     return Promise.resolve();
 };
 
-async function onEnvelope(envelope) {
-    try {
-        const rules = await matcher.match(envelope.companyId, envelope);
-        if (!rules.length) return;
+const logDispatchFailure = (envelope, error, rule) => {
+    const ruleLabel = rule ? ` rule ${rule._id}` : '';
+    logger.error(`${LOG_PREFIX} dispatch failed for ${domainEventBus.eventLabel(envelope)}${ruleLabel}: ${domainEventBus.failureText(error)}`);
+};
 
-        for (const rule of rules) {
-            // Sequential on purpose: matching rules for one event are few, and a
-            // burst of parallel writes against one tenant's pool of 10 is how you
-            // turn a working automation into a timeout.
-            // eslint-disable-next-line no-await-in-loop
-            const run = await runner.createRun(envelope.companyId, rule, envelope);
-            if (!run) continue; // duplicate event — the unique index rejected it
-            // eslint-disable-next-line no-await-in-loop
-            await enqueueRun({ companyId: envelope.companyId, runId: String(run._id), ruleId: String(rule._id) });
-        }
+async function dispatchRule(envelope, rule) {
+    const run = await runner.createRun(envelope.companyId, rule, envelope);
+    if (!run) return;
+    await enqueueRun({ companyId: envelope.companyId, runId: String(run._id), ruleId: String(rule._id) });
+}
+
+async function onEnvelope(envelope) {
+    let rules;
+    try {
+        rules = await matcher.match(envelope.companyId, envelope);
     } catch (error) {
-        logger.error(`${LOG_PREFIX} dispatch failed for ${envelope.type}: ${error.message}`);
+        logDispatchFailure(envelope, error);
+        return;
+    }
+    // Sequential on purpose: matching rules for one event are few, and a burst of
+    // parallel writes against one tenant's pool of 10 is how you turn a working
+    // automation into a timeout.
+    for (const rule of rules) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            await dispatchRule(envelope, rule);
+        } catch (error) {
+            logDispatchFailure(envelope, error, rule);
+        }
     }
 }
+
+// The bus drops whatever a listener returns, so the run starts after the write has answered and its promise needs its own handler.
+const dispatch = (envelope) => onEnvelope(envelope).catch((error) => logDispatchFailure(envelope, error));
 
 async function start() {
     if (started) return;
@@ -76,7 +91,7 @@ async function start() {
         await runner.execute({ companyId, runId, ruleId, enqueue: enqueueRun, keepAlive });
     });
     await driver.start();
-    domainEventBus.bus.on('domain.event', onEnvelope);
+    domainEventBus.bus.on('domain.event', dispatch);
     started = true;
     logger.info(`${LOG_PREFIX} started (queue=${driver.name})`);
     for (const [name, { intervalMs, handler }] of recurring) {
@@ -87,7 +102,7 @@ async function start() {
 
 async function stop() {
     if (!started) return;
-    domainEventBus.bus.removeListener('domain.event', onEnvelope);
+    domainEventBus.bus.removeListener('domain.event', dispatch);
     if (driver) await driver.stop();
     started = false;
 }

--- a/event/domainEventBus.js
+++ b/event/domainEventBus.js
@@ -109,27 +109,30 @@ const buildEnvelope = ({ companyId, type, doc, changedFields, previous, actor, d
     changedFields: Array.from(changedFields || []),
 });
 
+// Mongo rejects with strings, plain objects and sometimes nothing at all.
+const failureText = (error) => (error && error.message) || String(error);
+
+const eventLabel = (envelope) => {
+    const entity = (envelope && envelope.entity) || {};
+    return `${envelope && envelope.type} on ${entity.kind} ${entity.id} in company ${envelope && envelope.companyId}`;
+};
+
 async function record(envelope) {
     if (!recording) return;
-    try {
-        await MongoDbCrudOpration(envelope.companyId, {
-            type: SCHEMA_TYPE.AUTOMATION_EVENT_LOG,
-            data: {
-                eventId: envelope.id,
-                type: envelope.type,
-                occurredAt: envelope.occurredAt,
-                actor: envelope.actor,
-                depth: envelope.depth,
-                scope: envelope.scope,
-                entity: envelope.entity,
-                changedFields: envelope.changedFields,
-                hasPrevious: !!envelope.previous,
-            },
-        }, 'save');
-    } catch (error) {
-        // Recording is diagnostic. A failed write must never stop the envelope.
-        logger.error(`${LOG_PREFIX} could not record ${envelope.type}: ${error.message}`);
-    }
+    await MongoDbCrudOpration(envelope.companyId, {
+        type: SCHEMA_TYPE.AUTOMATION_EVENT_LOG,
+        data: {
+            eventId: envelope.id,
+            type: envelope.type,
+            occurredAt: envelope.occurredAt,
+            actor: envelope.actor,
+            depth: envelope.depth,
+            scope: envelope.scope,
+            entity: envelope.entity,
+            changedFields: envelope.changedFields,
+            hasPrevious: !!envelope.previous,
+        },
+    }, 'save');
 }
 
 function publish(envelope) {
@@ -139,7 +142,7 @@ function publish(envelope) {
     }
     bus.emit('domain.event', envelope);
     bus.emit(envelope.type, envelope);
-    record(envelope);
+    record(envelope).catch((error) => logger.error(`${LOG_PREFIX} could not record ${eventLabel(envelope)}: ${failureText(error)}`));
 }
 
 function flush(key) {
@@ -188,12 +191,12 @@ function onTaskEvent(emitType) {
                     try {
                         flush(key);
                     } catch (error) {
-                        logger.error(`${LOG_PREFIX} flush failed: ${error.message}`);
+                        logger.error(`${LOG_PREFIX} flush failed for ${emitType} on task ${doc._id} in company ${companyId}: ${failureText(error)}`);
                     }
                 }, DEBOUNCE_MS),
             });
         } catch (error) {
-            logger.error(`${LOG_PREFIX} event handling failed: ${error.message}`);
+            logger.error(`${LOG_PREFIX} event handling failed: ${failureText(error)}`);
         }
     };
 }
@@ -211,6 +214,8 @@ module.exports = {
     bus,
     isRecording,
     setRecording,
+    eventLabel,
+    failureText,
     MAX_DEPTH,
     ACTOR_KINDS,
     // Exported for unit tests — pure, no IO.

--- a/tests/automation-dispatch-rejection.test.js
+++ b/tests/automation-dispatch-rejection.test.js
@@ -1,0 +1,155 @@
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
+jest.mock('../Modules/Automations/engine/matcher', () => ({ match: jest.fn(), invalidateAll: jest.fn() }));
+jest.mock('../Modules/Automations/engine/runner', () => ({ createRun: jest.fn(), execute: jest.fn() }));
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+const logger = require('../Config/loggerConfig');
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const socketEmitter = require('../event/socketEventEmitter');
+const domainEventBus = require('../event/domainEventBus');
+const matcher = require('../Modules/Automations/engine/matcher');
+const runner = require('../Modules/Automations/engine/runner');
+const engine = require('../Modules/Automations/engine');
+const { publishFormSubmitted } = require('../Modules/Automations/engine/formEvent');
+
+const COMPANY_ID = '6a8ee973d625fca52e519a12';
+const TASK_ID = '6f0000000000000000000701';
+const PROJECT_ID = '6a9954186dd786246031e47b';
+const RULE_A = '6f0000000000000000000b01';
+const RULE_B = '6f0000000000000000000b02';
+const DEBOUNCE_MS = 2000;
+const CHILD = path.join(__dirname, 'fixtures', 'automationDispatchChild.js');
+
+const taskDoc = () => ({ _id: TASK_ID, CompanyId: COMPANY_ID, ProjectID: PROJECT_ID, TaskName: 'Fix the thing', TaskKey: '--', Task_Priority: 'LOW' });
+
+const writes = {
+    'a created task': () => socketEmitter.emit('insert', { type: 'insert', module: 'task', data: taskDoc() }),
+    'a priority change': () => socketEmitter.emit('update', { type: 'update', module: 'task', data: taskDoc(), updatedFields: { Task_Priority: 'HIGH' } }),
+};
+
+const formSubmission = () => ({ companyId: COMPANY_ID, form: { _id: 'f1', ProjectID: PROJECT_ID }, answers: [], task: { _id: TASK_ID, TaskKey: 'AR-1' }, actor: { kind: 'system' } });
+
+const rejectWithoutReason = () => Promise.reject(undefined);
+const settle = () => new Promise((resolve) => { setTimeout(resolve, 20); });
+const loggedWith = (...ids) => logger.error.mock.calls.map(([line]) => String(line)).filter((line) => ids.every((id) => line.includes(id)));
+
+function afterDebounce(write) {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'] });
+    try {
+        write();
+        jest.advanceTimersByTime(DEBOUNCE_MS);
+    } finally {
+        jest.useRealTimers();
+    }
+    return settle();
+}
+
+beforeAll(async () => {
+    process.env.AUTOMATION_QUEUE_DRIVER = 'inline';
+    domainEventBus.start();
+    await engine.start();
+});
+
+afterAll(async () => {
+    await engine.stop();
+    delete process.env.AUTOMATION_QUEUE_DRIVER;
+});
+
+beforeEach(() => {
+    jest.resetAllMocks();
+    domainEventBus.setRecording(false);
+});
+
+describe('automation dispatch rejections', () => {
+    // Jest gives each test file its own process object, so an unhandledRejection listener here never fires; the child sees the real one.
+    it('leaves the process without an unhandled rejection when the dispatcher rejects without a reason', () => {
+        const child = spawnSync(process.execPath, [CHILD, COMPANY_ID, TASK_ID], {
+            encoding: 'utf8',
+            timeout: 30000,
+            env: { ...process.env, AUTOMATION_ENGINE: 'true', AUTOMATION_QUEUE_DRIVER: 'inline', AUTOMATION_EVENT_LOG: 'false' },
+        });
+
+        expect({ status: child.status, stderr: child.stderr }).toMatchObject({ status: 0 });
+        const { errors, unhandled } = JSON.parse(child.stdout);
+        expect(unhandled).toEqual([]);
+        expect(errors.filter((line) => line.includes(TASK_ID) && line.includes(COMPANY_ID))).toHaveLength(1);
+    });
+
+    describe.each(Object.keys(writes))('for %s', (name) => {
+        it('logs a rejected rule lookup with the task and company ids', async () => {
+            matcher.match.mockRejectedValue(new Error('rule store offline'));
+
+            await afterDebounce(writes[name]);
+
+            expect(matcher.match).toHaveBeenCalledTimes(1);
+            expect(loggedWith(TASK_ID, COMPANY_ID, 'rule store offline')).toHaveLength(1);
+        });
+
+        it('logs a rejection without a reason with the task and company ids', async () => {
+            matcher.match.mockImplementation(rejectWithoutReason);
+
+            await afterDebounce(writes[name]);
+
+            expect(loggedWith(TASK_ID, COMPANY_ID)).toHaveLength(1);
+        });
+    });
+
+    it('still runs the other matching rules when one cannot be queued', async () => {
+        matcher.match.mockResolvedValue([{ _id: RULE_A, name: 'A' }, { _id: RULE_B, name: 'B' }]);
+        runner.createRun.mockRejectedValueOnce(new Error('write conflict')).mockResolvedValueOnce({ _id: 'run-b' });
+        runner.execute.mockResolvedValue({ status: 'success' });
+
+        await afterDebounce(writes['a created task']);
+
+        expect(runner.execute).toHaveBeenCalledTimes(1);
+        expect(runner.execute).toHaveBeenCalledWith(expect.objectContaining({ companyId: COMPANY_ID, runId: 'run-b', ruleId: RULE_B }));
+        expect(loggedWith(TASK_ID, COMPANY_ID, RULE_A, 'write conflict')).toHaveLength(1);
+    });
+
+    it('logs a run that fails inside the inline queue with the rule, task and company ids', async () => {
+        matcher.match.mockResolvedValue([{ _id: RULE_A, name: 'A' }]);
+        runner.createRun.mockResolvedValue({ _id: 'run-a' });
+        runner.execute.mockImplementation(rejectWithoutReason);
+
+        await afterDebounce(writes['a created task']);
+
+        expect(loggedWith(TASK_ID, COMPANY_ID, RULE_A)).toHaveLength(1);
+    });
+
+    it('logs a failed event-log write with the task and company ids', async () => {
+        domainEventBus.setRecording(true);
+        matcher.match.mockResolvedValue([]);
+        MongoDbCrudOpration.mockImplementation(rejectWithoutReason);
+
+        await afterDebounce(writes['a created task']);
+
+        expect(loggedWith(TASK_ID, COMPANY_ID)).toHaveLength(1);
+    });
+
+    it('logs a listener that throws while a task event is published instead of throwing out of the timer', async () => {
+        matcher.match.mockResolvedValue([]);
+        domainEventBus.bus.once('task.created', () => { throw undefined; });
+
+        await afterDebounce(writes['a created task']);
+
+        expect(loggedWith(TASK_ID, COMPANY_ID)).toHaveLength(1);
+    });
+
+    it('logs a rejected dispatch for a form submission that filed a task', async () => {
+        matcher.match.mockImplementation(rejectWithoutReason);
+
+        publishFormSubmitted(formSubmission());
+        await settle();
+
+        expect(loggedWith(TASK_ID, COMPANY_ID)).toHaveLength(1);
+    });
+
+    it('logs a listener that throws while a form submission is published instead of failing the submission', () => {
+        domainEventBus.bus.once('form.submitted', () => { throw undefined; });
+
+        expect(publishFormSubmitted(formSubmission())).toBeNull();
+        expect(loggedWith(TASK_ID, COMPANY_ID)).toHaveLength(1);
+    });
+});

--- a/tests/fixtures/automationDispatchChild.js
+++ b/tests/fixtures/automationDispatchChild.js
@@ -1,0 +1,37 @@
+const Module = require('module');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const [companyId, taskId] = process.argv.slice(2);
+const errors = [];
+const unhandled = [];
+
+process.on('unhandledRejection', (reason) => { unhandled.push(String((reason && reason.stack) || reason)); });
+
+const stub = (relative, exports) => {
+    const filename = require.resolve(path.join(ROOT, relative));
+    const stubbed = new Module(filename, module);
+    stubbed.filename = filename;
+    stubbed.loaded = true;
+    stubbed.exports = exports;
+    require.cache[filename] = stubbed;
+};
+
+const rejectWithoutReason = () => Promise.reject(undefined);
+
+stub('Config/loggerConfig', { info() {}, warn() {}, error: (line) => errors.push(String(line)) });
+stub('utils/mongo-handler/mongoQueries', { MongoDbCrudOpration: rejectWithoutReason });
+stub('Modules/Automations/engine/matcher', { match: rejectWithoutReason, invalidateAll() {} });
+stub('Modules/Automations/engine/runner', { createRun: rejectWithoutReason, execute: rejectWithoutReason });
+
+const domainEventBus = require(path.join(ROOT, 'event/domainEventBus'));
+const engine = require(path.join(ROOT, 'Modules/Automations/engine'));
+
+(async () => {
+    await engine.start();
+    const doc = { _id: taskId, CompanyId: companyId, TaskKey: '--' };
+    domainEventBus.bus.emit('domain.event', domainEventBus.buildEnvelope({ companyId, type: 'task.created', doc, changedFields: new Set(), actor: { kind: 'user', userId: null } }));
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    process.stdout.write(JSON.stringify({ errors, unhandled }));
+    process.exit(0);
+})();

--- a/tests/integration/automations.int.test.js
+++ b/tests/integration/automations.int.test.js
@@ -48,6 +48,12 @@ async function createRule(api, rule) {
 
 const removeRule = (api, id) => (id ? api.delete(`/api/v2/automations/${id}`) : null);
 
+const finishedRuns = (api, ruleId) => waitFor(async () => {
+    const res = await api.get(`/api/v2/automations/${ruleId}/runs`);
+    const rows = res.body.data || [];
+    return rows.length && rows.every((run) => FINISHED_RUN.includes(run.status)) ? rows : null;
+}, { timeout: 15000 });
+
 async function mcpCall(pat, method, params = {}) {
     const client = createApiClient({ baseURL: state.baseURL, accessToken: pat, companyId: state.companyId });
     return client.post('/mcp', { jsonrpc: '2.0', id: 1, method, params });
@@ -138,16 +144,40 @@ describe('automation rules (v2)', () => {
             await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: true });
             const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
 
-            const runs = await waitFor(async () => {
-                const res = await owner.api.get(`/api/v2/automations/${rule._id}/runs`);
-                const rows = res.body.data || [];
-                return rows.length && rows.every((run) => FINISHED_RUN.includes(run.status)) ? rows : null;
-            }, { timeout: 15000 });
+            const runs = await finishedRuns(owner.api, rule._id);
             expect(runs).toHaveLength(1);
             expect(runs[0]).toMatchObject({ status: 'success', entity: { kind: 'task', id: task._id } });
         } finally {
             await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: false });
             await removeRule(owner.api, rule._id);
+        }
+    });
+
+    it('runs every enabled rule a created task matches', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const rules = [];
+        try {
+            for (const body of ['E2E first rule comment', 'E2E second rule comment']) {
+                const rule = await createRule(owner.api, ruleFor(project._id, {
+                    trigger: { event: 'task.created' },
+                    steps: [{ id: 's1', type: 'action', action: 'add_comment', config: { body } }],
+                }));
+                rules.push(rule);
+                await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: true });
+            }
+            const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+
+            for (const rule of rules) {
+                const runs = await finishedRuns(owner.api, rule._id);
+                expect(runs).toHaveLength(1);
+                expect(runs[0]).toMatchObject({ status: 'success', entity: { kind: 'task', id: task._id } });
+            }
+        } finally {
+            for (const rule of rules) {
+                await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: false });
+                await removeRule(owner.api, rule._id);
+            }
         }
     });
 


### PR DESCRIPTION
## Summary

Follow-up 19: every task write reaches automation rules through `socketEmitter` → `event/domainEventBus.js` (2 s debounce) → `bus.emit('domain.event')` → the engine listener. That listener was the async `onEnvelope`, and EventEmitter drops what a listener returns. The HTTP response was never waiting on it, which is intended. The problem was what happened when the dispatch failed.

| Finding | Where | Fix | Test |
|---|---|---|---|
| The engine's catch read `error.message`. `MongoDbCrudOpration` rejects with strings, plain objects or nothing, so a rejection without a reason threw inside the catch and became an unhandled rejection. No failure line named the task or company. | `Modules/Automations/engine/index.js` | The bus listener is now a sync `dispatch` whose promise has a `.catch`. Failures log the event type, task id, company id and rule id through a null-safe `failureText`. | `tests/automation-dispatch-rejection.test.js`: a child process records real `unhandledRejection` events (Jest gives each test file its own `process`, so a listener in the test never fires). In-process cases cover a created task and a priority change. |
| One rule whose run could not be created or queued stopped every later rule for the same event. | `Modules/Automations/engine/index.js` | Each rule is dispatched in its own try/catch, still in order. | "still runs the other matching rules when one cannot be queued"; "logs a run that fails inside the inline queue…" |
| The event-log write in `publish` was unawaited, and its catch had the same `error.message` problem. | `event/domainEventBus.js` `record` | `record(envelope).catch(...)` logs the task and company ids. | "logs a failed event-log write…" |
| A listener throwing a non-Error while the debounce timer flushed turned into an uncaught exception inside a timer, which `processGuards` treats as fatal. | `event/domainEventBus.js` `onTaskEvent` | Null-safe message with the emit type, task id and company id. | "logs a listener that throws while a task event is published…" |
| Form submissions publish on the same bus. Their sync catch had the same problem and could turn a stored submission into a 500. | `Modules/Automations/engine/formEvent.js` | Null-safe log with the form, task and company ids. | Two form-submission cases |
| A created task should still trigger every enabled rule. | `tests/integration/automations.int.test.js` | New test with two enabled `task.created` rules; the existing test now uses the shared `finishedRuns` helper. | Integration |

## Notes

- **Upgrade impact:** none. No schema, API, env or config change, and no user-visible strings. Failure logs now read `[automation-engine] dispatch failed for task.created on task <id> in company <id> rule <id>: <reason>`. `event/domainEventBus.js` exports two new helpers, `eventLabel` and `failureText`.
- **The premise is partly out of date.** Since a13cda48, `Config/processGuards.js` only logs an `unhandledRejection` and does not exit; uncaught exceptions still exit. Before this change the failure surfaced as `[unhandledRejection] TypeError: Cannot read properties of undefined (reading 'message')`, with no event, task or company. The debounce-timer path was a synchronous throw, so it did reach the fatal exit.
- **Response timing and runs are unchanged.** The bus still emits from the debounce timer after the write, the listener still does not block it, and the run still goes `queued` → `running` → `success`.
- **All task write paths are covered.** Create, update, bulk, relations, log time, task index, the AI estimator and automation actions all go through `socketEmitter` → `domainEventBus` → this one listener, so one change covers them. Form submissions use the same listener.
- **Left out:**
  - `Modules/Webhooks/dispatcher.js` has the same `.catch((error) => … error.message)` pattern on its flush, but that file is held by #636.
  - A run whose enqueue fails after `createRun` stays `queued` in the run log; marking it failed is a separate change.
  - With the inline queue driver (tests and opt-in self-host), a retry awaits its backoff inside the dispatch loop, which delays later rules for the same event.

## Test plan

- [x] `npx jest --selectProjects unit tests/automation-dispatch-rejection.test.js` with the three source files checked out from `origin/beta`: **11 failed of 11**. The child process recorded `TypeError: Cannot read properties of undefined (reading 'message')` as an unhandled rejection, no log line carried the task and company ids, the second rule never ran, and the timer throw escaped. With the fix: **11 passed**.
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 247 suites, 3366 tests passed
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed (tenant-scoping baseline unchanged)
- [x] `E2E_MONGODB_URL=… npx jest --selectProjects integration --runInBand tests/integration/automations.int.test.js` on a throwaway `mongo:7`: 48 passed, including the new two-rule test
- [x] `npx eslint` on every touched file: clean
- [x] `npm run i18n:check`: exit 0
- [x] `BASE_BRANCH=origin/beta npm run lint:commits`: 0 problems
- Frontend unchanged, so vitest was not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
