### PR TITLE
fix(auth): keep the preset key out of urls and record owners who accept elsewhere

### DIFF
--- a/Config/presetKey.js
+++ b/Config/presetKey.js
@@ -1,0 +1,27 @@
+const crypto = require('crypto');
+const config = require('./config.js');
+
+const PRESET_KEY_HEADER = 'x-preset-key';
+const KEY_IN_URL_HINT = `Send the preset key in the ${PRESET_KEY_HEADER} header instead of the URL.`;
+
+const presented = (req) => {
+    const header = req && req.headers ? req.headers[PRESET_KEY_HEADER] : '';
+    const body = req && req.body ? req.body.presetKey : '';
+    return String(header || body || '');
+};
+
+const matchesPresetKey = (req) => {
+    const expected = String(config.PRECOMPANYKEY || '');
+    const given = presented(req);
+    if (!expected || given.length !== expected.length) return false;
+    return crypto.timingSafeEqual(Buffer.from(given), Buffer.from(expected));
+};
+
+const refusePresetKey = (res) => res.status(401).json({ status: false, statusText: 'Unauthorized', message: 'Unauthorized' });
+
+// The key used to arrive as a path segment, which put it in access logs, proxy logs and
+// browser history. The old shape is answered without ever comparing the key, so a request
+// made from an old bookmark cannot succeed and cannot confirm the key either.
+const refuseKeyInUrl = (res) => res.status(400).json({ status: false, statusText: KEY_IN_URL_HINT, message: KEY_IN_URL_HINT });
+
+module.exports = { PRESET_KEY_HEADER, matchesPresetKey, refusePresetKey, refuseKeyInUrl };

--- a/Modules/Auth/controller/createUser.js
+++ b/Modules/Auth/controller/createUser.js
@@ -8,6 +8,7 @@ const mongoose = require("mongoose");
 const { importUserNotifications } = require("../../../utils/data");
 const { addAndRemoveUserInMongodbNotificationCount } = require("../../Auth/controller");
 const { toAuthView } = require("../../Users/helpers/userAccessRules");
+const { recordInvitedOwner } = require("../../Company/helpers/recordInvitedOwner");
 
 
 exports.authenticateToken = "";
@@ -176,6 +177,10 @@ exports.googleSignup = async (req, res) => {
             }
             await mongoRef.MongoDbCrudOpration(assignCompany, query, 'findOneAndUpdate');
 
