### PR TITLE
fix(users): answer userAndCompanyCheck only for the signed-in user without secret fields

### DIFF
--- a/Modules/Users/controller.js
+++ b/Modules/Users/controller.js
@@ -71,121 +71,57 @@ exports.updateUserStatus = async (req, res) => {
     }
 }
 
-exports.checkUserAndCompany = (req, res) => {
-    if(!req.body.userId) {
-        res.send({status: false, message: 'userId is required'});
-        return;
-    }
-    let obj = {
-        type: dbCollections.USERS,
-        data: [
-            {
-                _id : new mongoose.Types.ObjectId(req.body.userId)
-            }
-        ]
+const noCompany = (userData) => ({ isCompanyFind: false, companyId: '', userData });
+
+exports.checkUserAndCompany = async (req, res) => {
+    if (!req.uid) return refuse(res, 401, 'Unauthorized');
+    const { userId } = req.body || {};
+    if (userId !== undefined && String(userId) !== String(req.uid)) {
+        return refuse(res, 403, 'You can only check your own account.');
     }
 
-    // BUG-027 / #81 fix: this handler has six different res.send sites
-    // across nested .then / .catch chains. Pre-fix, a sync throw in
-    // res.send (e.g. ERR_HTTP_HEADERS_SENT triggered by middleware) on
-    // the inner .then could land in the inner .catch which would also
-    // try to res.send — and the outer .catch would do it a third time.
-    // Wrap every res.send through a `sendOnce` so duplicate writes are
-    // suppressed instead of throwing.
-    let responded = false;
-    const sendOnce = (payload) => {
-        if (responded) {
-            logger.warn('checkUserAndCompany suppressed a duplicate res.send');
-            return;
-        }
-        responded = true;
-        res.send(payload);
-    };
+    let user;
+    try {
+        user = await loadGlobalUser(req.uid);
+    } catch (error) {
+        logger.error(`checkUserAndCompany: ${error.message || error}`);
+        return res.send({ status: false, statusText: "User Not Found", data: noCompany(null) });
+    }
+    const userData = user ? toSelfView(user) : null;
+
+    if (user && user.isEmailVerified === false) {
+        return res.send({ status: false, statusText: "Email Not Verified", data: { userData } });
+    }
+    const assigned = (user && user.AssignCompany) || [];
+    if (!assigned.length) {
+        return res.send({ status: true, statusText: "Comapny Not Found", data: noCompany(userData) });
+    }
 
     try {
-        MongoDbCrudOpration('global', obj, "findOne").then((response)=>{
-            if(response && response.isEmailVerified === false) {
-                sendOnce({
-                    status: false,
-                    statusText: "Email Not Verified",
-                    data: {userData:response}
-                });
-                return;
-            }
-            if(response && response.AssignCompany && response.AssignCompany.length > 0) {
-                const exists = response?.AssignCompany?.includes(response?.lastSelectedCompany);
-                let cObj = {
-                    type: dbCollections.COMPANIES,
-                    data: [
-                        {
-                            _id: { $in: exists ? [new mongoose.Types.ObjectId(response?.lastSelectedCompany)] : [...response.AssignCompany.map((x) => new mongoose.Types.ObjectId(x))] },
-                            isDisable: { $in : [false,undefined]}
-                        }
-                    ]
-                }
-
-                const allObj = {
-                    type: dbCollections.COMPANIES,
-                    data: [
-                        { _id: { $in: response.AssignCompany.map((x) => new mongoose.Types.ObjectId(x)) } },
-                        { Cst_CompanyName: 1, Cst_profileImage: 1, isDisable: 1 }
-                    ]
-                }
-                // The workspace switcher on the login screen needs every workspace, not only the last one.
-                const companiesPromise = MongoDbCrudOpration('global', allObj, "find")
-                    .then((list) => (list || []).map((c) => ({ _id: c._id, Cst_CompanyName: c.Cst_CompanyName, Cst_profileImage: c.Cst_profileImage || '', isDisable: c.isDisable === true })))
-                    .catch(() => []);
-
-                Promise.all([MongoDbCrudOpration('global', cObj, "findOne"), companiesPromise]).then(([company, companies])=>{
-                    if(company) {
-                        sendOnce({
-                            status: true,
-                            statusText: "Comapny Found",
-                            data: {isCompanyFind: true,companyId: company._id,userData:response, companies}
-                        });
-                        return;
-                    } else {
-                        sendOnce({
-                            status: true,
-                            statusText: "Comapny Not Found",
-                            data: {isCompanyFind: false,companyId: '',userData:response}
-                        });
-                        return;
-                    }
-                }).catch((error)=>{
-                    sendOnce({
-                        status: false,
-                        statusText: "Comapny Not Found",
-                        data: {isCompanyFind: false,companyId: '',userData:response}
-                    });
-                    logger.error('USER STATUS UPDATE ERROR checkUserAndCompany: ',error);
-                })
-
-            } else {
-                sendOnce({
-                    status: true,
-                    statusText: "Comapny Not Found",
-                    data: {isCompanyFind: false,companyId: '',userData:response}
-                });
-                return;
-            }
-        }).catch((error)=>{
-            sendOnce({
-                status: false,
-                statusText: "User Not Found",
-                data: {isCompanyFind: false,companyId: '',userData: null}
-            });
-            logger.error('USER STATUS UPDATE ERROR checkUserAndCompany: ',error);
-        })
+        const toObjectId = (id) => new mongoose.Types.ObjectId(String(id));
+        const preferred = assigned.includes(user.lastSelectedCompany) ? [user.lastSelectedCompany] : assigned;
+        const [company, companies] = await Promise.all([
+            MongoDbCrudOpration('global', {
+                type: dbCollections.COMPANIES,
+                data: [{ _id: { $in: preferred.map(toObjectId) }, isDisable: { $in: [false, undefined] } }]
+            }, "findOne"),
+            // The workspace switcher on the login screen needs every workspace, not only the last one.
+            MongoDbCrudOpration('global', {
+                type: dbCollections.COMPANIES,
+                data: [{ _id: { $in: assigned.map(toObjectId) } }, { Cst_CompanyName: 1, Cst_profileImage: 1, isDisable: 1 }]
+            }, "find")
+                .then((list) => (list || []).map((c) => ({ _id: c._id, Cst_CompanyName: c.Cst_CompanyName, Cst_profileImage: c.Cst_profileImage || '', isDisable: c.isDisable === true })))
+                .catch(() => []),
+        ]);
+        if (!company) {
+            return res.send({ status: true, statusText: "Comapny Not Found", data: noCompany(userData) });
+        }
+        return res.send({ status: true, statusText: "Comapny Found", data: { isCompanyFind: true, companyId: company._id, userData, companies } });
     } catch (error) {
-        sendOnce({
-            status: false,
-            statusText: "User Not Found",
-            data: {}
-        });
-        logger.error('USER STATUS UPDATE ERROR checkUserAndCompany: ',error);
+        logger.error(`checkUserAndCompany: ${error.message || error}`);
+        return res.send({ status: false, statusText: "Comapny Not Found", data: noCompany(userData) });
     }
-}
+};
 
 exports.getUserById = async(req, res) => {
     try {

--- a/tests/integration/user-and-company-check.int.test.js
+++ b/tests/integration/user-and-company-check.int.test.js
@@ -1,0 +1,64 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anon = createApiClient({ baseURL: state.baseURL });
+const SECRET_FIELDS = ['webTokens', 'verificationToken', 'verificationTokenTime', 'forgotPasswordToken', 'forgotPasswordTokenTime', 'passwordHash', 'twoFactor'];
+const exposesSecret = (body) => SECRET_FIELDS.some((field) => JSON.stringify(body || {}).includes(`"${field}"`));
+const CHECK = '/api/v1/userAndCompanyCheck';
+
+async function signUpStranger() {
+    const email = `check.stranger.${uniqueSuffix()}@e2e.alianhub.test`;
+    const res = await anon.post('/api/v2/createUser', { firstName: 'Sam', lastName: 'Stranger', email, password: state.password });
+    expect(res.body.status).toBe(true);
+    return String(res.body.statusText._id);
+}
+
+describe('POST /api/v1/userAndCompanyCheck answers only for the signed-in user', () => {
+    it('refuses an anonymous caller', async () => {
+        const res = await anon.post(CHECK, { userId: state.users.owner.userId });
+        expect(res.status).toBe(401);
+    });
+
+    it('gives the owner their own account and workspace without secrets', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.post(CHECK, { userId: owner.uid });
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe(true);
+        const { userData, companyId, isCompanyFind, companies } = res.body.data;
+        expect(isCompanyFind).toBe(true);
+        expect(String(companyId)).toBe(state.companyId);
+        expect(String(userData._id)).toBe(owner.uid);
+        expect(userData.isEmailVerified).toBe(true);
+        expect(userData.Employee_Email).toBe(state.users.owner.email);
+        expect(userData.AssignCompany).toContain(state.companyId);
+        expect(companies.map((c) => String(c._id))).toContain(state.companyId);
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+
+    it('answers for the caller when no userId is sent', async () => {
+        const member = await loginAs('member');
+        const res = await member.api.post(CHECK, {});
+        expect(res.status).toBe(200);
+        expect(String(res.body.data.userData._id)).toBe(member.uid);
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+
+    it('refuses a member asking about the owner', async () => {
+        const member = await loginAs('member');
+        const res = await member.api.post(CHECK, { userId: state.users.owner.userId });
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect(res.body.data).toBeUndefined();
+    });
+
+    it('refuses a guest reading an unrelated sign-up, so its verification token stays private', async () => {
+        const strangerId = await signUpStranger();
+        const guest = await loginAs('guest');
+        const res = await guest.api.post(CHECK, { userId: strangerId });
+        expect(res.status).toBe(403);
+        expect(res.body.data).toBeUndefined();
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+});

--- a/tests/user-access.test.js
+++ b/tests/user-access.test.js
@@ -16,6 +16,7 @@ const ADMIN = '6f0000000000000000000002';
 const MEMBER = '6f0000000000000000000003';
 const GUEST = '6f0000000000000000000004';
 const STRANGER = '6f0000000000000000000005';
+const UNVERIFIED = '6f0000000000000000000006';
 
 const SECRETS = { webTokens: ['push-token'], verificationToken: 'verify-secret', forgotPasswordToken: 'reset-secret', forgotPasswordTokenTime: 1 };
 const USERS = {
@@ -24,6 +25,7 @@ const USERS = {
     [MEMBER]: { _id: MEMBER, Employee_Name: 'Member', AssignCompany: [COMPANY], ...SECRETS },
     [GUEST]: { _id: GUEST, Employee_Name: 'Guest', AssignCompany: [COMPANY], ...SECRETS },
     [STRANGER]: { _id: STRANGER, Employee_Name: 'Stranger', AssignCompany: [OTHER_COMPANY], ...SECRETS },
+    [UNVERIFIED]: { _id: UNVERIFIED, Employee_Email: 'new@example.test', AssignCompany: [], isEmailVerified: false, ...SECRETS },
 };
 const ROLES = { [OWNER]: 1, [ADMIN]: 2, [MEMBER]: 3, [GUEST]: 0 };
 
@@ -38,6 +40,7 @@ beforeAll(async () => {
         server.put('/api/v1/user', ctrl.updateUserStatus);
         server.get('/api/v1/user/:id', ctrl.getUserById);
         server.post('/api/v1/user/find', ctrl.getUserByQuey);
+        server.post('/api/v1/userAndCompanyCheck', ctrl.checkUserAndCompany);
     });
 });
 afterAll(() => app.close());
@@ -48,6 +51,7 @@ beforeEach(() => {
     MongoDbCrudOpration.mockImplementation(async (db, obj, method) => {
         const filter = (obj.data && obj.data[0]) || {};
         if (obj.type === SCHEMA_TYPE.COMPANY_USERS) return db === COMPANY && ROLES[filter.userId] !== undefined ? { roleType: ROLES[filter.userId] } : null;
+        if (obj.type === SCHEMA_TYPE.COMPANIES) return method === 'find' ? [{ _id: COMPANY, Cst_CompanyName: 'Acme' }] : { _id: COMPANY };
         if (method === 'findOne') return USERS[String(filter._id)] || null;
         if (method === 'aggregate') return [USERS[OWNER], USERS[GUEST]];
         if (method === 'findOneAndUpdate') return { ...USERS[String(filter._id)], ...((obj.data[1] && obj.data[1].$set) || {}) };
@@ -212,5 +216,54 @@ describe('ACC-05 PUT /api/v1/user', () => {
     it('refuses an admin removing a member from a company they do not administer', async () => {
         const res = await put(ADMIN, { userId: STRANGER, updateObject: { $pull: { AssignCompany: OTHER_COMPANY } } });
         expect(res.status).toBe(403);
+    });
+});
+
+describe('POST /api/v1/userAndCompanyCheck', () => {
+    const check = (uid, body) => app.call('POST', '/api/v1/userAndCompanyCheck', { token: signSession(uid, uid === UNVERIFIED ? [] : [COMPANY]), body });
+    const userLookups = () => MongoDbCrudOpration.mock.calls.filter((call) => call[1].type === SCHEMA_TYPE.USERS);
+
+    it('refuses an anonymous caller', async () => {
+        const res = await app.call('POST', '/api/v1/userAndCompanyCheck', { body: { userId: OWNER } });
+        expect(res.status).toBe(401);
+    });
+
+    it('refuses asking about another user without reading them', async () => {
+        const res = await check(GUEST, { userId: STRANGER });
+        expect(res.status).toBe(403);
+        expect(res.body.data).toBeUndefined();
+        expect(userLookups()).toHaveLength(0);
+    });
+
+    it('answers the caller with their workspace and no secrets', async () => {
+        const res = await check(GUEST, { userId: GUEST });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ status: true, data: { isCompanyFind: true, companyId: COMPANY, userData: { _id: GUEST, AssignCompany: [COMPANY] } } });
+        expect(res.body.data.companies).toEqual([{ _id: COMPANY, Cst_CompanyName: 'Acme', Cst_profileImage: '', isDisable: false }]);
+        expect(leaksSecret(res.body)).toBe(false);
+    });
+
+    it('answers the caller when no userId is sent', async () => {
+        const res = await check(OWNER, {});
+        expect(res.status).toBe(200);
+        expect(res.body.data.userData).toMatchObject({ _id: OWNER, isProductOwner: true });
+        expect(leaksSecret(res.body)).toBe(false);
+    });
+
+    it('keeps the verification token out of the unverified answer', async () => {
+        const res = await check(UNVERIFIED, { userId: UNVERIFIED });
+        expect(res.body).toMatchObject({ status: false, statusText: 'Email Not Verified', data: { userData: { _id: UNVERIFIED, isEmailVerified: false, Employee_Email: 'new@example.test' } } });
+        expect(leaksSecret(res.body)).toBe(false);
+    });
+
+    it('keeps secrets out when the company lookup fails', async () => {
+        const base = MongoDbCrudOpration.getMockImplementation();
+        MongoDbCrudOpration.mockImplementation(async (db, obj, method) => {
+            if (obj.type === SCHEMA_TYPE.COMPANIES && method === 'findOne') throw new Error('down');
+            return base(db, obj, method);
+        });
+        const res = await check(GUEST, { userId: GUEST });
+        expect(res.body).toMatchObject({ status: false, data: { isCompanyFind: false, userData: { _id: GUEST } } });
+        expect(leaksSecret(res.body)).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

| Finding | Route | Fix | Test |
|---------|-------|-----|------|
| High: any signed-in user could read another user's full `users` document by posting that user's `_id`. The document included `verificationToken`, `webTokens`, `isProductOwner` and `customerIds`. With an unverified sign-up's token, the caller could also verify an address they don't own through `POST /api/v2/verifyEmail`. | `POST /api/v1/userAndCompanyCheck` (`Modules/Users/controller.js`, `checkUserAndCompany`) | The route now answers only for `req.uid`. A `userId` that names someone else gets 403 before any lookup, and a request with no `userId` answers for the caller. Every branch returns `toSelfView` (from `Modules/Users/helpers/userAccessRules.js`). | `tests/integration/user-and-company-check.int.test.js` (5 cases); new `POST /api/v1/userAndCompanyCheck` block in `tests/user-access.test.js` (6 cases) |

## Notes

**Reproduced on `beta` before the fix.** I used a throwaway integration test (not committed) that logged only field names and status text:
- **Member reads the owner:** a member posted the owner's `_id` and got 200 "Comapny Found" with the owner's document. It included `verificationToken`, `webTokens`, `isProductOwner` and `customerIds`.
- **Guest verifies a stranger:** a guest posted the `_id` of a new sign-up that shares no company with them. The answer was 200 "Email Not Verified" with a non-empty `verificationToken`. Posting that token to `/api/v2/verifyEmail` returned "Email verified successfully.", and a second call returned "Your email is already verified".
- **New tests failed first:** on the unfixed code, 4 of 5 new integration cases and 5 of 6 new unit cases failed.
- **Not in this response:** `passwordHash` and `twoFactor` are stored in `userAuth`, not `users`, so they never leaked here.

**Callers checked.** None of them asks about another user.
- `frontend/src/views/Authentication/Login/Login.vue` (`proceedAfterAuth`): sends the `uid` from its own login response. It reads:
  - `status`, `companyId`, `isCompanyFind`, `companies`
  - `userData.isEmailVerified`, `userData.AssignCompany`, `userData._id`, `userData.Employee_Email`

  Every one of these is still in the response. Login.vue is not modified.
- `frontend/src/plugins/oauth/google/GoogleAuth.vue`, `github/GithubAuth.vue`, `gitlab/GitlabAuth.vue`: same pattern, using the `uid` of the login they just made. They read `status`, `userData.isEmailVerified`, `userData.AssignCompany`, `companyId` and `isCompanyFind`.
- `time-tracker-app/`: no callers. There are no other callers anywhere in the repo.

**Behaviour changes**
- **No `userId` sent:** this used to return `{ status: false, message: 'userId is required' }`. It now answers for the caller.
- **`sendOnce` guard removed:** the guard from BUG-027 is gone, because each path now sends exactly once with `return res.send(...)`.
- **Response shape unchanged:** status texts and the `data` layout are the same as before.

**Other routes that return a raw `users` document (follow-ups, not fixed here).** All of them are outside `Modules/Users`, and another open change is editing `authHelpers.js`.
1. **Medium: `POST /api/v2/auth/login` (public).** `Modules/Auth/controller/authHelpers.js:81` (`generateTokenV2Fun`) returns `userData: response ?? null` for an unverified account, and `loginSession.js` sends it as the 400 body. Anyone who has the password, even without owning the mailbox, receives `verificationToken` and can verify the account through `/api/v2/verifyEmail`. That is the same email-ownership bypass. `POST /api/v2/auth/2fa/validate` returns the same object. Fix: `toSelfView`. Login.vue's resend-verification step only needs `_id` and `Employee_Email`.
2. **Low: `POST /api/v2/generateToken`.** `Modules/Auth/controller/loginSession.js` calls `res.status(400).json(gData)` with the same object. Reaching it needs a live refresh token for an account that has since become unverified.
3. **Low: `POST /api/v2/createUser` and the Google, GitHub and GitLab sign-up routes.** `Modules/Auth/controller/createUser.js:138` and its siblings return the saved document unfiltered, but only to the person who registered. No secret is in it today, because the verification token is written afterwards.

**Possible, not verified**
- `POST /api/v2/verifyEmail` returns `Employee_Email` for any `uid` whose link has expired.
- `GET /api/v2/sso/discover?email=` shows which workspace an email belongs to.

The other `Modules/Users` routes already project their output: `GET /api/v1/user/:id`, `POST /api/v1/user/find` and `PUT /api/v1/user`.

## Test plan

- [x] Reproduced on `beta` with a throwaway integration test (results above)
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 247 suites, 3372 tests passed
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed. Tenant baseline unchanged; no new `req.body.companyId` reads.
- [x] Integration against mongo:7 on port 27185, `--runInBand tests/integration/user-and-company-check.int.test.js tests/integration/access.int.test.js`: 2 suites, 51 tests passed
- [x] `npm run i18n:check`: exit 0
- [x] eslint on the 3 touched files: 0 errors. The 2 `no-async-promise-executor` warnings in `Modules/Users/controller.js` are already on `beta`.
- [ ] Frontend vitest not run, because nothing in the frontend changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
