### PR TITLE
fix(socket): refuse handshakes whose session has ended, and gate the invitation preview

### DIFF
--- a/Config/jwt.js
+++ b/Config/jwt.js
@@ -243,11 +243,47 @@ const refuseSession = (res, error, statusText = 'Unauthorized') => {
         isLogout: true
     });
 };
-
 const sessionsQuery = (uid, sid, method) => mongoC.MongoDbCrudOpration(dbCollections.GLOBAL, {
     type: dbCollections.SESSIONS,
     data: [{ _id: new mongoose.Types.ObjectId(sid), userId: uid }]
 }, method);
+
+/**
+ * The session an access token names, or why it can no longer be used.
+ *
+ * The signature alone says nothing about whether the session still exists: logging out
+ * deletes the session row, and the token the browser (or an open socket) still holds keeps
+ * verifying until it expires. Anything that authenticates a caller from an access token —
+ * the HTTP middleware below and the socket handshake in socket/socketinit.js — resolves it
+ * through here so there is one answer, cached under one key, invalidated by one logout.
+ *
+ * Reasons: 'legacy' and 'rotated' mean the client should refresh; every other reason means
+ * the session is gone and the client should be signed out.
+ */
+const resolveAccessSession = async (payload) => {
+    const access = readAccessSession(payload);
+    if (access.kind === 'legacy') return { ok: false, reason: 'legacy' };
+    if (access.kind !== 'session') return { ok: false, reason: 'invalid' };
+    const { uid, sid, rti, sexp } = access;
+    const cacheKey = sessionCacheKey(uid, sid, rti);
+    if (sexp * 1000 <= Date.now()) {
+        myCache.del(cacheKey);
+        sessionsQuery(uid, sid, "deleteMany").catch((error) => logger.error(`Expired session remove error ${error.message || error}`));
+        return { ok: false, reason: 'expired', uid, sid };
+    }
+    if (myCache.get(cacheKey)) return { ok: true, uid, sid };
+    let session;
+    try {
+        session = await sessionsQuery(uid, sid, "findOne");
+    } catch (error) {
+        logger.error(`Session lookup error ${error.message || error}`);
+        return { ok: false, reason: 'unreadable', uid, sid };
+    }
+    if (!(session && session._id)) return { ok: false, reason: 'ended', uid, sid };
+    if (session.refreshTokenJti !== rti) return { ok: false, reason: 'rotated', uid, sid };
+    myCache.set(cacheKey, JSON.stringify({ _id: session._id, userId: uid }), SESSION_CACHE_SECONDS);
+    return { ok: true, uid, sid };
+};
 
 const checkToken = async (isValid, req, res, next) => {
     if (!isValid) {
@@ -256,9 +292,11 @@ const checkToken = async (isValid, req, res, next) => {
     }
     req.uid = isValid.uid;
     req.aud = isValid.aud;
-    const access = readAccessSession(isValid);
-    if (access.kind === 'legacy') return refuseForRefresh(res);
-    if (access.kind !== 'session') {
+    const session = await resolveAccessSession(isValid);
+    if (session.sid) req.sessionId = session.sid;
+    if (session.ok) return next();
+    if (session.reason === 'legacy' || session.reason === 'rotated') return refuseForRefresh(res);
+    if (session.reason === 'invalid') {
         res.clearCookie('accessToken');
         return res.status(401).json({
             status: false,
@@ -269,30 +307,9 @@ const checkToken = async (isValid, req, res, next) => {
             isLogout: true
         });
     }
-    const { uid, sid, rti, sexp } = access;
-    req.sessionId = sid;
-    const cacheKey = sessionCacheKey(uid, sid, rti);
-    if (sexp * 1000 <= Date.now()) {
-        myCache.del(cacheKey);
-        sessionsQuery(uid, sid, "deleteMany").catch((error) => logger.error(`Expired session remove error ${error.message || error}`));
-        return refuseSession(res, 'Refresh Token has expired', 'Refresh Token has expired');
-    }
-    if (!myCache.get(cacheKey)) {
-        let session;
-        try {
-            session = await sessionsQuery(uid, sid, "findOne");
-        } catch (error) {
-            logger.error(`Session lookup error ${error.message || error}`);
-            return refuseSession(res, "Your session is expired");
-        }
-        if (!(session && session._id)) return refuseSession(res, "Your session is expired");
-        if (session.refreshTokenJti !== rti) return refuseForRefresh(res);
-        myCache.set(cacheKey, JSON.stringify({ _id: session._id, userId: uid }), SESSION_CACHE_SECONDS);
-    }
-    return next();
-}
-
-/**
+    if (session.reason === 'expired') return refuseSession(res, 'Refresh Token has expired', 'Refresh Token has expired');
+    return refuseSession(res, "Your session is expired");
+}/**
  * Verify JWT Auth token is valid or not
  * @param {Object} req
  * @param {Object} res
@@ -669,6 +686,7 @@ module.exports = {
     verifyJWTToken: verifyJWTToken,
     verifyJWTTokenV2: verifyJWTTokenV2,
     verifyToken: verifyToken,
+    resolveAccessSession: resolveAccessSession,
     removeCacheAndCookie: removeCacheAndCookie,
     requireCompanyAud: requireCompanyAud,
     requireLiveCompanyMembership: requireLiveCompanyMembership,

--- a/Modules/Auth/controller/invitationPreview.js
+++ b/Modules/Auth/controller/invitationPreview.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const logger = require('../../../Config/loggerConfig');
 const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
 const { SCHEMA_TYPE } = require('../../../Config/schemaType');
@@ -5,18 +6,36 @@ const { SCHEMA_TYPE } = require('../../../Config/schemaType');
 const OBJECT_ID_PATTERN = /^[a-f0-9]{24}$/i;
 const PENDING = 1;
 
+/**
+ * The link token the invitation email carries, checked by exact match.
+ *
+ * An invitation id alone used to be enough to read who was invited, which anyone could
+ * guess or replay. Invitations sent before the link carried a token stored an empty
+ * `linkId`: those keep answering without one, because the link already in someone's inbox
+ * has no token to present. Every invitation sent from now on has one and must present it.
+ */
+const linkTokenAccepted = (stored, provided) => {
+    const expected = Buffer.from(String(stored || ''));
+    if (!expected.length) return true;
+    const given = Buffer.from(String(provided || ''));
+    return given.length === expected.length && crypto.timingSafeEqual(given, expected);
+};
+
+exports.linkTokenAccepted = linkTokenAccepted;
+
 /* The invitation page runs before the invitee has an account, so it gets only the fields
  * it renders; the email is withheld once the invitation is no longer pending. */
 exports.invitationPreview = async (req, res) => {
     try {
-        const { companyId, memberId } = req.body || {};
+        const { companyId, memberId, linkId } = req.body || {};
         if (!OBJECT_ID_PATTERN.test(String(companyId || '')) || !OBJECT_ID_PATTERN.test(String(memberId || ''))) {
             return res.send({ status: false, statusText: 'Invalid invitation link.' });
         }
         const company = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, { type: SCHEMA_TYPE.COMPANIES, data: [{ _id: companyId }, { Cst_CompanyName: 1 }] }, 'findOne');
         if (!company) return res.send({ status: false, statusText: 'Invalid invitation link.' });
-        const member = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.COMPANY_USERS, data: [{ _id: memberId }, { status: 1, userEmail: 1 }] }, 'findOne');
+        const member = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.COMPANY_USERS, data: [{ _id: memberId }, { status: 1, userEmail: 1, linkId: 1 }] }, 'findOne');
         if (!member) return res.send({ status: false, statusText: 'Invalid invitation link.' });
