### PR TITLE
test(e2e): stop the mongo connector logging after a suite tears down

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -11,7 +11,7 @@ Backend variables: 182. Frontend build-time variables: 23.
 | `APIURL` | yes |  | Public base URL of this API, with a trailing slash (used in emails, OAuth callbacks and share links). | `Config/config.js`, `Modules/ApiTokens/controller.js` +6 |
 | `APP_NAME` |  | `Alian Hub` | Product name shown in emails and page titles. | `Config/config.js`, `Modules/Template/forgotPassword.js` +5 |
 | `BUILD_INFO_GIT_TIMEOUT_MS` |  | `10000` | Per-command timeout, in ms, for the git calls that resolve the running version. On timeout the server reports channel unknown and retries in the background. | `scripts/build-info.js` |
-| `NODE_ENV` |  | `development` | development \| production | `Config/config.js`, `Modules/AICore/persistence.js` +5 |
+| `NODE_ENV` |  | `development` | development \| production | `Config/config.js`, `Modules/AICore/persistence.js` +6 |
 | `PORT` | yes | `4000` | TCP port the HTTP server listens on. | `Config/config.js` |
 | `SERVER_HEADERS_TIMEOUT_MS` |  | `66000` | How long the HTTP server waits for a full request header block; always kept above the keep-alive timeout (default 66000). | `Modules/Agents/engine/timeouts.js` |
 | `SERVER_KEEP_ALIVE_TIMEOUT_MS` |  | `65000` | Idle keep-alive timeout of the HTTP server; keep it above the idle timeout of any proxy in front (default 65000). | `Modules/Agents/engine/timeouts.js` |

--- a/middlewares/mongoConnector/helper.js
+++ b/middlewares/mongoConnector/helper.js
@@ -77,7 +77,6 @@ exports.closeConnection = (db) => {
     if (index !== -1) {
         exports.connections[index].connection.close();
         exports.connections.splice(index, 1);
-        console.log("NEW CONNECTION", exports.connections.map((x) => ({ db: x.db, last: x.lastRequest })));
     }
 }
 

--- a/utils/mongo-handler/mongoConnector.js
+++ b/utils/mongo-handler/mongoConnector.js
@@ -5,6 +5,14 @@ const config = require('../../Config/config.js');
 const { mongoTimeoutOptions } = require('../../Modules/Agents/engine/timeouts');
 const { onFatal } = require('../../Config/processGuards');
 
