### PR TITLE
fix(storage): limit profile image and credit note reads to the people who may see them

### DIFF
--- a/Modules/Users/controller.js
+++ b/Modules/Users/controller.js
@@ -7,8 +7,9 @@ const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries.
 const mongoose = require("mongoose")
 const {
     isObjectId, toSelfView, toMemberView, sharedCompanies, sanitizeUserQuery, scopeQueryToCompany,
-    sanitizeSelfUpdate, companyRemovalOf, sanitizeUpdateOptions,
+    sanitizeSelfUpdate, companyRemovalOf, sanitizeUpdateOptions, unownedProfileImages, hasProfileImage,
 } = require("./helpers/userAccessRules.js");
+const { mayWriteProfileImage } = require("../storage/bucketAccess.js");
 
 const refuse = (res, code, message) => res.status(code).json({ status: false, statusText: message, message });
 
@@ -30,10 +31,15 @@ exports.updateUserStatus = async (req, res) => {
         if (String(userId) === String(req.uid)) {
             const checked = sanitizeSelfUpdate(updateObject);
             if (!checked.ok) return refuse(res, 403, checked.error);
-            const selected = checked.update.$set.lastSelectedCompany;
-            if (selected !== undefined) {
-                const me = await loadGlobalUser(req.uid);
-                if (!sharedCompanies(me, { AssignCompany: [selected] }).length) return refuse(res, 403, 'You are not a member of that company.');
+            const fields = checked.update.$set;
+            const selected = fields.lastSelectedCompany;
+            let me;
+            if (selected !== undefined || hasProfileImage(fields)) me = await loadGlobalUser(req.uid);
+            if (selected !== undefined && !sharedCompanies(me, { AssignCompany: [selected] }).length) {
+                return refuse(res, 403, 'You are not a member of that company.');
+            }
+            if (unownedProfileImages(fields, me, (value) => mayWriteProfileImage(req.uid, value)).length) {
+                return refuse(res, 403, 'You can only use a profile image you uploaded yourself.');
             }
             update = checked.update;
             view = toSelfView;

--- a/Modules/Users/helpers/userAccessRules.js
+++ b/Modules/Users/helpers/userAccessRules.js
@@ -117,6 +117,22 @@ const companyRemovalOf = (updateObject) => {
 
 const sanitizeUpdateOptions = (options) => (options && options.returnDocument === 'after' ? { returnDocument: 'after' } : undefined);
 
+const PROFILE_IMAGE_FIELDS = ['Employee_profileImage', 'Employee_profileImageURL'];
+
+/* A user may point their profile at an image they uploaded — the storage guards only let
+ * them write a name starting with their own id — or leave the one their record already
+ * holds, which is how an image uploaded before that rule keeps working. Any other name
+ * would be someone else's image. */
+const unownedProfileImages = (fields, currentUser, mayWrite) => {
+    const held = PROFILE_IMAGE_FIELDS.map((field) => String((currentUser && currentUser[field]) || '')).filter(Boolean);
+    return PROFILE_IMAGE_FIELDS
+        .filter((field) => fields[field] !== undefined)
+        .map((field) => String(fields[field] || ''))
+        .filter((value) => value !== '' && !held.includes(value) && !mayWrite(value));
+};
+
+const hasProfileImage = (fields) => PROFILE_IMAGE_FIELDS.some((field) => fields[field] !== undefined);
+
 module.exports = {
     MEMBER_FIELDS,
     SELF_FIELDS,
@@ -130,4 +146,6 @@ module.exports = {
     sanitizeSelfUpdate,
     companyRemovalOf,
     sanitizeUpdateOptions,
+    unownedProfileImages,
+    hasProfileImage,
 };

--- a/Modules/storage/bucketAccess.js
+++ b/Modules/storage/bucketAccess.js
@@ -3,14 +3,19 @@ const { verifyCompanyMembership } = require('../../Config/jwt');
 const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
 const { dbCollections } = require('../../Config/collections');
 const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { myCache } = require('../../Config/config');
+const { isPrivileged } = require('../../Config/roleTypes');
 const { safeFileFilter, safeRelativePath } = require('../../utils/uploadConfig');
 const { escapeRegex } = require('../../utils/escapeRegex');
 
 const OBJECT_ID = /^[a-f0-9]{24}$/i;
 const USER_PROFILES_BUCKET = 'USER_PROFILES';
 const ACTIVE_SEAT = 2;
-const OWNED_PROFILE_IMAGE = /^[a-f0-9]{24}_/i;
+const OWNED_PROFILE_IMAGE = /^([a-f0-9]{24})_/i;
 const THUMBNAIL_SUFFIX = /-\d+x\d+(\.[^./]+)$/i;
+const CREDIT_NOTES = 'InvoiceAndCreditNotes/';
+const CREDIT_NOTE_COMPANY = /^InvoiceAndCreditNotes\/CreditNotes\/([a-f0-9]{24})\//i;
+const LOOKUP_CACHE_TTL = 60;
 
 const refuse = (res, code, statusText) => res.status(code).json({ status: false, statusText, message: statusText });
 const refusal = (code, statusText) => ({ code, statusText });
@@ -45,7 +50,15 @@ function mayWriteProfileImage(uid, filePath) {
     return OBJECT_ID.test(id) && name.startsWith(`${id}_`) && !name.includes('/') && safeRelativePath(name) === name;
 }
 
-const findUser = (query) => MongoDbCrudOpration(dbCollections.GLOBAL, { type: dbCollections.USERS, data: [query, { _id: 1 }] }, 'findOne');
+const findUser = (query, projection = { _id: 1 }) => MongoDbCrudOpration(dbCollections.GLOBAL, { type: dbCollections.USERS, data: [query, projection] }, 'findOne');
+
+async function cached(key, resolve) {
+    const hit = myCache.get(key);
+    if (hit !== undefined) return hit;
+    const value = await resolve();
+    myCache.set(key, value, LOOKUP_CACHE_TTL);
+    return value;
+}
 
 const sameNameIgnoringCase = (name) => ({ $regex: `^${escapeRegex(name)}$`, $options: 'i' });
 
@@ -69,16 +82,70 @@ async function mayRemoveProfileImage(uid, filePath) {
     return mayWriteProfileImage(uid, filePath) || isOwnLegacyProfileImage(String(uid || ''), String(filePath || ''));
 }
 
-async function accessRefusal(req, bucketId, filePath, mayUseProfileImage) {
+/* An image uploaded since #639 names its owner. A legacy name has no owner but the user
+ * record pointing at it, and PUT /api/v1/user now only lets a user point at a name they
+ * may write or already hold, so that record is as good as the prefix. */
+async function profileImageOwner(name) {
+    const owned = OWNED_PROFILE_IMAGE.exec(name);
+    if (owned) return owned[1].toLowerCase();
+    return cached(`profileImageOwner:${name}`, async () => {
+        for (const candidate of new Set([name, name.replace(THUMBNAIL_SUFFIX, '$1')])) {
+            const sameName = sameNameIgnoringCase(candidate);
+            const holder = await findUser({ $or: [{ Employee_profileImage: sameName }, { Employee_profileImageURL: sameName }] });
+            if (holder) return String(holder._id).toLowerCase();
+        }
+        return null;
+    });
+}
+
+const companiesOf = (uid) => cached(`profileImageOwnerCompanies:${uid}`, async () => {
+    const owner = await findUser({ _id: new mongoose.Types.ObjectId(uid) }, { AssignCompany: 1 });
+    return ((owner && owner.AssignCompany) || []).map(String);
+});
+
+/* Avatars are shown all over the app, so a colleague may read one; someone with no live
+ * seat in any company the owner belongs to may not. */
+async function mayReadAvatar(req, name) {
+    const uid = String(req.uid || '').toLowerCase();
+    const ownerId = await profileImageOwner(name);
+    if (!ownerId) return false;
+    if (ownerId === uid) return true;
+    for (const companyId of await companiesOf(ownerId)) {
+        if (await belongsToCompany(req, companyId)) return true;
+    }
+    return false;
+}
+
+/* Credit notes are billing documents that happen to share the profile bucket. They go to
+ * the people the billing screens are for: an owner or admin of the company they belong to. */
+async function mayReadCreditNote(req, name) {
+    const match = CREDIT_NOTE_COMPANY.exec(name);
+    if (!match || !(await belongsToCompany(req, match[1]))) return false;
+    const { getRoleType } = require('../../Config/permissionGuard');
+    return isPrivileged(await getRoleType(match[1], req.uid));
+}
+
+async function mayReadProfileImage(req, filePath) {
+    const name = String(filePath || '');
+    if (!name || safeRelativePath(name) !== name) return false;
+    if (name.startsWith(CREDIT_NOTES)) return mayReadCreditNote(req, name);
+    return name.includes('/') ? false : mayReadAvatar(req, name);
+}
+
+const PROFILE_WRITE = { allows: (req, filePath) => mayWriteProfileImage(req.uid, filePath), refusal: 'You can only change your own profile image' };
+const PROFILE_REMOVAL = { allows: (req, filePath) => mayRemoveProfileImage(req.uid, filePath), refusal: 'You can only change your own profile image' };
+const PROFILE_READ = { allows: mayReadProfileImage, refusal: 'You do not have access to this file' };
+
+async function accessRefusal(req, bucketId, filePath, profileRule) {
     if (!req.uid) return refusal(401, 'Unauthorized');
     if (String(bucketId || '') === USER_PROFILES_BUCKET) {
-        return (await mayUseProfileImage(req.uid, filePath)) ? null : refusal(403, 'You can only change your own profile image');
+        return (await profileRule.allows(req, filePath)) ? null : refusal(403, profileRule.refusal);
     }
     return (await belongsToCompany(req, bucketId)) ? null : refusal(403, 'You do not have access to this bucket');
 }
 
 async function uploadRefusal(req, bucketId, filePath) {
-    return (await accessRefusal(req, bucketId, filePath, mayWriteProfileImage))
+    return (await accessRefusal(req, bucketId, filePath, PROFILE_WRITE))
         || (safeRelativePath(filePath) ? null : refusal(400, 'Invalid path'));
 }
 
@@ -107,10 +174,10 @@ function refuseUpload(findRefusal) {
     };
 }
 
-function requireAccess(pickBucketId, pickPath, mayUseProfileImage) {
+function requireAccess(pickBucketId, pickPath, profileRule) {
     return async (req, res, next) => {
         try {
-            const found = await accessRefusal(req, pickBucketId(req), pickPath(req), mayUseProfileImage);
+            const found = await accessRefusal(req, pickBucketId(req), pickPath(req), profileRule);
             return found ? refuse(res, found.code, found.statusText) : next();
         } catch (error) {
             return refuse(res, 500, error.message);
@@ -118,14 +185,15 @@ function requireAccess(pickBucketId, pickPath, mayUseProfileImage) {
     };
 }
 
-const requireBucketWrite = (pickBucketId, pickPath) => requireAccess(pickBucketId, pickPath, mayWriteProfileImage);
-const requireBucketRemoval = (pickBucketId, pickPath) => requireAccess(pickBucketId, pickPath, mayRemoveProfileImage);
+const requireBucketWrite = (pickBucketId, pickPath) => requireAccess(pickBucketId, pickPath, PROFILE_WRITE);
+const requireBucketRemoval = (pickBucketId, pickPath) => requireAccess(pickBucketId, pickPath, PROFILE_REMOVAL);
+const requireBucketRead = (pickBucketId, pickPath) => requireAccess(pickBucketId, pickPath, PROFILE_READ);
+const requireProfileImageRead = (pickPath) => requireAccess(() => USER_PROFILES_BUCKET, pickPath, PROFILE_READ);
 
-function requireOwnBucket(pickBucketId, { allowUserProfiles = false } = {}) {
+function requireOwnBucket(pickBucketId) {
     return async (req, res, next) => {
         if (!req.uid) return refuse(res, 401, 'Unauthorized');
         const bucketId = String(pickBucketId(req) || '');
-        if (allowUserProfiles && bucketId === USER_PROFILES_BUCKET) return next();
         try {
             if (await belongsToCompany(req, bucketId)) return next();
         } catch (error) {
@@ -142,21 +210,26 @@ function requireSafeObjectPath(pickPath) {
 const bucketIdParam = (req) => req.params && req.params.bucketId;
 const bodyField = (key) => (req) => req.body && req.body[key];
 const queryField = (key) => (req) => req.query && req.query[key];
+const paramField = (key) => (req) => req.params && req.params[key];
 
 module.exports = {
     USER_PROFILES_BUCKET,
     belongsToCompany,
     mayWriteProfileImage,
     mayRemoveProfileImage,
+    mayReadProfileImage,
     uploadRefusal,
     isProfileUpload,
     refuseBeforeWrite,
     refuseUpload,
     requireBucketWrite,
     requireBucketRemoval,
+    requireBucketRead,
+    requireProfileImageRead,
     requireOwnBucket,
     requireSafeObjectPath,
     bucketIdParam,
     bodyField,
     queryField,
+    paramField,
 };

--- a/Modules/storage/server/routes.js
+++ b/Modules/storage/server/routes.js
@@ -2,11 +2,10 @@ const { handleProfileGetForUser, handleTaskTypeImageGet } = require(`../../../co
 const ctrl = require('./controller');
 const { upload, validatePath } = require('./helpers/bucket.helper');
 const { requireInstanceAdmin } = require('../../Instance/guard');
-const { requireOwnBucket, requireBucketWrite, requireBucketRemoval, requireSafeObjectPath, bucketIdParam, bodyField, queryField } = require('../bucketAccess');
+const { requireOwnBucket, requireBucketWrite, requireBucketRemoval, requireBucketRead, requireProfileImageRead, requireSafeObjectPath, bucketIdParam, bodyField, queryField } = require('../bucketAccess');
 
 exports.init = (app) => {
     const ownBucket = requireOwnBucket(bucketIdParam);
-    const ownOrProfileBucket = requireOwnBucket(bucketIdParam, { allowUserProfiles: true });
 
     // No app screen manages buckets: a company's bucket is created with the company.
     app.post('/api/v1/createBucket', requireInstanceAdmin, requireOwnBucket(bodyField('bucketId')), ctrl.createBucketOnStorage);
@@ -16,11 +15,11 @@ exports.init = (app) => {
     app.get('/api/v1/getBucketSize/:bucketId', ownBucket, ctrl.getBucketSizeOnStorage);
 
     app.post('/api/v1/storage/uploadFile', upload.single("file"), validatePath, ctrl.uploadFileOnStorage);
-    app.get('/api/v1/generateSignedUrl/:bucketId', ownOrProfileBucket, requireSafeObjectPath(queryField('filepath')), ctrl.getSignedUrlFile);
+    app.get('/api/v1/generateSignedUrl/:bucketId', requireSafeObjectPath(queryField('filepath')), requireBucketRead(bucketIdParam, queryField('filepath')), ctrl.getSignedUrlFile);
     app.get('/api/v1/download/:bucketId/*', ctrl.handleFileRequest);
     app.delete('/api/v1/storage/removeFile/:bucketId', requireBucketRemoval(bucketIdParam, queryField('filepath')), requireSafeObjectPath(queryField('filepath')), ctrl.removeFileFromStorage);
 
-    app.post("/api/v1/getUserProfile", requireSafeObjectPath(bodyField('path')), handleProfileGetForUser);
+    app.post("/api/v1/getUserProfile", requireSafeObjectPath(bodyField('path')), requireProfileImageRead(bodyField('path')), handleProfileGetForUser);
     app.post("/api/v1/getTaskTypeImage", requireOwnBucket(bodyField('companyId')), requireSafeObjectPath(bodyField('path')), handleTaskTypeImageGet);
     app.post('/api/v1/storage/uploadFileBase64', requireBucketWrite(bodyField('companyId'), bodyField('path')), requireSafeObjectPath(bodyField('path')), ctrl.uploadBase64FileOnServerStorage);
 }

--- a/Modules/storage/wasabi/routes.js
+++ b/Modules/storage/wasabi/routes.js
@@ -2,7 +2,7 @@ const { handleProfileGetForUser, handleTaskTypeImageGet } = require(`../../../co
 const ctrl = require('./controller');
 const multer = require("multer");
 const { DEFAULT_LIMITS } = require('../../../utils/uploadConfig');
-const { USER_PROFILES_BUCKET, isProfileUpload, refuseBeforeWrite, refuseUpload, requireOwnBucket, uploadRefusal, bodyField } = require('../bucketAccess');
+const { USER_PROFILES_BUCKET, isProfileUpload, refuseBeforeWrite, refuseUpload, requireOwnBucket, requireProfileImageRead, requireSafeObjectPath, uploadRefusal, bodyField, paramField } = require('../bucketAccess');
 
 const wasabiUploadRefusal = (req) => {
     const body = req.body || {};
@@ -96,7 +96,7 @@ exports.init = (app) => {
     /**
      * get presigned url of the userProffileObject
      */
-    app.get("/api/v1/wasabi/retriveUserProfile/:companyId/:path",ctrl.getUserProfilePresignedUrl)
+    app.get("/api/v1/wasabi/retriveUserProfile/:companyId/:path", requireSafeObjectPath(paramField('path')), requireProfileImageRead(paramField('path')), ctrl.getUserProfilePresignedUrl)
 	
 	/**
     * @swagger
@@ -220,6 +220,6 @@ exports.init = (app) => {
      * delete file from wasabi api.
      */
 	app.post("/api/v1/wasabi/deleteFile", ctrl.deleteFileWasabi);
-    app.post("/api/v1/getUserProfile", handleProfileGetForUser);
+    app.post("/api/v1/getUserProfile", requireSafeObjectPath(bodyField('path')), requireProfileImageRead(bodyField('path')), handleProfileGetForUser);
     app.post("/api/v1/getTaskTypeImage", requireOwnBucket(bodyField("companyId")), handleTaskTypeImageGet);
 }

--- a/tests/integration/storage-profile-reads.int.test.js
+++ b/tests/integration/storage-profile-reads.int.test.js
@@ -1,0 +1,139 @@
+const crypto = require('node:crypto');
+const { createApiClient } = require('../../e2e/support/api');
+const { emailFor, inviteMember, login, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const COMPANY_A = state.companyId;
+const OTHER_COMPANY = crypto.randomBytes(12).toString('hex');
+const PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const uploadedProfileImages = [];
+
+afterAll(async () => {
+    for (const { api, filePath } of uploadedProfileImages) {
+        await api.delete('/api/v1/storage/removeFile/USER_PROFILES', { query: { filepath: filePath, thubmkey: 'userProfile' } });
+    }
+});
+
+const uploadProfileImage = (api, filePath) => api.post('/api/v1/storage/uploadFileBase64', { companyId: 'USER_PROFILES', path: filePath, key: 'userProfile', base64String: PNG, isUserProfile: true });
+
+/* The two ways the app asks for a profile image: the tracker posts the path, the web app
+ * asks for a signed URL and then fetches it. */
+const askForProfile = (api, path) => api.post('/api/v1/getUserProfile', { path });
+const signProfile = (api, filepath) => api.get('/api/v1/generateSignedUrl/USER_PROFILES', { query: { filepath, domainUrl: state.baseURL.replace(/\/$/, '') } });
+
+const apiFor = (accessToken) => createApiClient({ baseURL: state.baseURL, accessToken, companyId: COMPANY_A });
+
+async function freshMember(role = 'member') {
+    const owner = await loginAs('owner');
+    const suffix = uniqueSuffix();
+    const email = emailFor(role, `reads${suffix}`);
+    const member = await inviteMember({ baseURL: state.baseURL, ownerApi: owner.api, companyId: COMPANY_A, role, email, firstName: 'QA', lastName: `Reads ${suffix}` });
+    const session = await login(state.baseURL, email);
+    return { ...member, owner, accessToken: session.accessToken, api: apiFor(session.accessToken) };
+}
+
+let ownerSession;
+let avatar;
+
+beforeAll(async () => {
+    ownerSession = await loginAs('owner');
+    avatar = `${ownerSession.uid}_${uniqueSuffix()}_avatar.png`;
+    const uploaded = await uploadProfileImage(ownerSession.api, avatar);
+    expect(uploaded.status).toBe(200);
+    uploadedProfileImages.push({ api: ownerSession.api, filePath: avatar });
+});
+
+describe('an avatar under USER_PROFILES is readable by the owner and their colleagues', () => {
+    it('lets the owner read their own image and download it', async () => {
+        const signed = await signProfile(ownerSession.api, avatar);
+        expect(signed.status).toBe(200);
+        expect(await fetch(signed.body.url).then((res) => res.status)).toBe(200);
+        expect((await askForProfile(ownerSession.api, avatar)).body.status).toBe(true);
+    });
+
+    it.each(['admin', 'member', 'guest'])('lets a %s of the same company read it', async (role) => {
+        const colleague = await loginAs(role);
+        expect((await signProfile(colleague.api, avatar)).status).toBe(200);
+        expect((await askForProfile(colleague.api, avatar)).body.status).toBe(true);
+    });
+
+    it('lets a colleague read its thumbnail, the way the avatar components ask for it', async () => {
+        const colleague = await loginAs('member');
+        const thumbnail = avatar.replace(/\.png$/, '-35x35.png');
+        expect((await signProfile(colleague.api, thumbnail)).status).toBe(200);
+    });
+});
+
+describe('an avatar is not readable outside the companies its owner belongs to', () => {
+    it('refuses a signed-in user with no live seat in any of them', async () => {
+        const member = await freshMember();
+        const removed = await member.owner.api.put('/api/v1/members', { id: member.companyUserId, data: { isDelete: true } });
+        expect(removed.body.status).toBe(true);
+
+        expect((await signProfile(member.api, avatar)).status).toBe(403);
+        expect((await askForProfile(member.api, avatar)).status).toBe(403);
+    });
+
+    it('refuses a name no user holds', async () => {
+        const colleague = await loginAs('member');
+        expect((await signProfile(colleague.api, `${Date.now()}_nobody.png`)).status).toBe(403);
+        expect((await askForProfile(colleague.api, `${Date.now()}_nobody.png`)).status).toBe(403);
+    });
+
+    it('refuses an anonymous caller', async () => {
+        const anon = createApiClient({ baseURL: state.baseURL });
+        expect((await signProfile(anon, avatar)).status).toBe(401);
+    });
+});
+
+describe('the credit notes under USER_PROFILES are billing documents', () => {
+    const creditNote = (companyId) => `InvoiceAndCreditNotes/CreditNotes/${companyId}/${uniqueSuffix()}.pdf`;
+
+    it.each(['member', 'guest'])('refuses a %s of the company the credit note belongs to', async (role) => {
+        const caller = await loginAs(role);
+        const path = creditNote(COMPANY_A);
+        expect((await signProfile(caller.api, path)).status).toBe(403);
+        expect((await askForProfile(caller.api, path)).status).toBe(403);
+    });
+
+    it.each(['owner', 'admin'])('lets the %s of that company reach it', async (role) => {
+        const caller = await loginAs(role);
+        const path = creditNote(COMPANY_A);
+        expect((await signProfile(caller.api, path)).status).toBe(200);
+        expect((await askForProfile(caller.api, path)).body.status).toBe(true);
+    });
+
+    it('refuses an owner asking for another company\'s credit note', async () => {
+        const owner = await loginAs('owner');
+        expect((await signProfile(owner.api, creditNote(OTHER_COMPANY))).status).toBe(403);
+        expect((await askForProfile(owner.api, creditNote(OTHER_COMPANY))).status).toBe(403);
+    });
+});
+
+describe('PUT /api/v1/user binds a profile image to its owner', () => {
+    const pointAt = (member, value) => member.api.put('/api/v1/user', { userId: member.userId, updateObject: { $set: { Employee_profileImage: value } }, newObj: { returnDocument: 'after' } });
+
+    it('refuses pointing a profile at another user\'s image, and at a name nobody uploaded', async () => {
+        const member = await freshMember();
+        expect((await pointAt(member, avatar)).status).toBe(403);
+        expect((await pointAt(member, `${Date.now()}_legacy.png`)).status).toBe(403);
+    });
+
+    it('accepts the caller\'s own upload', async () => {
+        const member = await freshMember();
+        const own = `${member.userId}_${uniqueSuffix()}_avatar.png`;
+        expect((await uploadProfileImage(member.api, own)).status).toBe(200);
+        uploadedProfileImages.push({ api: member.api, filePath: own });
+
+        const saved = await pointAt(member, own);
+        expect(saved.status).toBe(200);
+        expect(saved.body.data.Employee_profileImage).toBe(own);
+    });
+
+    it('leaves a member unable to borrow an image by pointing their record at it', async () => {
+        const member = await freshMember();
+        expect((await pointAt(member, avatar)).status).toBe(403);
+        expect((await signProfile(member.api, avatar)).status).toBe(200);
+    });
+});

--- a/tests/integration/storage-tenant.int.test.js
+++ b/tests/integration/storage-tenant.int.test.js
@@ -6,6 +6,7 @@ const state = readState();
 const anon = createApiClient({ baseURL: state.baseURL });
 const COMPANY_A = state.companyId;
 const TASK_TYPE_IMAGE = 'setting/task_type/task.png';
+const PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
 /* The harness seeds one company and no pre-provisioned ones, so /api/v2/company/create
  * answers "Predefine company not found". Company B is an id outside every fixture
@@ -111,11 +112,16 @@ describe('own-company flows still work', () => {
         expect(file.status).toBe(200);
     });
 
-    it('a signed-in user without a company header gets a profile image URL', async () => {
+    it('a signed-in user without a company header gets their own profile image URL', async () => {
         const member = await loginAs('member');
+        const avatar = `${member.uid}_${crypto.randomBytes(3).toString('hex')}_avatar.png`;
+        expect((await member.api.post('/api/v1/storage/uploadFileBase64', { companyId: 'USER_PROFILES', path: avatar, key: 'userProfile', base64String: PNG, isUserProfile: true })).status).toBe(200);
+
         const noCompany = createApiClient({ baseURL: state.baseURL, accessToken: member.accessToken });
-        const res = await noCompany.post('/api/v1/getUserProfile', { path: 'avatar.png' });
+        const res = await noCompany.post('/api/v1/getUserProfile', { path: avatar });
         expect(res.status).toBe(200);
-        expect(res.body.statusText).toContain('/api/v1/download/USER_PROFILES/avatar.png?token=');
+        expect(res.body.statusText).toContain(`/api/v1/download/USER_PROFILES/${avatar}?token=`);
+
+        await member.api.delete('/api/v1/storage/removeFile/USER_PROFILES', { query: { filepath: avatar, thubmkey: 'userProfile' } });
     });
 });

--- a/tests/integration/storage-uploads.int.test.js
+++ b/tests/integration/storage-uploads.int.test.js
@@ -143,16 +143,16 @@ describe('USER_PROFILES images are bound to their owner', () => {
         uploadedProfileImages.push({ api: member.api, filePath: second });
     });
 
-    it('refuses deleting a legacy image another user holds under different letter case', async () => {
-        const victim = await freshMember();
+    /* The legacy-name delete guard now has a second lock in front of it: a user can no longer
+     * point their record at a name they did not upload, so they cannot claim one to delete it. */
+    it('refuses claiming a legacy image by name, and deleting one claimed that way', async () => {
         const attacker = await freshMember();
         const apiFor = (member) => createApiClient({ baseURL: state.baseURL, accessToken: member.accessToken, companyId: COMPANY_A });
-        const pointAt = (member, name) => apiFor(member).put('/api/v1/user', { userId: member.userId, updateObject: { $set: { Employee_profileImage: name } } });
         const legacyName = `${Date.now()}_${uniqueSuffix()}_photo.png`;
         const shouted = legacyName.toUpperCase();
 
-        expect((await pointAt(victim, legacyName)).body.status).toBe(true);
-        expect((await pointAt(attacker, shouted)).body.status).toBe(true);
+        const claimed = await apiFor(attacker).put('/api/v1/user', { userId: attacker.userId, updateObject: { $set: { Employee_profileImage: shouted } } });
+        expect(claimed.status).toBe(403);
 
         const res = await apiFor(attacker).delete('/api/v1/storage/removeFile/USER_PROFILES', { query: { filepath: shouted, thubmkey: 'userProfile' } });
         expect(res.status).toBe(403);

--- a/tests/storage-bucket-access.test.js
+++ b/tests/storage-bucket-access.test.js
@@ -56,12 +56,6 @@ describe('requireOwnBucket', () => {
         expect(out.status).toBe(403);
     });
 
-    it('lets USER_PROFILES through only where the route allows the shared profile bucket', async () => {
-        const profiles = requireOwnBucket(bucketIdParam, { allowUserProfiles: true });
-        expect((await run(profiles, { uid: USER_OF_A, aud: COMPANY_A, params: { bucketId: 'USER_PROFILES' } })).nextCalled).toBe(true);
-        expect((await run(profiles, { uid: USER_OF_A, aud: COMPANY_A, params: { bucketId: COMPANY_B } })).status).toBe(403);
-    });
-
     it('reads the company from the body for the signing routes', async () => {
         const fromBody = requireOwnBucket(bodyField('companyId'));
         expect((await run(fromBody, { uid: USER_OF_A, aud: COMPANY_A, body: { companyId: COMPANY_A } })).nextCalled).toBe(true);

--- a/tests/storage-profile-read-access.test.js
+++ b/tests/storage-profile-read-access.test.js
@@ -1,0 +1,168 @@
+jest.mock('../Config/jwt', () => ({ verifyCompanyMembership: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
+jest.mock('../Config/permissionGuard', () => ({ getRoleType: jest.fn() }));
+
+const crypto = require('node:crypto');
+const { verifyCompanyMembership } = require('../Config/jwt');
+const { getRoleType } = require('../Config/permissionGuard');
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { myCache } = require('../Config/config');
+const { ROLE_OWNER, ROLE_ADMIN, ROLE_MEMBER, ROLE_GUEST } = require('../Config/roleTypes');
+const bucketAccess = require('../Modules/storage/bucketAccess');
+
+const hex = () => crypto.randomBytes(12).toString('hex');
+const COMPANY_A = hex();
+const COMPANY_B = hex();
+const OWNER_OF_A = hex();
+const COLLEAGUE = hex();
+const OUTSIDER = hex();
+
+const AVATAR = `${OWNER_OF_A}_17_photo.png`;
+const AVATAR_THUMBNAIL = `${OWNER_OF_A}_17_photo-35x35.png`;
+const LEGACY_AVATAR = '171_photo.png';
+const CREDIT_NOTE = `InvoiceAndCreditNotes/CreditNotes/${COMPANY_A}/inv-9.pdf`;
+
+let assignCompany;
+let activeSeats;
+let roles;
+let users;
+
+const matches = (value, condition) => (condition && condition.$regex !== undefined
+    ? typeof value === 'string' && new RegExp(condition.$regex, condition.$options).test(value)
+    : value === condition);
+
+beforeEach(() => {
+    myCache.flushAll();
+    assignCompany = {
+        [OWNER_OF_A]: [COMPANY_A],
+        [COLLEAGUE]: [COMPANY_A],
+        [OUTSIDER]: [COMPANY_B],
+    };
+    activeSeats = { [COMPANY_A]: [OWNER_OF_A, COLLEAGUE], [COMPANY_B]: [OUTSIDER] };
+    roles = { [COMPANY_A]: { [OWNER_OF_A]: ROLE_OWNER, [COLLEAGUE]: ROLE_MEMBER }, [COMPANY_B]: { [OUTSIDER]: ROLE_OWNER } };
+    users = {};
+    verifyCompanyMembership.mockReset();
+    verifyCompanyMembership.mockImplementation(async (uid, companyId) => (assignCompany[uid] || []).includes(companyId));
+    getRoleType.mockReset();
+    getRoleType.mockImplementation(async (companyId, uid) => {
+        const role = (roles[companyId] || {})[uid];
+        return role === undefined ? null : role;
+    });
+    MongoDbCrudOpration.mockReset();
+    MongoDbCrudOpration.mockImplementation(async (dbName, { type, data }) => {
+        const [query] = data;
+        if (type === 'company_users') {
+            const seated = (activeSeats[dbName] || []).includes(String(query.userId));
+            return seated && query.status === 2 ? { _id: hex() } : null;
+        }
+        if (type === 'users') {
+            const wanted = query._id ? String(query._id) : null;
+            if (wanted) return assignCompany[wanted] ? { _id: wanted, AssignCompany: assignCompany[wanted] } : null;
+            const hit = Object.entries(users).find(([, record]) => (query.$or || []).some(
+                (fields) => Object.entries(fields).every(([field, condition]) => matches(record[field], condition)),
+            ));
+            return hit ? { _id: hit[0] } : null;
+        }
+        return null;
+    });
+});
+
+const session = (uid) => ({ uid, aud: (assignCompany[uid] || []).join(',') });
+
+describe('reading an avatar under USER_PROFILES', () => {
+    it('refuses a signed-in user who shares no company with the image owner', async () => {
+        expect(await bucketAccess.mayReadProfileImage(session(OUTSIDER), AVATAR)).toBe(false);
+        expect(await bucketAccess.mayReadProfileImage(session(OUTSIDER), AVATAR_THUMBNAIL)).toBe(false);
+    });
+
+    it('lets a colleague in the same company read it, thumbnails included', async () => {
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), AVATAR)).toBe(true);
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), AVATAR_THUMBNAIL)).toBe(true);
+    });
+
+    it('lets the owner read their own image whatever company they are in', async () => {
+        assignCompany[OWNER_OF_A] = [];
+        activeSeats[COMPANY_A] = [COLLEAGUE];
+        expect(await bucketAccess.mayReadProfileImage(session(OWNER_OF_A), AVATAR)).toBe(true);
+    });
+
+    it('refuses a member whose seat is gone while the token audience still names the company', async () => {
+        activeSeats[COMPANY_A] = [OWNER_OF_A];
+        expect(await bucketAccess.mayReadProfileImage({ uid: COLLEAGUE, aud: COMPANY_A }, AVATAR)).toBe(false);
+    });
+
+    it('resolves a legacy name through the user record that points at it', async () => {
+        users[OWNER_OF_A] = { Employee_profileImage: LEGACY_AVATAR };
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), LEGACY_AVATAR)).toBe(true);
+        myCache.flushAll();
+        expect(await bucketAccess.mayReadProfileImage(session(OUTSIDER), LEGACY_AVATAR)).toBe(false);
+    });
+
+    it('refuses a name no user holds, and anything outside the flat profile bucket', async () => {
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), LEGACY_AVATAR)).toBe(false);
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), `../${COMPANY_B}/secret.png`)).toBe(false);
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), 'thumbnails/photo.png')).toBe(false);
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), '')).toBe(false);
+    });
+});
+
+describe('reading a credit note under USER_PROFILES', () => {
+    it('refuses a member and a guest of the company it belongs to', async () => {
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), CREDIT_NOTE)).toBe(false);
+        roles[COMPANY_A][COLLEAGUE] = ROLE_GUEST;
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), CREDIT_NOTE)).toBe(false);
+    });
+
+    it('lets an owner and an admin of that company read it', async () => {
+        expect(await bucketAccess.mayReadProfileImage(session(OWNER_OF_A), CREDIT_NOTE)).toBe(true);
+        roles[COMPANY_A][COLLEAGUE] = ROLE_ADMIN;
+        expect(await bucketAccess.mayReadProfileImage(session(COLLEAGUE), CREDIT_NOTE)).toBe(true);
+    });
+
+    it('refuses an owner of another company, whose own role says nothing about this one', async () => {
+        expect(await bucketAccess.mayReadProfileImage(session(OUTSIDER), CREDIT_NOTE)).toBe(false);
+    });
+
+    it('refuses a credit-note path that names no company', async () => {
+        expect(await bucketAccess.mayReadProfileImage(session(OWNER_OF_A), 'InvoiceAndCreditNotes/CreditNotes/inv-9.pdf')).toBe(false);
+    });
+});
+
+describe('the read guards on the storage routes', () => {
+    const run = (middleware, req) => new Promise((resolve) => {
+        const res = {
+            statusCode: 200,
+            status(code) { this.statusCode = code; return this; },
+            json(body) { resolve({ nextCalled: false, status: this.statusCode, body }); return this; },
+            send(body) { return this.json(body); },
+        };
+        Promise.resolve(middleware(req, res, () => resolve({ nextCalled: true }))).catch((error) => resolve({ error }));
+    });
+
+    const signedUrl = bucketAccess.requireBucketRead(bucketAccess.bucketIdParam, bucketAccess.queryField('filepath'));
+    const profileRead = bucketAccess.requireProfileImageRead(bucketAccess.bodyField('path'));
+
+    it('answers 401 to a request with no verified session', async () => {
+        expect(await run(profileRead, { body: { path: AVATAR } })).toMatchObject({ nextCalled: false, status: 401 });
+    });
+
+    it('refuses signing another company\'s member image and lets a colleague through', async () => {
+        const outsider = await run(signedUrl, { ...session(OUTSIDER), params: { bucketId: 'USER_PROFILES' }, query: { filepath: AVATAR } });
+        expect(outsider).toMatchObject({ nextCalled: false, status: 403 });
+        const colleague = await run(signedUrl, { ...session(COLLEAGUE), params: { bucketId: 'USER_PROFILES' }, query: { filepath: AVATAR } });
+        expect(colleague.nextCalled).toBe(true);
+    });
+
+    it('refuses a credit note for a member and allows it for an owner', async () => {
+        expect((await run(profileRead, { ...session(COLLEAGUE), body: { path: CREDIT_NOTE } })).status).toBe(403);
+        expect((await run(profileRead, { ...session(OWNER_OF_A), body: { path: CREDIT_NOTE } })).nextCalled).toBe(true);
+    });
+
+    it('still checks company membership for company buckets', async () => {
+        const own = await run(signedUrl, { ...session(COLLEAGUE), params: { bucketId: COMPANY_A }, query: { filepath: 'task/a.png' } });
+        expect(own.nextCalled).toBe(true);
+        const other = await run(signedUrl, { uid: COLLEAGUE, aud: `${COMPANY_A},${COMPANY_B}`, params: { bucketId: COMPANY_B }, query: { filepath: 'task/a.png' } });
+        expect(other.status).toBe(403);
+    });
+});

