### PR TITLE
fix(time): scope planning reads and private sprint task reads

### DIFF
--- a/Modules/EstimatedTime/controller.js
+++ b/Modules/EstimatedTime/controller.js
@@ -5,26 +5,36 @@ const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries"
 const { replaceObjectKey } = require("../Auth/helper");
 const { estimateAndPersist: estimateTaskTimeWithAI, _internal: aiEstimatorInternal } = require("./aiTaskEstimator");
 const { updateRemainingTime } = require("../LogTime/controllerV2/helpers");
-const { resolveSheetScope, SHEET_PERMISSION } = require("../TimeSheet/helpers/timeScope");
+const { resolveSheetScope, SHEET_PERMISSION, scopedEstimateMatch } = require("../TimeSheet/helpers/timeScope");
 const { scopeEstimatePipeline, TimesheetQueryRefused } = require("../TimeSheet/helpers/timesheetQueryScope");
 const { buildEstimateWrite, EstimateWriteRefused } = require("./helpers/estimateWriteScope");
 
+/* The same grant that decides who may plan another person's time decides who may read it. */
+const ESTIMATE_SCOPE_PERMISSIONS = [SHEET_PERMISSION.workload, SHEET_PERMISSION.project];
+
 exports.getEstimatedTime = async(req,res) => {
     try {
+        const companyId = req.headers['companyid'];
         const projectId = req.params.pid;
         const TaskId = req.params.tid;
+
+        const scope = await resolveSheetScope(companyId, req.uid, ESTIMATE_SCOPE_PERMISSIONS);
+        if (scope.visible && !scope.visible.includes(String(projectId))) {
+            return res.status(200).json([]);
+        }
 
         const estimatedObj = {
             type: SCHEMA_TYPE.ESTIMATES_TIME,
             data: [
                 {
+                    ...scopedEstimateMatch(scope),
                     "ProjectId": projectId,
                     "TaskId": TaskId
                 }
             ]
         };
 
-        const estimatedTime =  await MongoDbCrudOpration(req.headers['companyid'], estimatedObj, 'find');
+        const estimatedTime =  await MongoDbCrudOpration(companyId, estimatedObj, 'find');
 
         if (!estimatedTime) {
             return res.status(404).json({ message: "Estimated time not found" });
@@ -39,7 +49,7 @@ exports.getEstimatedTime = async(req,res) => {
 exports.updateEstimatedTime = async(req,res) => {
     try {
         const companyId = req.headers['companyid'];
-        const scope = await resolveSheetScope(companyId, req.uid, [SHEET_PERMISSION.workload, SHEET_PERMISSION.project]);
+        const scope = await resolveSheetScope(companyId, req.uid, ESTIMATE_SCOPE_PERMISSIONS);
         let write;
         try {
             write = buildEstimateWrite(req.body, scope);
@@ -213,7 +223,7 @@ exports.generateAiEstimate = async (req, res) => {
 exports.getEstimateByAggregate = async (req,res) => {
     try {
         const companyId = req.headers['companyid'];
-        const scope = await resolveSheetScope(companyId, req.uid, [SHEET_PERMISSION.workload, SHEET_PERMISSION.project]);
+        const scope = await resolveSheetScope(companyId, req.uid, ESTIMATE_SCOPE_PERMISSIONS);
         let pipeline;
         try {
             /* replaceObjectKey rebuilds every object, so it runs before the guard adds ObjectIds. */

--- a/Modules/Sprints/helpers/sprintVisibility.js
+++ b/Modules/Sprints/helpers/sprintVisibility.js
@@ -1,0 +1,43 @@
+const mongoose = require('mongoose');
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+
+const OBJECT_ID = /^[a-f0-9]{24}$/i;
+
+const asObjectIds = (ids) => (ids || [])
+    .filter((id) => OBJECT_ID.test(String(id)))
+    .map((id) => new mongoose.Types.ObjectId(String(id)));
+
+/* A private sprint belongs to the people it is shared with; owners and admins read past
+ * it. The sidebar's sprint list (Project/controller/getSprintFolder.js), global search and
+ * the advanced filter all state this rule, so the task reads state it from here. */
+const canSeeSprint = (sprint, uid) => !sprint
+    || sprint.private !== true
+    || (sprint.AssigneeUserId || []).map(String).includes(String(uid));
+
+/* The sprints in `projectIds` the caller is not on, as _ids to exclude a task by sprintId. */
+const hiddenSprintIds = async (companyId, uid, projectIds) => {
+    const projects = asObjectIds(projectIds);
+    if (!projects.length) return [];
+    const sprints = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.SPRINTS,
+        data: [{ projectId: { $in: projects }, private: true }, 'private AssigneeUserId'],
+    }, 'find');
+    return (sprints || []).filter((sprint) => !canSeeSprint(sprint, uid)).map((sprint) => sprint._id);
+};
+
+const canSeeSprintById = async (companyId, uid, sprintId) => {
+    if (!OBJECT_ID.test(String(sprintId || ''))) return true;
+    const sprint = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.SPRINTS,
+        data: [{ _id: new mongoose.Types.ObjectId(String(sprintId)) }, 'private AssigneeUserId'],
+    }, 'findOne');
+    return canSeeSprint(sprint, uid);
+};
+
+module.exports = {
+    asObjectIds,
+    canSeeSprint,
+    canSeeSprintById,
+    hiddenSprintIds,
+};

--- a/Modules/Tasks/helpers/getTasksData.js
+++ b/Modules/Tasks/helpers/getTasksData.js
@@ -9,6 +9,8 @@ const logger = require("../../../Config/loggerConfig");
 const { QueryRefused, validatePipeline, visibilityStage } = require("./taskQueryGuard");
 const { WriteRefused, parseCascade, assertCanCascade, cascadeFilter } = require("./taskWriteGuard");
 const { canReadProject } = require("../../../Config/projectAccess");
+const { getRoleType, isPrivileged } = require("../../../Config/permissionGuard");
+const { canSeeSprintById } = require("../../Sprints/helpers/sprintVisibility");
 
 const refuse = (res, statusCode, statusText, message, extra = {}) => res.status(statusCode).json({ status: false, statusText, message, ...extra });
 
@@ -58,6 +60,11 @@ exports.getTask = async (req, res) => {
 
         const access = await canReadProject(companyId, req.uid, task.ProjectID);
         if (!access.allowed && !access.missing) return taskNotFound(res);
+
+        const roleType = await getRoleType(companyId, req.uid);
+        if (!isPrivileged(roleType) && !(await canSeeSprintById(companyId, req.uid, task.sprintId))) {
+            return taskNotFound(res);
+        }
         return res.status(200).json(task);
     } catch (error) {
         logger.error(`getTask error: ${error.message || error}`);

--- a/Modules/Tasks/helpers/taskQueryGuard.js
+++ b/Modules/Tasks/helpers/taskQueryGuard.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const { dbCollections } = require('../../../Config/collections');
 const { getRoleType, isPrivileged } = require('../../../Config/permissionGuard');
 const { visibleProjectIds } = require('../../Agents/scope');
+const { hiddenSprintIds } = require('../../Sprints/helpers/sprintVisibility');
 
 const MAX_LIMIT = 1000;
 const MAX_STAGES = 40;
@@ -110,12 +111,15 @@ const toObjectIds = (ids) => (ids || [])
     .filter((id) => /^[a-f0-9]{24}$/i.test(String(id)))
     .map((id) => new mongoose.Types.ObjectId(String(id)));
 
-/* Owners and admins keep company-wide task visibility; everyone else sees the projects the sidebar lists for them. */
+/* Owners and admins keep company-wide task visibility; everyone else sees the projects the
+ * sidebar lists for them, minus the private sprints they are not shared with. */
 const visibilityStage = async (companyId, uid) => {
     const roleType = await getRoleType(companyId, uid);
     if (isPrivileged(roleType)) return null;
     const ids = roleType === null ? [] : await visibleProjectIds(companyId, uid);
-    return { $match: { ProjectID: { $in: toObjectIds(ids) } } };
+    const projects = toObjectIds(ids);
+    const hidden = await hiddenSprintIds(companyId, uid, projects);
+    return { $match: { ProjectID: { $in: projects }, ...(hidden.length ? { sprintId: { $nin: hidden } } : {}) } };
 };
 
 module.exports = {

--- a/tests/integration/estimated-time-read-scope.int.test.js
+++ b/tests/integration/estimated-time-read-scope.int.test.js
@@ -1,0 +1,116 @@
+const { createProject, createTask, loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+
+jest.setTimeout(90000);
+
+const today = () => new Date().toISOString().slice(0, 10);
+const dateAt = (dayOffset = 0) => {
+    const day = new Date(`${today()}T00:00:00.000Z`);
+    day.setUTCDate(day.getUTCDate() + dayOffset);
+    return day.toISOString();
+};
+
+async function projectWithTask(owner, assignees, { isPrivate = false } = {}) {
+    const project = await createProject(owner.api, { assigneeIds: assignees.map((s) => s.uid), createdBy: owner.uid, isPrivate });
+    let lastErr;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+        try {
+            const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+            return { project, task };
+        } catch (err) {
+            lastErr = err;
+            await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+    }
+    throw lastErr;
+}
+
+/* The request EstimateHours.vue makes when the planner sidebar opens. */
+async function readPlan(session, { project, task }) {
+    return session.api.get(`/api/v1/estimatedTime/${project._id}/${task._id}`);
+}
+
+async function plan(session, { project, task }, { minutes = 90, date = dateAt(), userId } = {}) {
+    return session.api.put('/api/v1/estimatedTime', {
+        userId: userId || session.uid,
+        taskId: task._id,
+        projectId: project._id,
+        date,
+        minutes,
+    });
+}
+
+const ownersOf = (rows) => [...new Set(rows.map((row) => String(row.UserId || row.userId)))].sort();
+
+describe('GET /api/v1/estimatedTime/:pid/:tid only returns the plans the caller may read', () => {
+    it('hides another person\'s planned hours from a member', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        expect((await plan(owner, target, { minutes: 120, date: dateAt(1) })).status).toBe(200);
+        expect((await plan(member, target, { minutes: 30, date: dateAt(1) })).status).toBe(200);
+
+        const res = await readPlan(member, target);
+        expect(res.status).toBe(200);
+        expect(ownersOf(res.body)).toEqual([String(member.uid)]);
+        expect(res.body.every((row) => row.EstimatedTime === 30)).toBe(true);
+    });
+
+    it('hides everyone\'s planned hours from a guest who planned nothing', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const target = await projectWithTask(owner, [owner, guest]);
+
+        expect((await plan(owner, target, { minutes: 200, date: dateAt(2) })).status).toBe(200);
+
+        const res = await readPlan(guest, target);
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual([]);
+    });
+
+    it('keeps an owner and an admin reading the whole team\'s plan', async () => {
+        const owner = await loginAs('owner');
+        const admin = await loginAs('admin');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, admin, member]);
+
+        expect((await plan(owner, target, { minutes: 60, date: dateAt(3) })).status).toBe(200);
+        expect((await plan(member, target, { minutes: 45, date: dateAt(3) })).status).toBe(200);
+
+        for (const session of [owner, admin]) {
+            const res = await readPlan(session, target);
+            expect(res.status).toBe(200);
+            expect(ownersOf(res.body)).toEqual([String(member.uid), String(owner.uid)].sort());
+        }
+    });
+
+    it('returns nothing on a project the caller cannot open', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const hidden = await projectWithTask(owner, [owner], { isPrivate: true });
+
+        expect((await plan(owner, hidden, { minutes: 90, date: dateAt(4) })).status).toBe(200);
+
+        const res = await readPlan(member, hidden);
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual([]);
+    });
+
+    it('still shows a member the row they just saved, the way the planner reloads it', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+        const date = dateAt(5);
+
+        const created = await plan(member, target, { minutes: 75, date });
+        expect(created.status).toBe(200);
+
+        const res = await readPlan(member, target);
+        expect(res.status).toBe(200);
+        const mine = res.body.find((row) => String(row._id) === String(created.body._id));
+        expect(mine).toBeTruthy();
+        expect(mine.EstimatedTime).toBe(75);
+    });
+});

--- a/tests/integration/private-sprint-task-reads.int.test.js
+++ b/tests/integration/private-sprint-task-reads.int.test.js
@@ -1,0 +1,104 @@
+const { createProject, createTask, firstSprint, loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+
+jest.setTimeout(90000);
+
+async function projectWithTask(owner, assignees) {
+    const project = await createProject(owner.api, { assigneeIds: assignees.map((s) => s.uid), createdBy: owner.uid });
+    let lastErr;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+        try {
+            const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+            return { project, task };
+        } catch (err) {
+            lastErr = err;
+            await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+    }
+    throw lastErr;
+}
+
+/* What the sprint row's "Share With: Private" toggle sends (SprintsList.vue). */
+async function makeSprintPrivate(owner, { project }, assigneeIds) {
+    const sprint = await firstSprint(owner.api, project._id);
+    const res = await owner.api.patch(`/api/v1/sprint/${sprint._id}`, {
+        type: 'updateSprint',
+        companyId: state.companyId,
+        projectId: String(project._id),
+        updateObject: { $set: { private: true, AssigneeUserId: assigneeIds.map(String) } },
+    });
+    expect(res.body.status).toBe(true);
+    return String(sprint._id);
+}
+
+const findTasks = (session, projectId) => session.api.post('/api/v1/task/find', {
+    findQuery: [{ $match: { objId: { ProjectID: String(projectId) } } }],
+});
+
+describe('a private sprint hides its tasks from everyone who is not on it', () => {
+    it('leaves the tasks out of POST /api/v1/task/find for a member of the project', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        const before = await findTasks(member, target.project._id);
+        expect(before.status).toBe(200);
+        expect(before.body.map((task) => String(task._id))).toContain(String(target.task._id));
+
+        await makeSprintPrivate(owner, target, [owner.uid]);
+
+        const after = await findTasks(member, target.project._id);
+        expect(after.status).toBe(200);
+        expect(after.body.map((task) => String(task._id))).not.toContain(String(target.task._id));
+    });
+
+    it('answers GET /api/v1/task/:id like a task that does not exist', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        await makeSprintPrivate(owner, target, [owner.uid]);
+
+        const res = await member.api.get(`/api/v1/task/${target.task._id}`);
+        expect(res.status).toBe(404);
+    });
+
+    it('keeps the tasks for a member the sprint is shared with', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        await makeSprintPrivate(owner, target, [owner.uid, member.uid]);
+
+        const list = await findTasks(member, target.project._id);
+        expect(list.body.map((task) => String(task._id))).toContain(String(target.task._id));
+        expect((await member.api.get(`/api/v1/task/${target.task._id}`)).status).toBe(200);
+    });
+
+    it('keeps the tasks for an owner and an admin who are not on the sprint', async () => {
+        const owner = await loginAs('owner');
+        const admin = await loginAs('admin');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, admin, member]);
+
+        await makeSprintPrivate(owner, target, [member.uid]);
+
+        for (const session of [owner, admin]) {
+            const list = await findTasks(session, target.project._id);
+            expect(list.body.map((task) => String(task._id))).toContain(String(target.task._id));
+            expect((await session.api.get(`/api/v1/task/${target.task._id}`)).status).toBe(200);
+        }
+    });
+
+    it('leaves a public sprint in the same project alone', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        const list = await findTasks(member, target.project._id);
+        expect(list.status).toBe(200);
+        expect(list.body.map((task) => String(task._id))).toContain(String(target.task._id));
+        expect((await member.api.get(`/api/v1/task/${target.task._id}`)).status).toBe(200);
+    });
+});


