### PR TITLE
fix(time): build estimated-time writes on the server instead of the request body

### DIFF
--- a/Modules/EstimatedTime/controller.js
+++ b/Modules/EstimatedTime/controller.js
@@ -3,11 +3,11 @@ const loggerConfig = require("../../Config/loggerConfig");
 const { SCHEMA_TYPE } = require("../../Config/schemaType");
 const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries");
 const { replaceObjectKey } = require("../Auth/helper");
-const socketEmitter = require("../../event/socketEventEmitter");
 const { estimateAndPersist: estimateTaskTimeWithAI, _internal: aiEstimatorInternal } = require("./aiTaskEstimator");
 const { updateRemainingTime } = require("../LogTime/controllerV2/helpers");
 const { resolveSheetScope, SHEET_PERMISSION } = require("../TimeSheet/helpers/timeScope");
 const { scopeEstimatePipeline, TimesheetQueryRefused } = require("../TimeSheet/helpers/timesheetQueryScope");
+const { buildEstimateWrite, EstimateWriteRefused } = require("./helpers/estimateWriteScope");
 
 exports.getEstimatedTime = async(req,res) => {
     try {
@@ -38,30 +38,29 @@ exports.getEstimatedTime = async(req,res) => {
 
 exports.updateEstimatedTime = async(req,res) => {
     try {
-        let key = req.body.key;
-        let newObj = req.body.newObj || {}
-
-        let data =  [
-            req.body.compareObj, 
-            {
-                [key]: req.body.updateObject
-            },
-            newObj,
-        ]
-
-        let mongoObj = {
-            type: SCHEMA_TYPE.ESTIMATES_TIME,
-            data: data
+        const companyId = req.headers['companyid'];
+        const scope = await resolveSheetScope(companyId, req.uid, [SHEET_PERMISSION.workload, SHEET_PERMISSION.project]);
+        let write;
+        try {
+            write = buildEstimateWrite(req.body, scope);
+        } catch (error) {
+            if (!(error instanceof EstimateWriteRefused)) throw error;
+            return res.status(error.statusCode).json({ status: false, statusText: error.statusCode === 403 ? "Forbidden" : "Bad Request", message: error.message });
         }
-        const estimatedTime = await MongoDbCrudOpration(req.headers['companyid'], mongoObj, 'findOneAndUpdate');
+
+        const mongoObj = {
+            type: SCHEMA_TYPE.ESTIMATES_TIME,
+            data: write.data
+        }
+        const estimatedTime = await MongoDbCrudOpration(companyId, mongoObj, 'findOneAndUpdate');
 
         if (!estimatedTime) {
-            return res.status(400).json({ message: "Estimated time not updated" });
+            return res.status(404).json({ message: "Estimated time not updated" });
         }
         if (estimatedTime.TaskId) {
             // Fire-and-forget: a remaining-time recalc failure must not fail
             // the (already persisted) planning row.
-            Promise.resolve(updateRemainingTime(req.headers['companyid'], estimatedTime.TaskId))
+            Promise.resolve(updateRemainingTime(companyId, estimatedTime.TaskId))
                 .catch((error) => loggerConfig.error(`updateRemainingTime after planning save failed: ${error.message || error}`));
         }
         return res.status(200).json(estimatedTime);

--- a/Modules/EstimatedTime/helpers/estimateWriteScope.js
+++ b/Modules/EstimatedTime/helpers/estimateWriteScope.js
@@ -1,0 +1,94 @@
+const mongoose = require('mongoose');
+
+const MAX_ESTIMATE_MINUTES = 24 * 60;
+
+class EstimateWriteRefused extends Error {
+    constructor(reason, statusCode = 400) {
+        super(reason);
+        this.name = 'EstimateWriteRefused';
+        this.statusCode = statusCode;
+    }
+}
+
+const refuse = (reason, statusCode) => { throw new EstimateWriteRefused(reason, statusCode); };
+
+/* A planning row is addressed by four scalars. Anything else — an object, an
+ * array, a $-operator — is a query the caller is trying to smuggle in. */
+const asId = (value, what) => {
+    if (typeof value !== 'string' || !mongoose.Types.ObjectId.isValid(value)) refuse(`${what} must be an id.`);
+    return value;
+};
+
+const asDate = (value) => {
+    const date = typeof value === 'string' || value instanceof Date ? new Date(value) : new Date(NaN);
+    if (Number.isNaN(date.getTime())) refuse('date must be a date.');
+    return date;
+};
+
+const asMinutes = (value) => {
+    const minutes = typeof value === 'number' ? value : NaN;
+    if (!Number.isFinite(minutes) || minutes < 0 || minutes > MAX_ESTIMATE_MINUTES) {
+        refuse(`minutes must be a number between 0 and ${MAX_ESTIMATE_MINUTES}.`);
+    }
+    return Math.round(minutes);
+};
+
+/* The web app reads a plan's person from UserId and the desktop tracker from
+ * userId; a row without UserId belongs to its userId. Mirrors the read guard. */
+const ownRowsMatch = (scope) => ({ $or: [{ UserId: scope.uid }, { UserId: { $exists: false }, userId: scope.uid }] });
+
+const readEstimateWrite = (body) => {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) refuse('A planning save needs a body.');
+    if ('compareObj' in body || 'updateObject' in body || 'key' in body || 'newObj' in body) {
+        refuse('A planning save names the row it writes; it does not carry a Mongo query.');
+    }
+    return {
+        id: body.id === undefined || body.id === null || body.id === '' ? null : asId(body.id, 'id'),
+        userId: asId(body.userId, 'userId'),
+        taskId: asId(body.taskId, 'taskId'),
+        projectId: asId(body.projectId, 'projectId'),
+        date: asDate(body.date),
+        minutes: asMinutes(body.minutes),
+    };
+};
+
+/* Owners and admins, and the roles the matrix grants Everyone on the workload or
+ * project timesheet, plan for anyone; everyone else plans their own time only, and
+ * both stop at the projects they can open. */
+const authorize = (plan, scope) => {
+    if (!scope.everyone && plan.userId !== scope.uid) refuse('You can only plan your own time.', 403);
+    if (scope.visible && !scope.visible.includes(plan.projectId)) refuse('You cannot plan time on this project.', 403);
+};
+
+const buildEstimateWrite = (body, scope) => {
+    const plan = readEstimateWrite(body);
+    authorize(plan, scope);
+
+    const row = {
+        UserId: plan.userId,
+        userId: plan.userId,
+        TaskId: plan.taskId,
+        ProjectId: plan.projectId,
+        Date: plan.date,
+        EstimatedTime: plan.minutes,
+    };
+
+    /* Without an id this is the planner's first save for that person and day, so it
+     * upserts on the natural key the row is identified by. With one it rewrites a row
+     * the caller may already reach — the scope stays in the filter so a stolen id
+     * matches nothing. */
+    const filter = plan.id
+        ? { _id: new mongoose.Types.ObjectId(plan.id), ...(scope.everyone ? {} : ownRowsMatch(scope)), ...(scope.visible ? { ProjectId: { $in: scope.visible } } : {}) }
+        : { userId: plan.userId, Date: plan.date, TaskId: plan.taskId };
+
+    return {
+        plan,
+        data: [filter, { $set: row }, { new: true, upsert: !plan.id, setDefaultsOnInsert: true }],
+    };
+};
+
+module.exports = {
+    EstimateWriteRefused,
+    MAX_ESTIMATE_MINUTES,
+    buildEstimateWrite,
+};

--- a/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
+++ b/frontend/src/components/molecules/EstimateHours/EstimateHours.vue
@@ -345,27 +345,16 @@ function saveEta() {
         }
 
         estimates.forEach((data) => {
-            const firebaseObj = {
-                UserId: data.UserId,
-                TaskId: props.task._id,
-                ProjectId: props.task.ProjectID,
-                EstimatedTime: data.minutes,
-                Date: new Date(data.timeStamp),
-                createdAt: new Date(),
-                updatedAt: new Date()
+            const planObj = {
+                userId: data.UserId,
+                taskId: props.task._id,
+                projectId: props.task.ProjectID,
+                minutes: data.minutes,
+                date: new Date(data.timeStamp).toISOString()
             }
 
             if(data.id && data.id != null) {
-                const axiosObj = {
-                    updateObject: firebaseObj,
-                    key: "$set",
-                    compareObj: {
-                        _id: data.id
-                    },
-                    newObj: {
-                        new: true
-                    }
-                }
+                const axiosObj = { ...planObj, id: data.id }
 
                 apiRequest("put", `${env.ESTIMATED_TIME}`,axiosObj)
                 .then((resp) => {
@@ -386,23 +375,8 @@ function saveEta() {
                     savingETA.value = false;
                     console.error("ERROR in update ETA in mongo: ", error);
                 })
-                delete firebaseObj.createdAt;
             } else {
-                const axiosObj = {
-                    updateObject: firebaseObj,
-                    key: "$set",
-                    newObj: {
-                        upsert: true,
-                        new: true
-                    },
-                    compareObj: {
-                        userId: data.UserId,
-                        Date: new Date(data.timeStamp),
-                        TaskId: props.task._id
-                    }
-                }
-
-                apiRequest("put", `${env.ESTIMATED_TIME}`,axiosObj)
+                apiRequest("put", `${env.ESTIMATED_TIME}`,planObj)
                 .then((res) => {
                     const docData = res.data;
                     let changeDate = new Date(docData.Date).setHours(0,0,0,0);

--- a/tests/estimate-write-guard.test.js
+++ b/tests/estimate-write-guard.test.js
@@ -1,0 +1,155 @@
+const mockCrud = jest.fn(async (companyId, mongoObj) => ({ _id: 'row', TaskId: mongoObj.data[1].$set.TaskId }));
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockCrud(...a) }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../Config/permissionGuard', () => ({
+    getRoleType: jest.fn(),
+    evaluatePermission: jest.fn(),
+    isPrivileged: (r) => r === 1 || r === 2,
+}));
+jest.mock('../Modules/Agents/scope', () => ({ visibleProjectIds: jest.fn() }));
+jest.mock('../Modules/EstimatedTime/aiTaskEstimator', () => ({ estimateAndPersist: jest.fn(), _internal: {} }));
+jest.mock('../Modules/LogTime/controllerV2/helpers', () => ({ updateRemainingTime: jest.fn() }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+
+const { getRoleType, evaluatePermission } = require('../Config/permissionGuard');
+const { visibleProjectIds } = require('../Modules/Agents/scope');
+const estimates = require('../Modules/EstimatedTime/controller');
+
+const C = '6f0000000000000000000c01';
+const ME = '6f0000000000000000000001';
+const OTHER = '6f0000000000000000000002';
+const P1 = '6f0000000000000000000b01';
+const P2 = '6f0000000000000000000b02';
+const T1 = '6f0000000000000000000a01';
+const ROW = '6f0000000000000000000d01';
+const DATE = '2026-05-01T00:00:00.000Z';
+
+const res = () => {
+    const r = { code: 200, body: null };
+    r.status = (c) => { r.code = c; return r; };
+    r.json = (b) => { r.body = b; return r; };
+    r.send = r.json;
+    return r;
+};
+
+const save = async (body, uid = ME) => {
+    const r = res();
+    await estimates.updateEstimatedTime({ headers: { companyid: C }, body, query: {}, params: {}, uid }, r);
+    return r;
+};
+
+const plan = (over = {}) => ({ userId: ME, taskId: T1, projectId: P1, date: DATE, minutes: 60, ...over });
+const grant = (byKey) => evaluatePermission.mockImplementation(async (company, uid, key) => (key in byKey ? byKey[key] : null));
+const sent = () => {
+    expect(mockCrud).toHaveBeenCalledTimes(1);
+    return { filter: mockCrud.mock.calls[0][1].data[0], update: mockCrud.mock.calls[0][1].data[1], options: mockCrud.mock.calls[0][1].data[2] };
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    visibleProjectIds.mockResolvedValue([P1]);
+    grant({});
+});
+
+describe('PUT /api/v1/estimatedTime', () => {
+    it.each([
+        ['a raw Mongo query in place of the row', { key: '$set', compareObj: { _id: ROW }, updateObject: { EstimatedTime: 1 } }],
+        ['an options object', { ...plan(), newObj: { upsert: true } }],
+        ['an operator where the person should be', plan({ userId: { $ne: null } })],
+        ['an operator where the row should be', plan({ id: { $gt: '' } })],
+        ['an operator where the project should be', plan({ projectId: { $in: [P1, P2] } })],
+        ['minutes that are not a number', plan({ minutes: { $inc: 5 } })],
+        ['minutes below zero', plan({ minutes: -1 })],
+        ['minutes beyond a day', plan({ minutes: 1441 })],
+        ['a date that is not a date', plan({ date: 'whenever' })],
+        ['a missing task', plan({ taskId: undefined })],
+        ['a body that is not an object', 'UserId'],
+    ])('refuses %s and writes nothing', async (label, body) => {
+        getRoleType.mockResolvedValue(3);
+        const r = await save(body);
+        expect([label, r.code]).toEqual([label, 400]);
+        expect(mockCrud).not.toHaveBeenCalled();
+    });
+
+    it('refuses a member planning for someone else', async () => {
+        getRoleType.mockResolvedValue(3);
+        const r = await save(plan({ userId: OTHER }));
+        expect(r.code).toBe(403);
+        expect(mockCrud).not.toHaveBeenCalled();
+    });
+
+    it('refuses a member on a project they cannot open', async () => {
+        getRoleType.mockResolvedValue(3);
+        const r = await save(plan({ projectId: P2 }));
+        expect(r.code).toBe(403);
+        expect(mockCrud).not.toHaveBeenCalled();
+    });
+
+    it('refuses someone who is not in the company', async () => {
+        getRoleType.mockResolvedValue(null);
+        visibleProjectIds.mockResolvedValue([]);
+        const r = await save(plan());
+        expect(r.code).toBe(403);
+        expect(mockCrud).not.toHaveBeenCalled();
+    });
+
+    it('upserts a member\'s own row on the person, day and task', async () => {
+        getRoleType.mockResolvedValue(3);
+        const r = await save(plan());
+        expect(r.code).toBe(200);
+        const { filter, update, options } = sent();
+        expect(filter).toEqual({ userId: ME, Date: new Date(DATE), TaskId: T1 });
+        expect(update).toEqual({ $set: { UserId: ME, userId: ME, TaskId: T1, ProjectId: P1, Date: new Date(DATE), EstimatedTime: 60 } });
+        expect(options.upsert).toBe(true);
+    });
+
+    it('keeps a member\'s own scope in the filter when they name a row by id', async () => {
+        getRoleType.mockResolvedValue(3);
+        await save(plan({ id: ROW }));
+        const { filter, options } = sent();
+        expect(String(filter._id)).toBe(ROW);
+        expect(filter.$or).toEqual([{ UserId: ME }, { UserId: { $exists: false }, userId: ME }]);
+        expect(filter.ProjectId).toEqual({ $in: [P1] });
+        expect(options.upsert).toBe(false);
+    });
+
+    it('answers 404 when the named row is not one the caller may write', async () => {
+        getRoleType.mockResolvedValue(3);
+        mockCrud.mockResolvedValueOnce(null);
+        const r = await save(plan({ id: ROW }));
+        expect(r.code).toBe(404);
+    });
+
+    it('lets an admin plan anyone\'s time company-wide', async () => {
+        getRoleType.mockResolvedValue(2);
+        const r = await save(plan({ userId: OTHER, projectId: P2, id: ROW }));
+        expect(r.code).toBe(200);
+        const { filter, update } = sent();
+        expect(filter.$or).toBeUndefined();
+        expect(filter.ProjectId).toBeUndefined();
+        expect(update.$set.UserId).toBe(OTHER);
+    });
+
+    it.each([
+        ['workload', 'sheet_settings.workload_timesheet'],
+        ['project', 'sheet_settings.project_timesheet'],
+    ])('lets a member granted Everyone on the %s timesheet plan for others on visible projects only', async (label, key) => {
+        getRoleType.mockResolvedValue(3);
+        grant({ [key]: 2 });
+        const ok = await save(plan({ userId: OTHER }));
+        expect(ok.code).toBe(200);
+        expect(sent().update.$set.UserId).toBe(OTHER);
+
+        mockCrud.mockClear();
+        const hidden = await save(plan({ userId: OTHER, projectId: P2 }));
+        expect(hidden.code).toBe(403);
+        expect(mockCrud).not.toHaveBeenCalled();
+    });
+
+    it('never lets the body reach Mongo as an update operator', async () => {
+        getRoleType.mockResolvedValue(1);
+        await save({ ...plan(), $where: 'true', EstimatedTime: 5 });
+        expect(Object.keys(sent().update)).toEqual(['$set']);
+    });
+});

--- a/tests/integration/estimated-time-write-guard.int.test.js
+++ b/tests/integration/estimated-time-write-guard.int.test.js
@@ -1,0 +1,171 @@
+const { createProject, createTask, loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+
+jest.setTimeout(90000);
+
+const today = () => new Date().toISOString().slice(0, 10);
+const dateAt = (dayOffset = 0) => {
+    const day = new Date(`${today()}T00:00:00.000Z`);
+    day.setUTCDate(day.getUTCDate() + dayOffset);
+    return day.toISOString();
+};
+
+async function projectWithTask(owner, assignees, { isPrivate = false } = {}) {
+    const project = await createProject(owner.api, { assigneeIds: assignees.map((s) => s.uid), createdBy: owner.uid, isPrivate });
+    let lastErr;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+        try {
+            const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+            return { project, task };
+        } catch (err) {
+            lastErr = err;
+            await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+    }
+    throw lastErr;
+}
+
+/* EstimateHours.vue saves one planning row per person per day. */
+const planBody = (session, { project, task }, { minutes = 90, date = dateAt(), userId, id } = {}) => ({
+    ...(id ? { id } : {}),
+    userId: userId || session.uid,
+    taskId: task._id,
+    projectId: project._id,
+    date,
+    minutes,
+});
+
+async function plan(session, target, over = {}) {
+    const res = await session.api.put('/api/v1/estimatedTime', planBody(session, target, over));
+    return res;
+}
+
+async function rowsFor(session, { project, task }) {
+    const res = await session.api.get(`/api/v1/estimatedTime/${project._id}/${task._id}`);
+    expect(res.status).toBe(200);
+    return res.body;
+}
+
+const rowOf = (rows, userId) => rows.find((row) => String(row.UserId) === String(userId));
+
+describe('PUT /api/v1/estimatedTime is built on the server, not the request body', () => {
+    it('refuses the raw compareObj/key/updateObject body a member could use to rewrite anyone', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        expect((await plan(owner, target, { minutes: 120 })).status).toBe(200);
+        const victim = rowOf(await rowsFor(owner, target), owner.uid);
+        expect(victim.EstimatedTime).toBe(120);
+
+        const attack = await member.api.put('/api/v1/estimatedTime', {
+            key: '$set',
+            compareObj: { _id: victim._id },
+            updateObject: { EstimatedTime: 1, UserId: owner.uid, TaskId: target.task._id, ProjectId: target.project._id, Date: victim.Date },
+            newObj: { new: true },
+        });
+        expect(attack.status).toBe(400);
+
+        expect(rowOf(await rowsFor(owner, target), owner.uid).EstimatedTime).toBe(120);
+    });
+
+    it('refuses a member who names another member\'s row by id and leaves it alone', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        expect((await plan(owner, target, { minutes: 120 })).status).toBe(200);
+        const victim = rowOf(await rowsFor(owner, target), owner.uid);
+
+        const byId = await plan(member, target, { id: victim._id, minutes: 5, userId: owner.uid });
+        expect(byId.status).toBe(403);
+
+        const spoofed = await plan(member, target, { id: victim._id, minutes: 5 });
+        expect([403, 404]).toContain(spoofed.status);
+
+        expect(rowOf(await rowsFor(owner, target), owner.uid).EstimatedTime).toBe(120);
+    });
+
+    it('refuses a member planning time for someone else on a project they share', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        const res = await plan(member, target, { userId: owner.uid, minutes: 30, date: dateAt(1) });
+        expect(res.status).toBe(403);
+
+        expect(rowOf(await rowsFor(owner, target), owner.uid)).toBeUndefined();
+    });
+
+    it('refuses a member on a project they cannot open', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const hidden = await projectWithTask(owner, [owner], { isPrivate: true });
+
+        const res = await plan(member, hidden, { minutes: 30 });
+        expect(res.status).toBe(403);
+        expect(rowOf(await rowsFor(owner, hidden), member.uid)).toBeUndefined();
+    });
+
+    it('lets a member create and then update their own row, the way the planner does', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+        const date = dateAt(2);
+
+        const created = await plan(member, target, { minutes: 45, date });
+        expect(created.status).toBe(200);
+        expect(created.body.EstimatedTime).toBe(45);
+        expect(created.body.UserId).toBe(member.uid);
+
+        const updated = await plan(member, target, { id: created.body._id, minutes: 75, date });
+        expect(updated.status).toBe(200);
+        expect(updated.body.EstimatedTime).toBe(75);
+        expect(String(updated.body._id)).toBe(String(created.body._id));
+
+        const again = await plan(member, target, { minutes: 15, date });
+        expect(again.status).toBe(200);
+        expect(String(again.body._id)).toBe(String(created.body._id));
+
+        const rows = await rowsFor(owner, target);
+        expect(rows.filter((row) => String(row.UserId) === String(member.uid))).toHaveLength(1);
+    });
+
+    it('keeps an admin able to plan another person\'s time', async () => {
+        const owner = await loginAs('owner');
+        const admin = await loginAs('admin');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        const res = await admin.api.put('/api/v1/estimatedTime', planBody(admin, target, { userId: member.uid, minutes: 60, date: dateAt(3) }));
+        expect(res.status).toBe(200);
+        expect(res.body.UserId).toBe(member.uid);
+        expect(res.body.EstimatedTime).toBe(60);
+    });
+
+    it('keeps a guest to their own time and to what they can open', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const target = await projectWithTask(owner, [owner]);
+        const hidden = await projectWithTask(owner, [owner], { isPrivate: true });
+
+        expect((await plan(guest, target, { userId: owner.uid, minutes: 30 })).status).toBe(403);
+        expect((await plan(guest, hidden, { minutes: 30 })).status).toBe(403);
+        expect((await plan(guest, target, { minutes: 30 })).status).toBe(200);
+    });
+
+    it.each([
+        ['an operator where the person should be', { userId: { $ne: null } }],
+        ['an operator where the task should be', { taskId: { $gt: '' } }],
+        ['a minutes value that is not a number', { minutes: { $inc: 5 } }],
+        ['a date that is not a date', { date: 'not-a-date' }],
+    ])('refuses %s', async (label, over) => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        const res = await member.api.put('/api/v1/estimatedTime', { ...planBody(member, target), ...over });
+        expect([label, res.status]).toEqual([label, 400]);
+    });
+});

--- a/tests/integration/time.int.test.js
+++ b/tests/integration/time.int.test.js
@@ -145,10 +145,11 @@ describe('time — variance and estimates', () => {
         const admin = await loginAs('admin');
         const { project, task } = await projectWithTask(owner, admin);
         const up = await admin.api.put('/api/v1/estimatedTime', {
-            key: '$set',
-            compareObj: { ProjectId: project._id, TaskId: task._id, UserId: admin.uid },
-            updateObject: { EstimatedTime: 45, ProjectId: project._id, TaskId: task._id, UserId: admin.uid, Date: new Date().toISOString() },
-            newObj: { upsert: true, returnDocument: 'after' },
+            projectId: project._id,
+            taskId: task._id,
+            userId: admin.uid,
+            minutes: 45,
+            date: new Date().toISOString(),
         });
         expect(up.status).toBe(200);
         const got = await admin.api.get(`/api/v1/estimatedTime/${project._id}/${task._id}`);

--- a/tests/integration/timesheet-query-guard.int.test.js
+++ b/tests/integration/timesheet-query-guard.int.test.js
@@ -52,10 +52,7 @@ async function logHour(session, { project, task }) {
 async function planHour(session, { project, task }) {
     const date = `${today()}T00:00:00.000Z`;
     const res = await session.api.put('/api/v1/estimatedTime', {
-        key: '$set',
-        updateObject: { UserId: session.uid, TaskId: task._id, ProjectId: project._id, EstimatedTime: 90, Date: date },
-        compareObj: { userId: session.uid, Date: date, TaskId: task._id },
-        newObj: { upsert: true, new: true },
+        userId: session.uid, taskId: task._id, projectId: project._id, minutes: 90, date,
     });
     expect(res.status).toBe(200);
 }


### PR DESCRIPTION
## Summary

| Finding | Route | Fix | Test |
|---|---|---|---|
| Any company member could rewrite any planning row (another person's estimate included), because `compareObj`, `key` and `updateObject` came straight from the request body | `PUT /api/v1/estimatedTime` | The route takes named parameters (`id`, `userId`, `taskId`, `projectId`, `date`, `minutes`), validates each as a scalar id / date / number, and builds the Mongo filter and `$set` on the server. Non-privileged callers write their own rows only, and only on projects they can open (`visibleProjectIds`); owners, admins and roles with an Everyone grant on the workload or project timesheet key keep the reach #635 gave their reads. A row named by `id` keeps the caller's scope in the filter, so a stolen id matches nothing. A body still carrying `compareObj` / `key` / `updateObject` / `newObj` is refused. | `tests/integration/estimated-time-write-guard.int.test.js` (11 cases), `tests/estimate-write-guard.test.js` (21 cases) |

Reproduced first on `beta`: signed in as the fixture member, `PUT /api/v1/estimatedTime` with `compareObj: { _id: <owner's row> }` returned **200** and rewrote the owner's planning row from 120 minutes to 1.

No write operator from the body can reach Mongo any more, because the update document is built here rather than parsed — the equivalent of the read guard's `$out` / `$merge` / `$unionWith` / `$function` / `$where` refusals. The named parameters are rejected unless they are plain ids, a real date and a finite number in 0–1440, so `{"userId": {"$ne": null}}` and friends are refused too.

## Notes

**Callers checked.** `PUT /api/v1/estimatedTime` has exactly one product caller: `frontend/src/components/molecules/EstimateHours/EstimateHours.vue` (the task-detail planner), in both its branches — update an existing row by `_id`, and upsert on `userId` + `Date` + `TaskId`. Both now send the named body; the integration tests exercise those two real shapes end to end. `time-tracker-app/renderer/pages/logentry.jsx` touches `/api/v1/estimatedTime` only through the read route (`POST`), so the desktop tracker is unaffected. The other `ESTIMATED_TIME` call sites (`TimeEstimatedWorkloadComp.vue`, `TotalTaskCardComponent.vue`, `ProjectTimesheet.vue`, `TaskDetailRightSide.vue`) are all `POST` reads or the AI-estimate trigger.

**Upgrade impact.** The request shape changed, so a browser tab still running the pre-upgrade SPA gets `400` on a planning save until it reloads; the web app ships with the server, so this is one reload, not a version skew. No stored data changes: `createdAt` / `updatedAt` are left to Mongoose `timestamps` (the strict schema was already dropping the client-sent copies), and rows keep carrying both `UserId` and `userId`.

**Left deliberately.**
- `GET /api/v1/estimatedTime/:pid/:tid` still reads every row on a task without a scope check. It is a read, not a write, and belongs with the read-side work in #635's follow-up rather than here.
- `updateEstimatedTime` still returns the raw Mongoose document rather than the `{ status, statusText, data }` envelope, because the planner reads `resp.data._id` / `.Date` / `.EstimatedTime` directly; changing it is a separate frontend change.
- The planner shows its "Estimated time updated successfully" toast before the saves settle, so a refused row is only logged to the console. That is pre-existing and unrelated to the scope fix.
- Other write routes in this module: `POST /api/v1/estimatedTime/ai/:tid` builds its task payload from the database and takes only `userId` / `userName` for the activity-log line, so it does not carry a body-built query; it is untouched.

## Test plan

Node 20.20.2, Mongo 7 in `alianhub-e2e-t2` on port 27192 (removed afterwards).

- `npx jest --selectProjects unit --maxWorkers=2` — **262 suites, 3737 tests passed**
- `npx jest tests/conventions --maxWorkers=2` — **8 suites, 94 tests passed** (tenant-scoping baseline unchanged; the new code reads the company from the `companyid` header)
- `E2E_MONGODB_URL=mongodb://127.0.0.1:27192 npx jest --selectProjects integration --runInBand tests/integration/time.int.test.js tests/integration/timesheet-query-guard.int.test.js tests/integration/estimated-time-write-guard.int.test.js` — **3 suites, 35 tests passed**
- `cd frontend && npx vitest run` — **36 files, 259 tests passed**
- `npm run i18n:check` — exit 0 (no new strings)
- `npx eslint` on every touched file — clean

Before the fix, the new integration suite failed 7 of 11, including the raw-body rewrite and the id-spoof cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