--- a/tests/storage-route-auth-coverage.test.js
+++ b/tests/storage-route-auth-coverage.test.js
@@ -36,6 +36,8 @@ jest.mock('../Modules/storage/bucketAccess', () => {
         refuseUpload: tracked(actual.refuseUpload),
         requireBucketWrite: tracked(actual.requireBucketWrite),
         requireBucketRemoval: tracked(actual.requireBucketRemoval),
+        requireBucketRead: tracked(actual.requireBucketRead),
+        requireProfileImageRead: tracked(actual.requireProfileImageRead),
         requireOwnBucket: tracked(actual.requireOwnBucket),
     };
 });

--- a/tests/user-access.test.js
+++ b/tests/user-access.test.js
@@ -18,11 +18,12 @@ const GUEST = '6f0000000000000000000004';
 const STRANGER = '6f0000000000000000000005';
 const UNVERIFIED = '6f0000000000000000000006';
 
+const LEGACY_IMAGE = '171_member.png';
 const SECRETS = { webTokens: ['push-token'], verificationToken: 'verify-secret', forgotPasswordToken: 'reset-secret', forgotPasswordTokenTime: 1 };
 const USERS = {
     [OWNER]: { _id: OWNER, Employee_Name: 'Owner', AssignCompany: [COMPANY, OTHER_COMPANY], isProductOwner: true, customerId: 'cus_1', ...SECRETS },
     [ADMIN]: { _id: ADMIN, Employee_Name: 'Admin', AssignCompany: [COMPANY], ...SECRETS },
-    [MEMBER]: { _id: MEMBER, Employee_Name: 'Member', AssignCompany: [COMPANY], ...SECRETS },
+    [MEMBER]: { _id: MEMBER, Employee_Name: 'Member', AssignCompany: [COMPANY], Employee_profileImage: LEGACY_IMAGE, Employee_profileImageURL: LEGACY_IMAGE, ...SECRETS },
     [GUEST]: { _id: GUEST, Employee_Name: 'Guest', AssignCompany: [COMPANY], ...SECRETS },
     [STRANGER]: { _id: STRANGER, Employee_Name: 'Stranger', AssignCompany: [OTHER_COMPANY], ...SECRETS },
     [UNVERIFIED]: { _id: UNVERIFIED, Employee_Email: 'new@example.test', AssignCompany: [], isEmailVerified: false, ...SECRETS },
@@ -216,6 +217,25 @@ describe('ACC-05 PUT /api/v1/user', () => {
     it('refuses an admin removing a member from a company they do not administer', async () => {
         const res = await put(ADMIN, { userId: STRANGER, updateObject: { $pull: { AssignCompany: OTHER_COMPANY } } });
         expect(res.status).toBe(403);
+    });
+
+    it.each([
+        ['another user\'s upload', { Employee_profileImage: `${OWNER}_17_photo.png` }],
+        ['a name nobody uploaded', { Employee_profileImage: 'stolen.png' }],
+        ['another user\'s upload as the image URL', { Employee_profileImageURL: `${OWNER}_17_photo.png` }],
+        ['a path outside the flat profile bucket', { Employee_profileImage: `InvoiceAndCreditNotes/CreditNotes/${COMPANY}/inv-9.pdf` }],
+    ])('refuses pointing a profile at %s', async (_what, fields) => {
+        const res = await put(MEMBER, { userId: MEMBER, updateObject: { $set: fields } });
+        expect(res.status).toBe(403);
+        expect(callsOf('findOneAndUpdate')).toHaveLength(0);
+    });
+
+    it('accepts the caller\'s own upload, the name their record already holds, and clearing it', async () => {
+        const own = `${MEMBER}_17_photo.png`;
+        for (const fields of [{ Employee_profileImage: own, Employee_profileImageURL: own }, { Employee_profileImage: LEGACY_IMAGE }, { Employee_profileImage: '' }]) {
+            const res = await put(MEMBER, { userId: MEMBER, updateObject: { $set: { ...fields, Employee_Name: 'Member' } } });
+            expect([JSON.stringify(fields), res.status]).toEqual([JSON.stringify(fields), 200]);
+        }
     });
 });
 


### PR DESCRIPTION
## Summary

Follow-ups 38 and 39 from `Tasks/active/034-end-to-end-qa-programme/followups.md`, the two reads #639 left open.

| Finding | Route | Fix | Test |
|---|---|---|---|
| **High.** Anything under `USER_PROFILES/` could be read by any signed-in caller: `generateSignedUrl/USER_PROFILES` short-circuited its bucket guard, and `getUserProfile` / `retriveUserProfile` had no access check at all. | `GET /api/v1/generateSignedUrl/USER_PROFILES`, `POST /api/v1/getUserProfile` (server and Wasabi), `GET /api/v1/wasabi/retriveUserProfile/:companyId/:path` | A new `requireBucketRead` / `requireProfileImageRead` resolves the image's owner and refuses a caller who has no live seat in any company that owner belongs to. `requireOwnBucket`'s `allowUserProfiles` escape hatch is gone. | `tests/storage-profile-read-access.test.js`, `tests/integration/storage-profile-reads.int.test.js` |
| **High.** That included the credit-note PDFs under `USER_PROFILES/InvoiceAndCreditNotes/`. | same routes | A path under `InvoiceAndCreditNotes/` is matched against `InvoiceAndCreditNotes/CreditNotes/<companyId>/…` and needs a live seat in that company plus `isPrivileged(getRoleType(...))` — owner or admin, the roles `Modules/Milestone/controller/billing.js` treats as the billing audience. A path naming no company is refused. | same two files |
| **Medium.** `PUT /api/v1/user` accepted any string for `Employee_profileImage`, so a user could point their profile at another user's image path. | `PUT /api/v1/user` | A self update may set `Employee_profileImage` / `Employee_profileImageURL` only to a name the caller may write (#639's `<userId>_…` rule), to the value their own record already holds, or to empty. | `tests/user-access.test.js`, `tests/integration/storage-profile-reads.int.test.js`, `tests/integration/storage-uploads.int.test.js` |