### PR DESCRIPTION
## Summary

| Finding | Route | Fix | Test |
|---|---|---|---|
| New — a member reads the whole team's planned hours on a task | `GET /api/v1/estimatedTime/:pid/:tid` | The read resolves the same sheet scope the write guard from #650 uses and merges `scopedEstimateMatch` into the filter; a project the caller cannot open answers `[]` | `tests/integration/estimated-time-read-scope.int.test.js` |
| 4 — tasks in a private sprint are returned to any member who can see the project | `POST /api/v1/task/find`, `GET /api/v1/task/:id` | New `Modules/Sprints/helpers/sprintVisibility.js` states the rule the sprint list, global search, the advanced filter and the comment search already enforce; `visibilityStage` excludes the hidden sprints and `getTask` answers 404 | `tests/integration/private-sprint-task-reads.int.test.js` |

## Notes

**Private sprints do have a rule, and it is not a display grouping.** The field is `sprints.private` (Boolean, `utils/mongo-handler/schema.js:3468`), paired with `AssigneeUserId` — not `isPrivate`, which is the *project* flag and a red herring in git history. Four backend read paths already enforce the same rule, identically:

- `Modules/Project/controller/getSprintFolder.js:9-33` — the sidebar's sprint list, the canonical statement: a private sprint matches only when `roleType` is 1 or 2, or `AssigneeUserId` contains the caller.
- `Modules/GlobalSearch/controller.js:19-28` — `hiddenSprintIds`, whose comment states it as product intent: "Private sprints hide their tasks and comments from everyone not assigned to them, as the sidebar does."
- `Modules/AdvancedGlobalFilter/controller.js:122-139` — `sprintPrivacyFilter`.
- `Modules/Comments/controller.js:392-418` — an `isAccessible` `$addFields` on the sprint `$lookup`.