+// A connection closes asynchronously, so its last lifecycle events land after
+// the Jest suite that opened it has torn down; a console write there fails the
+// suite with "Cannot log after tests are done". The log file keeps every event.
+const reportConnectionState = (message) => {
+    logger.info(message);
+    if (process.env.NODE_ENV !== 'test') console.log(message);
+};
+
 const mailReport = (subject, body) => new Promise((resolve) => {
     sendMailRef.sendAttachMail(subject, body, config.ERRORRECIVEREMAIL, [], (result) => {
         if (!result.status) console.error(`[FATAL] crash report mail failed: ${result.statusText}`);
@@ -61,32 +69,17 @@ exports.connect = (db) => {
                 }
             );
 
+            const announce = (state) => reportConnectionState(`MONGO CONNECTION ${db}: ${state}`);
+
             connection.on('connected', () => {
-                logger.info(`MONGO CONNECTION ${db}: connected`);
-                console.log(`MONGO CONNECTION ${db}: connected`);
+                announce('connected');
                 resolve(connection);
             });
-            connection.on('open', () => {
-                logger.info(`MONGO CONNECTION ${db}: open`);
-                console.log(`MONGO CONNECTION ${db}: open`);
-                // resolve(connection);
-            });
-            connection.on('disconnected', () => {
-                logger.info(`MONGO CONNECTION ${db}: disconnected`);
-                console.log(`MONGO CONNECTION ${db}: disconnected`);
-            });
-            connection.on('reconnected', () => {
-                logger.info(`MONGO CONNECTION ${db}: reconnected`);
-                console.log(`MONGO CONNECTION ${db}: reconnected`);
-            });
-            connection.on('disconnecting', () => {
-                logger.info(`MONGO CONNECTION ${db}: disconnecting`);
-                console.log(`MONGO CONNECTION ${db}: disconnecting`);
-            });
-            connection.on('close', () => {
-                logger.info(`MONGO CONNECTION ${db}: close`);
-                console.log(`MONGO CONNECTION ${db}: close`);
-            });
+            connection.on('open', () => announce('open'));
+            connection.on('disconnected', () => announce('disconnected'));
+            connection.on('reconnected', () => announce('reconnected'));
+            connection.on('disconnecting', () => announce('disconnecting'));
+            connection.on('close', () => announce('close'));
 
             connection.on('error', (error) => {
                 logger.error(`MONGO CONNECTION: error >> ${JSON.stringify(error)}`)


### PR DESCRIPTION
## Summary

The `e2e` job on `beta` failed for the merge of #675 (run 34681006787, attempt 1) while reporting every suite and every test as passing. The failure was Jest's "Cannot log after tests are done", raised twice by `utils/mongo-handler/mongoConnector.js` lines 76 and 88 for the database of `tests/integration/workflow-runs.int.test.js`. This stops the connector writing those lines to the console during a test run, so the late write cannot happen.

## Notes

**What causes the late log.** Four integration suites (`workflow-runs`, `workflow-step-types`, `workflow-api`, `workflow-run-limit`) drive the real database in the Jest process through `MongoDbCrudOpration`, and release it in `afterAll` with `closeConnection(db)`. `closeConnection` calls `connection.close()` without awaiting it, so the `disconnecting` / `disconnected` / `close` events land a tick or more later; each handler did `logger.info(...)` **and** `console.log(...)`. The suites bridge the gap with `await sleep(50)`, which is enough on an idle machine and not always enough on a CI runner. When 50 ms is not enough, the `console.log` lands after teardown and Jest fails the suite even though all of its tests passed — exactly the CI signature.

**What changed.**
- `utils/mongo-handler/mongoConnector.js` — the six lifecycle handlers now go through one `reportConnectionState` helper that always writes to the logger and writes to the console only when `NODE_ENV !== 'test'`. Jest sets `NODE_ENV=test`, so nothing in the Jest process can write to the console from a connection event. The rotating log file (`Config/loggerConfig.js` has file transports only) keeps every event as before, and `e2e/support/server.js` starts the e2e server child with `NODE_ENV: 'development'`, so the server's own stdout is unchanged.
- `middlewares/mongoConnector/helper.js` — removed the leftover `console.log("NEW CONNECTION", ...)` that `closeConnection` printed on every *close* (mislabelled, and the sibling debug lines in that file are already commented out).
- `docs/ENV.md` — regenerated by `node scripts/env-doc.js`, which the conventions test requires: one usage count for `NODE_ENV` ticked from +5 to +6.

**Is anything suppressed?** No Jest flag, reporter option or warning filter was added, and no test file was touched. The console write that failed the suite no longer happens in a test run; the event is still recorded by the logger.

**Other suites at risk.** Before the change, one full integration run printed 30 late-risk console lines from exactly two places: the five connector handlers and the `closeConnection` line, for the six connections those four workflow suites open and close. No other integration suite writes to the console at teardown. After the change a full run prints no `console.log` block at all.

The `await sleep(50)` calls in those four suites are left alone — they are now harmless, and `tests/integration/workflow-runs.int.test.js` is being edited on another branch.

## Test plan

Node 20.20.2, `docker run -d --name alianhub-e2e-quiet -p 27234:27017 mongo:7`, container removed afterwards.

- **Reproduced first.** A full `E2E_MONGODB_URL=… npm run test:integration` is green locally (52 suites / 885 tests), with and without CPU load, so the CI ordering alone does not reproduce it here. A scratch Jest file outside the repo that does exactly what the suites do — one `MongoDbCrudOpration` call, then `closeConnection(db)` in `afterAll` without the 50 ms sleep — reproduces it every time on `beta`: `1 failed, 1 passed, 2 total`, with `Cannot log after tests are done. Attempted to log "MONGO CONNECTION …: disconnected"` at `mongoConnector.js:76` and `… : close` at `mongoConnector.js:88`, the same two lines and the same `NativeConnection.onClose` stack as the CI log. With this change the same file passes: `1 passed, 1 total`, and prints nothing.
- `npx jest --selectProjects unit --maxWorkers=2` — 286 suites, 4166 tests, all passing.
- `npx jest tests/conventions --maxWorkers=2` — 8 suites, 95 tests, all passing (the env-doc test failed until `docs/ENV.md` was regenerated; that regeneration is in this PR).
- `E2E_MONGODB_URL=mongodb://127.0.0.1:27234 npm run test:integration` — run twice after the change, 52 suites / 885 tests passing both times (101.9 s, 104.6 s), zero `MONGO CONNECTION` lines and zero console blocks in either run. The pre-change baseline run was also green but printed 30 such lines.
- `npx eslint utils/mongo-handler/mongoConnector.js middlewares/mongoConnector/helper.js` — no errors; one pre-existing `no-async-promise-executor` warning on the untouched `exports.connect` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
