### PR TITLE
fix(sprints): apply the private sprint rule everywhere, including team assignments

### DIFF
--- a/Modules/AdvancedGlobalFilter/controller.js
+++ b/Modules/AdvancedGlobalFilter/controller.js
@@ -4,7 +4,8 @@ const { SCHEMA_TYPE } = require("../../Config/schemaType");
 const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries");
 const { replaceObjectKey } = require("../Auth/helper");
 const { escapeRegex } = require("../../utils/escapeRegex");
-const { isPrivileged } = require('../../Config/roleTypes');
+const { getRoleType, isPrivileged } = require('../../Config/permissionGuard');
+const { sprintIdentities, visibleSprintClause } = require('../Sprints/helpers/sprintVisibility');
 const savedFilters = require("./helpers/savedFilters");
 
 /**
@@ -72,8 +73,6 @@ exports.searchTasks = async (req, res) => {
             skip = 0,
             batchSize = 20,
             sortBy = 'createdAt',
-            userId,
-            roleType,
         } = req.body;
 
         // Parse inputs and prepare default values
@@ -87,8 +86,6 @@ exports.searchTasks = async (req, res) => {
 
         additionalFilter = replaceObjectKey(additionalFilter, ["objId", "dbDate"]);
 
-        // Current user ID as string (because AssigneeUserId is stored as string) 
-        const currentUserId = userId ? userId.toString() : null;
 
         // Aggregation stages
         const searchResultMatch = {
@@ -123,20 +120,14 @@ exports.searchTasks = async (req, res) => {
 
         const sprintUnwind = { $unwind: '$sprintArray' };
 
+        /* The caller is read from the session, never from the body: the body's own userId and
+         * roleType would let a client name someone else and inherit their private sprints. */
+        const companyId = req.headers['companyid'] || '';
+        const roleType = await getRoleType(companyId, req.uid);
         let sprintPrivacyFilter = null;
         if (!isPrivileged(roleType)) {
-            sprintPrivacyFilter = currentUserId
-                ? {
-                    $match: {
-                        $or: [
-                            { 'sprintArray.private': { $ne: true } },
-                            { 'sprintArray.AssigneeUserId': currentUserId },
-                        ],
-                    },
-                }
-                : {
-                    $match: { 'sprintArray.private': { $ne: true } },
-                };
+            const identities = req.uid ? await sprintIdentities(companyId, req.uid) : [];
+            sprintPrivacyFilter = { $match: visibleSprintClause(identities, 'sprintArray.') };
         }
 
         const folderLookup = {
@@ -185,7 +176,7 @@ exports.searchTasks = async (req, res) => {
             data: [aggregationPipeline],
         };
 
-        const response = await MongoDbCrudOpration(req.headers['companyid'], params, 'aggregate');
+        const response = await MongoDbCrudOpration(companyId, params, 'aggregate');
 
         return res.status(200).json({
             status: true,

--- a/Modules/AgileReports/cfd.js
+++ b/Modules/AgileReports/cfd.js
@@ -9,6 +9,7 @@ const { SCHEMA_TYPE } = require('../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
 const mongoose = require('mongoose');
 const logger = require('../../Config/loggerConfig');
+const { hiddenSprintFilter } = require('../Sprints/helpers/sprintVisibility');
 
 const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
 const MAX_DAYS = 120;
@@ -46,7 +47,12 @@ exports.getCFD = async (req, res) => {
                 // Tasks declare ProjectID, not projectId (schema.js). Matching the
                 // wrong name returned nothing, so CFD has answered "No tasks yet."
                 // for every project since it shipped.
-                { ProjectID: projectObjId, deletedStatusKey: { $in: [0, 2, undefined] }, isParentTask: true },
+                {
+                    ProjectID: projectObjId,
+                    deletedStatusKey: { $in: [0, 2, undefined] },
+                    isParentTask: true,
+                    ...(await hiddenSprintFilter(companyId, req.uid, [projectId])),
+                },
                 '_id statusType createdAt updatedAt',
             ],
         }, 'find');

--- a/Modules/AgileReports/milestones.js
+++ b/Modules/AgileReports/milestones.js
@@ -4,6 +4,7 @@
 const mongoose = require('mongoose');
 const { SCHEMA_TYPE } = require('../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
+const { hiddenSprintFilter } = require('../Sprints/helpers/sprintVisibility');
 const logger = require('../../Config/loggerConfig');
 const H = require('./helpers/milestoneMoves');
 
@@ -66,7 +67,12 @@ exports.getMilestones = async (req, res) => {
             }, 'find').catch(() => []),
             MongoDbCrudOpration(companyId, {
                 type: SCHEMA_TYPE.TASKS,
-                data: [{ ProjectID: { $in: projectIds }, deletedStatusKey: { $in: [0, 2, undefined] }, isParentTask: true }, '_id ProjectID DueDate statusType'],
+                data: [{
+                    ProjectID: { $in: projectIds },
+                    deletedStatusKey: { $in: [0, 2, undefined] },
+                    isParentTask: true,
+                    ...(await hiddenSprintFilter(companyId, req.uid, projectIds)),
+                }, '_id ProjectID DueDate statusType'],
             }, 'find').catch(() => []),
         ]);
 

--- a/Modules/AgileReports/routes.js
+++ b/Modules/AgileReports/routes.js
@@ -4,15 +4,17 @@ const cfd = require('./cfd');
 const sprintInsights = require('./sprintInsights');
 const milestones = require('./milestones');
 const provenance = require('./provenance');
+const { requireSprintAccess } = require('../Sprints/helpers/sprintVisibility');
 
 exports.init = (app) => {
     // Unified agile-reports read API (S4). Burndown reuses the existing Sprints
     // handler (now query-param aware); velocity + CFD are computed in this module.
     // All read-only; auth/companyId come from the global middleware like other routes.
-    app.get('/api/v1/agile/burndown', getSprintBurndown);
+    const onSprint = requireSprintAccess((req) => (req.query || {}).sprintId);
+    app.get('/api/v1/agile/burndown', onSprint, getSprintBurndown);
     app.get('/api/v1/agile/velocity', velocity.getVelocity);
     app.get('/api/v1/agile/cfd', cfd.getCFD);
-    app.get('/api/v1/agile/sprint-insights', sprintInsights.getSprintInsights);
+    app.get('/api/v1/agile/sprint-insights', onSprint, sprintInsights.getSprintInsights);
     app.get('/api/v1/agile/milestones', milestones.getMilestones);
-    app.get('/api/v1/agile/provenance', provenance.getProvenance);
+    app.get('/api/v1/agile/provenance', onSprint, provenance.getProvenance);
 };

--- a/Modules/AgileReports/velocity.js
+++ b/Modules/AgileReports/velocity.js
@@ -20,6 +20,8 @@ const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries'
 const mongoose = require('mongoose');
 const logger = require('../../Config/loggerConfig');
 const provenance = require('../Tasks/helpers/provenanceRollup');
+const { canSeeSprint, sprintIdentities } = require('../Sprints/helpers/sprintVisibility');
+const { getRoleType, isPrivileged } = require('../../Config/permissionGuard');
 
 const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
 
@@ -45,17 +47,23 @@ exports.getVelocity = async (req, res) => {
                     mainChat: { $ne: true },
                     isBacklog: { $ne: true },
                 },
-                '_id name createdAt startDate endDate commitment closeReport',
+                '_id name createdAt startDate endDate commitment closeReport private AssigneeUserId',
             ],
         }, 'find');
 
-        const measurable = (sprints || []).filter((s) => s.commitment && s.commitment.at);
+        /* A private sprint is not on the chart for someone it was not shared with. */
+        const identities = await sprintIdentities(companyId, req.uid);
+        const visible = isPrivileged(await getRoleType(companyId, req.uid))
+            ? (sprints || [])
+            : (sprints || []).filter((sprint) => canSeeSprint(sprint, identities));
+
+        const measurable = visible.filter((s) => s.commitment && s.commitment.at);
 
         if (!measurable.length) {
             return res.send({
                 status: true,
                 statusText: 'No completed sprints yet.',
-                data: { sprints: [], skipped: (sprints || []).length },
+                data: { sprints: [], skipped: visible.length },
             });
         }
 
