### PR TITLE
fix(auth): never take instance ownership from a signup request

### DIFF
--- a/Modules/Auth/controller/createUser.js
+++ b/Modules/Auth/controller/createUser.js
@@ -33,128 +33,71 @@ exports.admitInvitee = async (body) => {
 };
 
 
-exports.addUserMongodbV2 = (data) => {
-    return new Promise((resolve, reject) => {
-        try {
-            let obj = {
-                AssignCompany: data.assignCompany ? [data.assignCompany] : [],
-                Employee_FName:  data.firstName,
-                Employee_LName:  data.lastName,
-                Employee_Email: data.email,
-                Employee_Name:  data.firstName +' '+ data.lastName,
-                Time_Format: "12",
-                isDeleted: false,
-                isActive: true,
-                isOnline: false,
-                isEmailVerified: data.isInvitation,
-            }
-            if (data.isProductOwner) {
-                obj.isProductOwner = data.isProductOwner;
-            }
-            let object = {
-                type: dbCollections.USERS,
-                data: obj
-            }
-            try {
-                ctr.insertAuthFun({email: data.email, password: data.password}, (iUserRes) => {
-                    if (iUserRes.status) {
-                        object.data._id = iUserRes.data._id;
-                        mongoRef.MongoDbCrudOpration('global',object,'save').then((res)=>{
-                            resolve({status: true, statusText: res})
-                        }).catch((error)=>{
-                            reject(error)
-                        })
-                        return;
-                    }
-                    reject(iUserRes.message);
-                });
-            } catch (error) {
-                reject(error)
-            }
-        } catch (error) {
-            reject(error);
-        }
-    })
-}
+const REGISTRANT_FIELDS = ['firstName', 'lastName', 'email', 'password', 'assignCompany', 'isInvitation'];
+const REQUIRED_SIGNUP_FIELDS = [['firstName', 'First Name'], ['lastName', 'Last Name'], ['email', 'Email'], ['password', 'Password']];
 
+/* A signup never copies ownership, verification, billing or token fields from the request:
+ * isProductOwner alone opens the Instance console. Setup grants it in its own update. */
+exports.registrantFields = (body) => REGISTRANT_FIELDS.reduce((picked, field) => {
+    if (body && Object.prototype.hasOwnProperty.call(body, field)) picked[field] = body[field];
+    return picked;
+}, {});
 
