### PR TITLE
fix(auth): return only a self view from login, token and signup responses

### DIFF
--- a/Modules/Auth/controller/authHelpers.js
+++ b/Modules/Auth/controller/authHelpers.js
@@ -12,6 +12,7 @@ const sesstionCtr = require("../session.js");
 const mongoose = require("mongoose");
 const { removeCache } = require("../../../utils/commonFunctions.js");
 const { updateUserFun } = require("../../Users/controller.js");
+const { toAuthView } = require("../../Users/helpers/userAccessRules");
 
 
 
@@ -88,7 +89,7 @@ exports.generateTokenV2Fun = (uid, refreshToken, cb) => {
                     status: false,
                     isLogout: true,
                     isEmailVerified: false,
-                    userData: response ?? null,
+                    userData: toAuthView(response),
                     message: 'Email is not verified.',
                 });
                 return;

--- a/Modules/Auth/controller/createUser.js
+++ b/Modules/Auth/controller/createUser.js
@@ -7,6 +7,7 @@ const { SCHEMA_TYPE } = require("../../../Config/schemaType");
 const mongoose = require("mongoose");
 const { importUserNotifications } = require("../../../utils/data");
 const { addAndRemoveUserInMongodbNotificationCount } = require("../../Auth/controller");
+const { toAuthView } = require("../../Users/helpers/userAccessRules");
 
 
 exports.authenticateToken = "";
@@ -62,7 +63,7 @@ exports.addUserMongodbV2 = (data) => new Promise((resolve, reject) => {
         if (!iUserRes.status) return reject(iUserRes.message);
         object.data._id = iUserRes.data._id;
         mongoRef.MongoDbCrudOpration(dbCollections.GLOBAL, object, 'save')
-            .then((res) => resolve({ status: true, statusText: res }))
+            .then((res) => resolve({ status: true, statusText: toAuthView(res) }))
             .catch(reject);
     });
 });
