### PR TITLE
docs(027): move sprint 4 to active and log the start

### DIFF
--- a/Tasks/active/027-sprint-4-model-router/progress.md
+++ b/Tasks/active/027-sprint-4-model-router/progress.md
@@ -16,6 +16,7 @@ One pull request per step; tick with the merge commit.
 | Date | Entry |
 |---|---|
 | 2026-09-10 | Filed from `docs/AI-PLATFORM-ARCHITECTURE.md` (sprint 4) |
+| 2026-09-12 | Started. Step 1 (provider registry with a Google adapter, model and provider on the chat options, per-provider normalisation) is in progress on `feat/sprint-4-provider-registry`. Steps 2–4 wait for it, because they build on the registry. Task 035's follow-ups are closed apart from the owner decisions and items 14, 26 and 48–51. |
 
 ## Last step
-Not started.
+Step 1 in progress.

--- a/Tasks/active/027-sprint-4-model-router/task.md
+++ b/Tasks/active/027-sprint-4-model-router/task.md
@@ -1,7 +1,7 @@
 ---
 id: 027
 title: Sprint 4 — the model router
-status: backlog
+status: active
 priority: high
 depends_on: [024, 026]
 created: 2026-09-10
@@ -9,7 +9,7 @@ created: 2026-09-10
 
 # 027 — Sprint 4 — the model router
 
-Status: backlog · depends on 024, 026 · sprint 4 · two weeks · branch `feat/sprint-4-model-router` (from `beta`)
+Status: active · depends on 024, 026 · sprint 4 · two weeks · branch `feat/sprint-4-model-router` (from `beta`)
 
 Source: `docs/AI-PLATFORM-ARCHITECTURE.md`, "Development and integration plan", Sprint 4. Filed 2026-09-10.
 

--- a/Tasks/index.md
+++ b/Tasks/index.md
@@ -32,7 +32,7 @@ Auto-maintained registry of all tasks. Reflects YAML frontmatter from each `task
 | 024 | Sprint 1 — shared AI core and run correctness | active | high | 023 | active/024-sprint-1-shared-core-run-correctness |
 | 025 | Sprint 2 — agent revisions and the skill record | active | high | 024 | active/025-sprint-2-revisions-and-skill-record |
 | 026 | Sprint 3 — observability foundation | active | high | 024 | active/026-sprint-3-observability-foundation |
-| 027 | Sprint 4 — the model router | backlog | high | 024, 026 | backlog/027-sprint-4-model-router |
+| 027 | Sprint 4 — the model router | active | high | 024, 026 | active/027-sprint-4-model-router |
 | 028 | Sprint 5 — the workflow engine | backlog | high | 024, 027 | backlog/028-sprint-5-workflow-engine |
 | 029 | Sprint 6 — skill authoring and migration | backlog | medium | 025, 028 | backlog/029-sprint-6-skill-authoring-migration |
 | 030 | Sprint 7 — knowledge and retrieval | backlog | medium | 024 | backlog/030-sprint-7-knowledge-and-retrieval |


### PR DESCRIPTION
## Summary

Moves task 027 (Sprint 4, the model router) from backlog to active and logs the start: step 1, the provider registry with a Google adapter, is in progress; steps 2 to 4 wait for it.

## Test plan

- [x] Task files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)