The frontend mirrors it in `frontend/src/views/Projects/helper.js:110`, `Projects.vue:1085` and most plainly `frontend/src/views/Chat/useChatDirectory.js:69-73`. The toggle itself (`SprintsList.vue:139-155`, "Share With: Everyone ⟷ Private" plus an assignee picker) adds the toggling user to `AssigneeUserId` on the way in and clears `private` when the last assignee is removed. So the rule the UI shows is: **a private sprint is visible to its assignees plus owners and admins** — exactly what the task reads now apply.

Two things deliberately left alone, both pre-existing and wider than this PR:

- **Team ids are not expanded.** `AssigneeUserId` can carry `tId_`-prefixed team entries, and none of the four existing filters expand them either — they all do a flat `includes(uid)`. The new helper matches that behaviour rather than quietly changing who can see what. Worth a separate look.
- **Other read paths still ignore the flag**: the `?count=true` branch of `getSprintFolder.js`, the Scrum lifecycle and report routes under `/api/v2/sprints/*`, public shares, trash, the MCP brief, the project and user dashboards. They guard at project level only. Fixing them is a bigger sweep than "the task reads" and would touch modules other agents are in.

On the planning read, the scope keys are the two `resolveSheetScope` already takes on the write and aggregate paths (`sheet_settings.workload_timesheet`, `sheet_settings.project_timesheet`), so read and write stay symmetric. Note that the planner sidebar has its own gate, `task.task_estimated_hours` — a role granted Everyone on that key but not on either timesheet key now reads only its own rows, which is what it can already *write* after #650. Aligning that key with the two sheet keys is a product decision, not a security one, so it is not made here.

