### PR TITLE
fix(company): refuse client writes to server-controlled company fields

### DIFF
--- a/Config/tenant.js
+++ b/Config/tenant.js
@@ -31,10 +31,24 @@ function tenantOf(req) {
     return candidate;
 }
 
+// Every company a request names, deduplicated. tenantOf and requireCompanyAud each pick one of these in a
+// different order, so a handler that must not be steered between two companies refuses more than one.
+function namedCompanyIds(req) {
+    const headers = req.headers || {};
+    const named = [
+        headers.companyid,
+        req.params && req.params.companyId,
+        req.query && req.query.companyId,
+        req.body && req.body.companyId,
+        req.body && req.body.CompanyId,
+    ].map((v) => String(v == null ? '' : v).trim()).filter(Boolean);
+    return [...new Set(named)];
+}
+
 function tenantDb(req) {
     const companyId = tenantOf(req);
     const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
     return (mongoObj, method) => MongoDbCrudOpration(companyId, mongoObj, method);
 }
 
-module.exports = { tenantOf, tenantDb, TenantError };
+module.exports = { tenantOf, tenantDb, namedCompanyIds, TenantError };

--- a/Modules/Company/controller/updateCompany.js
+++ b/Modules/Company/controller/updateCompany.js
@@ -6,17 +6,31 @@ const { default: mongoose } = require("mongoose");
 const { replaceObjectKey } = require("../../Auth/helper");
 const socketEmitter = require("../../../event/socketEventEmitter");
 const { isInstanceOwner } = require("../../Instance/guard");
-const { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, memberCompanyUpdate } = require("../helpers/companyAccessRules");
-const { getRoleType, evaluatePermission, isPrivileged, isWritable } = require("../../../Config/permissionGuard");
+const { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, companyUpdateKind } = require("../helpers/companyAccessRules");
+const { getRoleType, evaluatePermission, isPrivileged, isWritable, ROLE_OWNER } = require("../../../Config/permissionGuard");
 
