### PR TITLE
fix(teams): scope the team cache to its company and guard the agile routes

### DIFF
--- a/Modules/AgileReports/milestones.js
+++ b/Modules/AgileReports/milestones.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 const { SCHEMA_TYPE } = require('../../Config/schemaType');
 const { MongoDbCrudOpration } = require('../../utils/mongo-handler/mongoQueries');
 const { hiddenSprintFilter } = require('../Sprints/helpers/sprintVisibility');
+const { keepVisibleProjectIds } = require('../../Config/projectAccess');
 const logger = require('../../Config/loggerConfig');
 const H = require('./helpers/milestoneMoves');
 
@@ -50,9 +51,12 @@ exports.getMilestones = async (req, res) => {
                 deletedStatusKey: { $nin: [1, 2] },
             }, 'ProjectName status'],
         }, 'find') || [];
+        /* Without a projectId this reports on the whole company, so the catalogue is
+         * narrowed to what the caller may open before anything is read from it. */
+        const projectIds = await keepVisibleProjectIds(companyId, req.uid, projects.map((p) => String(p._id)));
+        const visible = new Set(projectIds);
         const projectName = {};
-        projects.forEach((p) => { projectName[String(p._id)] = p.ProjectName || ''; });
-        const projectIds = Object.keys(projectName);
+        projects.forEach((p) => { if (visible.has(String(p._id))) projectName[String(p._id)] = p.ProjectName || ''; });
         if (!projectIds.length) {
             return res.send({ status: true, statusText: 'No projects.', data: { milestones: [], totals: { total: 0, atRisk: 0, missed: 0 } } });
         }

--- a/Modules/AgileReports/routes.js
+++ b/Modules/AgileReports/routes.js
@@ -5,16 +5,20 @@ const sprintInsights = require('./sprintInsights');
 const milestones = require('./milestones');
 const provenance = require('./provenance');
 const { requireSprintAccess } = require('../Sprints/helpers/sprintVisibility');
+const { requireProjectAccess, READ } = require('../../Config/projectAccess');
 
 exports.init = (app) => {
     // Unified agile-reports read API (S4). Burndown reuses the existing Sprints
     // handler (now query-param aware); velocity + CFD are computed in this module.
     // All read-only; auth/companyId come from the global middleware like other routes.
     const onSprint = requireSprintAccess((req) => (req.query || {}).sprintId);
+    /* The project-addressed reports answer 404 for a project the caller cannot open; the
+     * ones that also take no projectId narrow to the visible projects in the handler. */
+    const onProject = requireProjectAccess({ mode: READ, projectIds: (req) => (req.query || {}).projectId });
     app.get('/api/v1/agile/burndown', onSprint, getSprintBurndown);
-    app.get('/api/v1/agile/velocity', velocity.getVelocity);
-    app.get('/api/v1/agile/cfd', cfd.getCFD);
+    app.get('/api/v1/agile/velocity', onProject, velocity.getVelocity);
+    app.get('/api/v1/agile/cfd', onProject, cfd.getCFD);
     app.get('/api/v1/agile/sprint-insights', onSprint, sprintInsights.getSprintInsights);
-    app.get('/api/v1/agile/milestones', milestones.getMilestones);
+    app.get('/api/v1/agile/milestones', onProject, milestones.getMilestones);
     app.get('/api/v1/agile/provenance', onSprint, provenance.getProvenance);
 };

--- a/Modules/ApiTokens/publicApi.js
+++ b/Modules/ApiTokens/publicApi.js
@@ -4,11 +4,17 @@ const mongoose = require("mongoose");
 const logger = require("../../Config/loggerConfig");
 const { verifyToken, logTokenActivity } = require('./controller');
 const { hasScope } = require('./helpers/apiTokenRules');
+const { visibilityStage } = require('../Tasks/helpers/taskQueryGuard');
+const { visibleProjectIds } = require('../Agents/scope');
 
 // Token-authenticated public REST namespace (/api/public-v1/*). Fully
 // self-contained: its own middleware, zero coupling with the session-JWT
 // auth the web app uses. Clients send:
 //   Authorization: Bearer ahp_…        companyId: <company id>