## Notes

**The rule per path.** Everything is decided on the object name, since most read callers send no company at all (see below).

- `<24-hex userId>_<rest>` — an image uploaded since #639. The owner is read straight off the name, thumbnails (`-35x35`) included. Readable by that user, and by a caller with an active `company_users` seat in a company the owner's `AssignCompany` lists. Live membership, exactly as #639 does for uploads: a removed member's old token no longer opens a colleague's avatar.
- Any other flat name — an image uploaded before that rule. The owner is the user record whose `Employee_profileImage` / `Employee_profileImageURL` points at it, matched anchored and case-insensitively, also against the name it is a thumbnail of. Same company rule from there. A name no user holds is refused.
- `InvoiceAndCreditNotes/…` — owner or admin of the company in the path, with a live seat.
- Anything else with a `/` in it, and any path that is not a safe relative path, is refused. A malformed path still answers 400: `requireSafeObjectPath` now runs before the access guard on these routes, so the existing 400s did not turn into 403s.

Owner lookups (`profileImageOwner`, `AssignCompany`) are cached for 60s in `myCache`; the membership and seat checks keep their own caches. Authorisation itself is not cached.

**Callers checked.** Every caller of the four read routes and of `PUT /api/v1/user`, in `frontend/src`, `time-tracker-app/` and the backend:

- `WasabiIamgeCompp.vue` with `userImage=true` — through `UserProfile.vue` this is every avatar in the app: member and assignee lists, chat (`MainChatAvatar`), comments, the members screen, task detail, timesheets, header, call overlay, My Settings. Server mode signs `USER_PROFILES`; Wasabi mode calls `retriveUserProfile/:companyId/:path`. It sends no `companyid` header in the profile branch and the `:companyId` segment was never read by the handler, which is why the rule is built on the image's owner rather than on a company the caller names.
- `composable/commonFunction.js` `getStorageImageServerStorage` / `getStorageImage` and `composable/index.js` `getWasabiImageLink` — attachments, clips, comments, chat media, form submissions, activity icons. These pass a real company id, not `USER_PROFILES`, and go down the unchanged company-bucket branch.
- `time-tracker-app/renderer/controller/user/user.js` `getUserImage` → `POST /api/v1/getUserProfile` with only `{ path }` — the tracker header and Settings avatar. It reads the signed-in user's own image, which the owner rule allows with no company at all.
- `GET /api/v1/download/:bucketId/*` is unchanged: it is only ever reached through a URL minted by `generateSignedUrl`, so the gate is at minting.
- `Modules/notification/prepare-notification-data/controllerV2.js` calls `getUserProfilePresignedUrlCallBackFunction` in-process, not over HTTP, so notification payloads are unaffected.
- `PUT /api/v1/user` with a profile image has exactly one caller, `MySettings.vue`. It always re-sends the value it loaded, so the "name your record already holds" allowance is what keeps a legacy avatar saving; a new photo is uploaded first and comes back `<userId>_…`. No other caller touches the field. Nothing reads a path under `InvoiceAndCreditNotes` — the two `getInvoiceAndCreditNote*` constants in `frontend/src/config/env.js` are unused and those routes are not registered.