-/**
- * Create User API
- * @param {Objcet} req
- * @param {Object} res
- * @returns
- */
-exports.createUserV2 = (req,res) => {
+exports.buildUserDocument = ({ firstName, lastName, email, assignCompany, isInvitation }) => ({
+    AssignCompany: assignCompany ? [assignCompany] : [],
+    Employee_FName: firstName,
+    Employee_LName: lastName,
+    Employee_Email: email,
+    Employee_Name: `${firstName} ${lastName}`,
+    Time_Format: "12",
+    isDeleted: false,
+    isActive: true,
+    isOnline: false,
+    isEmailVerified: Boolean(isInvitation),
+});
+
+exports.addUserMongodbV2 = (data) => new Promise((resolve, reject) => {
+    const object = { type: dbCollections.USERS, data: exports.buildUserDocument(data) };
+    ctr.insertAuthFun({ email: data.email, password: data.password }, (iUserRes) => {
+        if (!iUserRes.status) return reject(iUserRes.message);
+        object.data._id = iUserRes.data._id;
+        mongoRef.MongoDbCrudOpration(dbCollections.GLOBAL, object, 'save')
+            .then((res) => resolve({ status: true, statusText: res }))
+            .catch(reject);
+    });
+});
+
+const isFilledString = (value) => typeof value === 'string' && value.trim() !== '';
+
+exports.createUserV2 = (req, res) => {
     try {
-        if (!(req.body && req.body.firstName)) {
-            res.send({
-                status: false,
-                statusText: `First Name is required`
-            })
+        const registrant = exports.registrantFields(req.body);
+        const missing = REQUIRED_SIGNUP_FIELDS.find(([field]) => !isFilledString(registrant[field]));
+        if (missing) {
+            return res.send({ status: false, statusText: `${missing[1]} is required` });
         }
-        if (!(req.body && req.body.lastName)) {
-            res.send({
-                status: false,
-                statusText: `Last Name is required`
-            })
-        }
-        if (!(req.body && req.body.email)) {
-            res.send({
-                status: false,
-                statusText: `Email is required`
-            })
-        }
-        if (!(req.body && req.body.password)) {
-            res.send({
-                status: false,
-                statusText: `Password is required`
-            })
-        }
-        // CALL VALIDATE LICENCE FUNCTION HERE...............
-        let admitted = req.body;
-        exports.admitInvitee(req.body).then((body) => {
+        let admitted = registrant;
+        exports.admitInvitee(registrant).then((body) => {
             admitted = body;
             return exports.addUserMongodbV2(body);
-        }).then((respo)=>{
+        }).then((respo) => {
             if (!admitted.isInvitation) {
-                sendMailRef.sendVerificationEmailPromise(respo.statusText._id,respo.statusText.Employee_Email).catch((error)=>{
+                sendMailRef.sendVerificationEmailPromise(respo.statusText._id, respo.statusText.Employee_Email).catch((error) => {
                     logger.error(error.statusText);
-                })
-            }
-            try {
-                // if (process.env.PAYMENTMETHOD) {
-                //     paymentRef.createCustomerInPayment(respo.statusText._id).then(() => {
-                //         res.send(respo);
-                //     }).catch((error)=>{
-                //         logger.error(`Error create customer chargbee: ${error}`);
-                //         res.send({
-                //             status: false,
-                //             statusText: error
-                //         });
-                //     });
-                // } else {
-                //     res.send(respo);
-                // }
-                res.send(respo);
-            } catch (error) {
-                logger.error(`Error create customer In Payment: ${error}`);
-                res.send({
-                    status: false,
-                    statusText: error.message || error
                 });
             }
-            // res.send(respo);
-        }).catch((error)=>{
+            res.send(respo);
+        }).catch((error) => {
             res.send({
                 status: false,
                 statusText: error
-            })
-        })
+            });
+        });
     } catch (error) {
         res.send({
             status: false,
             statusText: `Error: ${error}`
-        })
+        });
     }
 }
 

--- a/Modules/Setup/createCompany.js
+++ b/Modules/Setup/createCompany.js
@@ -21,13 +21,14 @@ const importSettings = (payload) => new Promise((resolve, reject) => {
 });
 
 async function createOwner({ firstName, lastName, email, password }) {
-    const created = await createUserRef.addUserMongodbV2({ firstName, lastName, email, password, isInvitation: false, isProductOwner: true });
+    const created = await createUserRef.addUserMongodbV2({ firstName, lastName, email, password, isInvitation: false });
     const ownerId = String(created.statusText._id);
     // The person running setup is the operator and mail is rarely configured yet, so the
     // verification gate in generateTokenV2Fun would lock them out of the account they just made.
+    // Instance ownership is granted only here; the shared signup insert never writes it.
     await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
         type: dbCollections.USERS,
-        data: [{ _id: ownerId }, { $set: { isEmailVerified: true, verificationToken: '' } }],
+        data: [{ _id: ownerId }, { $set: { isProductOwner: true, isEmailVerified: true, verificationToken: '' } }],
     }, 'findOneAndUpdate');
     return ownerId;
 }

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -140,7 +140,7 @@ Backend variables: 149. Frontend build-time variables: 23.
 | Variable | Required | Default | Description | Read by |
 |---|---|---|---|---|
 | `FREE_COMPANY_COUNT` |  |  | Companies a user may create on the free plan. | `Modules/Company/controller.js` |
-| `PAYMENTMETHOD` |  |  | Payment provider used at sign-up (chargebee or paddle). | `Modules/Auth/controller/createUser.js`, `Modules/Company/controller.js` |
+| `PAYMENTMETHOD` |  |  | Payment provider used at sign-up (chargebee or paddle). | `Modules/Company/controller.js` |
 
 ## Security
 