-const mayUpdateCompany = async (companyId, req) => {
-    const roleType = await getRoleType(companyId, req.uid);
-    if (roleType === null) return false;
-    if (isPrivileged(roleType)) return true;
-    const kind = memberCompanyUpdate(req.body);
-    if (kind === 'projectType') return true;
-    if (kind !== 'seatRelease') return false;
-    return isWritable(await evaluatePermission(companyId, req.uid, 'settings.settings_member_list').catch(() => null));
+const managesMembers = async (companyId, uid) => isWritable(await evaluatePermission(companyId, uid, 'settings.settings_member_list').catch(() => null));
+
+const MAY_SEND = {
+    details: ({ roleType }) => isPrivileged(roleType),
+    projectType: () => true,
+    seatRelease: ({ roleType, companyId, req }) => isPrivileged(roleType) || managesMembers(companyId, req.uid),
+    ownerClaim: ({ roleType, req }) => roleType === ROLE_OWNER && req.body.updateObject.objId.userId === String(req.uid),
+};
+
+const ROLE_REFUSAL = {
+    ownerClaim: 'Only an owner can record themselves as the company owner.',
+};
+
+const companyWrite = (companyId, body, kind, uid) => {
+    if (kind === 'ownerClaim') {
+        return [{ _id: companyId }, { $set: { userId: new mongoose.Types.ObjectId(String(uid)) } }, { returnDocument: 'after' }];
+    }
+    const data = body.key
+        ? [{ _id: companyId }, { [body.key]: body.updateObject }]
+        : [{ _id: companyId }, { $set: body.updateObject }, { returnDocument: 'after' }];
+    if (body.arrayFilters?.length) data.push({ arrayFilters: body.arrayFilters });
+    return data;
 };
 
 const loadOwnCompanyIds = async (uid) => {
@@ -42,43 +56,20 @@ exports.updateCompany = async(req,res) => {
             return res.status(400).json({message: 'Update Object is Required'});
         }
 
-        if (!(await mayUpdateCompany(companyId, req))) {
-            return res.status(403).json({ status: false, message: 'Only an owner or an admin can change the company.' });
+        const kind = companyUpdateKind(req.body);
+        if (!kind) {
+            return res.status(403).json({ status: false, message: 'Only the company details can be changed here. Plan, billing, seat, storage and usage fields are managed by the server.' });
         }
 
-        let key;
-        let data;
-        if (req.body.key) {
-            key = req.body.key;
-            data =  [
-                { _id: companyId },
-                {   
-                    [key]: req.body.updateObject
-                },
-            ]
-        } else {
-            key = '$set'
-            data =  [
-                { _id: companyId }, 
-                {   
-                    [key]: req.body.updateObject
-                },
-                {
-                    returnDocument : 'after'
-                }
-            ]
+        const roleType = await getRoleType(companyId, req.uid);
+        if (roleType === null || !(await MAY_SEND[kind]({ roleType, companyId, req }))) {
+            return res.status(403).json({ status: false, message: ROLE_REFUSAL[kind] || 'Only an owner or an admin can change the company.' });
         }
 
-        if (req.body.arrayFilters?.length) {
-            let arrObj = {arrayFilters: req.body.arrayFilters}
-            data.push(arrObj)
-        }
-
-        const dataConvert = replaceObjectKey(data,"objId")        
-        let mongoObj = {
+        const mongoObj = {
             type: SCHEMA_TYPE.COMPANIES,
-            data: dataConvert
-        }
+            data: companyWrite(companyId, req.body, kind, req.uid)
+        };
 
         const company = await MongoDbCrudOpration('global', mongoObj, 'findOneAndUpdate');
 

--- a/Modules/Company/controller/updateCompany.js
+++ b/Modules/Company/controller/updateCompany.js
@@ -6,8 +6,14 @@ const { default: mongoose } = require("mongoose");
 const { replaceObjectKey } = require("../../Auth/helper");
 const socketEmitter = require("../../../event/socketEventEmitter");
 const { isInstanceOwner } = require("../../Instance/guard");
-const { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, companyUpdateKind } = require("../helpers/companyAccessRules");
-const { getRoleType, evaluatePermission, isPrivileged, isWritable, ROLE_OWNER } = require("../../../Config/permissionGuard");
+const { tenantOf, namedCompanyIds, TenantError } = require("../../../Config/tenant");
+const { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, companyUpdateKind, seatFilter } = require("../helpers/companyAccessRules");
+const { evaluatePermission, isPrivileged, isWritable, ROLE_OWNER } = require("../../../Config/permissionGuard");
+
+const findSeat = (companyId, uid, kind) => MongoDbCrudOpration(companyId, {
+    type: SCHEMA_TYPE.COMPANY_USERS,
+    data: [seatFilter(uid, kind), { roleType: 1 }]
+}, 'findOne');
 
 const managesMembers = async (companyId, uid) => isWritable(await evaluatePermission(companyId, uid, 'settings.settings_member_list').catch(() => null));
 
@@ -46,11 +52,14 @@ const hasSession = (req) => OBJECT_ID_PATTERN.test(String(req.uid || ''));
 
 exports.updateCompany = async(req,res) => {
     try {
-
-        const companyId = req.headers['companyid'] || req.body.companyId;
-        if (!OBJECT_ID_PATTERN.test(String(companyId || ''))) {
+        const named = namedCompanyIds(req);
+        if (named.length > 1) {
+            return res.status(403).json({ status: false, message: 'The request names more than one company.' });
+        }
+        if (!OBJECT_ID_PATTERN.test(named[0] || '')) {
             return res.status(400).json({ status: false, message: 'A valid company id is required' });
         }
+        const companyId = tenantOf(req);
 
         if (!(req.body && req.body.updateObject)) {
             return res.status(400).json({message: 'Update Object is Required'});
@@ -61,8 +70,11 @@ exports.updateCompany = async(req,res) => {
             return res.status(403).json({ status: false, message: 'Only the company details can be changed here. Plan, billing, seat, storage and usage fields are managed by the server.' });
         }
 
-        const roleType = await getRoleType(companyId, req.uid);
-        if (roleType === null || !(await MAY_SEND[kind]({ roleType, companyId, req }))) {
+        const seat = await findSeat(companyId, req.uid, kind);
+        if (!seat) {
+            return res.status(403).json({ status: false, message: 'Only active members of this company can change it.' });
+        }
+        if (!(await MAY_SEND[kind]({ roleType: seat.roleType, companyId, req }))) {
             return res.status(403).json({ status: false, message: ROLE_REFUSAL[kind] || 'Only an owner or an admin can change the company.' });
         }
 
@@ -81,6 +93,9 @@ exports.updateCompany = async(req,res) => {
 
         return res.status(200).json(company);
     } catch (error) {
+        if (error instanceof TenantError) {
+            return res.status(403).json({ status: false, message: error.message });
+        }
         return res.status(500).json({ message: "An error occurred while updating the company",error:error });
     }
 }

--- a/Modules/Company/helpers/companyAccessRules.js
+++ b/Modules/Company/helpers/companyAccessRules.js
@@ -36,23 +36,47 @@ const scopeCompanyPipeline = (findQuery, own) => {
 const PROJECT_TYPE_FIELDS = ['projectCount.privateCount', 'projectCount.publicCount'];
 const SEAT_FIELD = 'companyData.$[elementIndex].users';
 const SEAT_ARRAY_FILTERS = JSON.stringify([{ 'elementIndex.users': { $exists: true } }]);
+const COMPANY_DETAIL_FIELDS = ['Cst_profileImage', 'Cst_CompanyName', 'Cst_Phone', 'Cst_Country', 'Cst_DialCode', 'Cst_State', 'Cst_City',
+    'Cst_LogTimeDays', 'Cst_countryCode', 'Cst_stateCode', 'trackerEstimateLimit', 'updatedAt'];
 
-// The only company writes the app sends for someone who is not an owner or admin: moving a
-// project between the private and public counts, and releasing a seat after removing a member.
-const memberCompanyUpdate = (body) => {
-    const { key, updateObject, arrayFilters } = body || {};
-    if (key !== '$inc' || !isPlainContainer(updateObject) || Array.isArray(updateObject)) return null;
+const isPlainObject = (value) => isPlainContainer(value) && !Array.isArray(value);
+const hasNoArrayFilters = (arrayFilters) => arrayFilters === undefined || arrayFilters === null || (Array.isArray(arrayFilters) && arrayFilters.length === 0);
+
+const isDetailsUpdate = ({ key, updateObject, arrayFilters }) => {
+    const fields = Object.keys(updateObject);
+    return (!key || key === '$set') && hasNoArrayFilters(arrayFilters) && fields.length > 0
+        && fields.every((field) => COMPANY_DETAIL_FIELDS.includes(field));
+};
+
+const isOwnerClaim = ({ key, updateObject, arrayFilters }) => {
+    const claim = updateObject.objId;
+    return !key && hasNoArrayFilters(arrayFilters) && Object.keys(updateObject).join() === 'objId'
+        && isPlainObject(claim) && Object.keys(claim).join() === 'userId'
+        && typeof claim.userId === 'string' && OBJECT_ID_PATTERN.test(claim.userId);
+};
+
+const countUpdateKind = ({ key, updateObject, arrayFilters }) => {
+    if (key !== '$inc') return null;
     const entries = Object.entries(updateObject);
-    const hasArrayFilters = Array.isArray(arrayFilters) && arrayFilters.length > 0;
     const fields = entries.map(([field]) => field).sort();
-    if (!hasArrayFilters && entries.length === 2 && fields.join() === [...PROJECT_TYPE_FIELDS].sort().join()
+    if (hasNoArrayFilters(arrayFilters) && entries.length === 2 && fields.join() === [...PROJECT_TYPE_FIELDS].sort().join()
         && entries.every(([, step]) => step === 1 || step === -1) && entries[0][1] + entries[1][1] === 0) {
         return 'projectType';
     }
     if (entries.length !== 1 || entries[0][1] !== -1) return null;
-    if (fields[0] === 'trackerUsers' && !hasArrayFilters) return 'seatRelease';
+    if (fields[0] === 'trackerUsers' && hasNoArrayFilters(arrayFilters)) return 'seatRelease';
     if (fields[0] === SEAT_FIELD && JSON.stringify(arrayFilters) === SEAT_ARRAY_FILTERS) return 'seatRelease';
     return null;
 };
 
-module.exports = { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, memberCompanyUpdate };
+// Every company write a client may send, whatever its role: the Settings > Company form, the
+// private/public project count swap, a seat release after removing a member, and an invited owner
+// recording themselves. Plan, billing, seat, storage, usage and ownership fields stay server-side.
+const companyUpdateKind = (body) => {
+    if (!body || !isPlainObject(body.updateObject)) return null;
+    if (isDetailsUpdate(body)) return 'details';
+    if (isOwnerClaim(body)) return 'ownerClaim';
+    return countUpdateKind(body);
+};
+
+module.exports = { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, companyUpdateKind };

--- a/Modules/Company/helpers/companyAccessRules.js
+++ b/Modules/Company/helpers/companyAccessRules.js
@@ -79,4 +79,14 @@ const companyUpdateKind = (body) => {
     return countUpdateKind(body);
 };
 
-module.exports = { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, companyUpdateKind };
+const PENDING_SEAT = 1;
+const ACTIVE_SEAT = 2;
+
+// Invitation.vue records an invited owner while they accept, so only that write takes the caller's own pending row.
+const seatFilter = (uid, kind) => ({
+    userId: String(uid),
+    isDelete: { $ne: true },
+    status: { $in: kind === 'ownerClaim' ? [PENDING_SEAT, ACTIVE_SEAT] : [ACTIVE_SEAT] },
+});
+
+module.exports = { OBJECT_ID_PATTERN, ownCompanyIds, allowedCompanyIds, scopeCompanyPipeline, companyUpdateKind, seatFilter };

--- a/frontend/src/views/Authentication/Invitation/Invitation.vue
+++ b/frontend/src/views/Authentication/Invitation/Invitation.vue
@@ -196,7 +196,7 @@ const submit = async () => {
         if (!result.data.status) { logOut({ islogOut: true }); banner.value = t("Auth.server_error"); return; }
         if (result.data.data?.roleType === ROLE_OWNER) {
             await apiRequestWithoutCompnay("put", env.COMPANYINVITATION, {
-                updateObject: { objId: { userId: response.data.data._id }, companyData: [{ users: 1 }] },
+                updateObject: { objId: { userId: response.data.data._id } },
                 companyId: companyIdRoute.value
             }).catch((error) => console.error(error));
             try { addSubscription(companyIdRoute.value, response); } catch { /* optional plugin */ }

--- a/frontend/src/views/Authentication/Invitation/Invitation.vue
+++ b/frontend/src/views/Authentication/Invitation/Invitation.vue
@@ -187,23 +187,23 @@ const submit = async () => {
         if (user.status !== 200) { logOut({ islogOut: true }); banner.value = t("Auth.server_error"); return; }
         await getAuth(user.data.uid, true);
         localStorage.setItem("selectedCompany", companyIdRoute.value);
-        const newUserId = response.data.statusText._id;
+        const signedInUserId = String(user.data.uid);
         const result = await apiRequestWithoutCompnay("put", env.API_ROOT_MEMBERS, {
             id: requestId.value,
-            data: { userId: newUserId, status: 2 },
+            data: { userId: signedInUserId, status: 2 },
             companyId: companyIdRoute.value
         });
         if (!result.data.status) { logOut({ islogOut: true }); banner.value = t("Auth.server_error"); return; }
         if (result.data.data?.roleType === ROLE_OWNER) {
             await apiRequestWithoutCompnay("put", env.COMPANYINVITATION, {
-                updateObject: { objId: { userId: response.data.data._id } },
+                updateObject: { objId: { userId: signedInUserId } },
                 companyId: companyIdRoute.value
             }).catch((error) => console.error(error));
             try { addSubscription(companyIdRoute.value, response); } catch { /* optional plugin */ }
         }
-        apiRequest("post", env.IMPORT_NOTIFICATION_SETTING, { companyId: companyIdRoute.value, userId: newUserId })
+        apiRequest("post", env.IMPORT_NOTIFICATION_SETTING, { companyId: companyIdRoute.value, userId: signedInUserId })
             .catch((error) => console.error("ERROR in user notification settings: ", error.message));
-        apiRequest("post", env.REMOVE_USER_NOTIFICATION, { companyId: companyIdRoute.value, userId: newUserId, type: "Add" })
+        apiRequest("post", env.REMOVE_USER_NOTIFICATION, { companyId: companyIdRoute.value, userId: signedInUserId, type: "Add" })
             .catch((error) => console.error(error, "ERROR"));
         localStorage.setItem("isLogging", "false");
         $toast.success(t("Toast.User_has_been_registered_successfully"), { position: "top-right" });

--- a/frontend/tests/unit/invitationOwnerClaim.spec.js
+++ b/frontend/tests/unit/invitationOwnerClaim.spec.js
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+
+const COMPANY_ID = '6f0000000000000000000c01';
+const INVITE_ID = '6f00000000000000000a0001';
+const USER_ID = '6f0000000000000000000009';
+
+const mocks = vi.hoisted(() => ({
+    apiRequest: vi.fn(),
+    apiRequestWithoutCompnay: vi.fn(),
+    apiRequestWithoutSecure: vi.fn(),
+    getAuth: vi.fn(),
+    logOut: vi.fn(),
+    push: vi.fn(),
+}));
+
+vi.mock('@/services', () => ({
+    apiRequest: mocks.apiRequest,
+    apiRequestWithoutCompnay: mocks.apiRequestWithoutCompnay,
+    apiRequestWithoutSecure: mocks.apiRequestWithoutSecure,
+    getAuth: mocks.getAuth,
+    useAuth: () => ({ logOut: mocks.logOut }),
+}));
+vi.mock('vue-router', () => ({
+    useRoute: () => ({ query: { companyId: `${COMPANY_ID}-${INVITE_ID}` } }),
+    useRouter: () => ({ push: mocks.push }),
+}));
+vi.mock('vuex', () => ({ useStore: () => ({ getters: {} }) }));
+vi.mock('@/config/publicConfig', () => ({ enabledProviders: () => [] }));
+vi.mock('@/composable', () => ({ useCustomComposable: () => ({ debouncerWithPromise: () => Promise.resolve() }) }));
+vi.mock('@/plugins/oauth/ProviderButton.vue', () => ({ default: { name: 'ProviderButton', render: () => null } }));
+vi.mock('@/components/organisms/Shell/ShellIcon.vue', () => ({ default: { name: 'ShellIcon', render: () => null } }));
+vi.mock('@/components/templates/AuthShell/AuthShell.vue', async () => {
+    const { h } = await import('vue');
+    return { default: { name: 'AuthShell', setup: (props, { slots }) => () => h('div', slots.default && slots.default()) } };
+});
+
+import * as env from '@/config/env';
+import Invitation from '@/views/Authentication/Invitation/Invitation.vue';
+
+// POST /api/v2/createUser answers with the saved user under statusText and no data (Modules/Auth/controller/createUser.js).
+const CREATE_USER_RESPONSE = { data: { status: true, statusText: { _id: USER_ID, Employee_Email: 'new.owner@example.test', AssignCompany: [COMPANY_ID] } } };
+const LOGIN_RESPONSE = { status: 200, data: { uid: USER_ID, accessToken: 'token', refreshToken: 'refresh' } };
+const acceptedRow = (roleType) => ({ data: { status: true, statusText: 'Invitation accepted.', data: { _id: INVITE_ID, userId: USER_ID, roleType, status: 2 } } });
+
+const submitInvitation = async (roleType) => {
+    mocks.apiRequestWithoutSecure.mockResolvedValue(LOGIN_RESPONSE);
+    mocks.apiRequestWithoutCompnay.mockImplementation(async (type, url) => {
+        if (url === env.CREATE_USER_V2) return CREATE_USER_RESPONSE;
+        if (url === env.API_ROOT_MEMBERS) return acceptedRow(roleType);
+        if (url === env.COMPANYINVITATION) return { data: { _id: COMPANY_ID } };
+        throw new Error(`unexpected ${type} ${url}`);
+    });
+    const $axios = { post: vi.fn(async () => ({ data: { status: true, data: { status: 1, email: 'new.owner@example.test', workspaceName: 'Acme' } } })) };
+    const wrapper = mount(Invitation, { global: { provide: { $axios, addSubscription: vi.fn() } } });
+    await flushPromises();
+    await wrapper.find('#inv-name').setValue('New Owner');
+    await wrapper.find('#inv-password').setValue('E2e-Passw0rd!');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+    return wrapper;
+};
+
+const callsTo = (url) => mocks.apiRequestWithoutCompnay.mock.calls.filter((call) => call[1] === url);
+
+describe('Invitation page accepting an invitation', () => {
+    beforeEach(() => {
+        Object.values(mocks).forEach((mock) => mock.mockReset());
+        mocks.apiRequest.mockResolvedValue({ data: { status: true } });
+        mocks.getAuth.mockResolvedValue(undefined);
+    });
+
+    it('records an invited owner on the company with the signed-in user id', async () => {
+        const wrapper = await submitInvitation(1);
+        expect(callsTo(env.COMPANYINVITATION)).toEqual([
+            ['put', env.COMPANYINVITATION, { updateObject: { objId: { userId: USER_ID } }, companyId: COMPANY_ID }],
+        ]);
+        expect(wrapper.find('.auth__banner').exists()).toBe(false);
+        expect(mocks.push).toHaveBeenCalledWith({ name: 'Log-in' });
+    });
+
+    it('links the invitation row to the signed-in user', async () => {
+        await submitInvitation(1);
+        expect(callsTo(env.API_ROOT_MEMBERS)[0][2]).toEqual({ id: INVITE_ID, data: { userId: USER_ID, status: 2 }, companyId: COMPANY_ID });
+    });
+
+    it('does not claim the company for an invited admin', async () => {
+        const wrapper = await submitInvitation(2);
+        expect(callsTo(env.COMPANYINVITATION)).toHaveLength(0);
+        expect(wrapper.find('.auth__banner').exists()).toBe(false);
+        expect(mocks.push).toHaveBeenCalledWith({ name: 'Log-in' });
+    });
+});

--- a/tests/company-access.test.js
+++ b/tests/company-access.test.js
@@ -11,10 +11,10 @@ const mongoose = require('mongoose');
 const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
 const { myCache } = require('../Config/config');
 const { SCHEMA_TYPE } = require('../Config/schemaType');
-const { setMiddlewareV2 } = require('../Config/setMiddleware');
+const { setMiddlewareV2, setMiddlewareWithCV2 } = require('../Config/setMiddleware');
 const { getRoleType, evaluatePermission } = require('../Config/permissionGuard');
 const { signSession, startApp } = require('./fixtures/sessionApp');
-const { scopeCompanyPipeline, allowedCompanyIds, memberCompanyUpdate } = require('../Modules/Company/helpers/companyAccessRules');
+const { scopeCompanyPipeline, allowedCompanyIds, companyUpdateKind } = require('../Modules/Company/helpers/companyAccessRules');
 const ctrl = require('../Modules/Company/controller/updateCompany');
 
 const COMPANY = '6f0000000000000000000c01';
@@ -32,9 +32,11 @@ let app;
 
 beforeAll(async () => {
     app = await startApp((server) => {
+        setMiddlewareWithCV2(server);
         setMiddlewareV2(server);
         server.post('/api/v1/admin/company', ctrl.getCompany);
         server.post('/api/v1/admin/company/find', ctrl.getCompanyByAggregate);
+        server.put('/api/v1/company', ctrl.updateCompany);
         server.put('/api/v1/admin/company', ctrl.updateCompany);
         server.put('/api/v1/company-invitation', ctrl.updateCompany);
     });
@@ -138,19 +140,18 @@ const SEAT_RELEASE = { key: '$inc', updateObject: { 'companyData.$[elementIndex]
 const TRACKER_SEAT_RELEASE = { key: '$inc', updateObject: { trackerUsers: -1 } };
 const RENAME = { updateObject: { Cst_CompanyName: 'Taken over' } };
 
-describe('memberCompanyUpdate', () => {
+describe('companyUpdateKind', () => {
     it('recognises the project type swap in both directions', () => {
-        expect(memberCompanyUpdate(SWAP_TO_PRIVATE)).toBe('projectType');
-        expect(memberCompanyUpdate({ key: '$inc', updateObject: { 'projectCount.publicCount': 1, 'projectCount.privateCount': -1 } })).toBe('projectType');
+        expect(companyUpdateKind(SWAP_TO_PRIVATE)).toBe('projectType');
+        expect(companyUpdateKind({ key: '$inc', updateObject: { 'projectCount.publicCount': 1, 'projectCount.privateCount': -1 } })).toBe('projectType');
     });
 
     it('recognises the seat releases the members page sends', () => {
-        expect(memberCompanyUpdate(SEAT_RELEASE)).toBe('seatRelease');
-        expect(memberCompanyUpdate(TRACKER_SEAT_RELEASE)).toBe('seatRelease');
+        expect(companyUpdateKind(SEAT_RELEASE)).toBe('seatRelease');
+        expect(companyUpdateKind(TRACKER_SEAT_RELEASE)).toBe('seatRelease');
     });
 
     it.each([
-        [RENAME],
         [{ key: '$set', updateObject: SWAP_TO_PRIVATE.updateObject }],
         [{ key: '$inc', updateObject: { 'projectCount.privateCount': 5, 'projectCount.publicCount': -5 } }],
         [{ key: '$inc', updateObject: { 'projectCount.privateCount': 1, 'projectCount.publicCount': 1 } }],
@@ -162,7 +163,7 @@ describe('memberCompanyUpdate', () => {
         [{ key: '$inc', updateObject: { trackerUsers: -10 } }],
         [{ key: '$inc', updateObject: { 'projectCount.privateCount': '1', 'projectCount.publicCount': '-1' } }],
     ])('rejects %j', (body) => {
-        expect(memberCompanyUpdate(body)).toBe(null);
+        expect(companyUpdateKind(body)).toBe(null);
     });
 });
 
@@ -204,6 +205,116 @@ describe('PUT company update is for owners and admins', () => {
     it('refuses a seat release from a member without member-list write access', async () => {
         evaluatePermission.mockImplementation(async () => false);
         const res = await put('/api/v1/admin/company', MEMBER, SEAT_RELEASE);
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+});
+
+const OWNER_CLAIM = { updateObject: { objId: { userId: OWNER } }, companyId: COMPANY };
+const COMPANY_DETAILS_FORM = {
+    updateObject: {
+        Cst_profileImage: 'companyIcon/logo.png',
+        Cst_CompanyName: 'Acme',
+        Cst_Phone: '5550100',
+        Cst_Country: 'India',
+        Cst_DialCode: { name: 'India', dialCode: '+91', code: 'IN' },
+        Cst_State: 'Gujarat',
+        Cst_City: 'Surat',
+        Cst_LogTimeDays: '8',
+        trackerEstimateLimit: true,
+        Cst_countryCode: 'IN',
+        Cst_stateCode: 'GJ',
+        updatedAt: '2026-09-11T00:00:00.000Z',
+    },
+};
+const REFUSED_WRITES = [
+    ['the plan', { updateObject: { planFeature: { planName: 'enterPrise', users: null } } }],
+    ['a plan limit', { updateObject: { 'planFeature.users': 1000 } }],
+    ['the subscription', { updateObject: { isFree: false, subscriptionData: { users: 500 }, SubcriptionId: 'sub_1' } }],
+    ['the billing customer', { updateObject: { customerId: 'cus_1', billingDetails: { email: 'billing@example.test' } } }],
+    ['the payment state', { updateObject: { isPaymentFailed: false, paymentFailed_error_text: '' } }],
+    ['the renewal date', { updateObject: { subscriptionRenewalDate: 4102444800, isPlanShchedule: false } }],
+    ['the disabled flags', { updateObject: { isDisable: false, isInactive: false } }],
+    ['the seat allowance', { updateObject: { availableUser: 999, totalData: { users: 999 } } }],
+    ['the storage size', { updateObject: { bucketSize: 0 } }],
+    ['the seat count', { updateObject: { companyData: [{ users: 1 }] } }],
+    ['a seat count jump', { key: '$inc', updateObject: { 'companyData.$[elementIndex].users': -50 }, arrayFilters: SEAT_RELEASE.arrayFilters }],
+    ['the tracker seats', { updateObject: { trackerUsers: 0 } }],
+    ['the project counts', { updateObject: { projectCount: { projectCount: 0, privateCount: 0, publicCount: 0 } } }],
+    ['the AI usage', { key: '$inc', updateObject: { aiTotalRequestedCount: -100000 } }],
+    ['the company owner as a plain field', { updateObject: { userId: OWNER } }],
+    ['a plan field removal', { key: '$unset', updateObject: { planFeature: '' } }],
+    ['a detail next to a plan field', { updateObject: { Cst_CompanyName: 'Acme', availableUser: 999 } }],
+    ['a detail with array filters', { ...COMPANY_DETAILS_FORM, arrayFilters: [{ 'x.y': 1 }] }],
+    ['a nested detail path', { updateObject: { 'Cst_DialCode.code': 'US' } }],
+    ['the owner claim with a seat reset', { updateObject: { objId: { userId: OWNER }, companyData: [{ users: 1 }] } }],
+];
+
+describe('companyUpdateKind for owners and admins', () => {
+    it('recognises the company details form, with or without an explicit $set', () => {
+        expect(companyUpdateKind(COMPANY_DETAILS_FORM)).toBe('details');
+        expect(companyUpdateKind({ key: '$set', updateObject: { Cst_CompanyName: 'Acme' } })).toBe('details');
+    });
+
+    it('recognises the owner claim the invitation page sends', () => {
+        expect(companyUpdateKind(OWNER_CLAIM)).toBe('ownerClaim');
+    });
+
+    it.each(REFUSED_WRITES)('does not recognise a write to %s', (label, body) => {
+        expect(companyUpdateKind(body)).toBe(null);
+    });
+});
+
+describe('PUT company update never takes server-controlled fields', () => {
+    const put = (path, uid, body) => app.call('PUT', path, { token: signSession(uid, [COMPANY]), companyId: COMPANY, body });
+
+    describe.each([['owner', OWNER], ['admin', ADMIN]])('as the %s', (role, uid) => {
+        it.each(REFUSED_WRITES)('refuses writing %s', async (label, body) => {
+            const res = await put('/api/v1/company', uid, body);
+            expect(res.status).toBe(403);
+            expect(res.body).toEqual({ status: false, message: expect.any(String) });
+            expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+        });
+
+        it('saves the company details form', async () => {
+            const res = await put('/api/v1/company', uid, COMPANY_DETAILS_FORM);
+            expect(res.status).toBe(200);
+            expect(callsOf('findOneAndUpdate')[0][1].data[1]).toEqual({ $set: COMPANY_DETAILS_FORM.updateObject });
+        });
+
+        it('releases a seat and switches a project between private and public', async () => {
+            expect((await put('/api/v1/company', uid, SEAT_RELEASE)).status).toBe(200);
+            expect((await put('/api/v1/company', uid, TRACKER_SEAT_RELEASE)).status).toBe(200);
+            expect((await put('/api/v1/company', uid, SWAP_TO_PRIVATE)).status).toBe(200);
+        });
+    });
+
+    it.each(['/api/v1/company', '/api/v1/admin/company', '/api/v1/company-invitation'])('refuses the owner changing the plan through %s', async (path) => {
+        const res = await put(path, OWNER, { updateObject: { planFeature: { users: null } } });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+});
+
+describe('PUT /api/v1/company-invitation owner claim', () => {
+    const put = (uid, body) => app.call('PUT', '/api/v1/company-invitation', { token: signSession(uid, [COMPANY]), body });
+
+    it('records the invited owner on the company without touching the seat count', async () => {
+        const res = await put(OWNER, OWNER_CLAIM);
+        expect(res.status).toBe(200);
+        const [filter, update] = callsOf('findOneAndUpdate')[0][1].data;
+        expect(filter).toEqual({ _id: COMPANY });
+        expect(update).toEqual({ $set: { userId: new mongoose.Types.ObjectId(OWNER) } });
+    });
+
+    it('refuses an admin claiming the company', async () => {
+        const res = await put(ADMIN, { ...OWNER_CLAIM, updateObject: { objId: { userId: ADMIN } } });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it('refuses an owner recording someone else', async () => {
+        const res = await put(OWNER, { ...OWNER_CLAIM, updateObject: { objId: { userId: ADMIN } } });
         expect(res.status).toBe(403);
         expect(callsOf('findOneAndUpdate')).toHaveLength(0);
     });

--- a/tests/company-access.test.js
+++ b/tests/company-access.test.js
@@ -26,9 +26,20 @@ const GUEST = '6f0000000000000000000004';
 const OUTSIDER = '6f0000000000000000000005';
 const ROLE_OF = { [OWNER]: 1, [ADMIN]: 2, [MEMBER]: 3, [GUEST]: 0 };
 
+const ACTIVE = 2;
+const PENDING = 1;
+const CANCELLED = 3;
+
 const callsOf = (method) => MongoDbCrudOpration.mock.calls.filter((call) => call[2] === method);
 
+const matchesFilter = (row, filter) => Object.entries(filter).every(([field, expected]) => {
+    if (expected && typeof expected === 'object' && '$ne' in expected) return row[field] !== expected.$ne;
+    if (expected && typeof expected === 'object' && '$in' in expected) return expected.$in.includes(row[field]);
+    return row[field] === expected;
+});
+
 let app;
+let seats;
 
 beforeAll(async () => {
     app = await startApp((server) => {
@@ -45,8 +56,13 @@ afterAll(() => app.close());
 
 beforeEach(() => {
     myCache.flushAll();
+    seats = { [COMPANY]: Object.entries(ROLE_OF).map(([userId, roleType]) => ({ userId, roleType, status: ACTIVE, isDelete: false })) };
     getRoleType.mockReset();
-    getRoleType.mockImplementation(async (companyId, uid) => (companyId === COMPANY && uid in ROLE_OF ? ROLE_OF[uid] : null));
+    // The real lookup matches on userId alone, so removed and pending rows still report their role.
+    getRoleType.mockImplementation(async (companyId, uid) => {
+        const row = (seats[companyId] || []).find((seat) => seat.userId === uid);
+        return row ? row.roleType : null;
+    });
     evaluatePermission.mockReset();
     evaluatePermission.mockImplementation(async () => null);
     MongoDbCrudOpration.mockReset();
@@ -54,6 +70,7 @@ beforeEach(() => {
         const filter = (obj.data && obj.data[0]) || {};
         if (obj.type === SCHEMA_TYPE.USERS && obj.data[1] === 'isProductOwner') return { isProductOwner: String(filter._id) === OWNER };
         if (obj.type === SCHEMA_TYPE.USERS) return { AssignCompany: String(filter._id) === OWNER ? [COMPANY, OTHER_COMPANY] : [COMPANY] };
+        if (obj.type === SCHEMA_TYPE.COMPANY_USERS && method === 'findOne') return (seats[db] || []).find((seat) => matchesFilter(seat, filter)) || null;
         if (method === 'find') return filter._id ? filter._id.$in.map((id) => ({ _id: String(id) })) : [{ _id: COMPANY }, { _id: OTHER_COMPANY }];
         if (method === 'aggregate') return [];
         if (method === 'findOneAndUpdate') return { _id: COMPANY };
@@ -315,6 +332,80 @@ describe('PUT /api/v1/company-invitation owner claim', () => {
 
     it('refuses an owner recording someone else', async () => {
         const res = await put(OWNER, { ...OWNER_CLAIM, updateObject: { objId: { userId: ADMIN } } });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+});
+
+describe('PUT company update needs a live seat in the company it writes', () => {
+    const REMOVED_ADMIN = '6f0000000000000000000006';
+    const PENDING_ADMIN = '6f0000000000000000000007';
+    const PENDING_OWNER = '6f0000000000000000000008';
+    const REMOVED_OWNER = '6f000000000000000000000a';
+    const CANCELLED_OWNER = '6f000000000000000000000b';
+    const EVERY_KIND = [['the details', RENAME], ['a seat release', SEAT_RELEASE], ['a tracker seat release', TRACKER_SEAT_RELEASE], ['a project type swap', SWAP_TO_PRIVATE]];
+    const put = (path, uid, { audience = [COMPANY], header = COMPANY, body }) => app.call('PUT', path, { token: signSession(uid, audience), companyId: header, body });
+    const claimFor = (uid) => ({ updateObject: { objId: { userId: uid } }, companyId: COMPANY });
+
+    beforeEach(() => {
+        seats[COMPANY].push(
+            { userId: REMOVED_ADMIN, roleType: 2, status: ACTIVE, isDelete: true },
+            { userId: PENDING_ADMIN, roleType: 2, status: PENDING, isDelete: false },
+            { userId: PENDING_OWNER, roleType: 1, status: PENDING, isDelete: false },
+            { userId: REMOVED_OWNER, roleType: 1, status: ACTIVE, isDelete: true },
+            { userId: CANCELLED_OWNER, roleType: 1, status: CANCELLED, isDelete: true },
+        );
+    });
+
+    it('refuses a removed admin signed into another company who names this one in the header', async () => {
+        const res = await put('/api/v1/admin/company', REMOVED_ADMIN, { audience: [OTHER_COMPANY], body: { companyId: OTHER_COMPANY, ...RENAME } });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it.each(EVERY_KIND)('refuses a removed admin whose token still names the company sending %s', async (label, body) => {
+        const res = await put('/api/v1/admin/company', REMOVED_ADMIN, { body });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it.each(EVERY_KIND)('refuses a pending invitee sending %s', async (label, body) => {
+        const res = await put('/api/v1/admin/company', PENDING_ADMIN, { body });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it.each([
+        ['header and body companyId', '', { companyId: OTHER_COMPANY }],
+        ['header and body CompanyId', '', { CompanyId: OTHER_COMPANY }],
+        ['header and query', `?companyId=${OTHER_COMPANY}`, {}],
+    ])('refuses a request whose %s name different companies', async (label, query, named) => {
+        const res = await put(`/api/v1/admin/company${query}`, ADMIN, { audience: [COMPANY, OTHER_COMPANY], body: { ...named, ...RENAME } });
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it('accepts a header and body that name the same company', async () => {
+        const res = await put('/api/v1/admin/company', ADMIN, { body: { companyId: COMPANY, ...RENAME } });
+        expect(res.status).toBe(200);
+        expect(callsOf('findOneAndUpdate')[0][1].data[0]).toEqual({ _id: COMPANY });
+    });
+
+    it('lets an invited owner whose row is still pending record themselves', async () => {
+        const res = await app.call('PUT', '/api/v1/company-invitation', { token: signSession(PENDING_OWNER, [COMPANY]), body: claimFor(PENDING_OWNER) });
+        expect(res.status).toBe(200);
+        expect(callsOf('findOneAndUpdate')[0][1].data[1]).toEqual({ $set: { userId: new mongoose.Types.ObjectId(PENDING_OWNER) } });
+    });
+
+    it.each([['removed', REMOVED_OWNER], ['cancelled', CANCELLED_OWNER]])('refuses a %s owner recording themselves', async (label, uid) => {
+        const res = await app.call('PUT', '/api/v1/company-invitation', { token: signSession(uid, [COMPANY]), body: claimFor(uid) });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it('refuses a pending invitee claiming the company for someone else', async () => {
+        const res = await app.call('PUT', '/api/v1/company-invitation', { token: signSession(PENDING_OWNER, [COMPANY]), body: claimFor(OWNER) });
         expect(res.status).toBe(403);
         expect(callsOf('findOneAndUpdate')).toHaveLength(0);
     });

--- a/tests/conventions/tenant-scoping.baseline.json
+++ b/tests/conventions/tenant-scoping.baseline.json
@@ -8,7 +8,6 @@
   "CapacityPlanning/controller.js": 1,
   "CloudStorage/controller.js": 2,
   "Company/controller.js": 8,
-  "Company/controller/updateCompany.js": 1,
   "CustomReports/controller.js": 2,
   "EmailIn/controller.js": 2,
   "Integrations/controller.js": 2,

--- a/tests/integration/access.int.test.js
+++ b/tests/integration/access.int.test.js
@@ -1,5 +1,5 @@
 const { createApiClient } = require('../../e2e/support/api');
-const { loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+const { emailFor, inviteMember, login, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
 
 const state = readState();
 const anon = createApiClient({ baseURL: state.baseURL });
@@ -401,6 +401,85 @@ describe('access — plan, billing and count fields stay with the server', () =>
         const res = await admin.api.put('/api/v1/company-invitation', { updateObject: { objId: { userId: admin.uid } }, companyId: state.companyId });
         expect(res.status).toBe(403);
         expect(String((await readCompany(admin)).userId)).toBe(String(before.userId));
+    });
+});
+
+describe('access — company writes need a live seat in that company', () => {
+    const readCompany = async (session) => (await session.api.post('/api/v1/admin/company', { companyIds: [state.companyId] })).body[0];
+    const guarded = (company) => ({ Cst_CompanyName: company.Cst_CompanyName, companyData: company.companyData, trackerUsers: company.trackerUsers, userId: company.userId });
+    const WRITES = [
+        ['the company details', { updateObject: { Cst_CompanyName: 'Taken over' } }],
+        ['a seat release', { key: '$inc', updateObject: { 'companyData.$[elementIndex].users': -1 }, arrayFilters: [{ 'elementIndex.users': { $exists: true } }] }],
+    ];
+    const pullFromCompany = (ownerApi, userId) => ownerApi.put('/api/v1/user', { userId, updateObject: { $pull: { AssignCompany: state.companyId } }, newObj: { returnDocument: 'after' } });
+
+    // Signs in before the removal, the way a session opened earlier keeps the company in its audience.
+    async function removedAdmin() {
+        const owner = await loginAs('owner');
+        const suffix = uniqueSuffix();
+        const email = emailFor('admin', `seat${suffix}`);
+        const user = await inviteMember({ baseURL: state.baseURL, ownerApi: owner.api, companyId: state.companyId, role: 'admin', email, firstName: 'QA', lastName: `Seat ${suffix}` });
+        const session = await login(state.baseURL, email);
+        expect((await owner.api.put('/api/v1/members', { id: user.companyUserId, data: { isDelete: true, isTrackerUser: false } })).body.status).toBe(true);
+        expect((await pullFromCompany(owner.api, user.userId)).body.status).toBe(true);
+        return { ...user, api: createApiClient({ baseURL: state.baseURL, accessToken: session.accessToken, companyId: state.companyId }) };
+    }
+
+    async function pendingAdmin() {
+        const user = await removedAdmin();
+        const owner = await loginAs('owner');
+        const invite = await owner.api.post('/api/v2/sendInvitationEmail', { email: user.email, companyId: state.companyId, companyName: state.companyName, role: 2, designation: 0 });
+        expect(invite.status).toBe(200);
+        expect((await owner.api.get(`/api/v1/members/${user.userId}`)).body).toMatchObject({ userId: user.userId, roleType: 2, status: 1, isDelete: false });
+        return user;
+    }
+
+    it.each(WRITES)('refuses a removed admin changing %s', async (label, body) => {
+        const removed = await removedAdmin();
+        const owner = await loginAs('owner');
+        const before = await readCompany(owner);
+        const res = await removed.api.put('/api/v1/admin/company', body);
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect(guarded(await readCompany(owner))).toEqual(guarded(before));
+    });
+
+    it.each(WRITES)('refuses a pending invitee changing %s', async (label, body) => {
+        const pending = await pendingAdmin();
+        const owner = await loginAs('owner');
+        const before = await readCompany(owner);
+        const res = await pending.api.put('/api/v1/admin/company', body);
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect(guarded(await readCompany(owner))).toEqual(guarded(before));
+    });
+
+    it('refuses a request whose header and body name different companies', async () => {
+        const admin = await loginAs('admin');
+        const before = await readCompany(admin);
+        const res = await admin.api.withCompany(randomId()).put('/api/v1/admin/company', { companyId: state.companyId, updateObject: { Cst_CompanyName: 'Taken over' } });
+        expect(res.status).toBe(403);
+        expect(res.body).toMatchObject({ status: false, message: expect.stringMatching(/more than one company/) });
+        expect(guarded(await readCompany(admin))).toEqual(guarded(before));
+    });
+
+    it('lets a newly invited owner accept the invitation and record themselves as the company owner', async () => {
+        const owner = await loginAs('owner');
+        const suffix = uniqueSuffix();
+        const email = emailFor('owner', `claim${suffix}`);
+        const invited = await inviteMember({ baseURL: state.baseURL, ownerApi: owner.api, companyId: state.companyId, role: 'owner', email, firstName: 'QA', lastName: `Owner ${suffix}` });
+        const session = await login(state.baseURL, email);
+        const invitationPage = createApiClient({ baseURL: state.baseURL, accessToken: session.accessToken });
+        try {
+            const res = await invitationPage.put('/api/v1/company-invitation', { updateObject: { objId: { userId: session.uid } }, companyId: state.companyId });
+            expect(res.status).toBe(200);
+            expect(String((await readCompany(owner)).userId)).toBe(invited.userId);
+        } finally {
+            await owner.api.put('/api/v1/company-invitation', { updateObject: { objId: { userId: owner.uid } }, companyId: state.companyId });
+            await owner.api.put('/api/v1/members', { id: invited.companyUserId, data: { isDelete: true, isTrackerUser: false } });
+            await pullFromCompany(owner.api, invited.userId);
+        }
+        expect(String((await readCompany(owner)).userId)).toBe(owner.uid);
     });
 });
 

--- a/tests/integration/access.int.test.js
+++ b/tests/integration/access.int.test.js
@@ -340,6 +340,70 @@ describe('access — only owners and admins change the company', () => {
     });
 });
 
+describe('access — plan, billing and count fields stay with the server', () => {
+    const readCompany = async (session) => (await session.api.post('/api/v1/admin/company', { companyIds: [state.companyId] })).body[0];
+    const serverFields = (company) => ({
+        planFeature: company.planFeature,
+        subscriptionRenewalDate: company.subscriptionRenewalDate,
+        companyData: company.companyData,
+        trackerUsers: company.trackerUsers,
+        userId: company.userId,
+    });
+
+    it.each([
+        ['owner', '/api/v1/company', (company) => ({ updateObject: { 'planFeature.users': company.planFeature.users } })],
+        ['owner', '/api/v1/admin/company', () => ({ updateObject: { subscriptionRenewalDate: 4102444800 } })],
+        ['admin', '/api/v1/company', () => ({ key: '$inc', updateObject: { 'companyData.$[elementIndex].users': 0 }, arrayFilters: [{ 'elementIndex.users': { $exists: true } }] })],
+        ['admin', '/api/v1/admin/company', (company) => ({ updateObject: { trackerUsers: company.trackerUsers ?? 0 } })],
+        ['owner', '/api/v1/company-invitation', (company) => ({ updateObject: { objId: { userId: String(company.userId) }, companyData: company.companyData }, companyId: state.companyId })],
+    ])('refuses the %s writing server-controlled fields through %s', async (role, path, bodyFor) => {
+        const session = await loginAs(role);
+        const before = await readCompany(session);
+        const res = await session.api.put(path, bodyFor(before));
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect(serverFields(await readCompany(session))).toEqual(serverFields(before));
+    });
+
+    it('lets the owner save the whole company details form', async () => {
+        const owner = await loginAs('owner');
+        const before = await readCompany(owner);
+        const res = await owner.api.put('/api/v1/company', {
+            updateObject: {
+                Cst_profileImage: before.Cst_profileImage || '',
+                Cst_CompanyName: before.Cst_CompanyName,
+                Cst_Phone: before.Cst_Phone,
+                Cst_Country: before.Cst_Country,
+                Cst_DialCode: before.Cst_DialCode,
+                Cst_State: before.Cst_State || '',
+                Cst_City: before.Cst_City || '',
+                Cst_LogTimeDays: before.Cst_LogTimeDays,
+                trackerEstimateLimit: before.trackerEstimateLimit !== false,
+                Cst_countryCode: before.Cst_countryCode || '',
+                Cst_stateCode: before.Cst_stateCode || '',
+                updatedAt: new Date().toISOString(),
+            },
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.Cst_CompanyName).toBe(before.Cst_CompanyName);
+    });
+
+    it('lets an owner record themselves as the company owner through the invitation route', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.put('/api/v1/company-invitation', { updateObject: { objId: { userId: owner.uid } }, companyId: state.companyId });
+        expect(res.status).toBe(200);
+        expect(String((await readCompany(owner)).userId)).toBe(owner.uid);
+    });
+
+    it('refuses an admin recording themselves as the company owner', async () => {
+        const admin = await loginAs('admin');
+        const before = await readCompany(admin);
+        const res = await admin.api.put('/api/v1/company-invitation', { updateObject: { objId: { userId: admin.uid } }, companyId: state.companyId });
+        expect(res.status).toBe(403);
+        expect(String((await readCompany(admin)).userId)).toBe(String(before.userId));
+    });
+});
+
 describe('access — the invitation check stays inside the signed-in company', () => {
     it('refuses probing another company', async () => {
         const admin = await loginAs('admin');


### PR DESCRIPTION
## Summary

QA follow-up 29, after #633.

| Finding | Where | Fix | Test |
|---|---|---|---|
| 29. Owners and admins can write any company field, including plan, subscription, billing, seat and storage limits, renewal dates and member counts | `PUT /api/v1/company`, `PUT /api/v1/admin/company`, `PUT /api/v1/company-invitation` (shared handler `Modules/Company/controller/updateCompany.js`) | New `companyUpdateKind` in `Modules/Company/helpers/companyAccessRules.js` accepts only the exact writes the app sends (see Notes). Any other body gets 403 `{ status: false, message }` for every role, including the instance owner. After that, a role rule for each kind of write applies. | `tests/company-access.test.js` ("companyUpdateKind for owners and admins", "PUT company update never takes server-controlled fields", "PUT /api/v1/company-invitation owner claim"); `tests/integration/access.int.test.js` ("access — plan, billing and count fields stay with the server") |
| 29b. Accepting an owner invitation resets the seat count | `Invitation.vue` sent `companyData: [{ users: 1 }]` with the owner claim to `PUT /api/v1/company-invitation` | The page now sends only `{ objId: { userId } }`. The server builds `$set: { userId: <caller> }` itself and refuses the old body with 403. | same files |

## Notes

**Server-controlled company fields.** I checked every writer of the `companies` collection.

| Fields | Written only by |
|---|---|
| `planFeature` | the installer (`Modules/Setup/createCompany.js`) and company creation (`createCompanyV2`) |
| `isFree`, `subscriptionData`, `totalData`, `totalProjects`, `isInactive`, `userId` | company creation and the installer (`userId` also by the server-built owner claim below) |
| `SubcriptionId`, `customerId`, `billingDetails`, `isPaymentFailed`, `paymentFailed_error_text`, `subscriptionRenewalDate`, `isPlanShchedule`, `availableUser`, `isDisable` | billing and subscription code (declared in the schema; nothing in this repo writes them) |
| `companyData` (seat count) | `sendInvitation` and `decreaseUserCount`, through `updateCompanyFun` |
| `trackerUsers` | `trackerUserPermission`, through `updateCompanyFun` |
| `projectCount` | project create and delete, and channel counts in Sprints, through `updateCompanyFun` |
| `bucketSize` | the storage modules, through `updateCompanyFun` |
| `aiTotalRequestedCount` | AI usage, through `updateCompanyFun` |
| `screenshotRetention`, `autoCloseProjects`, `timeReminderSettings`, `agentPolicy` and the other `agent*` fields | their own validated endpoints and cron jobs |
| `teamFocus`, `legacyId` | setup, creation and imports |

**Client writes that stay allowed.** The allowlist has one entry per caller and is the same on all three routes.

| Caller | Accepted body | Who |
|---|---|---|
| `SettingCompanyDetails.vue` | `$set` (no `key`, or `key: '$set'`) of only `Cst_profileImage`, `Cst_CompanyName`, `Cst_Phone`, `Cst_Country`, `Cst_DialCode`, `Cst_State`, `Cst_City`, `Cst_LogTimeDays`, `Cst_countryCode`, `Cst_stateCode`, `trackerEstimateLimit`, `updatedAt`. No dotted paths, no `arrayFilters`. | owner, admin |
| `ProjectsListingSetting.vue` | `$inc` swap of `projectCount.privateCount` and `projectCount.publicCount`: steps of ±1 that sum to 0 | any company member (unchanged from #633) |
| `Members.vue` | `$inc { "companyData.$[elementIndex].users": -1 }` with the exact `arrayFilters`; `$inc { trackerUsers: -1 }` | owner, admin, or a member with write access to `settings.settings_member_list` (unchanged) |
| `Invitation.vue` | `{ objId: { userId } }` where `userId` is the caller | owner only. The server writes `$set: { userId: <caller as ObjectId> }` and ignores the body's values. |

- No other caller exists. The tracker app, MCP and agent tools do not write through these routes, and server-side counters call `updateCompanyFun` directly.
- `updatedAt` is on the list only because the form sends it; Mongoose timestamps overwrite it on every update.
- The unit test app now also mounts `setMiddlewareWithCV2`, so `PUT /api/v1/company` runs there with a real session instead of none.

**Upgrade impact**
- Any script or external admin panel that changed plan, subscription, billing, seat, storage, usage or ownership fields through these routes now gets 403, whatever its role, including the instance owner. Only the server code that owns those fields can change them.
- `teamFocus` and every other field outside the Settings > Company form can no longer be set through these routes.
- Operators other than `$set` and the `$inc` shapes above (`$unset`, `$rename`, `$push`, and so on) get 403.
- Update bodies no longer go through the `objId` conversion. Its only user was the owner claim, which the server now builds itself.
- A browser still running the old bundle sends the old owner claim, with `companyData`, when an owner accepts an invitation. It gets 403, which the page already catches and logs to the console. The invitation still completes, the seat count keeps its value, and the company `userId` is not updated. Nothing in this repo reads that field.
- Seat counts already reset by earlier owner acceptances are not repaired. No migration is needed.

**Left out**
- The client still sends the project count swap and the -1 seat releases, so owners, admins and member-list managers can still move those counters by one per request. Moving them into the project update and member removal handlers is a separate change.
- `Cst_profileImage` is not checked against the company's storage path.

## Test plan

- [x] Failing first: with `updateCompany.js` and `companyAccessRules.js` from `origin/beta` and the new tests, `tests/company-access.test.js` gave 79 failed, 27 passed (106 total). With the fix, all 106 pass.
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 246 suites, 3426 tests passed
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed (tenant-scoping baseline unchanged)
- [x] `E2E_MONGODB_URL=mongodb://127.0.0.1:27181 npx jest --selectProjects integration --runInBand tests/integration/access.int.test.js`: 1 suite, 54 tests passed, on a throwaway `mongo:7` container that was removed afterwards. I added the integration cases with the fix and did not run them against the old code.
- [x] `cd frontend && npx vitest run`: 31 files, 242 tests passed
- [x] `npm run i18n:check`: exit 0, no missing keys (no user-visible strings added)
- [x] eslint on the touched files: 0 errors. `updateCompany.js` has 2 existing `no-async-promise-executor` warnings, on lines this PR does not touch.
- [x] CI on `add66b7f`: branch name, commitlint, PR title, backend (1m30s), frontend (4m52s) and e2e (5m45s) all passed. CodeRabbit skipped because reviews are disabled for `beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review fixes

Two reviewer findings, each reproduced with a test that failed on `add66b7f` before the fix.

| Finding | Reproduced | Fix | Test |
|---|---|---|---|
| A. Owner invite acceptance read `response.data.data._id`, but `POST /api/v2/createUser` answers `{ status: true, statusText: <user> }` with no `data`. For an owner invitation, `Invitation.vue` threw after `root-members`, showed `Auth.server_error` and never sent the owner claim. | Yes. The new vitest spec, with the real createUser and root-members response shapes, saw no `company-invitation` call. | `Invitation.vue` uses the uid of the session it just opened (`user.data.uid` from login) for the `root-members` link, the owner claim and the notification calls. The server only accepts `objId.userId === req.uid`. | `frontend/tests/unit/invitationOwnerClaim.spec.js` |
| B. Removed members and pending invitees could still write a company. `updateCompany` took the header company while `requireCompanyAud` validated the body first. `getRoleType` matches `company_users` on `userId` alone, so a removed (`isDelete: true`) or pending (`status: 1`) row kept its role. | Yes. The unit suite failed 14 new cases. The integration suite had a removed admin still renaming the company and releasing a seat with a session opened before removal, and an admin who was removed and re-invited (pending, row still carrying `userId` and `roleType: 2`) doing the same. | 1. `namedCompanyIds(req)` in `Config/tenant.js` collects every company the request names (header, params, query, body `companyId`/`CompanyId`). More than one gets 403, then `tenantOf(req)` resolves the company. 2. The handler reads the caller's own `company_users` row with `seatFilter`: `status: 2` and not deleted, and the role comes from that row. 3. Only the owner claim also accepts the caller's own pending (`status: 1`) row. Removed and cancelled owners are refused. `getRoleType` is unchanged. | `tests/company-access.test.js` ("PUT company update needs a live seat in the company it writes"); `tests/integration/access.int.test.js` ("access — company writes need a live seat in that company") |

Notes
- The existing-account paths do not send the owner claim at all. The `/invitation` page stops with `Auth.email_in_use` on a 409. `/verify-invitation` (`POST /api/v2/checkPermission`) and the Google, GitHub and GitLab signups activate the row on the server and never record `companies.userId` for an invited owner. This is not a regression from this PR; it is listed below as a follow-up.
- `updateCompany.js` no longer reads a company id from the body or query itself, so its entry is removed from `tests/conventions/tenant-scoping.baseline.json` (238 → 237).
- The integration owner-acceptance case restores the fixture owner as `companies.userId` and removes the extra owner afterwards, so `instance-fixes` "removing the last owner" still sees one owner.

Follow-ups (not in this PR)
- `getRoleType` in `Config/permissionGuard.js` should match only active, undeleted rows. It is used by `requirePermission`, `evaluatePermission`, the member guards and many others, so it needs its own change and review.
- `PUT /api/v1/admin/company` and `PUT /api/v1/company-invitation` run `verifyJWTTokenV2` without the live membership re-check of `verifyJWTTokenWithCV2`, and `requireCompanyAud` checks the body before the header. Both are in `Config/jwt.js` (open in #638).
- Record `companies.userId` when an invited owner accepts through `/verify-invitation` or an OAuth signup.

Test plan for the review fixes
- [x] Failing first: `tests/company-access.test.js` failed 14 of 123 on the branch head with the new cases, and `tests/integration/access.int.test.js` failed 5 of 60. The vitest owner-claim spec failed. All pass with the fix.
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 247 suites, 3454 tests passed (after merging `origin/beta`)
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed
- [x] `E2E_MONGODB_URL=mongodb://127.0.0.1:27184 npx jest --selectProjects integration --runInBand tests/integration/access.int.test.js`: 1 suite, 60 tests passed, on a throwaway `mongo:7` container that was removed afterwards
- [x] `cd frontend && npx vitest run`: 35 files, 256 tests passed
- [x] `npm run i18n:check`: no missing keys (no user-visible strings added)
- [x] eslint on the touched files: 0 errors. The two `no-async-promise-executor` warnings in `updateCompany.js` were already there.