`EstimateHours.vue` needs no change: it already filters client-side (`getTotalMinutes`'s `canSeeAll`, and `:AssigneeUserId="permission == 2 || permission == true ? task?.AssigneeUserId : [companyUser.userId]"`), which is exactly the hiding that was the only thing protecting these rows. The server now agrees with it, and the integration tests drive the same GET the sidebar makes on open.

## Test plan

Node 20, Mongo in `alianhub-e2e-u4` on 27204 (removed afterwards).

- `npx jest --selectProjects unit --maxWorkers=2` — 268 suites, 3796 tests passed.
- `npx jest tests/conventions --maxWorkers=2` — 8 suites, 94 tests passed.
- `npm run i18n:check` — exit 0.
- `npx eslint` on every touched file — clean.
- `E2E_MONGODB_URL=mongodb://127.0.0.1:27204 npx jest --selectProjects integration --runInBand` — **42 suites, 785 tests passed**, the whole layer.

Both findings were reproduced first:

- `estimated-time-read-scope.int.test.js` before the fix: 3 failed, 2 passed — a member read the owner's 120-minute row, a guest read a plan it had no part in, and a member read a plan on a project it cannot open.
- `private-sprint-task-reads.int.test.js` before the fix: 2 failed, 3 passed — `POST /api/v1/task/find` still returned the task after the sprint went private, and `GET /api/v1/task/:id` answered 200. The three "still works" cases (shared-with member, owner and admin, public sprint) passed throughout, so the guard does not over-block.

No frontend change, so no `vitest` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