@@ -207,7 +208,7 @@ exports.googleSignup = async (req, res) => {
         return res.status(200).json({
             status: true,
             message: "Google signup successful",
-            data: userRes,
+            data: toAuthView(userRes),
         });
     } catch (error) {
         logger.error(`Google Signup API Error: ${error.message}`);
@@ -317,7 +318,7 @@ exports.githubSignup = async (req, res) => {
         return res.status(200).json({
             status: true,
             message: "Github signup successful",
-            data: userRes,
+            data: toAuthView(userRes),
         });
     } catch (error) {
         logger.error(`Github Signup API Error: ${error.message}`);
@@ -427,7 +428,7 @@ exports.gitlabSignup = async (req, res) => {
         return res.status(200).json({
             status: true,
             message: "Gitlab signup successful",
-            data: userRes,
+            data: toAuthView(userRes),
         });
     } catch (error) {
         logger.error(`Gitlab Signup API Error: ${error.message}`);

--- a/Modules/Users/helpers/userAccessRules.js
+++ b/Modules/Users/helpers/userAccessRules.js
@@ -11,6 +11,14 @@ const SELF_FIELDS = [
     'isEmailVerified', 'isProductOwner', 'tour', 'lastSelectedCompany', 'customerId', 'customerIds',
     'homeChecklist', 'localePreferences', 'agentAccount', 'demo',
 ];
+// What a pre-authentication answer may carry: the sign-in, OAuth and sign-up screens read
+// these, and the caller is only as trusted as the password or invite they arrived with, so
+// the billing and ownership fields of the self view stay out of it.
+const AUTH_FIELDS = [
+    '_id', 'Employee_Email', 'Employee_FName', 'Employee_LName', 'Employee_Name',
+    'Employee_profileImage', 'Employee_profileImageURL', 'Time_Format', 'Time_Zone',
+    'isActive', 'isEmailVerified', 'AssignCompany', 'languageCode', 'createdAt', 'updatedAt',
+];
 const SELF_WRITABLE = [
     'isOnline', 'lastActive', 'lastSelectedCompany', 'tour', 'homeChecklist', 'presence', 'languageCode',
     'localePreferences', 'updatedAt', 'Employee_FName', 'Employee_LName', 'Employee_Name',
@@ -32,6 +40,8 @@ const pick = (doc, fields) => {
 };
 
 const toSelfView = (doc) => pick(doc, SELF_FIELDS);
+
+const toAuthView = (doc) => (doc ? pick(doc, AUTH_FIELDS) : null);
 
 const toMemberView = (doc, sharedCompanyIds) => {
     const view = pick(doc, MEMBER_FIELDS);
@@ -120,9 +130,11 @@ const sanitizeUpdateOptions = (options) => (options && options.returnDocument ==
 module.exports = {
     MEMBER_FIELDS,
     SELF_FIELDS,
+    AUTH_FIELDS,
     SELF_WRITABLE,
     isObjectId,
     toSelfView,
+    toAuthView,
     toMemberView,
     sharedCompanies,
     sanitizeUserQuery,

--- a/tests/auth-response-self-view.test.js
+++ b/tests/auth-response-self-view.test.js
@@ -1,0 +1,167 @@
+process.env.JWT_SECRET = 'auth-response-self-view-secret';
+process.env.JWT_ALGORITHM = 'HS256';
+process.env.JWT_EXP = '24h';
+process.env.STORAGE_TYPE = process.env.STORAGE_TYPE || 'server';
+
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...args) => mockDb.crud(...args) }));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../Modules/service.js', () => ({ SendEmail: jest.fn((subject, mail, to, flag, cb) => cb({ status: true })) }));
+jest.mock('../utils/data', () => ({ importUserNotifications: jest.fn(async () => undefined) }));
+
+const bcrypt = require('bcrypt');
+const { dbCollections } = require('../Config/collections');
+const rules = require('../Modules/Users/helpers/userAccessRules');
+const loginSession = require('../Modules/Auth/controller/loginSession');
+const sessionCtr = require('../Modules/Auth/session');
+const { generateTokenV2Fun } = require('../Modules/Auth/controller/authHelpers');
+const createUser = require('../Modules/Auth/controller/createUser');
+
+const UNVERIFIED = '6f00000000000000000000a1';
+const COMPANY = '6f0000000000000000000c01';
+const EMAIL = 'unverified@example.test';
+const PASSWORD = 'Sup3r-Secret!';
+
+const SECRETS = {
+    verificationToken: 'verify-secret',
+    verificationTokenTime: new Date(),
+    webTokens: ['push-secret'],
+    forgotPasswordToken: 'reset-secret',
+    forgotPasswordTokenTime: new Date(),
+    customerId: 'cus_secret',
+    customerIds: ['cus_secret'],
+    isProductOwner: true,
+};
+const SECRET_FIELDS = Object.keys(SECRETS).concat('passwordHash');
+const exposesSecret = (body) => SECRET_FIELDS.some((field) => JSON.stringify(body || {}).includes(`"${field}"`));
+
+const response = () => {
+    const res = { statusCode: 200, body: undefined, cookies: {} };
+    res.done = new Promise((resolve) => { res.finish = resolve; });
+    res.status = (code) => { res.statusCode = code; return res; };
+    res.json = (body) => { res.body = body; res.finish(body); return res; };
+    res.send = (body) => { res.body = body; res.finish(body); return res; };
+    res.cookie = (name, value) => { res.cookies[name] = value; return res; };
+    res.clearCookie = (name) => { res.cookies[name] = null; return res; };
+    return res;
+};
+
+const seedUnverified = () => {
+    mockDb.seed(dbCollections.USERS, {
+        _id: UNVERIFIED,
+        Employee_Email: EMAIL,
+        Employee_FName: 'Una',
+        Employee_LName: 'Verified',
+        Employee_Name: 'Una Verified',
+        AssignCompany: [COMPANY],
+        isActive: true,
+        isEmailVerified: false,
+        ...SECRETS,
+    });
+    mockDb.seed(dbCollections.USER_AUTH, {
+        _id: UNVERIFIED,
+        email: EMAIL,
+        passwordHash: bcrypt.hashSync(UNVERIFIED + PASSWORD, 10),
+    });
+};
+
+const issueSession = (userId) => new Promise((resolve, reject) => {
+    sessionCtr.insertSessionFun({ userId }, 'jest', '127.0.0.1', (out) => (out.status ? resolve(out.data) : reject(new Error(out.message))));
+});
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((type) => { mockDb.store[type] = []; });
+    mockDb.crud.mockClear();
+});
+
+describe('the auth view', () => {
+    it('keeps what the login, OAuth and signup screens read', () => {
+        const view = rules.toAuthView({ _id: UNVERIFIED, Employee_Email: EMAIL, Employee_Name: 'Una Verified', AssignCompany: [COMPANY], isEmailVerified: false, ...SECRETS });
+        expect(view).toMatchObject({ _id: UNVERIFIED, Employee_Email: EMAIL, Employee_Name: 'Una Verified', AssignCompany: [COMPANY], isEmailVerified: false });
+    });
+
+    it('drops every secret, billing and ownership field', () => {
+        expect(exposesSecret(rules.toAuthView({ _id: UNVERIFIED, ...SECRETS }))).toBe(false);
+    });
+
+    it('stays a subset of the self view', () => {
+        expect(rules.AUTH_FIELDS.filter((field) => !rules.SELF_FIELDS.includes(field))).toEqual([]);
+    });
+
+    it('answers null for a missing account', () => {
+        expect(rules.toAuthView(null)).toBeNull();
+    });
+});
+
+describe('POST /api/v2/auth/login for an unverified account', () => {
+    it('refuses without handing over the verification token', async () => {
+        seedUnverified();
+        const req = { headers: { 'user-agent': 'jest' }, ip: '127.0.0.1', body: { email: EMAIL, password: PASSWORD } };
+        const res = response();
+        loginSession.loginAuth(req, res, () => res.status(400).json(req.errorMessageObject));
+        await res.done;
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toMatchObject({ status: false, isEmailVerified: false });
+        expect(res.body.userData).toMatchObject({ _id: UNVERIFIED, Employee_Email: EMAIL, isEmailVerified: false, AssignCompany: [COMPANY] });
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+});
+
+describe('generateTokenV2Fun', () => {
+    it('sends only the auth view to the caller it turns away', async () => {
+        seedUnverified();
+        const { refreshToken } = await issueSession(UNVERIFIED);
+        const out = await new Promise((resolve) => generateTokenV2Fun(UNVERIFIED, refreshToken, resolve));
+
+        expect(out.status).toBe(false);
+        expect(out.userData).toEqual(rules.toAuthView(mockDb.store[dbCollections.USERS][0]));
+        expect(exposesSecret(out)).toBe(false);
+    });
+});
+
+describe('POST /api/v2/generateToken', () => {
+    it('refuses an unverified account without leaking its verification token', async () => {
+        seedUnverified();
+        const { refreshToken } = await issueSession(UNVERIFIED);
+        const res = response();
+        await loginSession.generateTokenV2({ headers: { 'refresh-token': refreshToken }, body: { uid: UNVERIFIED } }, res);
+        await res.done;
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body.isEmailVerified).toBe(false);
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+});
+
+describe('POST /api/v2/createUser', () => {
+    it('answers the registrant with a self view only', async () => {
+        const res = response();
+        createUser.createUserV2({ body: { firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.test', password: PASSWORD, ...SECRETS } }, res);
+        await res.done;
+
+        expect(res.body.status).toBe(true);
+        expect(res.body.statusText).toMatchObject({ Employee_Email: 'ada@example.test', Employee_Name: 'Ada Lovelace', isEmailVerified: false });
+        expect(String(res.body.statusText._id)).toBe(String(mockDb.store[dbCollections.USERS][0]._id));
+        expect(Object.keys(res.body.statusText).filter((field) => !rules.AUTH_FIELDS.includes(field))).toEqual([]);
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+});
+
+describe.each([
+    ['googleSignup', 'googleId'],
+    ['githubSignup', 'githubId'],
+    ['gitlabSignup', 'gitlabId'],
+])('POST /api/v2/%s', (handler, idField) => {
+    it('answers the registrant with a self view only', async () => {
+        const res = response();
+        await createUser[handler]({ body: { firstName: 'Ada', lastName: 'Lovelace', email: `${idField}@example.test`, [idField]: 'provider-id', ...SECRETS } }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data).toMatchObject({ Employee_Email: `${idField}@example.test`, isEmailVerified: true });
+        expect(res.body.data._id).toBeDefined();
+        expect(Object.keys(res.body.data).filter((field) => !rules.AUTH_FIELDS.includes(field))).toEqual([]);
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+});

--- a/tests/integration/auth-response-self-view.int.test.js
+++ b/tests/integration/auth-response-self-view.int.test.js
@@ -1,0 +1,69 @@
+const { createApiClient } = require('../../e2e/support/api');
+const { readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anon = createApiClient({ baseURL: state.baseURL });
+const SECRET_FIELDS = ['webTokens', 'verificationToken', 'verificationTokenTime', 'forgotPasswordToken', 'forgotPasswordTokenTime', 'passwordHash', 'twoFactor', 'customerId', 'customerIds', 'isProductOwner'];
+const exposesSecret = (body) => SECRET_FIELDS.some((field) => JSON.stringify(body || {}).includes(`"${field}"`));
+
+/* Every string in the refusal, so a token hidden under any key would still be tried. */
+const stringsIn = (value) => {
+    if (typeof value === 'string') return [value];
+    if (Array.isArray(value)) return value.flatMap(stringsIn);
+    if (value && typeof value === 'object') return Object.values(value).flatMap(stringsIn);
+    return [];
+};
+
+async function signUpUnverified() {
+    const email = `login.unverified.${uniqueSuffix()}@e2e.alianhub.test`;
+    const created = await anon.post('/api/v2/createUser', { firstName: 'Una', lastName: 'Verified', email, password: state.password });
+    expect(created.body.status).toBe(true);
+    const uid = String(created.body.statusText._id);
+    // Mail points at a closed port, so this fails to send — but it stores the verification token first.
+    await anon.post('/api/v2/sendVerificationEmail', { uid });
+    return { uid, email, created };
+}
+
+describe('an unverified login refusal carries no verification token', () => {
+    it('answers the signup itself with a self view only', async () => {
+        const { created } = await signUpUnverified();
+        expect(created.body.statusText.isEmailVerified).toBe(false);
+        expect(exposesSecret(created.body)).toBe(false);
+    });
+
+    it('refuses the login and cannot be replayed at verifyEmail', async () => {
+        const { uid, email } = await signUpUnverified();
+
+        const refused = await anon.post('/api/v2/auth/login', { email, password: state.password });
+        expect(refused.status).toBe(400);
+        expect(refused.body.isEmailVerified).toBe(false);
+        expect(String(refused.body.userData._id)).toBe(uid);
+        expect(refused.body.userData.Employee_Email).toBe(email);
+        expect(refused.body.userData.AssignCompany).toEqual([]);
+
+        for (const token of stringsIn(refused.body)) {
+            const attempt = await anon.post('/api/v2/verifyEmail', { uid, token });
+            expect(attempt.body.status).toBe(false);
+        }
+        expect(exposesSecret(refused.body)).toBe(false);
+
+        const stillRefused = await anon.post('/api/v2/auth/login', { email, password: state.password });
+        expect(stillRefused.status).toBe(400);
+        expect(stillRefused.body.isEmailVerified).toBe(false);
+    });
+
+    it.each([
+        ['/api/v2/google-signup', 'googleId'],
+        ['/api/v2/github-signup', 'githubId'],
+        ['/api/v2/gitlab-signup', 'gitlabId'],
+    ])('answers %s with a self view only', async (path, idField) => {
+        const suffix = uniqueSuffix();
+        const res = await anon.post(path, {
+            firstName: 'Olly', lastName: 'Oauth', email: `selfview.oauth.${suffix}@e2e.alianhub.test`, [idField]: `id-${suffix}`,
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.isEmailVerified).toBe(true);
+        expect(exposesSecret(res.body)).toBe(false);
+    });
+});


### PR DESCRIPTION
Three authentication responses still answered with a raw `users` document. #644 fixed the same class of bug on `POST /api/v1/userAndCompanyCheck`; this applies the same field-allowlist approach to the remaining ones.

## Summary

| Finding | Route | Fix | Test |
|---|---|---|---|
| High — the refusal for an unverified account carried the account's email verification token, so knowing the password was enough to verify the address without access to the mailbox | `POST /api/v2/auth/login`, `POST /api/v2/auth/2fa/validate` | `generateTokenV2Fun` now sets `userData: toAuthView(response)` instead of the whole document | `tests/auth-response-self-view.test.js`, `tests/integration/auth-response-self-view.int.test.js` |
| Low — the same object was sent in the refresh refusal | `POST /api/v2/generateToken` | same call site (`loginSession.js` forwards what `generateTokenV2Fun` produces) | `tests/auth-response-self-view.test.js` |
| Low — the registrant got their saved document unfiltered (no secret in it today, but `webTokens` and `customerIds` were already along for the ride) | `POST /api/v2/createUser`, `/api/v2/{google,github,gitlab}-signup` | `addUserMongodbV2` and the three OAuth handlers answer with `toAuthView(...)` | `tests/auth-response-self-view.test.js`, `tests/integration/auth-response-self-view.int.test.js` |

## Notes

**The view.** `toAuthView` is a new export of `Modules/Users/helpers/userAccessRules.js` and a strict subset of `SELF_FIELDS` (a unit test asserts that). It is deliberately narrower than `toSelfView`: these answers go to a caller who has not completed authentication — an unverified password holder, or an anonymous registrant — so `isProductOwner`, `customerId`, `customerIds`, `tour`, `lastSelectedCompany` and the rest of the signed-in profile stay out, along with `verificationToken`, `verificationTokenTime`, `forgotPasswordToken`, `forgotPasswordTokenTime` and `webTokens`. `toSelfView` and the endpoints behind a session are untouched.

**Callers checked.** Every field they read survives:

- `frontend/src/views/Authentication/Login/Login.vue` — `userData._id` (resend-verification, #641), `isEmailVerified`, `AssignCompany`, `Employee_Email`.
- `frontend/src/plugins/oauth/{google,github,gitlab}/*.vue` — `userData.isEmailVerified`, `userData.AssignCompany`; the error branch only stores `userData`.
- `frontend/src/views/Authentication/Invitation/Invitation.vue` — takes the uid from the login response's top-level `uid` (#643), which this does not touch, and reads `response.data.status` / `statusText._id` from the sign-up response.
- `time-tracker-app/` — signs in through `/api/v1/auth/loginAuthTracker`, which reads `gData.token` only.
- Server-side users of `addUserMongodbV2`: `Modules/Setup/createCompany.js` and `scripts/demo/lib/appAdapter.js` both read `created.statusText._id`.

**Upgrade impact.** None for the shipped clients. An external client that read anything beyond the listed fields from a login refusal or a sign-up response no longer receives it — which is the point of the fix.

## Test plan

| Command | Result |
|---|---|
| `npx jest --selectProjects unit --maxWorkers=2` | 262 suites, 3727 tests passed |
| `npx jest tests/conventions --maxWorkers=2` | 8 suites, 94 tests passed |
| `E2E_MONGODB_URL=… npx jest --selectProjects integration --runInBand auth-response-self-view user-and-company-check signup-ownership access refresh-token` | 5 suites, 88 tests passed |
| `cd frontend && npx vitest run` | 36 files, 259 tests passed |
| `npm run i18n:check` | exit 0 (no new strings) |
| `npx eslint` on the touched files | 0 errors (7 pre-existing unused-import warnings in `authHelpers.js`) |

Both new suites were written first and fail on `beta`: the integration case walks every string in the login refusal back into `POST /api/v2/verifyEmail` and, before the fix, one of them verified the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