@@ -243,7 +243,7 @@ Backend variables: 149. Frontend build-time variables: 23.
 | `ERRORRECIVEREMAIL` |  | `admin@yourdomain.com` | Email to receive error alerts | `Config/config.js` |
 | `HEALTH_DB_TIMEOUT_MS` |  |  | How long /health waits for the database ping before reporting it down (default 2000). | `Modules/Instance/health.js` |
 | `MIGRATIONS_AUTO` |  |  | Apply pending migrations at boot (default true; false only reports them). | `Modules/Instance/controller.js` |
-| `MONGODB_URL` | yes |  | mongo connection string (no trailing slash) | `Config/config.js`, `Modules/AICore/persistence.js` +7 |
+| `MONGODB_URL` | yes |  | mongo connection string (no trailing slash) | `Config/config.js`, `Modules/AICore/persistence.js` +8 |
 | `NODEMAILER_EMAIL_PASSWORD` (secret) |  |  | Use app password for Gmail | `Config/config.js` |
 | `NODEMAILER_PORT` |  | `587` | 587 (STARTTLS) or 465 (SSL) | `Config/config.js` |
 | `NOOFPRESETCOMPANY` |  | `10` | Number of preset companies seeded at first run. | `Config/config.js` |

--- a/scripts/audit-product-owners.js
+++ b/scripts/audit-product-owners.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/* node scripts/audit-product-owners.js
+ * Read-only. Lists every account holding users.isProductOwner, the flag the Instance console
+ * trusts. Signup used to copy it from the request body, so any account here other than the one
+ * that ran the setup wizard needs a manual review. Nothing is written. */
+const path = require('path');
+
+require('../Config/applyEnv').loadDotEnv(path.join(__dirname, '..', '.env'));
+
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+
+const createdAt = (id) => new Date(parseInt(String(id).slice(0, 8), 16) * 1000).toISOString();
+
+async function main() {
+    if (!process.env.MONGODB_URL) throw new Error('MONGODB_URL is not set.');
+    const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+    const findUsers = (filter, projection, options) => MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+        type: SCHEMA_TYPE.USERS,
+        data: [filter, projection, { lean: true, ...options }],
+    }, 'find');
+
+    const [firstAccount] = await findUsers({}, { _id: 1 }, { sort: { _id: 1 }, limit: 1 });
+    const owners = await findUsers(
+        { isProductOwner: true },
+        { Employee_Email: 1, Employee_Name: 1, isEmailVerified: 1, isActive: 1, isDeleted: 1, AssignCompany: 1 },
+        { sort: { _id: 1 } },
+    );
+    const isFirst = (user) => Boolean(firstAccount) && String(firstAccount._id) === String(user._id);
+
+    console.log(`Accounts with isProductOwner: ${owners.length}`);
+    owners.forEach((user) => {
+        const active = user.isActive !== false && user.isDeleted !== true;
+        const note = isFirst(user) ? '  (first account on this instance: the setup wizard)' : '  REVIEW';
+        console.log(`  ${user._id}  created ${createdAt(user._id)}  ${user.Employee_Email || '-'}  verified=${Boolean(user.isEmailVerified)}  active=${active}  companies=${(user.AssignCompany || []).length}${note}`);
+    });
+
+    const toReview = owners.filter((user) => !isFirst(user)).length;
+    if (toReview) {
+        console.log(`\n${toReview} account(s) marked REVIEW did not run the setup wizard. If one is not a legitimate instance owner,`);
+        console.log('remove the flag in the "global" database and end its sessions, e.g. in mongosh:');
+        console.log('  db.users.updateOne({ _id: ObjectId("<id>") }, { $unset: { isProductOwner: "" } })');
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(`audit-product-owners: ${error.message || error}`);
+        process.exit(1);
+    });