**Upgrade impact for existing files.**

- Avatars keep loading for colleagues; nothing needs migrating and no file moves.
- An image whose name predates #639 keeps working while its owner's user record still points at it. One that no user record points at any more can no longer be read — it was already invisible in the app.
- A user whose record points at a legacy name can still save My Settings, but can no longer change that field to a name they did not upload. That also removes the first step of the case-insensitive legacy delete #639 added; the delete guard is kept for records that already hold such a name.
- Download URLs minted before the deploy stay valid until they expire (`JWT_EXP`); the fix is at minting.
- Refusals answer 401/403 JSON where these routes used to answer 200.

**Left out.** `POST /api/v1/wasabi/retriveObject` already checks the token audience against the body's company and is unchanged.

## Test plan

- [x] Failing first on beta, integration: `tests/integration/storage-profile-reads.int.test.js` failed 7 of 16 against beta's `Modules/` — a removed member and a name nobody holds both signed an avatar, a member and a guest both reached a credit note, an owner reached another company's credit note, and a member pointed their profile at the owner's image.
- [x] Failing first on beta, unit: the 4 new `PUT /api/v1/user` cases in `tests/user-access.test.js` failed (200 instead of 403); `tests/storage-profile-read-access.test.js` could not load, since no read rule existed to test.
- [x] `npx jest --selectProjects unit --maxWorkers=2`: 262 suites, 3737 tests passed
- [x] `npx jest tests/conventions --maxWorkers=2`: 8 suites, 94 tests passed
- [x] `E2E_MONGODB_URL=mongodb://127.0.0.1:27193 npx jest --selectProjects integration --runInBand tests/integration/storage-uploads.int.test.js tests/integration/storage-profile-reads.int.test.js tests/integration/storage-tenant.int.test.js tests/integration/public-routes.int.test.js tests/integration/access.int.test.js` against `mongo:7`: 5 suites, 177 tests passed
- [x] `npm run i18n:check`: exit 0, no strings added
- [x] eslint on the changed files: no new errors (two pre-existing `no-async-promise-executor` warnings in untouched parts of `Modules/Users/controller.js`)
- [ ] Frontend `vitest`: not run, no frontend file changed

Two existing tests were updated rather than left passing by luck: `storage-tenant.int.test.js` asked for `avatar.png`, a name no user holds, to prove no company header is needed — it now uploads the caller's own image first; and the legacy letter-case delete case in `storage-uploads.int.test.js` can no longer set up its victim through the API, so it asserts the claim itself is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