+            await recordInvitedOwner({ companyId: invitedCompany, invitation, userId: authRes._id }).catch((error) => {
+                logger.error(`Record invited owner error in googleSignup hook: ${error}`);
+            });
+
             // Import notification settings
             await importUserNotifications(assignCompany, authRes._id).catch((error) => {
                 logger.error(`Import notification setting error in googleSignup hook: ${error}`);
@@ -286,6 +291,10 @@ exports.githubSignup = async (req, res) => {
             }
             await mongoRef.MongoDbCrudOpration(assignCompany, query, 'findOneAndUpdate');
 
+            await recordInvitedOwner({ companyId: invitedCompany, invitation, userId: authRes._id }).catch((error) => {
+                logger.error(`Record invited owner error in githubSignup hook: ${error}`);
+            });
+
             // Import notification settings
             await importUserNotifications(assignCompany, authRes._id).catch((error) => {
                 logger.error(`Import notification setting error in githubSignup hook: ${error}`);
@@ -395,6 +404,10 @@ exports.gitlabSignup = async (req, res) => {
                 ]
             }
             await mongoRef.MongoDbCrudOpration(assignCompany, query, 'findOneAndUpdate');
+
+            await recordInvitedOwner({ companyId: invitedCompany, invitation, userId: authRes._id }).catch((error) => {
+                logger.error(`Record invited owner error in gitlabSignup hook: ${error}`);
+            });
 
             // Import notification settings
             await importUserNotifications(assignCompany, authRes._id).catch((error) => {

--- a/Modules/Auth/controller/verifyInvitation.js
+++ b/Modules/Auth/controller/verifyInvitation.js
@@ -11,6 +11,7 @@ const atob = (input) => Buffer.from(input, 'base64').toString('binary');
 const { updateUserFun, getUserByQueyFun } = require("../../Users/controller");
 const { updateMemberFunction } = require('../../settings/Members/controller');
 const { importUserNotifications } = require("../../../utils/data");
+const { recordInvitedOwner } = require("../../Company/helpers/recordInvitedOwner");
 
 /**
  * BUG-011 / #65 fix: parse the base64 invitation blob into a *local*
@@ -197,6 +198,11 @@ exports.checkPermission = (req, res) => {
 
                 updateMemberFunction(invite.companyId, memberObject, "updateOne")
                 .then(() => {
+                    recordInvitedOwner({ companyId: invite.companyId, invitation: userData, userId: invite.userId })
+                    .catch((error) => {
+                        logger.error(`ERROR in record invited owner: ${error.message}`);
+                    })
+
                     const userUpdateQuery = {
                         type: dbCollections.USERS,
                         data: [

--- a/Modules/Company/helpers/recordInvitedOwner.js
+++ b/Modules/Company/helpers/recordInvitedOwner.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+const { removeCache } = require('../../../utils/commonFunctions');
+const { ROLE_OWNER } = require('../../../Config/roleTypes');
+const { OBJECT_ID_PATTERN } = require('./companyAccessRules');
+
+/* An invitation that carries the owner role is what hands a company over, so the handler that
+ * verified the invitation records the new owner itself. The alternative — a second call from the
+ * browser saying "I am the owner now" — is a claim the server would have to re-verify anyway. */
+exports.recordInvitedOwner = async ({ companyId, invitation, userId }) => {
+    if (!invitation || Number(invitation.roleType) !== ROLE_OWNER) return false;
+    if (!OBJECT_ID_PATTERN.test(String(companyId || '')) || !OBJECT_ID_PATTERN.test(String(userId || ''))) return false;
+
+    await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+        type: SCHEMA_TYPE.COMPANIES,
+        data: [
+            { _id: new mongoose.Types.ObjectId(String(companyId)) },
+            { $set: { userId: new mongoose.Types.ObjectId(String(userId)) } }
+        ]
+    }, 'findOneAndUpdate');
+
+    removeCache(`companyData_${companyId}`, true);
+    return true;
+};

--- a/Modules/common/routes.js
+++ b/Modules/common/routes.js
@@ -1,8 +1,8 @@
 const { requireInstanceAdmin } = require('../Instance/guard');
 const { DateTime } = require("luxon");
 const fs = require("fs");
-const config =  require('../../Config/config.js');
 const { connections } = require("../../middlewares/mongoConnector/helper.js");
+const { matchesPresetKey, refusePresetKey, refuseKeyInUrl } = require('../../Config/presetKey.js');
 const commonctrl = require('./controller.js');
 
 /**
@@ -28,18 +28,28 @@ exports.init = (app) => {
     });
 
     // Get Connections
-    app.get("/connections/:id", (req, res) => {
-        if (req.params && req.params.id && req.params.id === config.PRECOMPANYKEY) {
-            const connectionsJSON = connections.map((x) => ({
-                db: x.db,
-                createdAt: new Date(x.createdAt),
-                lastRequest: new Date(x.lastRequest)
-            }))
-            res.json({data: connectionsJSON, total: connectionsJSON.length});
-        } else {
-            res.send('Unauthorized');
+    app.get("/connections", (req, res) => {
+        if (!matchesPresetKey(req)) {
+            return refusePresetKey(res);
         }
+        const connectionsJSON = connections.map((x) => ({
+            db: x.db,
+            createdAt: new Date(x.createdAt),
+            lastRequest: new Date(x.lastRequest)
+        }));
+        return res.json({ data: connectionsJSON, total: connectionsJSON.length });
     });
+
+    app.post("/api/v1/setPresetCompany", (req, res) => {
+        if (!matchesPresetKey(req)) {
+            return refusePresetKey(res);
+        }
+        require('../Company/controller2.js').preCompanySetup();
+        return res.json({ status: true, statusText: 'Preset Company Process Start Successful' });
+    });
+
+    app.get("/connections/:id", (req, res) => refuseKeyInUrl(res));
+    app.get("/api/v1/setPresetCompany/:id", (req, res) => refuseKeyInUrl(res));
 
     /**
      * Create Default Folder

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -158,7 +158,7 @@ Backend variables: 150. Frontend build-time variables: 23.
 | `HELMET_ENABLED` |  |  | Send the helmet security headers (default true). | `index.js` |
 | `INSTANCE_ADMIN_KEY` (secret) |  |  | Shared key that grants the instance-admin API without a product-owner session. | `Modules/Instance/guard.js` |
 | `MEMBERSHIP_CACHE_TTL_SECONDS` |  | `60` | Seconds a user-company membership check is cached before MongoDB is asked again. | `Config/jwt.js` |
-| `PRECOMPANYKEY` (secret) | yes | `your_preset_key` | Random key that identifies the preset company routes; generated at setup. | `Config/config.js` |
+| `PRECOMPANYKEY` (secret) | yes | `your_preset_key` | Random key for the preset company routes, presented in the x-preset-key header; generated at setup. | `Config/config.js` |
 | `SOCKETIO_ADMIN_PASSWORD_HASH` (secret) |  | `$2a$12$HHemhzmTrC8Dmf2Gd9v/Teo9oiCxfYJb.St3HKMBx1L3wJmZLeX5u` | bcrypt hash of the Socket.IO admin UI password; the UI stays off while unset. | `socket/socketinit.js` |
 | `SOCKETIO_ADMIN_USERNAME` |  | `alian` | Username for the Socket.IO admin UI; the UI stays off while unset. | `socket/socketinit.js` |
 | `WEBHOOK_ALLOWED_PRIVATE_HOSTS` |  |  | Private hosts webhooks may post to: exact hostnames or CIDR ranges, comma-separated (empty by default, so every private host is refused). Also editable under Instance > Settings > Security. Link-local and cloud metadata addresses stay blocked, and a range can be no wider than /8 (IPv4) or /32 (IPv6). | `Modules/Webhooks/helpers/privateHostAllowlist.js` |

--- a/index.js
+++ b/index.js
@@ -79,15 +79,6 @@ function initializeControllers() {
     const { startInterval } = require("./middlewares/mongoConnector/helper.js");
     startInterval();
     const { currentDirectory } = require(`./common-storage/common-${process.env.STORAGE_TYPE}.js`);
-    const { preCompanySetup, } = require("./Modules/Company/controller2.js");
-    app.get("/api/v1/setPresetCompany/:id", (req, res) => {
-        if (req.params && req.params.id && req.params.id === config.PRECOMPANYKEY) {
-            preCompanySetup();
-            res.send('Preset Company Process Start Successful');
-        } else {
-            res.send('Unauthorized');
-        }
-    })
     //IMPORT CUSTOM FILES
     require('./Modules/Auth/init').init(app);
     require('./Modules/SSO/init').init(app);

--- a/scripts/env-doc.meta.json
+++ b/scripts/env-doc.meta.json
@@ -510,7 +510,7 @@
   },
   "PRECOMPANYKEY": {
     "group": "security",
-    "description": "Random key that identifies the preset company routes; generated at setup.",
+    "description": "Random key for the preset company routes, presented in the x-preset-key header; generated at setup.",
     "required": true,
     "secret": true,
     "default": "your_preset_key"

--- a/tests/integration/instance.int.test.js
+++ b/tests/integration/instance.int.test.js
@@ -561,8 +561,19 @@ describe('common, admin and api docs', () => {
     });
 
     it('refuses the connections list without the preset key', async () => {
-        const res = await anonymous.get('/connections/not-the-key');
-        expect(res.body).toBe('Unauthorized');
+        const res = await anonymous.get('/connections', { headers: { 'x-preset-key': 'not-the-key' } });
+        expect(res.status).toBe(401);
+        expect(res.body.status).toBe(false);
+    });
+
+    it('QA-13 sends a preset key in the URL back unread, so it cannot leak through a log', async () => {
+        for (const path of ['/connections/not-the-key', '/api/v1/setPresetCompany/not-the-key']) {
+            const res = await anonymous.get(path);
+            expect(res.status).toBe(400);
+            expect(String(res.body.message)).toMatch(/x-preset-key/);
+        }
+        const started = await anonymous.post('/api/v1/setPresetCompany', {});
+        expect(started.status).toBe(401);
     });
 
     it('serves the API docs', async () => {

--- a/tests/integration/invited-owner.int.test.js
+++ b/tests/integration/invited-owner.int.test.js
@@ -1,0 +1,131 @@
+const { MongoClient, ObjectId } = require('mongodb');
+const { createApiClient } = require('../../e2e/support/api');
+const { loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+const { resolveMongoUrl } = require('../../e2e/support/env');
+
+const state = readState();
+const anonymous = createApiClient({ baseURL: state.baseURL });
+const ROLE_OWNER = 1;
+
+let client;
+let ownerSession;
+let originalOwnerId;
+
+const owner = async () => {
+    if (!ownerSession) ownerSession = await loginAs('owner');
+    return ownerSession;
+};
+
+const companies = () => client.db('global').collection('companies');
+const companyUsers = () => client.db(state.companyId).collection('company_users');
+
+const companyOwnerId = async () => {
+    const company = await companies().findOne({ _id: new ObjectId(state.companyId) }, { projection: { userId: 1 } });
+    return company && company.userId ? String(company.userId) : '';
+};
+
+/* The acceptance handlers answer the browser before they finish writing, so the owner row
+ * lands a moment after the response. */
+const ownerBecomes = async (userId) => {
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+        if (await companyOwnerId() === String(userId)) return true;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return false;
+};
+
+/* The invite answers before the company_users row is saved, so the row appears a moment later. */
+const invitationRow = async (email) => {
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+        const row = await companyUsers().findOne({ userEmail: email.toLowerCase() });
+        if (row) return row;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    throw new Error(`no invitation row for ${email}`);
+};
+
+const invite = async (email, role) => {
+    const { api } = await owner();
+    const sent = await api.post('/api/v2/sendInvitationEmail', {
+        email, companyId: state.companyId, companyName: 'E2E Workspace', role, designation: 0,
+    });
+    expect(sent.status).toBe(200);
+    return invitationRow(email);
+};
+
+const inviteOwner = (email) => invite(email, ROLE_OWNER);
+
+const inviteBlob = (row) => Buffer.from(
+    `userId=${String(row.userId)}&companyId=${state.companyId}&docId=${String(row._id)}&linkId=${row.linkId}`,
+    'binary',
+).toString('base64');
+
+beforeAll(async () => {
+    client = new MongoClient(resolveMongoUrl(), { serverSelectionTimeoutMS: 5000 });
+    await client.connect();
+    originalOwnerId = await companyOwnerId();
+});
+
+afterAll(async () => {
+    if (client) {
+        if (originalOwnerId) {
+            await companies().updateOne({ _id: new ObjectId(state.companyId) }, { $set: { userId: new ObjectId(originalOwnerId) } });
+        }
+        await client.close();
+    }
+});
+
+describe('QA-47 an invited owner is recorded as the company owner however they accept', () => {
+    it('records the owner when an existing account accepts through /verify-invitation', async () => {
+        const email = `invited.owner.verify.${uniqueSuffix()}@e2e.alianhub.test`;
+        const created = await anonymous.post('/api/v2/createUser', {
+            firstName: 'Vera', lastName: 'Verify', email, password: state.password,
+        });
+        expect(created.body.status).toBe(true);
+        const userId = String(created.body.statusText._id);
+
+        const row = await inviteOwner(email);
+        expect(String(row.userId)).toBe(userId);
+
+        const accepted = await anonymous.post('/api/v2/checkPermission', { id: inviteBlob(row) });
+        expect(accepted.body.status).toBe(true);
+        expect(accepted.body.key).toBe(5);
+
+        expect(await ownerBecomes(userId)).toBe(true);
+    });
+
+    it.each([
+        ['/api/v2/google-signup', 'googleId'],
+        ['/api/v2/github-signup', 'githubId'],
+        ['/api/v2/gitlab-signup', 'gitlabId'],
+    ])('records the owner when they sign up through %s', async (path, idField) => {
+        const suffix = uniqueSuffix();
+        const email = `invited.owner.${idField.toLowerCase()}.${suffix}@e2e.alianhub.test`;
+        const row = await inviteOwner(email);
+
+        const signup = await anonymous.post(path, {
+            firstName: 'Otto', lastName: 'Oauth', email, [idField]: `id-${suffix}`,
+            assignCompany: state.companyId, companyUserDocID: String(row._id),
+        });
+        expect(signup.status).toBe(200);
+        const userId = String(signup.body.data._id);
+
+        expect(await ownerBecomes(userId)).toBe(true);
+    });
+
+    it('leaves the company owner alone when the invitation is not for an owner', async () => {
+        const suffix = uniqueSuffix();
+        const email = `invited.member.${suffix}@e2e.alianhub.test`;
+        const row = await invite(email, 3);
+        const before = await companyOwnerId();
+
+        const signup = await anonymous.post('/api/v2/google-signup', {
+            firstName: 'Mia', lastName: 'Member', email, googleId: `id-${suffix}`,
+            assignCompany: state.companyId, companyUserDocID: String(row._id),
+        });
+        expect(signup.status).toBe(200);
+
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        expect(await companyOwnerId()).toBe(before);
+    });
+});

--- a/tests/preset-key.test.js
+++ b/tests/preset-key.test.js
@@ -1,0 +1,78 @@
+jest.mock('../Modules/Instance/guard', () => ({ requireInstanceAdmin: jest.fn() }));
+jest.mock('../Config/config.js', () => ({ PRECOMPANYKEY: 'preset-secret' }));
+jest.mock('../middlewares/mongoConnector/helper.js', () => ({ connections: [] }));
+jest.mock('../Modules/common/controller.js', () => ({ versionUpdateNotifyToClient: jest.fn() }));
+jest.mock('../Modules/Company/controller2.js', () => ({ preCompanySetup: jest.fn() }));
+
+const fs = require('fs');
+const { preCompanySetup } = require('../Modules/Company/controller2.js');
+
+const handlers = {};
+beforeAll(() => {
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+    const app = { get: (p, h) => { handlers[`GET ${p}`] = h; }, post: (p, ...h) => { handlers[`POST ${p}`] = h[h.length - 1]; } };
+    require('../Modules/common/routes').init(app);
+});
+afterAll(() => jest.restoreAllMocks());
+
+const call = (route, req) => {
+    const res = { code: 200 };
+    res.status = (c) => { res.code = c; return res; };
+    res.json = (b) => { res.body = b; return res; };
+    res.send = res.json;
+    handlers[route](req, res);
+    return res;
+};
+
+const blank = { headers: {}, params: {}, query: {}, body: {} };
+const connections = (req) => call('GET /connections', { ...blank, ...req });
+const preset = (req) => call('POST /api/v1/setPresetCompany', { ...blank, ...req });
+
+beforeEach(() => preCompanySetup.mockClear());
+
+describe('QA-13 the preset key never travels in the URL', () => {
+    it('reads the connection list when the key comes in a header', () => {
+        const res = connections({ headers: { 'x-preset-key': 'preset-secret' } });
+        expect(res.code).toBe(200);
+        expect(res.body).toMatchObject({ total: 0, data: [] });
+    });
+
+    it('refuses the connection list without the header', () => {
+        expect(connections({}).code).toBe(401);
+    });
+
+    it('refuses the connection list with the wrong key', () => {
+        expect(connections({ headers: { 'x-preset-key': 'nope' } }).code).toBe(401);
+    });
+
+    it('starts the preset company when the key comes in a header', () => {
+        const res = preset({ headers: { 'x-preset-key': 'preset-secret' } });
+        expect(res.code).toBe(200);
+        expect(preCompanySetup).toHaveBeenCalled();
+    });
+
+    it('starts the preset company when the key comes in the body', () => {
+        expect(preset({ body: { presetKey: 'preset-secret' } }).code).toBe(200);
+        expect(preCompanySetup).toHaveBeenCalled();
+    });
+
+    it('refuses the preset company without a key', () => {
+        expect(preset({}).code).toBe(401);
+        expect(preCompanySetup).not.toHaveBeenCalled();
+    });
+
+    it('never accepts the key from the query string', () => {
+        expect(connections({ query: { id: 'preset-secret' } }).code).toBe(401);
+        expect(preset({ query: { id: 'preset-secret' } }).code).toBe(401);
+        expect(preCompanySetup).not.toHaveBeenCalled();
+    });
+
+    it('answers the old key-in-path shape with guidance and never runs the setup', () => {
+        const old = call('GET /connections/:id', { ...blank, params: { id: 'preset-secret' } });
+        expect(old.code).toBe(400);
+        expect(String(old.body.message)).toMatch(/x-preset-key/);
+        const oldPreset = call('GET /api/v1/setPresetCompany/:id', { ...blank, params: { id: 'preset-secret' } });
+        expect(oldPreset.code).toBe(400);
+        expect(preCompanySetup).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

| Finding | Where | Fix | Test |
|---|---|---|---|
| 13 — the preset key travels in the URL, so it reaches access logs, proxy logs and browser history | `index.js` (`GET /api/v1/setPresetCompany/:id`), `Modules/common/routes.js` (`GET /connections/:id`) | Both routes now read the key from the `x-preset-key` header — the setup route, now `POST /api/v1/setPresetCompany`, also accepts `presetKey` in the body — and compare it in constant time (`Config/presetKey.js`). The setup route moved out of `index.js` into `Modules/common/routes.js` so it can be tested. | `tests/preset-key.test.js` (unit, 8 cases) |
| 47 — an invited owner who accepts through `/verify-invitation` or a Google, GitHub or GitLab sign-up is never recorded as the company owner | `Modules/Auth/controller/verifyInvitation.js`, `Modules/Auth/controller/createUser.js` | Both acceptance handlers call the new `recordInvitedOwner` helper with the invitation row they have already verified, so `companies.userId` is written server-side. Only an invitation carrying the owner role records an owner, and it records the account that accepted that invitation. | `tests/integration/invited-owner.int.test.js` (5 cases) |

## Notes

**Compatibility for old links and callers.** No caller of either preset route exists in `frontend/src` or `scripts/` — they are operator-only routes driven by hand — so nothing had to be updated. The old key-in-path shapes (`GET /connections/:id`, `GET /api/v1/setPresetCompany/:id`) stay registered, but they answer `400` with the header to use; they never compare the key and never start the setup. Keeping them as working aliases would have defeated the fix, and answering them this way is better than a 404 from the SPA fallback: an operator with an old bookmark gets told what to change, and the response reveals nothing about the key. The key is also no longer accepted from the query string.

**Server-side ownership rather than a second client call.** `Modules/Company/helpers/recordInvitedOwner.js` writes `companies.userId` and clears the company cache. It is called from inside the two acceptance handlers, after the invitation row has been matched by id, link token and expiry (`/verify-invitation`) or by company, e-mail, pending status and row id (the SSO signups). The caller can therefore only ever be recorded as the owner of the invitation that names them, which is the rule PR #643 enforced for `updateCompany`. That `ownerClaim` path and `companyUpdateKind` are untouched — the ordinary invitation page keeps working as it does today.

**Not touched.** `Modules/Auth/helpers/trackerCode.js`, `loginSession.js`, `TrackerLogin.vue`, `time-tracker-app/`, the socket handshake and the invitation preview endpoint.

## Test plan

Both findings were reproduced with failing tests before the fix:

- `tests/preset-key.test.js` — 8 failed / 8, including the old path shape returning `200` for a key presented in the URL.
- `tests/integration/invited-owner.int.test.js` — 4 failed / 5; the company owner never changed on any of the four acceptance paths, while the "an ordinary member invitation leaves the owner alone" case passed from the start.

Real results after the fix, Node 20.20.2:

| Command | Result |
|---|---|
| `npx jest --selectProjects unit --maxWorkers=2` | 269 suites, 3804 tests passed |
| `npx jest tests/conventions --maxWorkers=2` | 8 suites, 94 tests passed |
| `E2E_MONGODB_URL=mongodb://127.0.0.1:27203 npx jest --selectProjects integration --runInBand tests/integration/access.int.test.js tests/integration/invited-owner.int.test.js tests/integration/signup-ownership.int.test.js tests/integration/public-routes.int.test.js` | 4 suites, 141 tests passed (disposable `mongo:7` container, removed afterwards) |
| `cd frontend && npx vitest run` | 36 files, 259 tests passed |
| `npm run i18n:check` | exit 0, every locale 7631/7631, missing 0 |
| `npx eslint` on the eight touched files | clean |

`tests/integration/instance.int.test.js` asserted the old `'Unauthorized'` body for `GET /connections/:id`; it now covers the header shape, the refused URL shape and the refused keyless setup call (135 tests passed locally, and the CI `e2e` job is green).

`docs/ENV.md` and `.env.example` were regenerated with `node scripts/env-doc.js` after the `PRECOMPANYKEY` description changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
