### PR TITLE
fix(projects): give the project and channel quota back when something is deleted

### DIFF
--- a/Modules/Company/helpers/companyCounters.js
+++ b/Modules/Company/helpers/companyCounters.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { updateCompanyFun } = require('../controller/updateCompany');
+
+/**
+ * Step one or more `projectCount.*` quota counters by a signed amount.
+ *
+ * These fields are a live tally of what a company currently owns, not a history of
+ * everything it ever created, so every increment needs a matching decrement. They are
+ * also spent against the plan limits, which makes a negative value unrecoverable: it
+ * can never be spent back down, and the company stays locked out of creating forever.
+ * The pipeline form applies the step and pins the floor at zero in the same atomic
+ * write ($inc and $max cannot touch the same field in one update). The floor only ever
+ * changes a value that is already impossible — it does not recompute a drifted one.
+ */
+const stepCompanyCounters = (companyId, steps) => {
+    const fields = {};
+    for (const [field, step] of Object.entries(steps)) {
+        fields[field] = { $max: [0, { $add: [{ $ifNull: [`$${field}`, 0] }, step] }] };
+    }
+
+    const query = {
+        type: SCHEMA_TYPE.COMPANIES,
+        data: [
+            { _id: new mongoose.Types.ObjectId(String(companyId)) },
+            [{ $set: fields }],
+            { returnDocument: 'after' }
+        ]
+    };
+
+    return updateCompanyFun(SCHEMA_TYPE.GOLBAL, query, 'findOneAndUpdate', String(companyId), true);
+};
+
+module.exports = { stepCompanyCounters };