+//
+// A token acts for the person who minted it, so every read here is narrowed to
+// what that person may open in the web app — a token is not a way past project
+// and sprint visibility.
 
 const tokenAuth = async (req, res, next) => {
     const started = Date.now();
@@ -38,6 +44,15 @@ const tokenAuth = async (req, res, next) => {
     }
 };
 
+const tokenUid = (req) => String((req.apiToken && req.apiToken.userId) || '');
+
+/* Empty for an owner or admin, who read company-wide; otherwise the projects and sprints
+ * the token owner may open, as a filter to spread into a task read. */
+const taskVisibility = async (req) => {
+    const stage = await visibilityStage(req.apiCompanyId, tokenUid(req));
+    return stage ? stage.$match : {};
+};
+
 const requireScope = (scope) => (req, res, next) => {
     if (!hasScope(req.apiToken, scope)) {
         return res.status(403).send({ status: false, statusText: `Token lacks the '${scope}' scope.` });
@@ -48,9 +63,14 @@ const requireScope = (scope) => (req, res, next) => {
 /* GET /api/public-v1/projects */
 const listProjects = async (req, res) => {
     try {
+        const visible = await visibleProjectIds(req.apiCompanyId, tokenUid(req));
         const projects = await MongoDbCrudOpration(req.apiCompanyId, {
             type: SCHEMA_TYPE.PROJECTS,
-            data: [{ deletedStatusKey: { $in: [0, undefined] } }, 'ProjectName ProjectCode createdAt', { limit: 200 }],
+            data: [
+                { _id: { $in: visible.map((id) => new mongoose.Types.ObjectId(id)) }, deletedStatusKey: { $in: [0, undefined] } },
+                'ProjectName ProjectCode createdAt',
+                { limit: 200 },
+            ],
         }, 'find');
         return res.send({ status: true, data: projects || [] });
     } catch (error) {
@@ -66,10 +86,14 @@ const listTasks = async (req, res) => {
             return res.status(400).send({ status: false, statusText: 'A valid projectId query param is required.' });
         }
         const limit = Math.min(500, Math.max(1, Number(req.query?.limit) || 100));
+        const visibility = await taskVisibility(req);
+        if (visibility.ProjectID && !(visibility.ProjectID.$in || []).map(String).includes(projectId)) {
+            return res.status(404).send({ status: false, statusText: 'Project not found.' });
+        }
         const tasks = await MongoDbCrudOpration(req.apiCompanyId, {
             type: SCHEMA_TYPE.TASKS,
             data: [
-                { ProjectID: new mongoose.Types.ObjectId(projectId), deletedStatusKey: { $ne: 1 } },
+                { ...visibility, ProjectID: new mongoose.Types.ObjectId(projectId), deletedStatusKey: { $ne: 1 } },
                 'TaskKey TaskName status statusType Task_Priority AssigneeUserId DueDate sprintId epicId createdAt updatedAt',
                 { limit, sort: { updatedAt: -1 } },
             ],
@@ -89,7 +113,7 @@ const getTaskByKey = async (req, res) => {
         }
         const task = await MongoDbCrudOpration(req.apiCompanyId, {
             type: SCHEMA_TYPE.TASKS,
-            data: [{ TaskKey: key, deletedStatusKey: { $ne: 1 } }],
+            data: [{ ...(await taskVisibility(req)), TaskKey: key, deletedStatusKey: { $ne: 1 } }],
         }, 'findOne');
         if (!task) {
             return res.status(404).send({ status: false, statusText: 'Task not found.' });

--- a/Modules/Sprints/helpers/sprintVisibility.js
+++ b/Modules/Sprints/helpers/sprintVisibility.js
@@ -4,6 +4,7 @@ const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueri
 const { myCache } = require('../../../Config/config');
 const { getRoleType, isPrivileged } = require('../../../Config/permissionGuard');
 const logger = require('../../../Config/loggerConfig');
+const { teamIdentitiesKey } = require('../../Teams/cacheKeys');
 
 const OBJECT_ID = /^[a-f0-9]{24}$/i;
 const TEAM_PREFIX = 'tId_';
@@ -16,10 +17,10 @@ const asObjectIds = (ids) => (ids || [])
 /* A sprint's AssigneeUserId holds user ids and `tId_<teamId>` entries, so membership is
  * decided against the caller's own identities rather than their user id alone. Expanding
  * the caller's teams once per company and user costs a single query instead of one per
- * sprint; the key carries "teams" so Modules/Teams' removeCache('teams', true) drops it
- * as soon as a membership changes. */
+ * sprint; the key sits under Modules/Teams' own `teams:<companyId>:` prefix so a team
+ * write drops it as soon as a membership changes, and never reaches another company. */
 const sprintIdentities = async (companyId, uid) => {
-    const key = `teams:sprintIdentities:${companyId}:${uid}`;
+    const key = teamIdentitiesKey(companyId, uid);
     const cached = myCache.get(key);
     if (cached !== undefined) return cached;
     const teams = await MongoDbCrudOpration(companyId, {

--- a/Modules/Teams/cacheKeys.js
+++ b/Modules/Teams/cacheKeys.js
@@ -1,0 +1,10 @@
+/* Every teams entry sits under `teams:<companyId>:` so one company's list can never be
+ * served to another, and so a single prefix delete drops the list together with the
+ * per-user sprint identities Modules/Sprints derives from it. */
+const teamsCachePrefix = (companyId) => `teams:${companyId}:`;
+
+const teamsListKey = (companyId) => `${teamsCachePrefix(companyId)}list`;
+
+const teamIdentitiesKey = (companyId, uid) => `${teamsCachePrefix(companyId)}identities:${uid}`;
+
+module.exports = { teamsCachePrefix, teamsListKey, teamIdentitiesKey };

--- a/Modules/Teams/controller.js
+++ b/Modules/Teams/controller.js
@@ -2,20 +2,22 @@ const { SCHEMA_TYPE } = require("../../Config/schemaType");
 const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries");
 const { myCache } = require('../../Config/config');
 const { removeCache } = require("../../utils/commonFunctions");
+const { teamsCachePrefix, teamsListKey } = require("./cacheKeys");
 
 exports.getTeams = async(req,res) => {
     try {
+        const companyId = req.headers['companyid'];
         const teamsObj = {
             type: SCHEMA_TYPE.TEAMS_MANAGEMENT,
             data: []
         };
 
-        const teamCache = 'teams';
+        const teamCache = teamsListKey(companyId);
         let teams = myCache.get(teamCache);
         let isFromCache = true;
         if(!teams){
             isFromCache = false;
-            teams =  await MongoDbCrudOpration(req.headers['companyid'], teamsObj, 'find');
+            teams =  await MongoDbCrudOpration(companyId, teamsObj, 'find');
             myCache.set(teamCache, teams, 604800);
         }
 
@@ -43,7 +45,7 @@ exports.addTeam = async (req,res) => {
         if (!response) {
             return res.status(400).json({ message: "Teams not added" });
         }
-        removeCache('teams',true);
+        removeCache(teamsCachePrefix(req.headers['companyid']), true);
         return res.status(200).json(response);
     } catch (error) {
         res.status(500).json({ message: "An error occurred while creating the teams", error: error.message });
@@ -74,7 +76,7 @@ exports.updateTeam = async(req,res) => {
         if (!team) {
             return res.status(400).json({ message: "Team not updated" });
         }
-        removeCache('teams',true);
+        removeCache(teamsCachePrefix(req.headers['companyid']), true);
         return res.status(200).json(team);
 
     } catch (error) {

--- a/tests/agile-report-access.test.js
+++ b/tests/agile-report-access.test.js
@@ -1,0 +1,112 @@
+const fakeMongo = require('./fixtures/fakeMongo');
+
+let mockDb;
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({
+    MongoDbCrudOpration: (...args) => mockDb.crud(...args),
+    validateObjectId: (id) => /^[a-f0-9]{24}$/i.test(String(id)),
+}));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+
+const mongoose = require('mongoose');
+const { myCache } = require('../Config/config');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+
+const C = 'c00000000000000000000001';
+const OWNER = 'a00000000000000000000001';
+const MEMBER = 'a00000000000000000000003';
+const MEMBER_ROLE = 3;
+
+const oid = () => new mongoose.Types.ObjectId().toString();
+
+const routesOf = (modulePath) => {
+    const table = {};
+    const register = (method) => (path, ...handlers) => { table[`${method} ${path}`] = handlers; };
+    const app = { get: register('GET'), post: register('POST'), put: register('PUT'), patch: register('PATCH'), delete: register('DELETE'), use: register('USE') };
+    require(modulePath).init(app);
+    return table;
+};
+
+const response = () => {
+    const res = { statusCode: 200, body: undefined };
+    res.status = jest.fn((code) => { res.statusCode = code; return res; });
+    res.json = jest.fn((body) => { res.body = body; return res; });
+    res.send = res.json;
+    res.set = jest.fn(() => res);
+    return res;
+};
+
+const run = async (handlers, request) => {
+    const res = response();
+    for (const handler of handlers) {
+        let advanced = false;
+        await handler(request, res, () => { advanced = true; });
+        if (!advanced) break;
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+    return res;
+};
+
+const seedRules = (grants = {}) => {
+    const parents = {};
+    const parentOf = (section) => {
+        if (!parents[section]) parents[section] = mockDb.seed(SCHEMA_TYPE.RULES, { key: section, isParent: true, roles: [{ key: MEMBER_ROLE, permission: true }] });
+        return parents[section];
+    };
+    Object.entries(grants).forEach(([path, permission]) => {
+        const [section, key] = path.split('.');
+        mockDb.seed(SCHEMA_TYPE.RULES, { key, isParent: false, parentId: String(parentOf(section)._id), roles: [{ key: MEMBER_ROLE, permission }] });
+    });
+};
+
+const routes = () => routesOf('../Modules/AgileReports/routes');
+const call = (path, uid, query) => run(routes()[path], { uid, params: {}, body: {}, query, headers: { companyid: C } });
+
+let hidden;
+beforeEach(() => {
+    myCache.flushAll();
+    mockDb = fakeMongo.create();
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: OWNER, roleType: 1, status: 2, isDelete: false });
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: MEMBER, roleType: MEMBER_ROLE, status: 2, isDelete: false });
+    seedRules({ 'project.private_projects': 1 });
+    hidden = mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: oid(), ProjectName: 'Secret', isPrivateSpace: true, AssigneeUserId: [OWNER] });
+});
+
+describe.each([
+    ['GET /api/v1/agile/velocity'],
+    ['GET /api/v1/agile/cfd'],
+    ['GET /api/v1/agile/milestones'],
+])('%s is bound to the projects the caller may open', (path) => {
+    it('answers 404 for a private project the caller is not on', async () => {
+        const res = await call(path, MEMBER, { projectId: String(hidden._id) });
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toMatchObject({ status: false, error: 'Not Found' });
+    });
+
+    it('lets an owner through to the handler', async () => {
+        const res = await call(path, OWNER, { projectId: String(hidden._id) });
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject({ status: true });
+    });
+
+    it('lets an assigned member through to the handler', async () => {
+        const mine = mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: oid(), ProjectName: 'Mine', isPrivateSpace: true, AssigneeUserId: [MEMBER] });
+        const res = await call(path, MEMBER, { projectId: String(mine._id) });
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject({ status: true });
+    });
+});
+
+describe('GET /api/v1/agile/milestones without a projectId', () => {
+    it('reports on the caller\'s visible projects only', async () => {
+        const mine = mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: oid(), ProjectName: 'Mine', isPrivateSpace: false, AssigneeUserId: [MEMBER] });
+        mockDb.seed(SCHEMA_TYPE.MILESTONE, { projectId: String(hidden._id), milestoneName: 'Secret launch', dueDate: new Date('2030-01-01') });
+        mockDb.seed(SCHEMA_TYPE.MILESTONE, { projectId: String(mine._id), milestoneName: 'My launch', dueDate: new Date('2030-01-01') });
+
+        const res = await call('GET /api/v1/agile/milestones', MEMBER, {});
+        expect(res.statusCode).toBe(200);
+        const names = (res.body.data.milestones || []).map((m) => m.name);
+        expect(names).toContain('My launch');
+        expect(names).not.toContain('Secret launch');
+    });
+});

--- a/tests/public-api-task-scope.test.js
+++ b/tests/public-api-task-scope.test.js
@@ -1,0 +1,113 @@
+const fakeMongo = require('./fixtures/fakeMongo');
+
+let mockDb;
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({
+    MongoDbCrudOpration: (...args) => mockDb.crud(...args),
+    validateObjectId: (id) => /^[a-f0-9]{24}$/i.test(String(id)),
+}));
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+
+const mongoose = require('mongoose');
+const { myCache } = require('../Config/config');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+
+const C = 'c00000000000000000000001';
+const OWNER = 'a00000000000000000000001';
+const MEMBER = 'a00000000000000000000003';
+const MEMBER_ROLE = 3;
+
+const oid = () => new mongoose.Types.ObjectId().toString();
+
+const routesOf = (modulePath) => {
+    const table = {};
+    const register = (method) => (path, ...handlers) => { table[`${method} ${path}`] = handlers; };
+    const app = { get: register('GET'), post: register('POST'), put: register('PUT'), delete: register('DELETE'), use: register('USE') };
+    require(modulePath).init(app);
+    return table;
+};
+
+const response = () => {
+    const res = { statusCode: 200, body: undefined };
+    res.status = jest.fn((code) => { res.statusCode = code; return res; });
+    res.json = jest.fn((body) => { res.body = body; return res; });
+    res.send = res.json;
+    res.set = jest.fn(() => res);
+    res.on = jest.fn(() => res);
+    return res;
+};
+
+/* The token middleware is exercised by its own suite; these cases start from a verified
+ * token so they can say what a verified token may read. */
+const call = async (path, uid, { params = {}, query = {} } = {}) => {
+    const handlers = routesOf('../Modules/ApiTokens/publicApi')[path].slice(1);
+    const req = {
+        params, query, body: {}, headers: { companyid: C },
+        apiCompanyId: C,
+        apiToken: { _id: 'tok', userId: uid, scopes: ['read'], active: true },
+    };
+    const res = response();
+    for (const handler of handlers) {
+        let advanced = false;
+        await handler(req, res, () => { advanced = true; });
+        if (!advanced) break;
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+    return res;
+};
+
+const seedRules = (grants = {}) => {
+    const parents = {};
+    const parentOf = (section) => {
+        if (!parents[section]) parents[section] = mockDb.seed(SCHEMA_TYPE.RULES, { key: section, isParent: true, roles: [{ key: MEMBER_ROLE, permission: true }] });
+        return parents[section];
+    };
+    Object.entries(grants).forEach(([path, permission]) => {
+        const [section, key] = path.split('.');
+        mockDb.seed(SCHEMA_TYPE.RULES, { key, isParent: false, parentId: String(parentOf(section)._id), roles: [{ key: MEMBER_ROLE, permission }] });
+    });
+};
+
+let hidden;
+let mine;
+beforeEach(() => {
+    myCache.flushAll();
+    mockDb = fakeMongo.create();
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: OWNER, roleType: 1, status: 2, isDelete: false });
+    mockDb.seed(SCHEMA_TYPE.COMPANY_USERS, { userId: MEMBER, roleType: MEMBER_ROLE, status: 2, isDelete: false });
+    seedRules({ 'project.private_projects': 1 });
+    hidden = mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: oid(), ProjectName: 'Secret', isPrivateSpace: true, AssigneeUserId: [OWNER] });
+    mine = mockDb.seed(SCHEMA_TYPE.PROJECTS, { _id: oid(), ProjectName: 'Mine', isPrivateSpace: false, AssigneeUserId: [MEMBER] });
+    mockDb.seed(SCHEMA_TYPE.TASKS, { _id: oid(), TaskKey: 'AH-1', TaskName: 'Secret task', ProjectID: String(hidden._id), deletedStatusKey: 0 });
+    mockDb.seed(SCHEMA_TYPE.TASKS, { _id: oid(), TaskKey: 'AH-2', TaskName: 'My task', ProjectID: String(mine._id), deletedStatusKey: 0 });
+});
+
+describe('GET /api/public-v1/tasks/:key answers for the token owner', () => {
+    it('does not hand over a task in a project the token owner cannot open', async () => {
+        const res = await call('GET /api/public-v1/tasks/:key', MEMBER, { params: { key: 'AH-1' } });
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toMatchObject({ status: false });
+    });
+
+    it('still returns a task in a project they can open', async () => {
+        const res = await call('GET /api/public-v1/tasks/:key', MEMBER, { params: { key: 'AH-2' } });
+        expect(res.body).toMatchObject({ status: true, data: { TaskName: 'My task' } });
+    });
+
+    it('lets an owner read across the company', async () => {
+        const res = await call('GET /api/public-v1/tasks/:key', OWNER, { params: { key: 'AH-1' } });
+        expect(res.body).toMatchObject({ status: true, data: { TaskName: 'Secret task' } });
+    });
+});
+
+describe('the rest of the namespace answers for the token owner too', () => {
+    it('lists only the projects the token owner can open', async () => {
+        const res = await call('GET /api/public-v1/projects', MEMBER);
+        expect((res.body.data || []).map((p) => p.ProjectName)).toEqual(['Mine']);
+    });
+
+    it('refuses a task listing for a project the token owner cannot open', async () => {
+        const res = await call('GET /api/public-v1/tasks', MEMBER, { query: { projectId: String(hidden._id) } });
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toMatchObject({ status: false });
+    });
+});

--- a/tests/teams-cache-scope.test.js
+++ b/tests/teams-cache-scope.test.js
@@ -1,0 +1,62 @@
+jest.mock('../Config/loggerConfig', () => ({ error: jest.fn(), info: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({
+    MongoDbCrudOpration: jest.fn(async (companyId, { data }, method) => (
+        method === 'save' ? { _id: 'saved', ...data } : [{ _id: `team-${companyId}`, name: `Team of ${companyId}` }]
+    )),
+}));
+
+const { myCache } = require('../Config/config');
+const { teamsListKey, teamIdentitiesKey } = require('../Modules/Teams/cacheKeys');
+const { getTeams, addTeam } = require('../Modules/Teams/controller');
+
+const A = '6f0000000000000000000a01';
+const B = '6f0000000000000000000b01';
+const USER = '6f0000000000000000000001';
+
+const response = () => {
+    const res = { statusCode: 0, body: undefined };
+    res.status = jest.fn((code) => { res.statusCode = code; return res; });
+    res.json = jest.fn((body) => { res.body = body; return res; });
+    res.set = jest.fn(() => res);
+    return res;
+};
+
+const get = async (companyId) => {
+    const res = response();
+    await getTeams({ headers: { companyid: companyId }, uid: USER, body: {} }, res);
+    return res;
+};
+
+beforeEach(() => myCache.flushAll());
+
+describe('the team list cache is keyed by company', () => {
+    it('never serves one company the team list of another', async () => {
+        expect((await get(A)).body).toEqual([{ _id: `team-${A}`, name: `Team of ${A}` }]);
+        expect((await get(B)).body).toEqual([{ _id: `team-${B}`, name: `Team of ${B}` }]);
+    });
+
+    it('serves the second read of the same company from its own cached entry', async () => {
+        await get(A);
+        const second = await get(A);
+        expect(second.body).toEqual([{ _id: `team-${A}`, name: `Team of ${A}` }]);
+        expect(second.set).toHaveBeenCalledWith(expect.objectContaining({ FromCache: 'true' }));
+        expect(myCache.has(teamsListKey(A))).toBe(true);
+        expect(myCache.has(teamsListKey(B))).toBe(false);
+    });
+});
+
+describe('a team write drops the caller company cache only', () => {
+    it('drops the list and the sprint identities of that company, and nothing of another', async () => {
+        myCache.set(teamsListKey(A), ['stale']);
+        myCache.set(teamIdentitiesKey(A, USER), [USER]);
+        myCache.set(teamsListKey(B), ['kept']);
+        myCache.set(teamIdentitiesKey(B, USER), [USER]);
+
+        await addTeam({ headers: { companyid: A }, uid: USER, body: { name: 'New' } }, response());
+
+        expect(myCache.has(teamsListKey(A))).toBe(false);
+        expect(myCache.has(teamIdentitiesKey(A, USER))).toBe(false);
+        expect(myCache.has(teamsListKey(B))).toBe(true);
+        expect(myCache.has(teamIdentitiesKey(B, USER))).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

| Finding | Where | Fix | Test |
| --- | --- | --- | --- |
| Cross-tenant: the team list was cached under the bare key `teams`, so the first company to warm it served its teams to every other company | `Modules/Teams/controller.js` | Keys now sit under `teams:<companyId>:` — `teams:<companyId>:list` and `teams:<companyId>:identities:<uid>` (the sprint identities from #662), minted in the new `Modules/Teams/cacheKeys.js`; `addTeam`/`updateTeam` invalidate with the company prefix instead of the instance-wide `removeCache('teams', true)` | `tests/teams-cache-scope.test.js` |
| `GET /api/v1/agile/velocity`, `/cfd`, `/milestones` had no project guard, and `/milestones` with no `projectId` reported on every project in the company | `Modules/AgileReports/routes.js`, `milestones.js` | `requireProjectAccess({ mode: READ, projectIds: req.query.projectId })` on all three — the rule the sibling agile routes already use — answering 404 for a project the caller cannot open; the unscoped milestone listing narrows through `keepVisibleProjectIds` | `tests/agile-report-access.test.js` |
| `GET /api/public-v1/tasks/:key` matched a `TaskKey` anywhere in the company with no project scoping (and `tasks` / `projects` were equally unscoped) | `Modules/ApiTokens/publicApi.js` | Every read is answered as the token's owner: `visibilityStage` from `Modules/Tasks/helpers/taskQueryGuard.js` on both task reads, `visibleProjectIds` on the project listing; a `projectId` the owner cannot open answers 404 | `tests/public-api-task-scope.test.js` |

All three reproduced as failing tests before the fix. The cache one reproduced exactly as reported: company B's `GET /api/v1/teams` returned company A's rows off the shared `teams` entry.

## Notes

**What `/api/public-v1` is for.** It is not anonymous. `Modules/ApiTokens/publicApi.js` gates the whole namespace behind `tokenAuth` (an `ahp_` personal access token plus a `companyid` header) and `requireScope('read')`; `tests/integration/access.int.test.js` asserts it answers 401 without one. The tenancy was already right — every query goes through `MongoDbCrudOpration(req.apiCompanyId, …)`. What was missing is the person: a token doc carries the `userId` of whoever minted it, so the route is effectively signed-in, and the right rule is the normal task visibility rule. That is what this applies, rather than inventing a share or token-to-project binding that does not exist in the schema. An owner or admin still reads company-wide, exactly as in the web app.

**Other bare cache keys.** Swept every `myCache.set` / `myCache.get` / `removeCache` call in `Modules`, `utils`, `Config`, `middlewares`, `event` and `common-storage`. Three other keys carry no company:

- `file_extensions_caches` (`Modules/settings/restrictedExtensions/controller.js`)
- `subscriptionPlan` (`Modules/SubscriptionPlan/controller.js`)
- `tours` (`Modules/tours/controller.js`)

All three are correct as they stand: each reads from the global database (`SCHEMA_TYPE.GOLBAL` / `'global'`), not a company one, so the value is genuinely instance-wide. `removeCacheHandler` already refuses to let a session drop them. Everything else already embeds the company, the user, or a hash of both. Left alone.

Two invalidations stay deliberately broad — `removeCache('UserProjectData:', true)` and `removeCache('UserAllData:', true)` drop those prefixes across every company. That is wasted work, not a leak, and widening the blast radius of a cache drop is safe; out of scope here.

**Invalidation checked.** `Modules/Teams` is the only writer of the teams collection in the repo, so the prefix delete is the whole invalidation surface. `teams:<companyId>:` covers the list and every user's sprint identities in that company, and `tests/teams-cache-scope.test.js` asserts another company's two entries survive the write.

## Test plan

Node 20.20.2, all run in this worktree.

- `npx jest --selectProjects unit --maxWorkers=2` — 276 suites, 4007 tests passed
- `npx jest tests/conventions --maxWorkers=2` — 8 suites, 94 tests passed
- `E2E_MONGODB_URL=mongodb://127.0.0.1:27231 npm run test:integration` against `mongo:7` in Docker — 47 suites, 817 tests passed (full layer; caching and agile reach across modules). Container removed afterwards.
- `npm run i18n:check` — exit 0, every locale 7632/7632, 0 missing
- `npx eslint` on all six touched source files and the three new tests — clean
- No frontend change, so no vitest run.

Before the fix, the new tests failed as expected: company B received `Team of <companyA>`; velocity, cfd and milestones each answered 200 for a private project the member is not on, and the milestone listing carried `Secret launch`; the member's token read the task in the project they cannot open and listed the private space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