@@ -105,7 +113,7 @@ exports.getVelocity = async (req, res) => {
         return res.send({
             status: true,
             statusText: 'Velocity computed.',
-            data: { sprints: withAvg, skipped: (sprints || []).length - measurable.length },
+            data: { sprints: withAvg, skipped: visible.length - measurable.length },
         });
     } catch (error) {
         logger.error(`ERROR in agile velocity: ${error.message}`);

--- a/Modules/Comments/controller.js
+++ b/Modules/Comments/controller.js
@@ -9,6 +9,7 @@ const { escapeRegex } = require("../../utils/escapeRegex");
 const { parseMentionIds } = require("./helpers/parseMentions");
 const { handleNotificationtFun } = require("../notification/prepare-notification-data/controllerV2");
 const { getRoleType, isPrivileged } = require("../../Config/permissionGuard");
+const { sprintIdentities, visibleSprintExpr } = require("../Sprints/helpers/sprintVisibility");
 
 /* @mention delivery: record the mention (feeds the in-app "mentions" tab, which
  * queries the mentions collection by mentionIds) and fire the notification
@@ -399,16 +400,13 @@ exports.searchComments = async (req, res) => {
                 },
             });
         } else{
+            /* The assignee list holds user ids and `tId_<teamId>`, and the caller comes from the
+             * session: a body userId would let a client read someone else's private sprints. */
+            const identities = await sprintIdentities(req.headers['companyid'], req.uid);
             sprintLookup.$lookup.pipeline.push(
                 {
                     $addFields: {
-                        isAccessible: {
-                            $cond: {
-                                if: { $eq: ['$private', true] },
-                                then: { $in: [req.body.userId, '$AssigneeUserId'] },
-                                else: true,
-                            },
-                        },
+                        isAccessible: visibleSprintExpr(identities),
                     },
                 },
                 {

--- a/Modules/CustomReports/controller.js
+++ b/Modules/CustomReports/controller.js
@@ -7,6 +7,8 @@ const { resolveRate } = require('../TimeSheet/helpers/billingRules');
 const R = require('./helpers/reportRules');
 const T = require('./helpers/reportTemplates');
 const access = require('./helpers/reportAccess');
+const { visibleProjectIds } = require('../Agents/scope');
+const { asObjectIds, hiddenSprintFilter } = require('../Sprints/helpers/sprintVisibility');
 
 const { oidOrNull } = access;
 
@@ -63,9 +65,23 @@ const foldRevenue = async (companyId, raw) => {
 
 const UNITS = { hours: 'hours', revenue: 'currency', points: 'points', count: 'count', entries: 'count' };
 
-const runConfig = async (companyId, cfg) => {
+/* A report aggregates the whole tasks collection, so it is narrowed to what the person it
+ * runs for may read: their projects, minus the private sprints they are not on. `viewer` is
+ * the session for a live run, and the report's author for a schedule or a public link —
+ * neither may show more than its author could see on screen. */
+const viewerScope = async (companyId, viewer, isLogs) => {
+    const uid = String(viewer || '');
+    if (!uid) return null;
+    if (await access.isPrivilegedUser(companyId, uid)) return null;
+    const projects = await visibleProjectIds(companyId, uid);
+    if (isLogs) return { ProjectId: { $in: asObjectIds(projects) } };
+    return { ProjectID: { $in: asObjectIds(projects) }, ...(await hiddenSprintFilter(companyId, uid, projects)) };
+};
+
+const runConfig = async (companyId, cfg, viewer) => {
     const isLogs = cfg.source === 'timelogs';
-    const pipeline = R.buildPipeline(cfg);
+    const scope = await viewerScope(companyId, viewer, isLogs);
+    const pipeline = [...(scope ? [{ $match: scope }] : []), ...R.buildPipeline(cfg)];
     let raw = await MongoDbCrudOpration(companyId, {
         type: isLogs ? SCHEMA_TYPE.TIMESHEET : SCHEMA_TYPE.TASKS, data: [pipeline],
     }, 'aggregate');
@@ -130,7 +146,7 @@ exports.runReport = async (req, res) => {
         const check = R.validateConfig(req.body || {});
         if (!check.valid) return reply(res, 400, check.errors.join('; '));
         if (refusesFinancial(caller, check.value, res)) return undefined;
-        const out = await runConfig(caller.companyId, check.value);
+        const out = await runConfig(caller.companyId, check.value, caller.uid);
         return res.json({ status: true, data: { config: check.value, result: out.rows, unit: out.unit } });
     } catch (e) { return serverError(res, 'runReport', e); }
 };
@@ -169,7 +185,7 @@ exports.getReportResult = async (req, res) => {
         if (!rep) return undefined;
         if (refusesFinancial(caller, rep, res)) return undefined;
         const check = R.validateConfig(rep);
-        const out = check.valid ? await runConfig(caller.companyId, check.value) : { rows: [], unit: 'count' };
+        const out = check.valid ? await runConfig(caller.companyId, check.value, caller.uid) : { rows: [], unit: 'count' };
         return res.json({ status: true, data: { report: rep, config: check.value, result: out.rows, unit: out.unit } });
     } catch (e) { return serverError(res, 'getReportResult', e); }
 };

--- a/Modules/ExportJobs/controller.js
+++ b/Modules/ExportJobs/controller.js
@@ -5,6 +5,7 @@ const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries"
 const mongoose = require("mongoose");
 const logger = require("../../Config/loggerConfig");
 const { visibleProjectIds } = require('../Agents/scope');
+const { canSeeSprintById, hiddenSprintFilter } = require('../Sprints/helpers/sprintVisibility');
 const { validateExportInput, buildFileName, taskToRow, rowsToCsv } = require('./helpers/exportRules');
 
 // Files stay on the server and only stream back through the download endpoint,
@@ -32,6 +33,10 @@ async function processJob(companyId, jobId) {
         };
         if (job.filters.sprintId) {
             filter.sprintId = new mongoose.Types.ObjectId(job.filters.sprintId);
+        } else {
+            /* The job runs detached from the request, so the private sprints are excluded
+             * again here against the person the export belongs to. */
+            Object.assign(filter, await hiddenSprintFilter(companyId, job.userId, [String(job.filters.projectId)]));
         }
         const tasks = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.TASKS,
@@ -77,6 +82,9 @@ exports.createExport = async (req, res) => {
         const visible = await visibleProjectIds(companyId, userId);
         if (!visible.includes(String(projectId))) {
             return res.status(404).send({ status: false, statusText: 'Project not found.' });
+        }
+        if (sprintId && !(await canSeeSprintById(companyId, userId, sprintId))) {
+            return res.status(404).send({ status: false, statusText: 'Sprint not found.' });
         }
 
         const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');

--- a/Modules/GlobalSearch/controller.js
+++ b/Modules/GlobalSearch/controller.js
@@ -7,6 +7,7 @@ const { getRoleType, isPrivileged } = require("../../Config/permissionGuard");
 const { visibleProjectIds } = require("../Agents/scope");
 const { pageVisibilityFilter } = require("../Pages/helpers/pageRules");
 const { validateSearchInput, truncate, RESULT_LIMIT_PER_TYPE } = require('./helpers/searchRules');
+const { hiddenSprintIds } = require('../Sprints/helpers/sprintVisibility');
 
 // Regex rather than $text: it works on every existing tenant database and keeps
 // short queries and substring matches predictable.
@@ -15,18 +16,6 @@ const asObjectIds = (ids) => ids
     .map(String)
     .filter((id) => mongoose.Types.ObjectId.isValid(id))
     .map((id) => new mongoose.Types.ObjectId(id));
-
-/* Private sprints hide their tasks and comments from everyone not assigned to them, as the sidebar does. */
-const hiddenSprintIds = async (companyId, uid, projectIds, privileged) => {
-    if (privileged || !projectIds.length) return [];
-    const sprints = await MongoDbCrudOpration(companyId, {
-        type: SCHEMA_TYPE.SPRINTS,
-        data: [{ projectId: { $in: projectIds }, private: true }, 'AssigneeUserId'],
-    }, 'find');
-    return (sprints || [])
-        .filter((sprint) => !(sprint.AssigneeUserId || []).map(String).includes(uid))
-        .map((sprint) => sprint._id);
-};
 
 /* A task comment is visible where its task is, whatever project id the comment row carries. */
 const onVisibleTasks = async (companyId, comments, projectIds, sprintClause) => {
@@ -56,7 +45,7 @@ exports.globalSearch = async (req, res) => {
             return res.status(403).send({ status: false, statusText: 'You are not a member of this company.' });
         }
         const projectIds = asObjectIds(await visibleProjectIds(companyId, uid));
-        const hidden = await hiddenSprintIds(companyId, uid, projectIds, isPrivileged(roleType));
+        const hidden = isPrivileged(roleType) ? [] : await hiddenSprintIds(companyId, uid, projectIds);
         const sprintClause = hidden.length ? { sprintId: { $nin: hidden } } : {};
 
         const rx = { $regex: escapeRegex(String(query).trim()), $options: 'i' };

--- a/Modules/Project/controller/getSprintFolder.js
+++ b/Modules/Project/controller/getSprintFolder.js
@@ -2,64 +2,38 @@ const { SCHEMA_TYPE } = require("../../../Config/schemaType");
 const { MongoDbCrudOpration,validateObjectId } = require("../../../utils/mongo-handler/mongoQueries");
 const { mongoose } = require("mongoose");
 const logger = require("../../../Config/loggerConfig");
+const { isPrivileged } = require("../../../Config/roleTypes");
+const { sprintIdentities, visibleSprintClause } = require("../../Sprints/helpers/sprintVisibility");
 
 
-exports.getDefaultSprintData = (uid, query, companyId, projectId, roleType) => {
-    return new Promise((resolve, reject) => {
-        try {
-            const defaultPrivate = {
-                private: true,
-                projectId : new mongoose.Types.ObjectId(projectId),
-                deletedStatusKey: { $nin: [1] },
-            };
-            if(roleType !== 1 && roleType !== 2) {
-                defaultPrivate.AssigneeUserId = {
-                    $in: [uid]
-                }
-            }
-            const defaultPublic = {
-                projectId : new mongoose.Types.ObjectId(projectId),
-                deletedStatusKey: { $nin: [1] },
-                private: false
-            };
-            const queryArray = [
-                {
-                    $match: {
-                        $or: [
-                            defaultPrivate,
-                            defaultPublic
-                        ]
-                    }
-                }
-            ];
-            if (query.fields) {
-                const fields = query.fields.split(',');
-                const projection = {};
-                fields.forEach((field) => {
-                    projection[field] = 1;
-                });
-                queryArray.push(projection);
-            }
-            if (query.skip) {
-                queryArray.push({$skip: query.skip});
-            }
-            if (query.limit) {
-                queryArray.push({$limit: query.limit});
-            }
-            let mongoObj = {
-                type: SCHEMA_TYPE.SPRINTS,
-                data: [queryArray]
-            }
-            MongoDbCrudOpration(companyId, mongoObj, 'aggregate').then((res)=>{
-                resolve(res);
-            }).catch((error)=>{
-                reject(error);
-            })
-        } catch (error) {
-            reject(error);
-        }
-    })
-}
+exports.sprintVisibilityMatch = async (uid, companyId, projectId, roleType) => ({
+    projectId: new mongoose.Types.ObjectId(projectId),
+    deletedStatusKey: { $nin: [1] },
+    ...(isPrivileged(roleType) ? {} : visibleSprintClause(await sprintIdentities(companyId, uid))),
+});
+
+exports.getDefaultSprintData = async (uid, query, companyId, projectId, roleType) => {
+    const queryArray = [
+        { $match: await exports.sprintVisibilityMatch(uid, companyId, projectId, roleType) }
+    ];
+    if (query.fields) {
+        const projection = {};
+        query.fields.split(',').forEach((field) => {
+            projection[field] = 1;
+        });
+        queryArray.push(projection);
+    }
+    if (query.skip) {
+        queryArray.push({ $skip: query.skip });
+    }
+    if (query.limit) {
+        queryArray.push({ $limit: query.limit });
+    }
+    return MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.SPRINTS,
+        data: [queryArray]
+    }, 'aggregate');
+};
 
 
 exports.getDefaultFolderData = (uid,query,companyId,projectId) => {
@@ -137,19 +111,16 @@ exports.getSprintFolder = async (req,res) => {
         if (req.query.collection) {
             if (req.query.collection === 'sprints' || req.query.collection === 'folders') {
                 if (req.query.count) {
-                    let data = [
-                        {
-                            $match: {
-                                projectId: new mongoose.Types.ObjectId(projectId),
-                                // BUG-032 / #86 fix: count was including
-                                // soft-deleted sprints/folders, which made the
-                                // sidebar counters disagree with the actual
-                                // list (the list-rendering branches below use
-                                // `deletedStatusKey: { $nin: [1] }`).
-                                deletedStatusKey: { $nin: [1] }
-                            }
-                        },
-                    ]
+                    // BUG-032 / #86 fix: count was including soft-deleted
+                    // sprints/folders, which made the sidebar counters disagree
+                    // with the actual list.
+                    const countMatch = req.query.collection === 'sprints'
+                        ? await exports.sprintVisibilityMatch(uid, companyId, projectId, roleType)
+                        : {
+                            projectId: new mongoose.Types.ObjectId(projectId),
+                            deletedStatusKey: { $nin: [1] }
+                        };
+                    let data = [{ $match: countMatch }]
                     if (req.query.fields) {
                         const fields = req.query.fields.split(',');
                         const projection = {};

--- a/Modules/ProjectDashboard/controller.js
+++ b/Modules/ProjectDashboard/controller.js
@@ -1,4 +1,5 @@
 const { SCHEMA_TYPE } = require('../../Config/schemaType');
+const { hiddenSprintFilter } = require('../Sprints/helpers/sprintVisibility');
 const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
 const logger = require('../../Config/loggerConfig');
 const { evaluatePermission } = require('../../Config/permissionGuard');
@@ -43,6 +44,7 @@ exports.getProjectDashboard = async (req, res) => {
             deletedStatusKey: { $in: [0, undefined] },
         };
         if (!seeAll) filter.AssigneeUserId = String(req.uid);
+        Object.assign(filter, await hiddenSprintFilter(companyId, req.uid, [String(projectId)]));
 
         const tasks = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.TASKS,

--- a/Modules/PublicShares/controller.js
+++ b/Modules/PublicShares/controller.js
@@ -55,7 +55,12 @@ exports.createShare = async (req, res) => {
             return refuse(res, allowed, entityType === 'page' ? 'Doc not found.' : 'Not found.');
         }
         if (allowed.privateDoc) {
-            return res.send({ status: false, statusText: 'This doc is private. Set it to Shared before creating a public link.' });
+            return res.send({
+                status: false,
+                statusText: entityType === 'sprint'
+                    ? 'This sprint is private. Set it to Shared before creating a public link.'
+                    : 'This doc is private. Set it to Shared before creating a public link.',
+            });
         }
 
         const existing = await MongoDbCrudOpration(companyId, {

--- a/Modules/PublicShares/helpers/shareAccess.js
+++ b/Modules/PublicShares/helpers/shareAccess.js
@@ -3,6 +3,7 @@ const { SCHEMA_TYPE } = require('../../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
 const { projectAccess, isCompanyAdmin, isCompanyMember } = require('../../../Config/contentAccess');
 const { pageVisibleTo } = require('../../Pages/helpers/pageRules');
+const { canSeeSprint, sprintIdentities } = require('../../Sprints/helpers/sprintVisibility');
 
 const OBJECT_ID = /^[a-f0-9]{24}$/i;
 const NOT_FOUND = Object.freeze({ ok: false, statusCode: 404 });
@@ -21,7 +22,8 @@ const findOne = (companyId, type, filter) => MongoDbCrudOpration(companyId, { ty
  * entity: they must be able to edit the project the entity lives in. A saved report
  * aggregates every project unless it is filtered to one, so an unfiltered report is
  * owner/admin only. `privateDoc` marks the author's own private doc: they may manage an
- * existing link, but a new one is refused because the renderer would not serve it.
+ * existing link, but a new one is refused because the renderer would not serve it. A
+ * private sprint is marked the same way.
  */
 const canManageShare = async ({ companyId, uid, entityType, entityId }) => {
     const user = String(uid || '');
@@ -38,7 +40,15 @@ const canManageShare = async ({ companyId, uid, entityType, entityId }) => {
     }
     if (entityType === 'sprint') {
         const sprint = await findOne(companyId, SCHEMA_TYPE.SPRINTS, { _id, deletedStatusKey: { $ne: 1 } });
-        return sprint ? fromProject(companyId, user, sprint.projectId) : NOT_FOUND;
+        if (!sprint) return NOT_FOUND;
+        const decision = await fromProject(companyId, user, sprint.projectId);
+        if (sprint.private !== true) return decision;
+        /* A private sprint is only its assignees' to publish, and like a private doc a new
+         * link is refused outright: the sharer sets it back to Shared first. An existing
+         * link keeps serving while its author can still see the sprint, and stops the
+         * moment they cannot — the same rule the project half of this check already uses. */
+        if (!(await isCompanyAdmin(companyId, user)) && !canSeeSprint(sprint, await sprintIdentities(companyId, user))) return NOT_FOUND;
+        return decision.ok ? { ...decision, privateDoc: true } : decision;
     }
     if (entityType === 'form') {
         const form = await findOne(companyId, SCHEMA_TYPE.FORMS, { _id, deletedStatusKey: 0 });

--- a/Modules/PublicShares/publicRenderer.js
+++ b/Modules/PublicShares/publicRenderer.js
@@ -5,6 +5,7 @@ const logger = require("../../Config/loggerConfig");
 const { isShareToken, validateIntakeSubmission, escapeHtml, sanitizeDocHtml } = require('./helpers/shareRules');
 const { shareStillAuthorised } = require('./helpers/shareAccess');
 const reportRules = require('../CustomReports/helpers/reportRules'); // REP-09 — share saved reports
+const customReports = require('../CustomReports/controller');
 const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 
@@ -300,10 +301,11 @@ async function resolveShare(token) {
 const DIM_LABELS = { status: 'Status', project: 'Project', sprint: 'Sprint' };
 const METRIC_LABELS = { count: 'Task count', points: 'Story points' };
 
-async function runReportRows(companyId, cfg) {
-    const pipeline = reportRules.buildPipeline(cfg);
-    const raw = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [pipeline] }, 'aggregate');
-    return (raw || []).map((r) => ({ label: (r._id === null || r._id === undefined || r._id === '') ? '(none)' : String(r._id), value: r.value || 0 }));
+/* The public page shows what the person who published it could see, no more: the rows are
+ * built by the reports module under the share author's own project and sprint scope. */
+async function runReportRows(companyId, cfg, viewer) {
+    const out = await customReports.runConfig(companyId, cfg, viewer);
+    return (out.rows || []).map((r) => ({ label: r.label, value: r.value }));
 }
 
 async function renderReport(companyId, share) {
@@ -315,7 +317,7 @@ async function renderReport(companyId, share) {
     }
     // Resolve through the same whitelist engine — never raw fields.
     const check = reportRules.validateConfig(report);
-    const rows = check.valid ? await runReportRows(companyId, check.value) : [];
+    const rows = check.valid ? await runReportRows(companyId, check.value, share.createdBy) : [];
     const total = rows.reduce((a, r) => a + (r.value || 0), 0);
     const dimLabel = DIM_LABELS[check.value && check.value.dimension] || 'Group';
     const metricLabel = METRIC_LABELS[check.value && check.value.metric] || 'Value';

--- a/Modules/ScheduledReports/controller.js
+++ b/Modules/ScheduledReports/controller.js
@@ -33,7 +33,7 @@ const sendOne = (subject, html, recipients) => new Promise((resolve) => {
 const runSavedReport = async (companyId, report) => {
     const check = reportRules.validateConfig(report);
     if (!check.valid) return { rows: [], total: 0, config: null };
-    const out = await customReports.runConfig(companyId, check.value);
+    const out = await customReports.runConfig(companyId, check.value, report.createdBy);
     const rows = out.rows.map((r) => ({ label: r.label, value: r.value }));
     return { rows, total: Math.round(rows.reduce((a, r) => a + (r.value || 0), 0) * 100) / 100, config: check.value };
 };

--- a/Modules/Sprints/helpers/sprintVisibility.js
+++ b/Modules/Sprints/helpers/sprintVisibility.js
@@ -1,43 +1,97 @@
 const mongoose = require('mongoose');
 const { SCHEMA_TYPE } = require('../../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+const { myCache } = require('../../../Config/config');
 
 const OBJECT_ID = /^[a-f0-9]{24}$/i;
+const TEAM_PREFIX = 'tId_';
+const IDENTITY_TTL_SECONDS = 60;
 
 const asObjectIds = (ids) => (ids || [])
     .filter((id) => OBJECT_ID.test(String(id)))
     .map((id) => new mongoose.Types.ObjectId(String(id)));
 
-/* A private sprint belongs to the people it is shared with; owners and admins read past
- * it. The sidebar's sprint list (Project/controller/getSprintFolder.js), global search and
- * the advanced filter all state this rule, so the task reads state it from here. */
-const canSeeSprint = (sprint, uid) => !sprint
-    || sprint.private !== true
-    || (sprint.AssigneeUserId || []).map(String).includes(String(uid));
+/* A sprint's AssigneeUserId holds user ids and `tId_<teamId>` entries, so membership is
+ * decided against the caller's own identities rather than their user id alone. Expanding
+ * the caller's teams once per company and user costs a single query instead of one per
+ * sprint; the key carries "teams" so Modules/Teams' removeCache('teams', true) drops it
+ * as soon as a membership changes. */
+const sprintIdentities = async (companyId, uid) => {
+    const key = `teams:sprintIdentities:${companyId}:${uid}`;
+    const cached = myCache.get(key);
+    if (cached !== undefined) return cached;
+    const teams = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.TEAMS_MANAGEMENT,
+        data: [{ assigneeUsersArray: { $in: [String(uid)] } }, { _id: 1 }],
+    }, 'find').catch(() => []);
+    const identities = [String(uid), ...(teams || []).map((team) => `${TEAM_PREFIX}${team._id}`)];
+    myCache.set(key, identities, IDENTITY_TTL_SECONDS);
+    return identities;
+};
+
+const identitySet = (identities) => (identities instanceof Set
+    ? identities
+    : new Set((Array.isArray(identities) ? identities : [identities]).filter(Boolean).map(String)));
+
+/* A private sprint belongs to the people it is shared with; owners and admins read past it. */
+const canSeeSprint = (sprint, identities) => {
+    if (!sprint || sprint.private !== true) return true;
+    const mine = identitySet(identities);
+    return (sprint.AssigneeUserId || []).map(String).some((id) => mine.has(id));
+};
+
+/* The same rule as a find/match clause, for queries that already read the sprint rows.
+ * `prefix` names the embedded sprint when a pipeline has joined it, e.g. 'sprintArray.'. */
+const visibleSprintClause = (identities, prefix = '') => ({
+    $or: [
+        { [`${prefix}private`]: { $ne: true } },
+        { [`${prefix}AssigneeUserId`]: { $in: [...identitySet(identities)] } },
+    ],
+});
+
+/* The same rule as an aggregation expression, for $lookup sub-pipelines and $cond. */
+const visibleSprintExpr = (identities, assigneeField = '$AssigneeUserId', privateField = '$private') => ({
+    $or: [
+        { $ne: [privateField, true] },
+        { $gt: [{ $size: { $setIntersection: [{ $ifNull: [assigneeField, []] }, [...identitySet(identities)]] } }, 0] },
+    ],
+});
 
 /* The sprints in `projectIds` the caller is not on, as _ids to exclude a task by sprintId. */
 const hiddenSprintIds = async (companyId, uid, projectIds) => {
     const projects = asObjectIds(projectIds);
     if (!projects.length) return [];
-    const sprints = await MongoDbCrudOpration(companyId, {
-        type: SCHEMA_TYPE.SPRINTS,
-        data: [{ projectId: { $in: projects }, private: true }, 'private AssigneeUserId'],
-    }, 'find');
-    return (sprints || []).filter((sprint) => !canSeeSprint(sprint, uid)).map((sprint) => sprint._id);
+    const [sprints, identities] = await Promise.all([
+        MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.SPRINTS,
+            data: [{ projectId: { $in: projects }, private: true }, 'private AssigneeUserId'],
+        }, 'find'),
+        sprintIdentities(companyId, uid),
+    ]);
+    const mine = identitySet(identities);
+    return (sprints || []).filter((sprint) => !canSeeSprint(sprint, mine)).map((sprint) => sprint._id);
 };
 
 const canSeeSprintById = async (companyId, uid, sprintId) => {
     if (!OBJECT_ID.test(String(sprintId || ''))) return true;
-    const sprint = await MongoDbCrudOpration(companyId, {
-        type: SCHEMA_TYPE.SPRINTS,
-        data: [{ _id: new mongoose.Types.ObjectId(String(sprintId)) }, 'private AssigneeUserId'],
-    }, 'findOne');
-    return canSeeSprint(sprint, uid);
+    const [sprint, identities] = await Promise.all([
+        MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.SPRINTS,
+            data: [{ _id: new mongoose.Types.ObjectId(String(sprintId)) }, 'private AssigneeUserId'],
+        }, 'findOne'),
+        sprintIdentities(companyId, uid),
+    ]);
+    return canSeeSprint(sprint, identities);
 };
 
 module.exports = {
+    TEAM_PREFIX,
     asObjectIds,
     canSeeSprint,
     canSeeSprintById,
     hiddenSprintIds,
+    identitySet,
+    sprintIdentities,
+    visibleSprintClause,
+    visibleSprintExpr,
 };

--- a/Modules/Sprints/helpers/sprintVisibility.js
+++ b/Modules/Sprints/helpers/sprintVisibility.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 const { SCHEMA_TYPE } = require('../../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
 const { myCache } = require('../../../Config/config');
+const { getRoleType, isPrivileged } = require('../../../Config/permissionGuard');
+const logger = require('../../../Config/loggerConfig');
 
 const OBJECT_ID = /^[a-f0-9]{24}$/i;
 const TEAM_PREFIX = 'tId_';
@@ -84,8 +86,41 @@ const canSeeSprintById = async (companyId, uid, sprintId) => {
     return canSeeSprint(sprint, identities);
 };
 
+/* Owners and admins read past sprint privacy, so every caller-facing entry point starts here. */
+const privileged = async (companyId, uid) => isPrivileged(await getRoleType(String(companyId || ''), String(uid || '')));
+
+/* `{ sprintId: { $nin: [...] } }` for a task read already scoped to `projectIds`, or `{}`
+ * when the caller may see every sprint in them. Spread into an existing find filter. */
+const hiddenSprintFilter = async (companyId, uid, projectIds) => {
+    if (await privileged(companyId, uid)) return {};
+    const hidden = await hiddenSprintIds(companyId, uid, projectIds);
+    return hidden.length ? { sprintId: { $nin: hidden } } : {};
+};
+
+/* Express middleware for the routes addressed by sprint id — the scrum board, the agile
+ * reports, the hour and burndown charts. A private sprint the caller is not on answers 404
+ * rather than 403, so the refusal says nothing the sprint list would not already say. */
+const requireSprintAccess = (pick) => async (req, res, next) => {
+    try {
+        const companyId = String(req.headers['companyid'] || '');
+        const ids = [...new Set([].concat(pick(req) || []).map(String).filter((id) => OBJECT_ID.test(id)))];
+        if (!ids.length || await privileged(companyId, req.uid)) return next();
+        for (const id of ids) {
+            if (!(await canSeeSprintById(companyId, req.uid, id))) {
+                return res.status(404).json({ status: false, statusText: 'Sprint not found.', error: 'Not Found' });
+            }
+        }
+        return next();
+    } catch (error) {
+        logger.error(`requireSprintAccess error: ${error.message || error}`);
+        return res.status(403).json({ status: false, statusText: 'Permission check failed.', error: 'Forbidden' });
+    }
+};
+
 module.exports = {
     TEAM_PREFIX,
+    hiddenSprintFilter,
+    requireSprintAccess,
     asObjectIds,
     canSeeSprint,
     canSeeSprintById,

--- a/Modules/Sprints/routes.js
+++ b/Modules/Sprints/routes.js
@@ -4,6 +4,7 @@ const hours = require('./hours');
 const scrum = require('./scrum');
 const { SCHEMA_TYPE } = require('../../Config/schemaType');
 const { READ, WRITE, requireProjectAccess, projectIdsFrom } = require('../../Config/projectAccess');
+const { requireSprintAccess } = require('./helpers/sprintVisibility');
 
 // Whitelist of functions allowed to be called via PATCH /sprint/:id
 const ALLOWED_SPRINT_TYPES = ['editSprintName', 'updateSprint', 'deleteChannel'];
@@ -21,6 +22,10 @@ const FOLDER_RENAME = 'project.project_folder_name_edit';
 const FOLDER_STATUS = { 0: 'project.folder_restore', 1: 'project.folder_delete', 2: 'project.folder_archive' };
 
 const bodyOf = (req) => req.body || {};
+
+// The project guard lets any project member through, so the scrum board needs the sprint
+// rule on top: a private sprint is only its assignees', their teams' and the admins'.
+const onSprint = (pick) => requireSprintAccess(pick);
 
 const sprintProject = (pick, direct) => projectIdsFrom({ records: [[SCHEMA_TYPE.SPRINTS, pick]], direct });
 
@@ -41,19 +46,21 @@ const folderPatchPermissions = (req) => {
 };
 
 exports.init = (app) => {
-    app.post('/api/v2/sprints/burndown', guard(READ, sprintProject((req) => bodyOf(req).sprintId || (req.query && req.query.sprintId))), burndown.getSprintBurndown);
-    app.post('/api/v2/sprints/hours', guard(READ, sprintProject((req) => bodyOf(req).sprintId)), hours.getSprintHours);
+    const burndownSprint = (req) => bodyOf(req).sprintId || (req.query && req.query.sprintId);
+    app.post('/api/v2/sprints/burndown', guard(READ, sprintProject(burndownSprint)), onSprint(burndownSprint), burndown.getSprintBurndown);
+    app.post('/api/v2/sprints/hours', guard(READ, sprintProject((req) => bodyOf(req).sprintId)), onSprint((req) => bodyOf(req).sprintId), hours.getSprintHours);
 
     // Scrum lifecycle. Deliberately under /api/v2/sprints: setMiddleware.js
     // registers that as a PREFIX, so these are behind a token by default.
     // /api/v1/sprints (plural) is NOT registered anywhere and would be open.
     const managesSprint = guard(WRITE, sprintProject((req) => [bodyOf(req).sprintId, bodyOf(req).incompleteDestination]), () => [SPRINT_CREATE]);
-    app.post('/api/v2/sprints/scrum', managesSprint, scrum.setScrum);
-    app.post('/api/v2/sprints/start', managesSprint, scrum.startSprint);
-    app.post('/api/v2/sprints/complete', managesSprint, scrum.completeSprint);
-    app.get('/api/v2/sprints/complete-preview', guard(READ, sprintProject((req) => req.query && req.query.sprintId)), scrum.completePreview);
+    const writesSprint = onSprint((req) => [bodyOf(req).sprintId, bodyOf(req).incompleteDestination]);
+    app.post('/api/v2/sprints/scrum', managesSprint, writesSprint, scrum.setScrum);
+    app.post('/api/v2/sprints/start', managesSprint, writesSprint, scrum.startSprint);
+    app.post('/api/v2/sprints/complete', managesSprint, writesSprint, scrum.completeSprint);
+    app.get('/api/v2/sprints/complete-preview', guard(READ, sprintProject((req) => req.query && req.query.sprintId)), onSprint((req) => req.query && req.query.sprintId), scrum.completePreview);
     app.post('/api/v2/sprints/backlog', guard(READ, (req) => bodyOf(req).projectId), scrum.getBacklog);
-    app.get('/api/v2/sprints/report', guard(READ, sprintProject((req) => req.query && req.query.sprintId)), scrum.sprintReport);
+    app.get('/api/v2/sprints/report', guard(READ, sprintProject((req) => req.query && req.query.sprintId)), onSprint((req) => req.query && req.query.sprintId), scrum.sprintReport);
 
     const addsSprint = projectIdsFrom({ records: [[SCHEMA_TYPE.FOLDERS, (req) => bodyOf(req).folder && bodyOf(req).folder.folderId]], direct: (req) => bodyOf(req).projectId });
     app.post('/api/v1/sprint', guard(WRITE, addsSprint, () => [SPRINT_CREATE]), ctrl.addSprint);

--- a/Modules/VarianceReport/controller.js
+++ b/Modules/VarianceReport/controller.js
@@ -3,6 +3,7 @@ const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries'
 const logger = require('../../Config/loggerConfig');
 const R = require('./helpers/varianceRules');
 const { resolveTimeScope, visibleProjectsFor } = require('../TimeSheet/helpers/timeScope');
+const { canSeeSprintById, hiddenSprintFilter } = require('../Sprints/helpers/sprintVisibility');
 
 const companyOf = (req) => req.headers['companyid'] || (req.query && req.query.companyId);
 
@@ -27,6 +28,12 @@ exports.getVarianceReport = async (req, res) => {
             return res.status(403).json({ status: false, statusText: 'You do not have access to this project.' });
         }
         if (visible && !q.projectId) match.ProjectID = { $in: visible };
+        if (q.sprintId && !(await canSeeSprintById(companyId, req.uid, q.sprintId))) {
+            return res.status(404).json({ status: false, statusText: 'Sprint not found.' });
+        }
+        if (!q.sprintId) {
+            Object.assign(match, await hiddenSprintFilter(companyId, req.uid, q.projectId ? [String(q.projectId)] : (visible || [])));
+        }
 
         const tasks = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.TASKS,

--- a/docs/TESTING-E2E.md
+++ b/docs/TESTING-E2E.md
@@ -83,7 +83,7 @@ Every account uses the password in `PASSWORD` (`fixtures.js`). The run state (`r
 
 ## Rules for every test
 
-1. **Create your own data.** The shared fixtures (company, the four users, two projects, three tasks) are read-only context. If a test changes something, it creates that thing first with `createProject`, `createTask` or `inviteMember`, and uses `uniqueSuffix()` for names and codes.
+1. **Create your own data.** The shared fixtures (company, the four users, two projects, three tasks) are read-only context. If a test changes something, it creates that thing first with `createProject`, `createTask` or `inviteMember`, and uses `uniqueSuffix()` for names and codes. `createTask` takes an optional `assigneeIds` when the test needs the task to belong to somebody — the views that show a plain member only their own work read it.
 2. **Never depend on test order.** Any test must pass when run alone (`npx playwright test -g "<title>"`, `npx jest -t "<title>"`) and in parallel with every other test. No test reads what another test wrote.
 3. **Assert through the product.** Sign in with `loginAs` or a role's storage state; do not write to MongoDB from a test.
 4. **Keep strings stable.** UI assertions use the English copy from `frontend/src/locales/en.js` or a `data-test` attribute. Add a `data-test` to the component when a selector would otherwise depend on layout.

--- a/e2e/support/fixtures.js
+++ b/e2e/support/fixtures.js
@@ -128,7 +128,7 @@ async function firstSprint(api, projectId, { timeoutMs = 15000, intervalMs = 100
 }
 
 /* Same payload the create-task forms send (see ConvertNoteToTask.vue). */
-async function createTask(api, { project, name, user, companyOwnerId }) {
+async function createTask(api, { project, name, user, companyOwnerId, assigneeIds = [] }) {
     const sprint = await firstSprint(api, project._id);
     if (!sprint) throw new Error(`project ${project._id} has no sprint to hold a task`);
     const sprintId = String(sprint._id || sprint.id);
@@ -138,7 +138,7 @@ async function createTask(api, { project, name, user, companyOwnerId }) {
         data: {
             TaskName: name || `E2E Task ${uniqueSuffix()}`,
             TaskKey: '--',
-            AssigneeUserId: [],
+            AssigneeUserId: assigneeIds.map(String),
             watchers: [user.userId],
             DueDate: '',
             dueDateDeadLine: [],

--- a/tests/comments-search-role.test.js
+++ b/tests/comments-search-role.test.js
@@ -25,7 +25,8 @@ const pipelineFor = async ({ storedRole, bodyRole }) => {
     const res = { status: jest.fn(() => res), json: jest.fn() };
     await searchComments({ headers: { companyid: COMPANY }, uid: USER, body: { pids: [PROJECT], roleType: bodyRole } }, res);
     expect(res.status).toHaveBeenCalledWith(200);
-    return MongoDbCrudOpration.mock.calls[0][1].data[0];
+    const search = MongoDbCrudOpration.mock.calls.find(([, params]) => params.type === 'comments');
+    return search[1].data[0];
 };
 
 beforeEach(() => jest.clearAllMocks());

--- a/tests/integration/private-sprint-everywhere.int.test.js
+++ b/tests/integration/private-sprint-everywhere.int.test.js
@@ -1,0 +1,192 @@
+const { createProject, createTask, firstSprint, loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+
+jest.setTimeout(120000);
+
+async function projectWithTask(owner, assignees, taskAssigneeIds = []) {
+    const project = await createProject(owner.api, { assigneeIds: assignees.map((s) => s.uid), createdBy: owner.uid });
+    let lastErr;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+        try {
+            const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid, assigneeIds: taskAssigneeIds });
+            return { project, task };
+        } catch (err) {
+            lastErr = err;
+            await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+    }
+    throw lastErr;
+}
+
+/* What the sprint row's "Share With: Private" toggle sends (SprintsList.vue). */
+async function makeSprintPrivate(owner, { project }, assigneeIds) {
+    const sprint = await firstSprint(owner.api, project._id);
+    const res = await owner.api.patch(`/api/v1/sprint/${sprint._id}`, {
+        type: 'updateSprint',
+        companyId: state.companyId,
+        projectId: String(project._id),
+        updateObject: { $set: { private: true, AssigneeUserId: assigneeIds.map(String) } },
+    });
+    expect(res.body.status).toBe(true);
+    return String(sprint._id);
+}
+
+async function teamOf(owner, members) {
+    const name = `Squad ${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    const res = await owner.api.post('/api/v1/teams/addTeam', {
+        name,
+        value: name,
+        teamColor: { color: '#4f46e5' },
+        assigneeUsersArray: members.map(String),
+    });
+    expect(res.status).toBe(200);
+    return String(res.body._id);
+}
+
+describe('a sprint shared with a team belongs to that team', () => {
+    it('keeps the tasks readable for a member who is only on the sprint through their team', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const target = await projectWithTask(owner, [owner, member]);
+
+        const teamId = await teamOf(owner, [member.uid]);
+        await makeSprintPrivate(owner, target, [owner.uid, `tId_${teamId}`]);
+
+        const list = await member.api.post('/api/v1/task/find', {
+            findQuery: [{ $match: { objId: { ProjectID: String(target.project._id) } } }],
+        });
+        expect(list.status).toBe(200);
+        expect(list.body.map((task) => String(task._id))).toContain(String(target.task._id));
+        expect((await member.api.get(`/api/v1/task/${target.task._id}`)).status).toBe(200);
+    });
+
+    it('still refuses a member of no assigned team', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const guest = await loginAs('guest');
+        const target = await projectWithTask(owner, [owner, member, guest]);
+
+        const teamId = await teamOf(owner, [member.uid]);
+        await makeSprintPrivate(owner, target, [`tId_${teamId}`]);
+
+        expect((await guest.api.get(`/api/v1/task/${target.task._id}`)).status).toBe(404);
+    });
+
+    it('lists the sprint itself for the team member and hides it from everyone else', async () => {
+        const owner = await loginAs('owner');
+        const member = await loginAs('member');
+        const guest = await loginAs('guest');
+        const target = await projectWithTask(owner, [owner, member, guest]);
+
+        const teamId = await teamOf(owner, [member.uid]);
+        const sprintId = await makeSprintPrivate(owner, target, [`tId_${teamId}`]);
+
+        const idsFor = async (session) => {
+            const res = await session.api.get(`/api/v1/project/sprintFolder/${target.project._id}?collection=sprints`);
+            expect(res.status).toBe(200);
+            return (res.body || []).map((sprint) => String(sprint._id));
+        };
+        expect(await idsFor(member)).toContain(sprintId);
+        expect(await idsFor(guest)).not.toContain(sprintId);
+    });
+
+    it('leaves the private sprint out of the ?count=true sidebar counter', async () => {
+        const owner = await loginAs('owner');
+        const guest = await loginAs('guest');
+        const target = await projectWithTask(owner, [owner, guest]);
+
+        const countFor = async (session) => {
+            const res = await session.api.get(`/api/v1/project/sprintFolder/${target.project._id}?collection=sprints&count=true`);
+            expect(res.status).toBe(200);
+            return (res.body && res.body[0] && res.body[0].count) || 0;
+        };
+        const before = await countFor(guest);
+        await makeSprintPrivate(owner, target, [owner.uid]);
+        expect(await countFor(guest)).toBe(before - 1);
+        expect(await countFor(owner)).toBe(before);
+    });
+});
+
+describe('the paths that used to guard at project level only', () => {
+    let owner;
+    let guest;
+    let target;
+    let sprintId;
+
+    beforeAll(async () => {
+        owner = await loginAs('owner');
+        guest = await loginAs('guest');
+        /* The dashboard shows a plain member only their own tasks, so the task is the
+         * guest's: without the sprint rule it would still be counted for them. */
+        target = await projectWithTask(owner, [owner, guest], [guest.uid]);
+        sprintId = await makeSprintPrivate(owner, target, [owner.uid]);
+    });
+
+    it('answers the scrum board reads with 404 for a project member who is not on the sprint', async () => {
+        const refusals = [
+            await guest.api.get(`/api/v2/sprints/report?sprintId=${sprintId}&companyId=${state.companyId}`),
+            await guest.api.get(`/api/v2/sprints/complete-preview?sprintId=${sprintId}&companyId=${state.companyId}`),
+            await guest.api.post('/api/v2/sprints/burndown', { sprintId, companyId: state.companyId }),
+            await guest.api.post('/api/v2/sprints/hours', { sprintId, companyId: state.companyId }),
+        ];
+        refusals.forEach((res) => expect(res.status).toBe(404));
+    });
+
+    it('answers the agile reports addressed by sprint id with 404', async () => {
+        for (const path of ['burndown', 'sprint-insights', 'provenance']) {
+            const res = await guest.api.get(`/api/v1/agile/${path}?sprintId=${sprintId}`);
+            expect(res.status).toBe(404);
+        }
+    });
+
+    it('serves the same reads to the owner', async () => {
+        expect((await owner.api.get(`/api/v2/sprints/report?sprintId=${sprintId}&companyId=${state.companyId}`)).status).toBe(200);
+        expect((await owner.api.get(`/api/v1/agile/burndown?sprintId=${sprintId}`)).status).toBe(200);
+    });
+
+    it('leaves the private sprint\'s task out of the project dashboard counts', async () => {
+        /* A fresh project, because the counters are read before and after the toggle. */
+        const own = await projectWithTask(owner, [owner, guest], [guest.uid]);
+        const totalFor = async (session) => {
+            const res = await session.api.get(`/api/v1/project-dashboard/${own.project._id}`);
+            expect(res.status).toBe(200);
+            return res.body.data.totalTasks;
+        };
+        expect(await totalFor(guest)).toBe(1);
+        await makeSprintPrivate(owner, own, [owner.uid]);
+        expect(await totalFor(guest)).toBe(0);
+        expect(await totalFor(owner)).toBe(1);
+    });
+
+    it('leaves the private sprint out of a custom report grouped by sprint', async () => {
+        const config = { source: 'tasks', dimension: 'sprint', metric: 'count', chartType: 'bar', filters: {} };
+        const mine = await owner.api.post('/api/v1/reports/custom/run', config);
+        expect(mine.status).toBe(200);
+        expect(mine.body.data.result.map((row) => String(row.key))).toContain(sprintId);
+
+        const theirs = await guest.api.post('/api/v1/reports/custom/run', config);
+        expect(theirs.status).toBe(200);
+        expect(theirs.body.data.result.map((row) => String(row.key))).not.toContain(sprintId);
+    });
+
+    it('refuses to export the private sprint for someone not on it', async () => {
+        const res = await guest.api.post('/api/v2/exports', {
+            format: 'csv', projectId: String(target.project._id), sprintId, projectName: 'P',
+        });
+        expect(res.body.status).toBe(false);
+    });
+
+    it('refuses a variance report for the private sprint', async () => {
+        const res = await guest.api.get(`/api/v1/reports/variance?sprintId=${sprintId}`);
+        expect(res.status).toBe(404);
+    });
+
+    it('refuses a public link to the private sprint', async () => {
+        const res = await guest.api.post('/api/v2/public-shares', { entityType: 'sprint', entityId: sprintId });
+        expect(res.body.status).toBe(false);
+        const asOwner = await owner.api.post('/api/v2/public-shares', { entityType: 'sprint', entityId: sprintId });
+        expect(asOwner.body.status).toBe(false);
+        expect(String(asOwner.body.statusText)).toContain('private');
+    });
+});

--- a/tests/sprint-visibility.test.js
+++ b/tests/sprint-visibility.test.js
@@ -1,0 +1,106 @@
+const mockDb = require('./fixtures/fakeMongo').create();
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (...a) => mockDb.crud(...a) }));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+
+const { myCache } = require('../Config/config');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const {
+    canSeeSprint,
+    canSeeSprintById,
+    hiddenSprintIds,
+    sprintIdentities,
+    visibleSprintClause,
+    visibleSprintExpr,
+} = require('../Modules/Sprints/helpers/sprintVisibility');
+
+const C = '6f0000000000000000000f01';
+const OWNER = '6f0000000000000000000f11';
+const MEMBER = '6f0000000000000000000f12';
+const OUTSIDER = '6f0000000000000000000f13';
+const PROJECT = '6f0000000000000000000f21';
+
+const team = (members) => mockDb.seed(SCHEMA_TYPE.TEAMS_MANAGEMENT, { name: 'Core', assigneeUsersArray: members });
+const sprint = (over) => mockDb.seed(SCHEMA_TYPE.SPRINTS, { projectId: PROJECT, private: false, AssigneeUserId: [], ...over });
+
+beforeEach(() => {
+    Object.keys(mockDb.store).forEach((k) => { mockDb.store[k].length = 0; });
+    myCache.flushAll();
+});
+
+describe('sprintIdentities expands the caller into their user id and team ids', () => {
+    it('returns the user id alone when they are on no team', async () => {
+        expect(await sprintIdentities(C, MEMBER)).toEqual([MEMBER]);
+    });
+
+    it('adds a tId_ entry for each team the caller belongs to', async () => {
+        const core = team([MEMBER]);
+        expect(await sprintIdentities(C, MEMBER)).toEqual([MEMBER, `tId_${core._id}`]);
+        expect(await sprintIdentities(C, OUTSIDER)).toEqual([OUTSIDER]);
+    });
+
+    it('reads the teams once and serves the rest of the request from cache', async () => {
+        team([MEMBER]);
+        const before = mockDb.calls.length;
+        await sprintIdentities(C, MEMBER);
+        await sprintIdentities(C, MEMBER);
+        await sprintIdentities(C, MEMBER);
+        expect(mockDb.calls.length - before).toBe(1);
+    });
+});
+
+describe('canSeeSprint recognises a team assignment', () => {
+    it('lets a public sprint through for anyone', () => {
+        expect(canSeeSprint({ private: false, AssigneeUserId: [OWNER] }, [OUTSIDER])).toBe(true);
+    });
+
+    it('refuses a private sprint the caller has no identity on', () => {
+        expect(canSeeSprint({ private: true, AssigneeUserId: [OWNER, 'tId_1'] }, [OUTSIDER])).toBe(false);
+    });
+
+    it('accepts a private sprint assigned to a team the caller is on', () => {
+        expect(canSeeSprint({ private: true, AssigneeUserId: ['tId_7'] }, [MEMBER, 'tId_7'])).toBe(true);
+    });
+});
+
+describe('hiddenSprintIds and canSeeSprintById follow team assignments', () => {
+    it('keeps a private sprint assigned to the caller\'s team out of the hidden list', async () => {
+        const core = team([MEMBER]);
+        const shared = sprint({ private: true, AssigneeUserId: [`tId_${core._id}`] });
+        const secret = sprint({ private: true, AssigneeUserId: [OWNER] });
+
+        const hidden = (await hiddenSprintIds(C, MEMBER, [PROJECT])).map(String);
+        expect(hidden).toEqual([String(secret._id)]);
+        expect(hidden).not.toContain(String(shared._id));
+
+        expect((await hiddenSprintIds(C, OUTSIDER, [PROJECT])).map(String).sort())
+            .toEqual([String(shared._id), String(secret._id)].sort());
+    });
+
+    it('answers canSeeSprintById for a member of an assigned team', async () => {
+        const core = team([MEMBER]);
+        const shared = sprint({ private: true, AssigneeUserId: [`tId_${core._id}`] });
+        expect(await canSeeSprintById(C, MEMBER, shared._id)).toBe(true);
+        expect(await canSeeSprintById(C, OUTSIDER, shared._id)).toBe(false);
+    });
+});
+
+describe('the query and aggregation forms carry the same identities', () => {
+    it('matches a public sprint or one assigned to any of the identities', () => {
+        expect(visibleSprintClause([MEMBER, 'tId_7'], 'sprintArray.')).toEqual({
+            $or: [
+                { 'sprintArray.private': { $ne: true } },
+                { 'sprintArray.AssigneeUserId': { $in: [MEMBER, 'tId_7'] } },
+            ],
+        });
+    });
+
+    it('intersects the assignee list with the identities as an expression', () => {
+        expect(visibleSprintExpr([MEMBER, 'tId_7'])).toEqual({
+            $or: [
+                { $ne: ['$private', true] },
+                { $gt: [{ $size: { $setIntersection: [{ $ifNull: ['$AssigneeUserId', []] }, [MEMBER, 'tId_7']] } }, 0] },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## Summary

PR #656 established the rule — a private sprint (`sprints.private` with `AssigneeUserId`) belongs to its assignees plus owners and admins — and the helper `Modules/Sprints/helpers/sprintVisibility.js`. This closes the two follow-ups: team assignments were never expanded, and several read paths never applied the rule at all.

| Finding | Where | Fix | Test |
|---|---|---|---|
| `tId_<teamId>` assignees ignored, so a member of an assigned team is an outsider | `sprintVisibility.js`, and the four filters that restated the rule | `sprintIdentities()` expands the caller into `[uid, tId_…]` once per request; the rule is offered as a predicate, a find clause and an aggregation expression, and all four filters call it | `tests/sprint-visibility.test.js`; int: team member reads the tasks, the sprint and the sidebar list |
| Advanced filter trusted `req.body.userId` / `roleType` | `Modules/AdvancedGlobalFilter/controller.js` | caller taken from the session | unit (existing suites), int |
| Comment search trusted `req.body.userId` | `Modules/Comments/controller.js` | same | `tests/comments-search-role.test.js` |
| `?count=true` sidebar counter skipped the privacy filter its sibling branch applies | `Modules/Project/controller/getSprintFolder.js` | the count and the list share one `sprintVisibilityMatch` | int: counter drops by one for an outsider, unchanged for the owner |
| Scrum board reads guarded the project only | `Modules/Sprints/routes.js` (report, complete-preview, burndown, hours, scrum/start/complete) | new `requireSprintAccess` middleware → 404 | int: four reads 404 for a project member, 200 for the owner |
| Agile reports by sprint id had no guard at all | `Modules/AgileReports/routes.js` (burndown, sprint-insights, provenance) | same middleware | int: three reads 404 |
| Velocity listed private sprints' names and points | `Modules/AgileReports/velocity.js` | sprints filtered through `canSeeSprint` | covered by the helper's unit tests |
| CFD and milestones counted private-sprint tasks | `Modules/AgileReports/cfd.js`, `milestones.js` | `hiddenSprintFilter` | — |
| Project dashboard counted them | `Modules/ProjectDashboard/controller.js` | `hiddenSprintFilter` | int: `totalTasks` 1 → 0 for the outsider, 1 for the owner |
| Custom reports aggregated the whole tasks collection and resolved private sprint *names* | `Modules/CustomReports/controller.js` | `runConfig(companyId, cfg, viewer)` prepends the viewer's project scope and hidden sprints; viewer = session, schedule → report author, public link → share author | int: a sprint-dimension report shows the sprint to its assignee and not to an outsider |
| Export accepted any `sprintId` in the project | `Modules/ExportJobs/controller.js` | refused at creation, and the detached job re-excludes hidden sprints | int: refused |
| Variance report accepted any `sprintId` | `Modules/VarianceReport/controller.js` | 404 on an unseeable sprint; otherwise `hiddenSprintFilter` | int: 404 |
| A public link could publish a private sprint | `Modules/PublicShares/helpers/shareAccess.js` | see Notes | int: refused for an outsider and for the owner |

## Notes

**Team expansion and its cost.** The naive reading — expand every sprint's `AssigneeUserId` into member ids — costs a teams lookup per sprint. This does the opposite: it expands *the caller* once into `[uid, 'tId_<teamId>', …]` and matches sprints against that set, which is how `Modules/Agents/scope.js` already decides project visibility. That is one `teams_management` query per company and user, cached 60s in the existing `node-cache`; the key is `teams:sprintIdentities:<companyId>:<uid>`, which contains `teams`, so `Modules/Teams`' existing `removeCache('teams', true)` drops it the moment a membership changes. Filtering a list of sprints adds no queries at all, and the aggregation call sites (`visibleSprintClause` / `visibleSprintExpr`) push the whole test into Mongo.

**Public shares — what a share link is meant to expose.** A share pins one entity id and re-checks on every request that its *creator* could still make the link (`shareStillAuthorised`), so a link dies when its author loses access. Two gaps: the sprint branch only asked about the project, and the report branch ran unscoped. Both are now tied to the author:

- A sprint share requires the author to be able to see the sprint. A *private* sprint is additionally marked `privateDoc`, so **creating** a new link is refused with "This sprint is private. Set it to Shared before creating a public link." This is exactly the treatment private docs already get (`entityType: 'page'`), and it is deliberate parity rather than a new policy.
- An **existing** link to a sprint that was later made private keeps serving while its author can still see it, and stops the moment they cannot. That is the same behaviour private docs have, and the alternative — killing live links on the privacy toggle — would break shares silently. Flagging it explicitly as the judgement call in this PR.
- A public report now runs through `runConfig` under `share.createdBy`'s scope, so the page shows what the person who published it could see and no more.

**Deliberately left alone.**
- `Modules/UserDashboard` — every non-privileged card pins `AssigneeUserId: uid`, so a member only ever sees their own tasks; a private sprint they are assigned to is theirs to see. Left with that evidence rather than filtered.
- `Modules/Portfolio` — rollup counts only, no task identity. Not changed in this PR.
- Broader holes found while sweeping and **not** fixed here, because they are project-level auth rather than the sprint rule: `/api/v1/agile/velocity|cfd|milestones` take a `projectId` with no project guard at all; `/api/public-v1/tasks/:key` matches on `TaskKey` with no project scoping; `Modules/Mcp/tools.js` scopes to projects only. Worth their own PR.

## Test plan

All run on Node 20 in a clean worktree.

- `npx jest --selectProjects unit --maxWorkers=2` → **271 suites, 3829 tests passed**
- `npx jest tests/conventions --maxWorkers=2` → **8 suites, 94 tests passed**
- `E2E_MONGODB_URL=mongodb://127.0.0.1:27211 npm run test:integration` (mongo:7 in a throwaway container) → **47 suites, 817 tests passed**
- `npm run i18n:check` → clean, 0 missing across every locale; no new keys (no frontend change)
- `npx eslint` on every touched file → 0 errors (only pre-existing warnings in `Sprints/controller.js` and `PublicShares/publicRenderer.js`)

**Reproduce-first evidence.** `tests/integration/private-sprint-everywhere.int.test.js` was run with `Modules/` reverted to `origin/beta`: **10 of its 12 tests failed**, one per finding above. With the fix in place all 12 pass. The two that pass either way are the negative controls — an outsider with no team is still refused, and the owner still reads everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