--- a/Modules/Project/controller/updateProject.js
+++ b/Modules/Project/controller/updateProject.js
@@ -3,8 +3,20 @@ const { MongoDbCrudOpration,validateObjectId } = require("../../../utils/mongo-h
 const {removeCache} = require('../../../utils/commonFunctions');
 const { resolveProjectSkills } = require('../../settings/ProjectSkills/helper');
 const { PROJECT_SOURCES, normaliseSource, sourceOrDefault, cleanProposalId, numericProposalId, validateProposalId } = require('../helpers/projectSourceRules');
+const { quotaStatus, syncProjectQuota } = require('../helpers/projectQuota');
+const logger = require('../../../Config/loggerConfig');
 
 exports.updateProjectInternal = async (companyId, projectId, updateObject, key, arrayFilters) => {
+    // Trashing and restoring a project are the only writes that change what a company
+    // owns, and every client reaches them through here. A counter failure must not block
+    // the delete: a stuck count is recoverable, a project nobody can remove is not.
+    const nextStatus = quotaStatus(updateObject, key);
+    if (nextStatus !== null && companyId && validateObjectId(projectId)) {
+        await syncProjectQuota(companyId, projectId, nextStatus).catch((error) => {
+            logger.error(`syncProjectQuota ${projectId}: ${error && error.message ? error.message : error}`);
+        });
+    }
+
     return new Promise((resolve, reject) => {
         if (!(updateObject && Object.keys(updateObject).length)) {
             reject("Update Object is Required");

--- a/Modules/Project/helpers/projectQuota.js
+++ b/Modules/Project/helpers/projectQuota.js
@@ -1,0 +1,48 @@
+const mongoose = require('mongoose');
+const { SCHEMA_TYPE } = require('../../../Config/schemaType');
+const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueries');
+const { stepCompanyCounters } = require('../../Company/helpers/companyCounters');
+
+const TRASHED = 1;
+
+const bucketOf = (isPrivateSpace) => (isPrivateSpace === true ? 'privateCount' : 'publicCount');
+
+const stepProjectCount = (companyId, isPrivateSpace, step) => stepCompanyCounters(companyId, {
+    'projectCount.projectCount': step,
+    [`projectCount.${bucketOf(isPrivateSpace)}`]: step
+});
+
+/* The quota is spent by projects that still exist for the company. Closed (2) still
+   shows in the listing and still owns its work, so only the trash frees a slot. */
+const quotaStatus = (updateObject, key) => {
+    if (!updateObject || (key && key !== '$set')) return null;
+    if (!Object.prototype.hasOwnProperty.call(updateObject, 'deletedStatusKey')) return null;
+    const next = Number(updateObject.deletedStatusKey);
+    return Number.isFinite(next) ? next : null;
+};
+
+/**
+ * Move a project in or out of the company's project quota, exactly once.
+ *
+ * The conditional write is what decides: only the caller that actually carries the
+ * project across the trash boundary gets a document back, so re-deleting something
+ * already in the trash — or restoring what was never there — steps nothing. It also
+ * returns the stored isPrivateSpace, so the public/private bucket comes from the
+ * project rather than from whatever the request happened to send.
+ */
+const syncProjectQuota = async (companyId, projectId, nextStatus) => {
+    const trashing = nextStatus === TRASHED;
+    const claimed = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.PROJECTS,
+        data: [
+            { _id: new mongoose.Types.ObjectId(String(projectId)), deletedStatusKey: trashing ? { $ne: TRASHED } : TRASHED },
+            { $set: { deletedStatusKey: nextStatus } },
+            { projection: { isPrivateSpace: 1 }, returnDocument: 'after' }
+        ]
+    }, 'findOneAndUpdate');
+
+    if (!claimed) return null;
+    return stepProjectCount(companyId, claimed.isPrivateSpace, trashing ? -1 : 1);
+};
+
+module.exports = { TRASHED, bucketOf, quotaStatus, stepProjectCount, syncProjectQuota };

--- a/Modules/Sprints/controller.js
+++ b/Modules/Sprints/controller.js
@@ -8,7 +8,7 @@ const { dbCollections } = require("../../Config/collections");
 const { unsetAllCounts } = require("../notification-count/controller");
 const requestQueue = new RequestQueue();
 const { getCachedCompanyData } = require('../../utils/planHelper');
-const { updateCompanyFun } = require("../Company/controller/updateCompany");
+const { stepCompanyCounters } = require("../Company/helpers/companyCounters");
 const scrumRules = require("./scrumRules");
 
 exports.addSprint = (req, res) => {
@@ -21,26 +21,14 @@ exports.addSprint = (req, res) => {
 
 exports.updateChannelsCounts = (companyId, private, type) => {
     return new Promise((resolve, reject) => {
-        let params = {};
-
         const channelType = private ? 'privateChannels' : 'publicChannels';
-        params.$inc = {
-            [`projectCount.${channelType}`]: type === 'inc' ? 1 : -1,
-            [`projectCount.channels`]: type === 'inc' ? 1 : -1
-        };
-        const queryObj = [
-            { _id: new mongoose.Types.ObjectId(companyId) },
-            params,
-            { new: true }
-        ];
-
-        const query = {
-            type: SCHEMA_TYPE.COMPANIES,
-            data: queryObj
-        };
+        const step = type === 'inc' ? 1 : -1;
 
         requestQueue.enqueue(() => {
-            updateCompanyFun(SCHEMA_TYPE.GOLBAL,query,"findOneAndUpdate",companyId,true)
+            stepCompanyCounters(companyId, {
+                [`projectCount.${channelType}`]: step,
+                'projectCount.channels': step
+            })
             .then((response) => {
                 // BUG-030 / #84 fix: pre-fix code went straight to
                 // `JSON.stringify(response.data)` and then read deeply
@@ -259,6 +247,19 @@ exports.editSprintName = (req, res) => {
     }
 };
 
+/* Only a sprint whose container is a main-chat project was ever counted: addSprintFun
+   increments the channel quota for `mainChat` creates alone, while this route accepts
+   any sprint id. Decrementing for a plain project list is what drove the live counters
+   negative, and a negative quota can never be spent back. */
+const isCountedChannel = async (companyId, sprint) => {
+    if (!sprint || !sprint.projectId) return false;
+    const container = await MongoQ.MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.MAIN_CHATS,
+        data: [{ _id: new mongoose.Types.ObjectId(String(sprint.projectId)) }, { _id: 1 }]
+    }, 'findOne').catch(() => null);
+    return Boolean(container);
+};
+
 /**
  * Soft-delete a main-chat channel.
  *
@@ -279,19 +280,23 @@ exports.deleteChannel = (req, res) => {
         const object = {
             type: SCHEMA_TYPE.SPRINTS,
             data: [
-                { _id: new mongoose.Types.ObjectId(id) },
+                // The filter is what makes the quota step once: a channel already in the
+                // trash matches nothing, so a repeated delete cannot decrement again.
+                { _id: new mongoose.Types.ObjectId(id), deletedStatusKey: { $ne: 1 } },
                 { $set: { deletedStatusKey: 1 } },
                 { returnDocument: 'after' }
             ]
         };
 
-        MongoQ.MongoDbCrudOpration(companyId, object, "findOneAndUpdate").then((response) => {
+        MongoQ.MongoDbCrudOpration(companyId, object, "findOneAndUpdate").then(async (response) => {
             if (!response) {
                 res.send({ status: false, statusText: "Channel not found" });
                 return;
             }
 
             res.send({ status: true, statusText: "Sprint_deleted_successfully", data: response });
+
+            if (!(await isCountedChannel(companyId, response))) return;
 
             // Read the private flag off the STORED document, not the request body, so
             // a stale or forged value cannot decrement the wrong quota bucket.

--- a/Modules/createProject/controller.js
+++ b/Modules/createProject/controller.js
@@ -57,6 +57,7 @@ function seedTemplateSamples (project, createObject, sprintRes) {
 }
 const { resolveProjectSkills } = require("../settings/ProjectSkills/helper");
 const { normaliseSource, cleanProposalId, numericProposalId, validateProposalId } = require("../Project/helpers/projectSourceRules");
+const { stepProjectCount } = require("../Project/helpers/projectQuota");
 
 exports.checkProjectPlan = (req) => {
     return new Promise(async(resolve,reject) => {
@@ -759,22 +760,14 @@ exports.deleteProject = (data,companyId) => {
     }
 }
 
+// Rolls back the increment `checkProjectPlan` already applied, for a creation that
+// never produced a project. The delete path decrements on its own transition, so the
+// two can never both fire for the same project.
 exports.removeProjectCount = (companyId,isPrivateSpace) => {
     try {
-        let decObj = {
-            type: SCHEMA_TYPE.COMPANIES,
-            data: [
-                { _id : new mongoose.Types.ObjectId(companyId)},
-                { $inc: {'projectCount.projectCount': -1} },
-                { new: true }
-            ]
-        }
-        if(isPrivateSpace === true){
-            decObj.data[1].$inc = {...decObj.data[1].$inc,'projectCount.privateCount': -1 }
-        }else{
-            decObj.data[1].$inc = {...decObj.data[1].$inc,'projectCount.publicCount': -1 }
-        }
-        updateCompanyFun(SCHEMA_TYPE.GOLBAL,decObj,"findOneAndUpdate",companyId,true);
+        stepProjectCount(companyId, isPrivateSpace, -1).catch((error) => {
+            logger.error(`removeProjectCount ${companyId}: ${error && error.message ? error.message : error}`);
+        });
     } catch (error) {
         logger.error(`ERROR: ${error}`);
     }

--- a/tests/integration/project-counters.int.test.js
+++ b/tests/integration/project-counters.int.test.js
@@ -1,0 +1,205 @@
+const { MongoClient, ObjectId } = require('mongodb');
+const { resolveMongoUrl } = require('../../e2e/support/env');
+const { createProject, firstSprint, loginAs, readState, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+const state = readState();
+
+let client;
+let owner;
+let channelProjectId;
+
+/* The stored quota, not what an endpoint reports: a counter that drifts only shows up
+   in the company document the plan gates read. Missing fields read as 0, negatives as
+   themselves, so "never below zero" is a real assertion. */
+const counters = async () => {
+    const company = await client.db('global').collection('companies').findOne({ _id: new ObjectId(String(state.companyId)) });
+    const stored = (company && company.projectCount) || {};
+    return {
+        projectCount: stored.projectCount || 0,
+        publicCount: stored.publicCount || 0,
+        privateCount: stored.privateCount || 0,
+        channels: stored.channels || 0,
+        publicChannels: stored.publicChannels || 0,
+        privateChannels: stored.privateChannels || 0,
+    };
+};
+
+const step = (from, changes) => ({ ...from, ...changes });
+
+const trash = (projectId) => owner.api.put(`/api/v1/project/${projectId}`, { updateObject: { deletedStatusKey: 1 } });
+const restore = (projectId) => owner.api.put(`/api/v2/trash/projects/${projectId}/restore`, {});
+const deleteChannel = (sprintId, projectId) => owner.api.patch(`/api/v1/sprint/${sprintId}`, {
+    type: 'deleteChannel',
+    companyId: owner.companyId,
+    projectId,
+});
+
+const addChannel = (isPrivate) => owner.api.post('/api/v1/sprint', {
+    companyId: owner.companyId,
+    projectId: channelProjectId,
+    sprintName: `Counter channel ${uniqueSuffix()}`,
+    projectName: 'CHANNELS',
+    userData: { id: owner.uid, Employee_Name: 'Owner' },
+    mainChat: true,
+    private: isPrivate,
+    sendMessage: true,
+    AssigneeUserId: [owner.uid],
+    icon: {},
+    folder: null,
+});
+
+beforeAll(async () => {
+    client = new MongoClient(resolveMongoUrl(), { serverSelectionTimeoutMS: 5000 });
+    await client.connect();
+    owner = await loginAs('owner');
+
+    const chats = await owner.api.get('/api/v1/main-chats');
+    const rows = Array.isArray(chats.body) ? chats.body : (chats.body && chats.body.data) || [];
+    const container = rows.find((row) => row.default !== true) || rows[0];
+    channelProjectId = container && String(container._id);
+});
+
+afterAll(async () => {
+    if (client) await client.close();
+});
+
+describe('the project quota follows the projects that exist', () => {
+    it('gives the slot back when a project is trashed', async () => {
+        const before = await counters();
+
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        expect(await counters()).toEqual(step(before, { projectCount: before.projectCount + 1, publicCount: before.publicCount + 1 }));
+
+        expect((await trash(project._id)).status).toBe(200);
+        expect(await counters()).toEqual(before);
+    });
+
+    it('counts a private project in privateCount and releases it from there', async () => {
+        const before = await counters();
+
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid, isPrivate: true });
+        expect(await counters()).toEqual(step(before, { projectCount: before.projectCount + 1, privateCount: before.privateCount + 1 }));
+
+        expect((await trash(project._id)).status).toBe(200);
+        expect(await counters()).toEqual(before);
+    });
+
+    it('releases one slot however many times the same project is trashed', async () => {
+        const before = await counters();
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+
+        await trash(project._id);
+        await trash(project._id);
+        await trash(project._id);
+
+        expect(await counters()).toEqual(before);
+    });
+
+    it('takes the slot back when a project is restored from the trash, once', async () => {
+        const before = await counters();
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const held = await counters();
+
+        await trash(project._id);
+        expect(await counters()).toEqual(before);
+
+        expect((await restore(project._id)).status).toBe(200);
+        expect(await counters()).toEqual(held);
+
+        await restore(project._id);
+        expect(await counters()).toEqual(held);
+
+        await trash(project._id);
+    });
+
+    it('keeps the slot when a project is only closed', async () => {
+        const before = await counters();
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const held = await counters();
+
+        expect((await owner.api.put(`/api/v1/project/${project._id}`, { updateObject: { deletedStatusKey: 2 } })).status).toBe(200);
+        expect(await counters()).toEqual(held);
+
+        await trash(project._id);
+        expect(await counters()).toEqual(before);
+    });
+
+    it('leaves the counters alone for an edit that is not a delete', async () => {
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const held = await counters();
+
+        await owner.api.put(`/api/v1/project/${project._id}`, { updateObject: { ProjectName: `Renamed ${uniqueSuffix()}` } });
+        expect(await counters()).toEqual(held);
+
+        await trash(project._id);
+    });
+});
+
+/* deleteChannel answers before it touches the quota, and every channel counter write
+   goes through one FIFO queue. Creating a channel joins that queue and only answers
+   once its own write landed, so a create doubles as a barrier: whatever a delete under
+   test was going to do has already happened by the time the create comes back. That is
+   what makes "the counter did NOT move" an assertion rather than a race. */
+const channelBarrier = async () => {
+    const created = await addChannel(false);
+    expect(created.body && created.body.status).toBe(true);
+};
+
+const heldByOnePublicChannel = (before) => step(before, {
+    channels: before.channels + 1,
+    publicChannels: before.publicChannels + 1,
+});
+
+describe('the channel quota counts channels only', () => {
+    it('releases one channel slot however many times the same channel is deleted', async () => {
+        const before = await counters();
+
+        const created = await addChannel(false);
+        expect(created.body && created.body.status).toBe(true);
+        const sprintId = String(created.body.data._id);
+        expect(await counters()).toEqual(heldByOnePublicChannel(before));
+
+        expect((await deleteChannel(sprintId, channelProjectId)).body.status).toBe(true);
+        await deleteChannel(sprintId, channelProjectId);
+        await deleteChannel(sprintId, channelProjectId);
+
+        await channelBarrier();
+        expect(await counters()).toEqual(heldByOnePublicChannel(before));
+    });
+
+    it('tracks a private channel in privateChannels', async () => {
+        const before = await counters();
+
+        const created = await addChannel(true);
+        expect(created.body && created.body.status).toBe(true);
+        const sprintId = String(created.body.data._id);
+        expect(await counters()).toEqual(step(before, { channels: before.channels + 1, privateChannels: before.privateChannels + 1 }));
+
+        await deleteChannel(sprintId, channelProjectId);
+
+        await channelBarrier();
+        expect(await counters()).toEqual(heldByOnePublicChannel(before));
+    });
+
+    /* The live drift: the channel route accepts any sprint id, and a project list was
+       never counted as a channel, so decrementing for one drove the quota negative. */
+    it('does not spend a channel slot on a project list', async () => {
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const sprint = await firstSprint(owner.api, project._id);
+        const before = await counters();
+
+        await deleteChannel(String(sprint._id), String(project._id));
+
+        await channelBarrier();
+        expect(await counters()).toEqual(heldByOnePublicChannel(before));
+
+        await trash(project._id);
+    });
+
+    it('never stores a negative counter', async () => {
+        await channelBarrier();
+        for (const [field, value] of Object.entries(await counters())) {
+            expect([field, value >= 0]).toEqual([field, true]);
+        }
+    });
+});


### PR DESCRIPTION
`projectCount` on the company document only ever went up. A company on a plan with a project cap that deleted projects never got the slots back, and eventually could not create a project at all with no way out from the UI.

Verified on the local dev instance (company `6a8ee973d625fca52e519a12`) before the change — create, then delete through the flow the UI uses:

```
before            {"projectCount":18,"publicCount":14,"channels":-2,"publicChannels":-2,"privateCount":4}
created           {"projectCount":19,"publicCount":15,"channels":-2,"publicChannels":-2,"privateCount":4}
deleted (http 200) {"projectCount":19,"publicCount":15,"channels":-2,"publicChannels":-2,"privateCount":4}
```

## Defect 1 — the delete path never decremented

`removeProjectCount` ran from the create-failure rollback alone. Nothing in the delete path touched the counters: `updateProject` just `$set`s `deletedStatusKey`.

Every client — the projects listing, `DELETE /api/v2/sample-data`, and the trash restore — reaches the project through `updateProjectInternal`, so the quota moves there (`Modules/Project/controller/updateProject.js`, helper in `Modules/Project/helpers/projectQuota.js`).

The double-count trap is handled by making a conditional write the thing that decides. `syncProjectQuota` carries the project across the trash boundary with `{ _id, deletedStatusKey: { $ne: 1 } }` (or `: 1` for the way back); only the caller that actually flips the flag gets a document back, and only that caller steps the counters. So deleting the same project three times releases one slot, and two concurrent deletes release one between them. The public/private bucket and the aggregate both move, and the bucket is read off the **stored** `isPrivateSpace` rather than the request.

The create-failure rollback still works and cannot double-decrement: it only fires for a creation that produced no project (the partial-failure paths already hard-delete the document via `deleteProject`), so there is never a later delete for the same project to decrement again.

A project that is only **closed** (`deletedStatusKey: 2`) keeps its slot — it still shows in the listing and still owns its work. Only the trash frees one.

## Defect 2 — the channel counters had gone negative

The asymmetry, confirmed against the live data: `addSprintFun` increments the channel quota for `mainChat` creates only, but `PATCH /api/v1/sprint/:id` with `type: 'deleteChannel'` accepts **any** sprint id. Deleting a plain project list decremented a quota that list had never been counted in. All 7 soft-deleted sprints in the dev company belong to real projects, not to a `main_chats` container, and the only real channel (`sweep-channel`) is still live — which is exactly how `publicChannels` and `channels` reached `-2`.

`deleteChannel` now decrements only when the sprint's container is a main-chat project (`Modules/Sprints/controller.js`), and its write is conditional on the channel not already being in the trash, so a repeated delete cannot decrement twice either.

## The zero floor is defence in depth, and it is worth saying what it does

Both counter paths now go through `stepCompanyCounters` (`Modules/Company/helpers/companyCounters.js`), which applies the step and pins the floor at zero in one atomic pipeline write (`$inc` and `$max` cannot touch the same field in a single update).

This is **in addition to** fixing the asymmetry above, not instead of it, because a negative quota is unrecoverable — it can never be spent back down, so the company stays locked out forever. It matters here beyond theory: the dev company's `projectCount` is 18 against 20 project documents, so two projects exist that were created without an increment (the in-process `createProject` callers — PersonalList and the setup seeder — bypass `checkProjectPlan`). Deleting those would otherwise push the counters below zero.

One consequence to be aware of: on a company whose counter is **already** negative, the floor lifts it to 0 the next time anyone creates or deletes. It does not compute the true value, so a repair is still needed — see below.

## Restore from the trash re-increments — deliberately

`PUT /api/v2/trash/projects/:id/restore` → `Modules/Trash/controller.js:38` → `updateProjectInternal(companyId, id, { deletedStatusKey: 0 })`, which is the same funnel, so a restore takes the slot back. Without it, delete-then-restore would silently free a slot — the mirror image of the original bug — and a company could exceed its cap by cycling projects through the trash. Restoring twice still increments once, for the same conditional-write reason.

## Not in this PR: repairing the existing drifted counters

Deliberately no migration. A data migration against live counters is the owner's call. For the record, a repair would recompute all six fields per company from the documents rather than adjusting them:

| Field | Computed from |
|---|---|
| `projectCount.projectCount` | `projects` where `deletedStatusKey != 1` |
| `projectCount.publicCount` | those with `isPrivateSpace != true` |
| `projectCount.privateCount` | those with `isPrivateSpace == true` |
| `projectCount.channels` | `sprints` where `deletedStatusKey != 1` **and** `projectId` resolves to a `main_chats` document |
| `projectCount.publicChannels` | those with `private != true` |
| `projectCount.privateChannels` | those with `private == true` |

For the dev company that is `{projectCount: 10, publicCount: 8, privateCount: 2, channels: 1, publicChannels: 1, privateChannels: 0}` — the channel figures excluding the `defaultSprint` the one-to-one seed creates under `isPreCompany`, which was never counted on create. (The 11th project and the `+1` in the counters above are my scratch project, now in the trash; recomputing from the documents absorbs it either way.)

## Tests

`tests/integration/project-counters.int.test.js`, asserting the stored counter values rather than HTTP status. Against the unfixed code 7 of the 10 fail; all 10 pass with the change, and the full integration suite is green (57 suites, 926 tests).

- the project quota follows the projects that exist
  - gives the slot back when a project is trashed
  - counts a private project in privateCount and releases it from there
  - releases one slot however many times the same project is trashed
  - takes the slot back when a project is restored from the trash, once
  - keeps the slot when a project is only closed
  - leaves the counters alone for an edit that is not a delete
- the channel quota counts channels only
  - releases one channel slot however many times the same channel is deleted
  - tracks a private channel in privateChannels
  - does not spend a channel slot on a project list
  - never stores a negative counter

`deleteChannel` answers before it touches the quota and the channel writes run through one FIFO queue, so the tests use a channel create as a barrier — a create joins the same queue and only answers once its own write landed. That is what makes "the counter did **not** move" an assertion rather than a race.

## Behaviour change worth a second look

`deleteChannel` on a channel that is already in the trash now answers `{status: false, statusText: "Channel not found"}` instead of `{status: true}`. That is the precondition that stops the double-decrement. No shipped client calls the endpoint twice, and no UI path calls it on a project list at all.

## Left alone

Flipping a channel's `private` flag after creation (`updateSprintFun` applies the client update verbatim, `Modules/Sprints/controller.js`) moves it between the public and private buckets without moving the counters, so the split can still drift for that case while the `channels` aggregate stays right. Not reachable from the UI today, and the zero floor bounds the damage — flagging it rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