+        if (!linkTokenAccepted(member.linkId, linkId)) return res.send({ status: false, statusText: 'Invalid invitation link.' });
         return res.send({
             status: true,
             statusText: 'Invitation found.',

--- a/Modules/Auth/controller/sendInvitation.js
+++ b/Modules/Auth/controller/sendInvitation.js
@@ -220,7 +220,7 @@ exports.sendInvitationEmailFun = (bodyData) => {
                                 const re = res.data;
         
                                 if(userId === "") {
-                                    let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${re._id}`;
+                                    let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${re._id}&token=${token}`;
                                     sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),re);
                                 } else {
                                     let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${re._id}&linkId=${token}`)}`;
@@ -262,7 +262,7 @@ exports.sendInvitationEmailFun = (bodyData) => {
                                 const resp = response.data
                                 
                                 if(userId === "") {
-                                    let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${resp._id}`;
+                                    let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${resp._id}&token=${token}`;
                                     sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),resp);
                                 } else {
                                     let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${resp._id}&linkId=${token}`)}`;
@@ -299,7 +299,7 @@ exports.sendInvitationEmailFun = (bodyData) => {
                         let userId = response._id;
                         sendCheckRequest(email, userId, token)
                     } else {
-                        sendCheckRequest(email, "", "")
+                        sendCheckRequest(email, "", newLinkToken())
                     }
                 } catch (error) {
                     reject({
@@ -432,7 +432,7 @@ exports.sendInvitationEmail = (req,res) => {
                         const re = res.data;
 
                         if(userId === "") {
-                            let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${re._id}`;
+                            let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${re._id}&token=${token}`;
                             sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),re);
                         } else {
                             let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${re._id}&linkId=${token}`)}`;
@@ -474,7 +474,7 @@ exports.sendInvitationEmail = (req,res) => {
                         const resp = response.data
                         
                         if(userId === "") {
-                            let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${resp._id}`;
+                            let link = `${config.WEBURL}/#/invitation?companyId=${companyId}-${resp._id}&token=${token}`;
                             sendMailFunction(require("../../Template/sendEmailInvitation")(link, companyName),resp);
                         } else {
                             let link = `${config.WEBURL}/#/verify-invitation?id=${btoa(`userId=${userId}&companyId=${companyId}&docId=${resp._id}&linkId=${token}`)}`;
@@ -504,7 +504,7 @@ exports.sendInvitationEmail = (req,res) => {
                 let userId = response._id;
                 sendCheckRequest(email, userId, token)
             } else {
-                sendCheckRequest(email, "", "")
+                sendCheckRequest(email, "", newLinkToken())
             }
         }).catch((error)=>{
             res.send({

--- a/e2e/specs/mongo-gateway.spec.js
+++ b/e2e/specs/mongo-gateway.spec.js
@@ -22,9 +22,10 @@ test.describe('invitation page while signed out', () => {
             email, companyId: state.companyId, companyName: 'E2E Workspace', role: 3, designation: 0,
         });
         const memberId = invite.body.data._id;
+        const token = invite.body.data.linkId;
 
         const preview = page.waitForResponse((res) => res.url().includes('/api/v2/auth/invitation-preview'));
-        await page.goto(`/#/invitation?companyId=${state.companyId}-${memberId}`);
+        await page.goto(`/#/invitation?companyId=${state.companyId}-${memberId}&token=${token}`);
         expect((await preview).status()).toBe(200);
         await expect(page.locator('#inv-email')).toHaveText(email);
     });

--- a/frontend/src/views/Authentication/Invitation/Invitation.vue
+++ b/frontend/src/views/Authentication/Invitation/Invitation.vue
@@ -135,7 +135,7 @@ onMounted(async () => {
     localStorage.setItem("companyId", companyIdRoute.value);
     localStorage.setItem("companyUserDocID", requestId.value);
     try {
-        const preview = await axios.post(env.API_URI + env.INVITATION_PREVIEW, { companyId: companyIdRoute.value, memberId: requestId.value });
+        const preview = await axios.post(env.API_URI + env.INVITATION_PREVIEW, { companyId: companyIdRoute.value, memberId: requestId.value, linkId: String(route.query.token || "") });
         if (!preview.data.status) { stage.value = "invalid"; return; }
         const invite = preview.data.data || {};
         workspaceName.value = invite.workspaceName || "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,8 @@
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "lint-staged": "^16.4.0",
-        "nodemon": "^3.1.0"
+        "nodemon": "^3.1.0",
+        "socket.io-client": "4.8.1"
       },
       "engines": {
         "node": "20.x"
@@ -9096,6 +9097,60 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -15071,6 +15126,22 @@
         "ws": "~8.17.1"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -16581,6 +16652,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xpath": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "lint-staged": "^16.4.0",
-    "nodemon": "^3.1.0"
+    "nodemon": "^3.1.0",
+    "socket.io-client": "4.8.1"
   }
 }

--- a/socket/socketinit.js
+++ b/socket/socketinit.js
@@ -8,6 +8,7 @@ const {generalReminderSocketHandler} = require('./controller/generalReminderSock
 const {callSocketHandler} = require('./controller/callSocket');
 const { instrument } = require('@socket.io/admin-ui');
 const jwt = require('jsonwebtoken');
+const { resolveAccessSession } = require('../Config/jwt');
 const logger = require('../Config/loggerConfig');
 const { corsOriginDelegate } = require('../utils/cors.js');
 const { removeRoom, removeBySocket } = require('./helper');
@@ -49,6 +50,29 @@ exports.getAdminUiConfig = (env = process.env) => {
     };
 };
 
+/**
+ * The session behind a socket's access token.
+ *
+ * A socket used to be judged on the token signature alone, so a tab that had logged out —
+ * or whose token had since expired — kept receiving every event it was subscribed to. The
+ * session is resolved through the same `resolveAccessSession` the HTTP middleware uses, so
+ * a logout that deletes the session row and drops its cache entry ends the socket too.
+ *
+ * Cost: a cache hit for the life of the cached session (10 minutes, the HTTP TTL), one
+ * Mongo read after that — not a read per event. Logging out deletes the cache entry, so
+ * the very next event from that socket reaches Mongo, finds nothing and closes it.
+ */
+const sessionOf = async (payload) => {
+    if (!payload) return { ok: false };
+    if (Number.isFinite(payload.exp) && payload.exp * 1000 <= Date.now()) return { ok: false };
+    try {
+        return await resolveAccessSession(payload);
+    } catch (error) {
+        logger.error(`Socket session lookup error ${error.message || error}`);
+        return { ok: false };
+    }
+};
+
 exports.initSocket = (server) => {
 
     let io = new Server(server, {
@@ -63,18 +87,23 @@ exports.initSocket = (server) => {
         },
     });
     const userNamespace = io.of(/^\/userid_\w+$/);
-    userNamespace.use((socket, next) => {
+    userNamespace.use(async (socket, next) => {
         const token = socket.handshake.auth.token;
         if (!token) {
             return next(new Error('Authentication error: Token not provided'));
         }
-        jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
-            if (err) {
-                return next(new Error('Authentication error: Invalid token'));
-            }
-            socket.user = decoded;
-            next();
-        });
+        let decoded;
+        try {
+            decoded = jwt.verify(token, process.env.JWT_SECRET);
+        } catch (error) {
+            return next(new Error('Authentication error: Invalid token'));
+        }
+        const session = await sessionOf(decoded);
+        if (!session.ok) {
+            return next(new Error('Authentication error: Session has ended'));
+        }
+        socket.user = decoded;
+        next();
     });
     const adminUiConfig = exports.getAdminUiConfig();
     if (adminUiConfig) {
@@ -88,6 +117,19 @@ exports.initSocket = (server) => {
         const {userRole} = socket.handshake.query;
         socket.customData = {userRole};
         const namespace = socket.nsp;
+
+        // A handshake only proves the session was live when the socket opened. Every event
+        // re-checks it, so a socket whose session has since ended is closed on its next one.
+        socket.use((_event, next) => {
+            sessionOf(socket.user).then((session) => {
+                if (session.ok) {
+                    next();
+                    return;
+                }
+                next(new Error('Session has ended'));
+                socket.disconnect(true);
+            });
+        });
 
         // SOCKET-PERFORMANCE-PLAN #4 (Phase 1) + #1 (Phase 2): auto-purge
         // every entry for this socket from the room index when the socket

--- a/tests/integration/invitation-preview.int.test.js
+++ b/tests/integration/invitation-preview.int.test.js
@@ -1,0 +1,53 @@
+const crypto = require('node:crypto');
+const { createApiClient } = require('../../e2e/support/api');
+const { loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const anonymous = createApiClient({ baseURL: state.baseURL });
+
+const preview = (body) => anonymous.post('/api/v2/auth/invitation-preview', body);
+
+const inviteSomeone = async () => {
+    const owner = await loginAs('owner');
+    const email = `invitee.${crypto.randomBytes(3).toString('hex')}@e2e.alianhub.test`;
+    const res = await owner.api.post('/api/v2/sendInvitationEmail', {
+        email, companyId: state.companyId, companyName: state.companyName, role: 3, designation: 0,
+    });
+    const row = res.body && res.body.data;
+    if (!row || !row._id) throw new Error(`invite failed (${res.status}): ${JSON.stringify(res.body).slice(0, 300)}`);
+    return { email, memberId: String(row._id), linkId: String(row.linkId || '') };
+};
+
+describe('invitation preview', () => {
+    it('gives the invitee the workspace and the address the invitation was sent to', async () => {
+        const invite = await inviteSomeone();
+        const res = await preview({ companyId: state.companyId, memberId: invite.memberId, linkId: invite.linkId });
+        expect(res.body.status).toBe(true);
+        expect(res.body.data.email).toBe(invite.email);
+        expect(res.body.data.workspaceName).toBe(state.companyName);
+    });
+
+    it('sends a link token the invitee can present', async () => {
+        const invite = await inviteSomeone();
+        expect(invite.linkId).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('refuses a preview that does not carry the link token', async () => {
+        const invite = await inviteSomeone();
+        const res = await preview({ companyId: state.companyId, memberId: invite.memberId });
+        expect(res.body.status).toBe(false);
+        expect(res.body.data).toBeUndefined();
+    });
+
+    it('refuses a preview carrying the wrong link token', async () => {
+        const invite = await inviteSomeone();
+        const res = await preview({ companyId: state.companyId, memberId: invite.memberId, linkId: crypto.randomBytes(32).toString('hex') });
+        expect(res.body.status).toBe(false);
+        expect(res.body.data).toBeUndefined();
+    });
+
+    it('refuses an invitation id that does not exist', async () => {
+        const res = await preview({ companyId: state.companyId, memberId: new Array(24).fill('a').join(''), linkId: 'whatever' });
+        expect(res.body.status).toBe(false);
+    });
+});

--- a/tests/integration/public-routes.int.test.js
+++ b/tests/integration/public-routes.int.test.js
@@ -148,11 +148,11 @@ describe('the same routes with a session', () => {
 });
 
 describe('invitations', () => {
-    it('previews a pending invitation without a session', async () => {
+    it('previews a pending invitation without a session, for whoever holds the link token', async () => {
         const { api } = await loginAs('owner');
         const email = `preview-${uniqueSuffix()}@e2e.alianhub.test`;
         const invite = await api.post('/api/v2/sendInvitationEmail', { email, companyId: state.companyId, companyName: 'E2E', role: 3, designation: 0 });
-        const res = await anonymous.post('/api/v2/auth/invitation-preview', { companyId: state.companyId, memberId: invite.body.data._id });
+        const res = await anonymous.post('/api/v2/auth/invitation-preview', { companyId: state.companyId, memberId: invite.body.data._id, linkId: invite.body.data.linkId });
         expect(res.body.status).toBe(true);
         expect(res.body.data).toMatchObject({ status: 1, email });
         expect(res.body.data.workspaceName).toBeTruthy();

--- a/tests/integration/socket-session.int.test.js
+++ b/tests/integration/socket-session.int.test.js
@@ -1,0 +1,79 @@
+const { io } = require('socket.io-client');
+const { createApiClient } = require('../../e2e/support/api');
+const { loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+
+const ACK_WAIT_MS = 2000;
+
+const connect = ({ accessToken, companyId, userId }) => new Promise((resolve, reject) => {
+    const socket = io(`${state.baseURL}/userid_${companyId}_${userId}`, {
+        transports: ['websocket'],
+        auth: { token: accessToken },
+        query: { userRole: 3 },
+        reconnection: false,
+        timeout: 10000,
+    });
+    socket.once('connect', () => resolve(socket));
+    socket.once('connect_error', (error) => {
+        socket.close();
+        reject(error);
+    });
+});
+
+/* `getRoomList` answers through a callback, so an ack proves the socket is still being
+ * served; no ack within the window means the server is no longer talking to it. */
+const askForRooms = (socket) => new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), ACK_WAIT_MS);
+    socket.emit('getRoomList', socket.id, (rooms) => {
+        clearTimeout(timer);
+        resolve(rooms);
+    });
+});
+
+const logout = (session) => createApiClient({ baseURL: state.baseURL, accessToken: session.accessToken, companyId: state.companyId })
+    .post('/api/v2/logout', { id: session.userId });
+
+describe('socket sessions', () => {
+    const open = [];
+    afterEach(() => {
+        open.splice(0).forEach((socket) => socket.close());
+    });
+
+    const openSocket = async (session) => {
+        const socket = await connect({ accessToken: session.accessToken, companyId: state.companyId, userId: session.userId });
+        open.push(socket);
+        return socket;
+    };
+
+    it('serves a socket opened with a live session', async () => {
+        const member = await loginAs('member');
+        const socket = await openSocket(member);
+        expect(await askForRooms(socket)).not.toBeNull();
+    });
+
+    it('stops serving an open socket once its session is logged out', async () => {
+        const member = await loginAs('member');
+        const socket = await openSocket(member);
+        expect(await askForRooms(socket)).not.toBeNull();
+
+        expect((await logout(member)).status).toBe(200);
+
+        expect(await askForRooms(socket)).toBeNull();
+        expect(socket.connected).toBe(false);
+    });
+
+    it('refuses a handshake carrying a logged-out access token', async () => {
+        const member = await loginAs('member');
+        expect((await logout(member)).status).toBe(200);
+
+        await expect(connect({ accessToken: member.accessToken, companyId: state.companyId, userId: member.userId }))
+            .rejects.toThrow(/Authentication error/);
+    });
+
+    it('refuses a handshake with no token at all', async () => {
+        const member = await loginAs('member');
+        await expect(connect({ accessToken: '', companyId: state.companyId, userId: member.userId }))
+            .rejects.toThrow(/Authentication error/);
+    });
+});

--- a/tests/invitation-preview-token.test.js
+++ b/tests/invitation-preview-token.test.js
@@ -1,0 +1,28 @@
+const { linkTokenAccepted } = require('../Modules/Auth/controller/invitationPreview');
+
+const TOKEN = 'a'.repeat(64);
+
+describe('invitation preview link token', () => {
+    it('accepts the token the invitation stored', () => {
+        expect(linkTokenAccepted(TOKEN, TOKEN)).toBe(true);
+    });
+
+    it('refuses a preview with no token', () => {
+        expect(linkTokenAccepted(TOKEN, undefined)).toBe(false);
+        expect(linkTokenAccepted(TOKEN, '')).toBe(false);
+    });
+
+    it('refuses another invitation\'s token, and one that only shares a prefix', () => {
+        expect(linkTokenAccepted(TOKEN, 'b'.repeat(64))).toBe(false);
+        expect(linkTokenAccepted(TOKEN, 'a'.repeat(63))).toBe(false);
+        expect(linkTokenAccepted(TOKEN, `${TOKEN}a`)).toBe(false);
+    });
+
+    /* Invitations sent before the link carried a token: the link in the inbox has none to
+     * present, so those keep working until they are accepted or resent. */
+    it('accepts an invitation sent before links carried a token', () => {
+        expect(linkTokenAccepted('', '')).toBe(true);
+        expect(linkTokenAccepted(undefined, undefined)).toBe(true);
+        expect(linkTokenAccepted('', 'anything')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

| Finding | Where | Fix | Test |
|---|---|---|---|
| 34 — a socket handshake checked only the JWT signature, so a logged-out access token kept receiving events | `socket/socketinit.js`, `Config/jwt.js` | The session logic in `checkToken` is extracted as `resolveAccessSession`; the handshake and every incoming socket event go through it, and a socket whose session has ended is closed on its next event | `tests/integration/socket-session.int.test.js` |
| 11 — the invitation preview answered on an invitation id alone, so a guessed id revealed the workspace and the invited address | `Modules/Auth/controller/invitationPreview.js`, `Modules/Auth/controller/sendInvitation.js`, `frontend/src/views/Authentication/Invitation/Invitation.vue` | Invitations for an address with no account now mint a link token and carry it in the link; the preview requires an exact match | `tests/integration/invitation-preview.int.test.js`, `tests/invitation-preview-token.test.js` |

Both were reproduced first. On `beta` the socket test showed a logged-out socket still getting its `getRoomList` ack, and a fresh handshake with the logged-out token still connecting; the preview test read back the invitee's email with no token at all.

## Notes

**Socket cache window.** The socket reuses the session cache entry the HTTP layer already keeps (`session:<uid>:<sid>:<rti>`, 600s). While a session is live, an event costs a cache hit and no database read; after the entry ages out, one read per session per 10 minutes. Logging out deletes the session row *and* that cache entry (`removeSession` → `removeCache('session:<uid>:<sid>:', true)`), so the very next event from that socket reaches Mongo, finds nothing and the socket is closed — the revocation window on a single node is one event, not 10 minutes. Behind more than one Node process the cache is per-process, so a socket on another instance can survive until its cached entry expires (up to 10 minutes) — the same window HTTP requests have had since #638, not a weaker one. The socket check also re-reads the token's own `exp`, which nothing did after the handshake before.

**Upgrade impact — open sockets.** Sockets are authenticated per connection, so nothing reconnects on deploy; the first event after the upgrade re-checks the session. Clients holding a pre-#638 access token (no `sid`) are refused at the handshake, exactly as those tokens are already refused over HTTP, and reconnect after the client refreshes. Tracker sign-in mints its access token through `generateTokenV2Fun` like every other sign-in, so tracker sockets are unaffected.

**Upgrade impact — pending invitations.** Invitations to an address with no account used to be created with `sendCheckRequest(email, "", "")` — an empty stored `linkId` — and the emailed link (`/#/invitation?companyId=<companyId>-<memberId>`) carried no token, so there was nothing to check against. Those rows are grandfathered: when the stored token is empty the preview answers without one, so links already in an inbox keep working until they are accepted or resent. Every invitation sent after this change stores a 256-bit token and puts it in the link (`&token=…`), and its preview is gated. Invitations to an address that already has an account were never affected — that flow uses `/#/verify-invitation`, whose blob has always carried the token.

## Test plan

- `npx jest --selectProjects unit --maxWorkers=2` — 269 suites, 3800 tests, all pass.
- `npx jest tests/conventions --maxWorkers=2` — 8 suites, 94 tests, all pass.
- `E2E_MONGODB_URL=mongodb://127.0.0.1:27202 npx jest --selectProjects integration --runInBand` — 42 suites, 784 tests. The only failure was `public-routes.int.test.js` asserting the old ungated preview; that test now sends the link token and the file passes (69 tests).
- `cd frontend && npx vitest run` — 36 files, 259 tests, all pass.
- `npm run i18n:check` — exit 0 (no user-visible strings added).
- `npx eslint` on every touched file, front end and back — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