--- a/tests/integration/signup-ownership.int.test.js
+++ b/tests/integration/signup-ownership.int.test.js
@@ -1,0 +1,96 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { emailFor, login, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anonymous = createApiClient({ baseURL: state.baseURL });
+const GRANTS = { isProductOwner: true, isVesionUpdate: true, customerId: 'cus_signup', customerIds: ['cus_signup'], webTokens: ['x'], agentAccount: { mode: 'x' } };
+
+const expectNoGrants = (doc) => {
+    ['isProductOwner', 'isVesionUpdate', 'customerId', 'agentAccount'].forEach((field) => expect([field, doc[field]]).toEqual([field, undefined]));
+    expect(doc.customerIds || []).toEqual([]);
+    expect(doc.webTokens || []).toEqual([]);
+};
+
+/* One login per role per file: the refresh token is derived from the second a session starts. */
+let ownerSession;
+const owner = async () => {
+    if (!ownerSession) ownerSession = await loginAs('owner');
+    return ownerSession;
+};
+
+const sessionFor = async (email) => {
+    const session = await login(state.baseURL, email);
+    return createApiClient({ baseURL: state.baseURL, accessToken: session.accessToken, companyId: state.companyId });
+};
+
+describe('a signup request never grants instance ownership', () => {
+    it('drops ownership, billing and token fields from an anonymous signup', async () => {
+        const email = `signup.stranger.${uniqueSuffix()}@e2e.alianhub.test`;
+        const res = await anonymous.post('/api/v2/createUser', { firstName: 'Sam', lastName: 'Stranger', email, password: state.password, ...GRANTS });
+
+        expect(res.body.status).toBe(true);
+        expectNoGrants(res.body.statusText);
+        expect(res.body.statusText.isEmailVerified).toBe(false);
+    });
+
+    it('keeps an invitee who asks for ownership out of the instance console', async () => {
+        const { api: ownerApi } = await owner();
+        const email = emailFor('member', `own${uniqueSuffix()}`);
+        const invite = await ownerApi.post('/api/v2/sendInvitationEmail', { email, companyId: state.companyId, companyName: 'E2E Workspace', role: 3, designation: 0 });
+        expect(invite.status).toBe(200);
+
+        const created = await anonymous.post('/api/v2/createUser', {
+            firstName: 'Ivy', lastName: 'Invitee', email, password: state.password, isInvitation: true, assignCompany: state.companyId, ...GRANTS,
+        });
+        expect(created.body.status).toBe(true);
+        expect(created.body.statusText.isEmailVerified).toBe(true);
+
+        const invitee = await sessionFor(email);
+        const access = await invitee.get('/api/v2/instance/access');
+        expect(access.status).toBe(403);
+        const settings = await invitee.get('/api/v2/instance/settings');
+        expect(settings.status).toBe(403);
+        expectNoGrants(created.body.statusText);
+        const check = await invitee.post('/api/v1/userAndCompanyCheck', {});
+        expect(check.body.data.userData.isProductOwner).toBeUndefined();
+    });
+
+    it.each([
+        ['/api/v2/google-signup', 'googleId'],
+        ['/api/v2/github-signup', 'githubId'],
+        ['/api/v2/gitlab-signup', 'gitlabId'],
+    ])('drops ownership from %s', async (path, idField) => {
+        const suffix = uniqueSuffix();
+        const res = await anonymous.post(path, {
+            firstName: 'Olly', lastName: 'Oauth', email: `signup.oauth.${suffix}@e2e.alianhub.test`, [idField]: `id-${suffix}`, ...GRANTS,
+        });
+
+        expect(res.status).toBe(200);
+        expectNoGrants(res.body.data);
+    });
+});
+
+describe('the setup wizard still creates the instance owner', () => {
+    it('lets the account that ran setup into the instance console', async () => {
+        const { api, uid } = await owner();
+        expect(uid).toBe(state.users.owner.userId);
+
+        const access = await api.get('/api/v2/instance/access');
+        expect(access.status).toBe(200);
+        expect(access.body.data).toEqual({ allowed: true, via: 'owner' });
+
+        const check = await api.post('/api/v1/userAndCompanyCheck', {});
+        expect(check.body.data.userData.isProductOwner).toBe(true);
+    });
+
+    it('refuses a second run of the wizard, so it cannot mint another owner', async () => {
+        const email = `setup.again.${uniqueSuffix()}@e2e.alianhub.test`;
+        const res = await anonymous.post('/api/v2/setup/complete', {
+            firstName: 'Second', lastName: 'Owner', email, password: state.password, companyName: `Again ${uniqueSuffix()}`, sampleData: false,
+        });
+
+        expect(res.status).toBe(409);
+        const signIn = await anonymous.post('/api/v2/auth/login', { email, password: state.password });
+        expect(signIn.body.accessToken).toBeUndefined();
+    });
+});

--- a/tests/signup-user-document.test.js
+++ b/tests/signup-user-document.test.js
@@ -1,0 +1,153 @@
+process.env.STORAGE_TYPE = process.env.STORAGE_TYPE || 'server';
+
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
+jest.mock('../utils/data', () => ({ importUserNotifications: jest.fn(async () => undefined) }));
+jest.mock('../Modules/Auth/controller', () => ({ addAndRemoveUserInMongodbNotificationCount: jest.fn(async () => undefined), insertAuthFun: jest.fn() }));
+jest.mock('../Modules/Auth/controller/sendVerificationMail', () => ({ sendVerificationEmailPromise: jest.fn(async () => undefined) }));
+jest.mock('../Modules/notification/defaults', () => ({ ensureNotificationDefaults: jest.fn() }));
+jest.mock('../Modules/ImportSettings/controller', () => ({ importSettingsFunction: jest.fn() }));
+jest.mock('../Modules/Company/controller/updateCompany', () => ({ updateCompanyFun: jest.fn() }));
+jest.mock('../Modules/Users/controller', () => ({ updateUserFun: jest.fn() }));
+jest.mock('../Modules/Affiliate/controller', () => ({ storeRefferalCode: jest.fn() }));
+jest.mock('../Modules/Setup/demoProject', () => ({ createDemoProject: jest.fn() }));
+jest.mock('../common-storage/common-server.js', () => ({ handleCreateCompanyDataStorageFun: jest.fn() }));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { insertAuthFun } = require('../Modules/Auth/controller');
+const createUser = require('../Modules/Auth/controller/createUser');
+const { createOwner } = require('../Modules/Setup/createCompany');
+
+const USER_ID = '6f0000000000000000000001';
+const COMPANY = '6f0000000000000000000c01';
+const USER_DOCUMENT_FIELDS = ['AssignCompany', 'Employee_Email', 'Employee_FName', 'Employee_LName', 'Employee_Name', 'Time_Format', 'isActive', 'isDeleted', 'isEmailVerified', 'isOnline'];
+const PRIVILEGED = {
+    isProductOwner: true,
+    isEmailVerified: true,
+    isVesionUpdate: true,
+    AssignCompany: [COMPANY],
+    customerId: 'cus_x',
+    customerIds: ['cus_x'],
+    webTokens: ['token'],
+    verificationToken: 'token',
+    forgotPasswordToken: 'token',
+    agentAccount: { mode: 'x' },
+    demo: true,
+    _id: '6f00000000000000000000ff',
+};
+
+const response = () => {
+    const res = { statusCode: 200, body: undefined };
+    res.status = jest.fn((code) => { res.statusCode = code; return res; });
+    res.json = jest.fn((body) => { res.body = body; return res; });
+    res.send = jest.fn((body) => { res.body = body; return res; });
+    return res;
+};
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+const savedUsers = () => MongoDbCrudOpration.mock.calls.filter(([, query, method]) => method === 'save' && query.type === 'users').map(([, query]) => query.data);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    insertAuthFun.mockImplementation((data, cb) => cb({ status: true, data: { ...data, _id: USER_ID } }));
+    MongoDbCrudOpration.mockImplementation(async (db, query, method) => (method === 'save' ? { ...query.data, _id: query.data._id || USER_ID } : null));
+});
+
+describe('buildUserDocument', () => {
+    it('writes only the profile a registrant may set', () => {
+        const doc = createUser.buildUserDocument({ firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.com', password: 'secret', ...PRIVILEGED, assignCompany: '', isInvitation: false });
+
+        expect(Object.keys(doc).sort()).toEqual(USER_DOCUMENT_FIELDS);
+        expect(doc).toMatchObject({ AssignCompany: [], Employee_Name: 'Ada Lovelace', isEmailVerified: false, isActive: true, isDeleted: false });
+    });
+
+    it('marks an admitted invitee verified in the invited company', () => {
+        const doc = createUser.buildUserDocument({ firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.com', assignCompany: COMPANY, isInvitation: true });
+        expect(doc).toMatchObject({ AssignCompany: [COMPANY], isEmailVerified: true });
+    });
+});
+
+describe('registrantFields', () => {
+    it('keeps the signup form fields and nothing else', () => {
+        const picked = createUser.registrantFields({ firstName: 'Ada', lastName: 'L', email: 'a@b.c', password: 'p', assignCompany: COMPANY, isInvitation: true, ...PRIVILEGED });
+        expect(Object.keys(picked).sort()).toEqual(['assignCompany', 'email', 'firstName', 'isInvitation', 'lastName', 'password']);
+    });
+
+    it('ignores inherited properties', () => {
+        const body = Object.create({ isProductOwner: true, firstName: 'Inherited' });
+        body.email = 'a@b.c';
+        expect(createUser.registrantFields(body)).toEqual({ email: 'a@b.c' });
+    });
+});
+
+describe('addUserMongodbV2', () => {
+    it('never stores ownership even when a caller passes it', async () => {
+        await createUser.addUserMongodbV2({ firstName: 'Ada', lastName: 'L', email: 'a@b.c', password: 'p', isInvitation: false, ...PRIVILEGED });
+
+        const [doc] = savedUsers();
+        expect(Object.keys(doc).sort()).toEqual([...USER_DOCUMENT_FIELDS, '_id'].sort());
+        expect(String(doc._id)).toBe(USER_ID);
+        expect(insertAuthFun.mock.calls[0][0]).toEqual({ email: 'a@b.c', password: 'p' });
+    });
+});
+
+describe('POST /api/v2/createUser', () => {
+    it('saves an anonymous signup without ownership, verification or billing fields', async () => {
+        const res = response();
+        createUser.createUserV2({ body: { firstName: 'Ada', lastName: 'L', email: 'a@b.c', password: 'p', ...PRIVILEGED } }, res);
+        await settle();
+
+        expect(res.body.status).toBe(true);
+        const [doc] = savedUsers();
+        expect(doc.isProductOwner).toBeUndefined();
+        expect(doc.isEmailVerified).toBe(false);
+        expect(doc.AssignCompany).toEqual([]);
+        expect(Object.keys(doc).sort()).toEqual([...USER_DOCUMENT_FIELDS, '_id'].sort());
+    });
+
+    it.each([
+        ['firstName', { lastName: 'L', email: 'a@b.c', password: 'p' }],
+        ['lastName', { firstName: 'A', email: 'a@b.c', password: 'p' }],
+        ['email', { firstName: 'A', lastName: 'L', email: { $ne: null }, password: 'p' }],
+        ['password', { firstName: 'A', lastName: 'L', email: 'a@b.c' }],
+    ])('answers once and creates nothing without a valid %s', async (field, body) => {
+        const res = response();
+        createUser.createUserV2({ body }, res);
+        await settle();
+
+        expect(res.send).toHaveBeenCalledTimes(1);
+        expect(res.body.status).toBe(false);
+        expect(insertAuthFun).not.toHaveBeenCalled();
+        expect(savedUsers()).toEqual([]);
+    });
+});
+
+describe.each([
+    ['googleSignup', 'googleId'],
+    ['githubSignup', 'githubId'],
+    ['gitlabSignup', 'gitlabId'],
+])('%s', (handler, idField) => {
+    it('saves the user without ownership fields from the body', async () => {
+        const res = response();
+        await createUser[handler]({ body: { firstName: 'Ada', lastName: 'L', email: 'a@b.c', [idField]: 'provider-id', ...PRIVILEGED } }, res);
+
+        expect(res.statusCode).toBe(200);
+        const [doc] = savedUsers();
+        expect(doc.isProductOwner).toBeUndefined();
+        expect(Object.keys(doc).sort()).toEqual([...USER_DOCUMENT_FIELDS, '_id'].sort());
+        const authSave = MongoDbCrudOpration.mock.calls.find(([, query, method]) => method === 'save' && query.type !== 'users');
+        expect(Object.keys(authSave[1].data).sort()).toEqual(['email', 'isBlocked', idField].sort());
+    });
+});
+
+describe('setup createOwner', () => {
+    it('grants ownership in its own update after the shared insert', async () => {
+        const ownerId = await createOwner({ firstName: 'Olivia', lastName: 'Owner', email: 'owner@example.com', password: 'p' });
+
+        expect(ownerId).toBe(USER_ID);
+        const [doc] = savedUsers();
+        expect(doc.isProductOwner).toBeUndefined();
+        const update = MongoDbCrudOpration.mock.calls.find(([, , method]) => method === 'findOneAndUpdate');
+        expect(update[1].data[0]).toEqual({ _id: USER_ID });
+        expect(update[1].data[1].$set).toMatchObject({ isProductOwner: true, isEmailVerified: true });
+    });
+});


### PR DESCRIPTION
## Summary

| Finding | Where | Fix | Test |
|---|---|---|---|
| Signup stored `isProductOwner` from the request body, and `requireInstanceAdmin` trusts that flag, so a registrant could reach instance-owner-only routes | `Modules/Auth/controller/createUser.js` (`addUserMongodbV2`, `POST /api/v2/createUser`) | The users insert is built by `buildUserDocument` from an allowlist of profile fields; `createUserV2` keeps only the form fields (`registrantFields`) before anything else runs | `tests/signup-user-document.test.js`; `tests/integration/signup-ownership.int.test.js` |
| `addUserMongodbV2` accepted an ownership flag from any caller | same | The shared insert never writes `isProductOwner`; the setup wizard sets it in its own update after the insert (`Modules/Setup/createCompany.js` `createOwner`), which no request body reaches | unit: `createOwner` grants it only in the update; integration: the setup owner still gets `GET /api/v2/instance/access` 200 |
| `createUserV2` sent a "required" response and kept going, creating the user anyway | `createUser.js` | Returns after the first missing or non-string field | unit: one response, nothing created |
| Google / GitHub / GitLab signup | `createUser.js` | Already built an explicit document; now covered by tests | unit + integration: ownership fields in the body are not stored |

Checked and unchanged: `PUT /api/v1/user` already goes through the `SELF_WRITABLE` allowlist, SSO JIT provisioning builds an explicit document, and the demo seeder calls `addUserMongodbV2` without ownership.

## Notes

- **Upgrade step.** Accounts that already hold `isProductOwner` from a signup are not changed by this fix. After deploying, run `node scripts/audit-product-owners.js` (reads `MONGODB_URL`). It lists every account with the flag, marks the first account on the instance (the one that ran the setup wizard), and marks every other one `REVIEW`. It writes nothing; the owner decides which flags to remove.
- The setup wizard still creates the instance owner: the integration harness runs `POST /api/v2/setup/complete` and the new suite asserts that account passes `requireInstanceAdmin`, and that a second wizard run is refused.
- `docs/ENV.md` is regenerated: the new script reads `MONGODB_URL`, and removing a commented-out payment block dropped `createUser.js` from the `PAYMENTMETHOD` readers.

## Test plan

- [x] Reproduced before the fix: the new integration test failed because an account created through signup passed `requireInstanceAdmin` (`GET /api/v2/instance/access` answered 200, expected 403)
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 249 suites, 3415 tests passed
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed
- [x] `E2E_MONGODB_URL=... npx jest --selectProjects integration --runInBand` on `signup-ownership`, `smoke`, `user-and-company-check`, `public-routes`, `instance`: 5 suites, 225 tests passed (the harness runs the setup wizard)
- [x] `node scripts/audit-product-owners.js` against the test database: before the fix it listed the two accounts the repro made owners as `REVIEW`; after the fix it listed only the setup owner
- [x] `npm run i18n:check`: exit 0 (no frontend changes)
- [x] eslint on every touched file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
