### PR TITLE
fix: keep a view with no _id from blanking a project's task view

### DIFF
--- a/Modules/createProject/controller.js
+++ b/Modules/createProject/controller.js
@@ -12,6 +12,7 @@ const { tenantOf } = require("../../Config/tenant");
 const { updateCompanyFun } = require("../Company/controller/updateCompany");
 const projectTemplate = require("../../utils/projectTemplates.json");
 const { pickKnownApps } = require("./apps");
+const { withViewIds } = require("./viewEntries");
 const blankTemplate = require("./blankTemplate");
 const { focusForTemplate, normaliseFocus, sampleTaskNamesFor, SAMPLE_TASK_COUNT } = require("./sampleTasks");
 
@@ -507,6 +508,9 @@ exports.createProject = async (req) => {
                     if (clientApps) {
                         createProjectObject.apps = pickKnownApps(clientApps, appArray);
                     }
+                    // Every branch above can leave an entry whose view the company's catalogue does
+                    // not carry, and the project view bar cannot render an entry with no id.
+                    createProjectObject.ProjectRequiredComponent = withViewIds(createProjectObject.ProjectRequiredComponent, tabComponentsArray);
                     createProjectObject.skills = await resolveProjectSkills(req.body.CompanyId, createProjectObject.skills);
                     createProjectObject.DueDate = createProjectObject.DueDate ? new Date(createProjectObject.DueDate) : '';
                     createProjectObject.viewColumn = [

--- a/Modules/createProject/viewEntries.js
+++ b/Modules/createProject/viewEntries.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+const VIEW_ID_LENGTH = 24;
+
+const idText = (value) => (value === undefined || value === null ? '' : String(value));
+
+const catalogueIdFor = (entry, catalogue) => {
+    const rows = Array.isArray(catalogue) ? catalogue : [];
+    // keyName first: `name` is the label an owner can rename in the view catalogue.
+    const row = (entry.keyName && rows.find((item) => item && item.keyName === entry.keyName))
+        || (entry.name && rows.find((item) => item && item.name === entry.name));
+    const id = row ? idText(row.id || row._id) : '';
+    return id.length === VIEW_ID_LENGTH ? id : '';
+};
+
+/* A view entry's `_id` is the company's project_tab_components row id, as a string. The
+ * project view bar reads its length to tell a view (24) from an embed (6), and a rename,
+ * pin or delete matches it with `===` against an id the browser sends as a string.
+ *
+ * A template view the company's catalogue does not carry matched no row and was stored
+ * with no `_id` at all, which is neither, so the view bar threw on it. Such an entry gets
+ * a fresh id here; an entry that already has one is never renumbered, because the ids
+ * already stored are what those later writes match on. */
+const withViewId = (entry, catalogue) => {
+    if (!entry || typeof entry !== 'object') return entry;
+    if (idText(entry._id)) return entry;
+    return { ...entry, _id: catalogueIdFor(entry, catalogue) || new mongoose.Types.ObjectId().toString() };
+};
+
+const withViewIds = (entries, catalogue) => (Array.isArray(entries) ? entries.map((entry) => withViewId(entry, catalogue)) : entries);
+
+const isMissingViewId = (entry) => !(entry && typeof entry === 'object' && idText(entry._id));
+
+module.exports = { VIEW_ID_LENGTH, withViewId, withViewIds, isMissingViewId };

--- a/frontend/src/locales/ar.js
+++ b/frontend/src/locales/ar.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/ar.pending.json
+++ b/frontend/src/locales/ar.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ar",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.045Z",
+  "updatedAt": "2026-09-12T11:04:20.426Z",
   "keys": {
     "Scrum.stranded_head": "These {count} will stay in this sprint",
     "Scrum.stranded_hint": "They are unfinished, but their parent task is done — and a subtask moves with its parent. Finish them, or reopen the parent task, before completing the sprint.",
@@ -7862,6 +7862,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/ch.js
+++ b/frontend/src/locales/ch.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/ch.pending.json
+++ b/frontend/src/locales/ch.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ch",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.072Z",
+  "updatedAt": "2026-09-12T11:04:20.454Z",
   "keys": {
     "errorPage.card_name": "card name",
     "Auth.welcome_back": "Welcome back",
@@ -5720,6 +5720,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -5111,6 +5111,8 @@ export default {
         no_tasks_action: "Create task",
         no_match_title: "Nothing matches your filters",
         no_match_msg: "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        no_visible_tasks_title: "No tasks to show here",
+        no_visible_tasks_msg: "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         no_sprints_title: "No lists yet",
         no_sprints_msg: "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         no_sprints_action: "Create list",

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/fr.pending.json
+++ b/frontend/src/locales/fr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "fr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.096Z",
+  "updatedAt": "2026-09-12T11:04:20.483Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5729,6 +5729,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/ge.js
+++ b/frontend/src/locales/ge.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/ge.pending.json
+++ b/frontend/src/locales/ge.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ge",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.120Z",
+  "updatedAt": "2026-09-12T11:04:20.509Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5801,6 +5801,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/gr.js
+++ b/frontend/src/locales/gr.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/gr.pending.json
+++ b/frontend/src/locales/gr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.150Z",
+  "updatedAt": "2026-09-12T11:04:20.541Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5722,6 +5722,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/gu.js
+++ b/frontend/src/locales/gu.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/gu.pending.json
+++ b/frontend/src/locales/gu.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gu",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.175Z",
+  "updatedAt": "2026-09-12T11:04:20.577Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5720,6 +5720,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/hi.pending.json
+++ b/frontend/src/locales/hi.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "hi",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.201Z",
+  "updatedAt": "2026-09-12T11:04:20.604Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5721,6 +5721,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/it.pending.json
+++ b/frontend/src/locales/it.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "it",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.225Z",
+  "updatedAt": "2026-09-12T11:04:20.635Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5720,6 +5720,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/ru.pending.json
+++ b/frontend/src/locales/ru.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ru",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.250Z",
+  "updatedAt": "2026-09-12T11:04:20.663Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5719,6 +5719,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/locales/spa.js
+++ b/frontend/src/locales/spa.js
@@ -4980,6 +4980,8 @@ export default {
         "no_tasks_action": "Create task",
         "no_match_title": "Nothing matches your filters",
         "no_match_msg": "There is work in this project, it is just hidden right now. Try clearing a filter or widening the date range.",
+        "no_visible_tasks_title": "No tasks to show here",
+        "no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
         "no_sprints_title": "No lists yet",
         "no_sprints_msg": "Lists group related tasks together — a sprint, a phase, or simply a heading. Add one to organise this project.",
         "no_sprints_action": "Create list",

--- a/frontend/src/locales/spa.pending.json
+++ b/frontend/src/locales/spa.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "spa",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T08:53:54.274Z",
+  "updatedAt": "2026-09-12T11:04:20.690Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5719,6 +5719,8 @@
     "Workflows.lineage_unowned": "Waiting on nobody in particular",
     "Workflows.lineage_run_by": "{person} started the run",
     "Workflows.lineage_run_unowned": "Started by the system",
-    "Workflows.lineage_somebody": "somebody"
+    "Workflows.lineage_somebody": "somebody",
+    "EmptyState.no_visible_tasks_title": "No tasks to show here",
+    "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
   }
 }

--- a/frontend/src/views/Projects/Kanban/BoardView.vue
+++ b/frontend/src/views/Projects/Kanban/BoardView.vue
@@ -48,8 +48,8 @@
                 <div class="d-flex align-items-center justify-content-center flex-column mt-1">
                     <EmptyState
                         v-if="project?.deletedStatusKey !== 2"
-                        :title="!project?.lastTaskId ? $t('EmptyState.no_tasks_title') : $t('EmptyState.no_match_title')"
-                        :message="!project?.lastTaskId ? $t('EmptyState.no_tasks_msg') : $t('EmptyState.no_match_msg')"
+                        :title="$t(emptyTitleKey)"
+                        :message="$t(emptyMessageKey)"
                         helpPath="tasks"
                     />
                 </div>
@@ -73,6 +73,7 @@ import Skelaton from '@/components/atom/Skelaton/Skelaton.vue';
 
 // Helpers
 import { taskListHelper } from '@/views/Projects/helper.js';
+import { useTaskEmptyState } from '@/views/Projects/composables/useTaskEmptyState.js';
 import { useRoute } from 'vue-router';
 const route = useRoute();
 
@@ -92,6 +93,7 @@ const { groupBy, checkCase } = taskListHelper();
 const showArchiveVar = inject("showArchived");
 const searchedTask = inject('searchedTask');
 const project = inject('selectedProject');
+const { emptyTitleKey, emptyMessageKey } = useTaskEmptyState(project);
 
 // --- Reactive State ---
 const isLoading = ref(true);

--- a/frontend/src/views/Projects/ListView/ListView.vue
+++ b/frontend/src/views/Projects/ListView/ListView.vue
@@ -90,13 +90,11 @@
                 </div>
             </template>
             <div class="list_view d-flex align-items-center justify-content-center flex-column" v-else>
-                <!-- lastTaskId is 0 until the project's first task is ever created, which is what
-                     separates "nothing here yet" from "a filter is hiding the work". -->
                 <EmptyState
                     v-if="project?.deletedStatusKey !== 2"
                     :image="noSearchResult"
-                    :title="showArchived ? $t('ProjectSlider.no_archived') : (!project?.lastTaskId ? $t('EmptyState.no_tasks_title') : $t('EmptyState.no_match_title'))"
-                    :message="showArchived ? '' : (!project?.lastTaskId ? $t('EmptyState.no_tasks_msg') : $t('EmptyState.no_match_msg'))"
+                    :title="showArchived ? $t('ProjectSlider.no_archived') : $t(emptyTitleKey)"
+                    :message="showArchived ? '' : $t(emptyMessageKey)"
                     :helpPath="showArchived ? '' : 'tasks'"
                 />
             </div>
@@ -124,6 +122,7 @@ import isEqual from 'lodash/isEqual';
 import { taskListHelper } from '@/views/Projects/helper.js';
 import { useTaskSelection } from '@/composable/useTaskSelection.js';
 import { useProjectAgentActivity } from './useProjectAgentActivity.js';
+import { useTaskEmptyState } from '@/views/Projects/composables/useTaskEmptyState.js';
 import { openTask } from '@/components/organisms/TaskDetailOverlay/useTaskOverlay';
 
 // UTILS
@@ -140,6 +139,7 @@ const {
     getMongoDBUpdate
 } = taskListHelper();
 const agents = useProjectAgentActivity();
+const { emptyTitleKey, emptyMessageKey } = useTaskEmptyState(project);
 
 // EMITS
 defineEmits(['change'])

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -496,6 +496,7 @@ import { useProjectLifecycle } from './composables/useProjectLifecycle';
 import { useProjectAvatar } from './composables/useProjectAvatar';
 import { useProjectSearch } from './composables/useProjectSearch';
 import { useProjectTree } from './composables/useProjectTree';
+import { splitProjectViews } from './composables/projectViewBar';
 
 import { useProjectsHelper } from './helper';
 import { isOwnerOrAdmin } from "@/utils/roles";
@@ -875,17 +876,11 @@ const getChange = () => {
     const userTabs = (companyUser.value?.ProjectRequiredComponent)
         ? (Object.entries(companyUser.value?.ProjectRequiredComponent)).map((element) => ({ uniqueId: element[0], ...element[1] })).filter((item) => item.projectId === projectData.value._id)
         : [];
-    const Tabs2 = projectData.value.ProjectRequiredComponent?.filter((item) => item._id.length > 6);
-    const ids = projectData.value.ProjectRequiredComponent?.map((item) => item._id);
-    viewsListArray.value = [...(userTabs.filter((element) => element.id.length > 6 && (!ids.includes(element.id)))), ...Tabs2].sort((a, b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))));
-    // Drop the dead legacy 'Gantt'/'Timeline' keyNames (replaced by 'GanttView'/'TimelineView').
-    // getView() has no case for them so they render NotFound; older projects may still carry the
-    // stale entry. The "+ View" catalog already hides them, so mirror that filter in the tab bar.
-    viewsListArray.value = viewsListArray.value.filter((item) => item.keyName !== 'Timeline' && item.keyName !== 'Gantt');
-    embedViews.value = ([...projectData.value.ProjectRequiredComponent.filter((item) => item._id.length == 6), ...(userTabs.filter((element) => element.id.length == 6))].sort((a, b) => (a.name.toLowerCase() < b.name.toLowerCase()) ? -1 : ((b.name.toLowerCase() < a.name.toLowerCase()) ? 1 : 0))).sort((a, b) => !(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))));
-    if (projectDetailPermission.value === null) {
-        viewsListArray.value = viewsListArray.value.filter((item) => item.keyName !== 'ProjectDetail');
-    }
+    const { views, embeds } = splitProjectViews(projectData.value.ProjectRequiredComponent, userTabs);
+    viewsListArray.value = projectDetailPermission.value === null
+        ? views.filter((item) => item.keyName !== 'ProjectDetail')
+        : views;
+    embedViews.value = embeds;
 };
 
 function checkSprint(sprintData) {

--- a/frontend/src/views/Projects/TableView/TableView.vue
+++ b/frontend/src/views/Projects/TableView/TableView.vue
@@ -55,8 +55,8 @@
                 <div class="d-flex align-items-center justify-content-center flex-column" v-if="!totalTaskInFirstSprint.length">
                     <EmptyState
                         v-if="project?.deletedStatusKey !== 2"
-                        :title="!project?.lastTaskId ? $t('EmptyState.no_tasks_title') : $t('EmptyState.no_match_title')"
-                        :message="!project?.lastTaskId ? $t('EmptyState.no_tasks_msg') : $t('EmptyState.no_match_msg')"
+                        :title="$t(emptyTitleKey)"
+                        :message="$t(emptyMessageKey)"
                         helpPath="tasks"
                     />
                 </div>
@@ -82,6 +82,7 @@ import ListBulkBar from '@/views/Projects/ListView/ListBulkBar.vue';
 import { useCustomComposable } from "@/composable";
 import isEqual from 'lodash/isEqual';
 import { taskListHelper } from '@/views/Projects/helper.js';
+import { useTaskEmptyState } from '@/views/Projects/composables/useTaskEmptyState.js';
 import { openTask } from '@/components/organisms/TaskDetailOverlay/useTaskOverlay';
 
 // PACKAGES
@@ -116,6 +117,7 @@ const project = inject('selectedProject');
 const companyId = inject('$companyId');
 const searchedTask = inject('searchedTask');
 const showArchiveVar = inject("showArchived");
+const { emptyTitleKey, emptyMessageKey } = useTaskEmptyState(project);
 
 const createTask = ref(false);
 const globalSortKey = ref('');

--- a/frontend/src/views/Projects/composables/projectViewBar.js
+++ b/frontend/src/views/Projects/composables/projectViewBar.js
@@ -1,0 +1,40 @@
+const VIEW_ID_LENGTH = 6;
+
+// getView() has no case for the dead 'Gantt'/'Timeline' keyNames (replaced by 'GanttView'
+// and 'TimelineView') so they render NotFound; older projects may still carry the stale
+// entry. The "+ View" catalog already hides them, so the tab bar mirrors that filter.
+const LEGACY_KEY_NAMES = ['Timeline', 'Gantt'];
+
+const idOf = (entry, key) => (entry && entry[key] !== undefined && entry[key] !== null ? String(entry[key]) : '');
+
+const label = (entry) => String((entry && entry.name) || '').toLowerCase();
+
+const byPin = (a, b) => (!(a.isPin) ? 0 : (a.isPin == b.isPin ? 0 : (((!a.isPin && b.isPin) ? 1 : -1))));
+const byName = (a, b) => (label(a) < label(b) ? -1 : (label(b) < label(a) ? 1 : 0));
+
+/* Splits a project's views into the tab bar and the embed menu. An entry's id length is what
+ * separates the two: a project view carries the 24-character id of the company's view-catalogue
+ * row, an embed a 6-character one of its own.
+ *
+ * An entry saved without an id is neither, and is left out of both rather than repaired here:
+ * only the server can mint an id that the later rename, pin and delete writes — which match on
+ * it — will still find. Reading `.length` straight off the missing id used to throw, which left
+ * the project with no view bar and no task list at all. */
+export function splitProjectViews(projectViews, userTabs = []) {
+    const views = Array.isArray(projectViews) ? projectViews : [];
+    const tabs = Array.isArray(userTabs) ? userTabs : [];
+    const takenIds = views.map((item) => idOf(item, '_id'));
+    const isView = (id) => id.length > VIEW_ID_LENGTH;
+    const isEmbed = (id) => id.length === VIEW_ID_LENGTH;
+
+    return {
+        views: [
+            ...tabs.filter((tab) => isView(idOf(tab, 'id')) && !takenIds.includes(idOf(tab, 'id'))),
+            ...views.filter((item) => isView(idOf(item, '_id'))),
+        ].sort(byPin).filter((item) => !LEGACY_KEY_NAMES.includes(item.keyName)),
+        embeds: [
+            ...views.filter((item) => isEmbed(idOf(item, '_id'))),
+            ...tabs.filter((tab) => isEmbed(idOf(tab, 'id'))),
+        ].sort(byName).sort(byPin),
+    };
+}

--- a/frontend/src/views/Projects/composables/useTaskEmptyState.js
+++ b/frontend/src/views/Projects/composables/useTaskEmptyState.js
@@ -1,0 +1,21 @@
+import { computed, inject, ref } from 'vue';
+
+/* Which empty state a task view shows when it has nothing to list.
+ *
+ * `searchedTask` is the task list's own flag for "a search, an assignee pick, a saved filter
+ * or the archive toggle is narrowing this list" (useProjectSearch). Without consulting it the
+ * views blamed a filter for every empty list on a project that had ever held a task — so a
+ * project whose tasks were all deleted, or whose view bar failed to render, sent the user
+ * hunting for a filter that was never set. */
+export function useTaskEmptyState(project) {
+    const searchedTask = inject('searchedTask', ref(false));
+    const kind = computed(() => {
+        if (!project?.value?.lastTaskId) return 'no_tasks';
+        return searchedTask?.value ? 'no_match' : 'no_visible_tasks';
+    });
+
+    return {
+        emptyTitleKey: computed(() => `EmptyState.${kind.value}_title`),
+        emptyMessageKey: computed(() => `EmptyState.${kind.value}_msg`),
+    };
+}

--- a/frontend/tests/unit/projectViewBar.spec.js
+++ b/frontend/tests/unit/projectViewBar.spec.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, ref } from 'vue';
+
+import { splitProjectViews } from '@/views/Projects/composables/projectViewBar';
+import { useTaskEmptyState } from '@/views/Projects/composables/useTaskEmptyState';
+
+const view = (keyName, _id, extra = {}) => ({ keyName, name: keyName, _id, viewStatus: true, ...extra });
+const LIST = '6a97261fb28e840202058560';
+const GANTT = '6a97261fb28e840202058561';
+
+/* Every project that has ever had a Board view carries a ProjectKanban entry with no `_id`:
+   createProject copied the company's view-catalogue row, and a catalogue with no Board row
+   matched nothing and stored the raw template entry. Reading `_id.length` off it threw inside
+   getChange(), which assigns the view bar and the task list, so the whole project rendered
+   blank. */
+describe('splitProjectViews', () => {
+    it('lists the other views and does not throw on an entry with no _id', () => {
+        const entries = [view('ProjectListView', LIST), { keyName: 'ProjectKanban', name: 'Board', viewStatus: true }, view('GanttView', GANTT)];
+
+        let result;
+        expect(() => { result = splitProjectViews(entries); }).not.toThrow();
+        expect(result.views.map((v) => v.keyName)).toEqual(['ProjectListView', 'GanttView']);
+        expect(result.embeds).toEqual([]);
+    });
+
+    it('tolerates a null _id, a null entry and a missing array', () => {
+        for (const entries of [undefined, null, {}, [null], [undefined], [{ keyName: 'X', _id: null }]]) {
+            expect(() => splitProjectViews(entries)).not.toThrow();
+            expect(splitProjectViews(entries).views).toEqual([]);
+        }
+    });
+
+    it('keeps the 24-character ids in the tab bar and the 6-character ones in the embeds', () => {
+        const embed = { name: 'Figma', _id: 'ab12cd', id: 'ab12cd', type: 'Figma' };
+        const { views, embeds } = splitProjectViews([view('ProjectListView', LIST), embed]);
+
+        expect(views.map((v) => v.keyName)).toEqual(['ProjectListView']);
+        expect(embeds.map((v) => v.name)).toEqual(['Figma']);
+    });
+
+    it('adds a member\'s private views and drops the ones the project already has', () => {
+        const userTabs = [
+            { uniqueId: 'u1', id: GANTT, keyName: 'GanttView', name: 'Gantt View' },
+            { uniqueId: 'u2', id: 'ff00aa', name: 'My embed' },
+        ];
+        const { views, embeds } = splitProjectViews([view('GanttView', GANTT)], userTabs);
+
+        expect(views.map((v) => v.keyName)).toEqual(['GanttView']);
+        expect(embeds.map((v) => v.name)).toEqual(['My embed']);
+    });
+
+    it('drops the dead legacy Gantt and Timeline keyNames', () => {
+        const entries = [view('Gantt', LIST), view('Timeline', GANTT), view('GanttView', '6a97261fb28e840202058562')];
+
+        expect(splitProjectViews(entries).views.map((v) => v.keyName)).toEqual(['GanttView']);
+    });
+
+    it('pins sort ahead of the rest', () => {
+        const entries = [view('ProjectListView', LIST), view('GanttView', GANTT, { isPin: true })];
+
+        expect(splitProjectViews(entries).views.map((v) => v.keyName)).toEqual(['GanttView', 'ProjectListView']);
+    });
+});
+
+/* A render crash used to reach the user as "Nothing matches your filters", so they went
+   looking for a filter that was never set: the views picked that copy on lastTaskId alone. */
+describe('useTaskEmptyState', () => {
+    const emptyState = (project, searchedTask) => {
+        let state;
+        mount(defineComponent({
+            setup() { state = useTaskEmptyState(project); return () => null; },
+        }), { global: { provide: searchedTask === undefined ? {} : { searchedTask } } });
+        return state;
+    };
+
+    it('does not blame a filter when none is applied', () => {
+        const state = emptyState(ref({ lastTaskId: 4 }), ref(false));
+
+        expect(state.emptyTitleKey.value).toBe('EmptyState.no_visible_tasks_title');
+        expect(state.emptyMessageKey.value).toBe('EmptyState.no_visible_tasks_msg');
+    });
+
+    it('offers to clear the filter while one narrows the list', () => {
+        const searchedTask = ref(true);
+        const state = emptyState(ref({ lastTaskId: 4 }), searchedTask);
+
+        expect(state.emptyTitleKey.value).toBe('EmptyState.no_match_title');
+        expect(state.emptyMessageKey.value).toBe('EmptyState.no_match_msg');
+
+        searchedTask.value = false;
+        expect(state.emptyTitleKey.value).toBe('EmptyState.no_visible_tasks_title');
+    });
+
+    it('says the project has no tasks yet before its first one exists', () => {
+        expect(emptyState(ref({ lastTaskId: 0 }), ref(true)).emptyTitleKey.value).toBe('EmptyState.no_tasks_title');
+        expect(emptyState(ref(undefined), undefined).emptyTitleKey.value).toBe('EmptyState.no_tasks_title');
+    });
+});

--- a/migrations/021-project-view-ids.js
+++ b/migrations/021-project-view-ids.js
@@ -1,0 +1,47 @@
+const { withViewIds, isMissingViewId } = require('../Modules/createProject/viewEntries');
+
+/* Projects created from a template view the company's project_tab_components catalogue does
+ * not carry stored that entry with no `_id` — Board, on every workspace whose catalogue was
+ * pruned. The project view bar reads `_id.length` to tell a view from an embed, so the entry
+ * threw there and left the project with no view bar and no task list at all.
+ *
+ * Only an entry with no id is given one, from the company's catalogue row for that keyName
+ * when there is one. An entry that already has an id keeps it: that id is what a rename, pin
+ * or delete matches on, so renumbering would orphan those writes. */
+
+const ID = '021-project-view-ids';
+
+async function repairCompany(ctx, companyId) {
+    const type = ctx.SCHEMA_TYPE.PROJECTS;
+    const catalogue = await ctx.company(companyId, { type: ctx.SCHEMA_TYPE.PROJECT_TAB_COMPONENTS, data: [{}] }, 'find') || [];
+    const projects = await ctx.company(companyId, { type, data: [{}, { _id: 1, ProjectRequiredComponent: 1 }] }, 'find') || [];
+    let repaired = 0;
+    let entries = 0;
+    for (const project of projects) {
+        const views = Array.isArray(project.ProjectRequiredComponent) ? project.ProjectRequiredComponent : [];
+        const missing = views.filter(isMissingViewId).length;
+        if (!missing) continue;
+        await ctx.company(companyId, {
+            type,
+            data: [{ _id: project._id }, { $set: { ProjectRequiredComponent: withViewIds(views, catalogue) } }],
+        }, 'updateOne');
+        repaired += 1;
+        entries += missing;
+    }
+    return { projects: projects.length, repaired, entries };
+}
+
+module.exports = {
+    id: ID,
+    scope: 'company',
+    repairCompany,
+    async up(ctx) {
+        const { removeCache } = require('../utils/commonFunctions');
+        await ctx.forEachCompany(async (companyId) => {
+            const counts = await repairCompany(ctx, companyId);
+            if (counts.repaired) removeCache(`UserProjectData:${companyId}:`, true);
+            ctx.logger.info(`[migrations] 021 ${companyId}: ${JSON.stringify(counts)}`);
+            return counts;
+        });
+    },
+};

--- a/tests/create-project-view-ids.test.js
+++ b/tests/create-project-view-ids.test.js
@@ -1,0 +1,81 @@
+/* A project's view entries carry the `_id` of the company's project_tab_components row, as a
+   string, and the project view bar reads that id's length to tell a view (24 characters) from
+   an embed (6). The category merge matched catalogue rows by name and fell through to the raw
+   template entry when none matched, so a company whose catalogue holds no "Board" row stored
+   the blank template's Board view with no `_id` at all — and Projects.vue threw on it, leaving
+   the project with no view bar and no task list. */
+const fs = require('fs');
+const path = require('path');
+
+const blankTemplate = require('../Modules/createProject/blankTemplate');
+const { withViewId, withViewIds, isMissingViewId, VIEW_ID_LENGTH } = require('../Modules/createProject/viewEntries');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', 'Modules', 'createProject', 'controller.js'), 'utf8');
+
+const LIST_ROW = { _id: '6a97261fb28e840202058560', keyName: 'ProjectListView', name: 'List' };
+const GANTT_ROW = { _id: '6a97261fb28e840202058561', keyName: 'GanttView', name: 'Gantt View' };
+const BOARD_ROW = { _id: '6a97261fb28e840202058562', keyName: 'ProjectKanban', name: 'Board' };
+
+const idsOf = (entries) => entries.map((entry) => String(entry._id));
+
+describe('project view entry ids', () => {
+    test('the blank template ships no ids of its own, so the writer has to supply them', () => {
+        expect(blankTemplate.TemplateRequiredComponent.every((entry) => entry._id === undefined)).toBe(true);
+        expect(blankTemplate.TemplateRequiredComponent.map((entry) => entry.keyName)).toEqual(['ProjectListView', 'ProjectKanban']);
+    });
+
+    test('every entry of the blank template gets a view-length id on a catalogue with no Board row', () => {
+        const entries = withViewIds(blankTemplate.TemplateRequiredComponent, [LIST_ROW, GANTT_ROW]);
+
+        expect(entries.some(isMissingViewId)).toBe(false);
+        entries.forEach((entry) => expect(String(entry._id)).toHaveLength(VIEW_ID_LENGTH));
+        expect(entries.map((entry) => entry.keyName)).toEqual(['ProjectListView', 'ProjectKanban']);
+    });
+
+    test('a catalogued view takes the catalogue row id, matched on keyName not the renamable label', () => {
+        const renamed = { ...BOARD_ROW, name: 'Kanban' };
+
+        expect(withViewId({ keyName: 'ProjectKanban', name: 'Board' }, [renamed])._id).toBe(BOARD_ROW._id);
+        expect(withViewId({ name: 'Board' }, [BOARD_ROW])._id).toBe(BOARD_ROW._id);
+    });
+
+    test('the id the catalogue cannot supply is a fresh ObjectId, distinct per entry', () => {
+        const entries = withViewIds([{ keyName: 'ProjectKanban' }, { keyName: 'Comments' }], []);
+
+        entries.forEach((entry) => expect(String(entry._id)).toMatch(/^[0-9a-f]{24}$/));
+        expect(new Set(idsOf(entries)).size).toBe(2);
+    });
+
+    test('an entry that already has an id keeps it, so a later rename or delete still matches', () => {
+        const embed = { name: 'Figma', _id: 'ab12cd', id: 'ab12cd' };
+        const entries = withViewIds([{ ...LIST_ROW, viewStatus: true }, embed], [BOARD_ROW]);
+
+        expect(idsOf(entries)).toEqual([LIST_ROW._id, 'ab12cd']);
+    });
+
+    test('repeating the repair changes nothing', () => {
+        const once = withViewIds(blankTemplate.TemplateRequiredComponent, [LIST_ROW]);
+
+        expect(withViewIds(once, [LIST_ROW])).toEqual(once);
+    });
+
+    test('the shapes a broken entry actually takes never throw', () => {
+        for (const entries of [undefined, null, [null], [undefined], [{ _id: null }], [{ _id: '' }]]) {
+            expect(() => withViewIds(entries, undefined)).not.toThrow();
+        }
+        expect(isMissingViewId({ _id: null })).toBe(true);
+        expect(isMissingViewId({ _id: '' })).toBe(true);
+        expect(isMissingViewId({ _id: LIST_ROW._id })).toBe(false);
+    });
+});
+
+describe('createProject wiring', () => {
+    test('the repair runs after every template branch, on the object that is saved', () => {
+        const repair = SRC.indexOf('createProjectObject.ProjectRequiredComponent = withViewIds(');
+        expect(repair).toBeGreaterThan(-1);
+        // the branches that can leave an entry without an id
+        expect(repair).toBeGreaterThan(SRC.indexOf('createProjectObject.ProjectRequiredComponent = res.TemplateRequiredComponent'));
+        expect(repair).toBeGreaterThan(SRC.indexOf('createProjectObject.ProjectRequiredComponent = projectRequiredTempComponent'));
+        expect(repair).toBeLessThan(SRC.indexOf('MongoDbCrudOpration(req.body.CompanyId, finalObj, "save")'));
+    });
+});

--- a/tests/migration-project-view-ids.test.js
+++ b/tests/migration-project-view-ids.test.js
@@ -1,0 +1,118 @@
+const mockDbs = {};
+const mockDbFor = (companyId) => { mockDbs[companyId] = mockDbs[companyId] || require('./fixtures/fakeMongo').create(); return mockDbs[companyId]; };
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (companyId, q, method) => mockDbFor(String(companyId)).crud(companyId, q, method) }));
+jest.mock('../Config/config', () => ({ myCache: { get: () => undefined, set: () => {}, del: () => {}, getTtl: () => 0 } }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+
+const { buildContext, validateMigration, listMigrations } = require('../migrations');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { settingsCollectionDocs } = require('../Config/collections');
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { removeCache } = require('../utils/commonFunctions');
+const migration = require('../migrations/021-project-view-ids');
+
+const BROKEN = '6f0000000000000000000d01';
+const CLEAN = '6f0000000000000000000d02';
+const logger = { info: jest.fn(), error: jest.fn() };
+const contextFor = (companies) => buildContext({ MongoDbCrudOpration, SCHEMA_TYPE, settingsCollectionDocs, logger, listCompanies: async () => companies.map((_id) => ({ _id })) });
+
+const projects = (companyId) => mockDbFor(companyId).store[SCHEMA_TYPE.PROJECTS] || [];
+const projectNamed = (companyId, name) => projects(companyId).find((p) => p.ProjectName === name);
+const viewIds = (companyId, name) => (projectNamed(companyId, name).ProjectRequiredComponent || []).map((v) => String(v._id));
+
+/* The shape Local360 (6a8ee973d625fca52e519a12) has: a view catalogue with no "Board" row, so
+   every project created from a template that offers Board carries a ProjectKanban entry with
+   no `_id` at all — and Projects.vue reads `_id.length` on it. */
+const LIST_ROW = { _id: '6a97261fb28e840202058560', keyName: 'ProjectListView', name: 'List' };
+const GANTT_ROW = { _id: '6a97261fb28e840202058561', keyName: 'GanttView', name: 'Gantt View' };
+const BOARD = { keyName: 'ProjectKanban', value: 'ProjectKanban', name: 'Board', viewStatus: true, setAsDefault: false };
+const listView = { ...LIST_ROW, viewStatus: true, setAsDefault: true };
+
+const seedCompany = (companyId, { board = true } = {}) => {
+    const db = mockDbFor(companyId);
+    db.seed(SCHEMA_TYPE.PROJECT_TAB_COMPONENTS, { ...LIST_ROW });
+    db.seed(SCHEMA_TYPE.PROJECT_TAB_COMPONENTS, { ...GANTT_ROW });
+    if (board) db.seed(SCHEMA_TYPE.PROJECT_TAB_COMPONENTS, { _id: '6a97261fb28e840202058562', keyName: 'ProjectKanban', name: 'Board' });
+    return db;
+};
+
+beforeEach(() => {
+    Object.keys(mockDbs).forEach((k) => { delete mockDbs[k]; });
+    jest.clearAllMocks();
+});
+
+describe('021-project-view-ids', () => {
+    test('is a valid company-scoped migration listed after 020', () => {
+        expect(() => validateMigration(migration, '021-project-view-ids')).not.toThrow();
+        const ids = listMigrations().map((m) => m.id);
+        expect(ids.indexOf('021-project-view-ids')).toBeGreaterThan(ids.indexOf('020-workflow-definitions'));
+    });
+
+    test('gives the Board entry an id and leaves every other entry alone', async () => {
+        const db = seedCompany(BROKEN, { board: false });
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'SPWB', ProjectRequiredComponent: [{ ...listView }, { ...BOARD }] });
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'Local Smoke', ProjectRequiredComponent: [{ ...listView }, { ...GANTT_ROW, viewStatus: true }] });
+
+        const ctx = contextFor([BROKEN]);
+        await migration.up(ctx);
+
+        expect(ctx.companies[BROKEN]).toEqual({ ok: true, projects: 2, repaired: 1, entries: 1 });
+        const [listId, boardId] = viewIds(BROKEN, 'SPWB');
+        expect(listId).toBe(LIST_ROW._id);
+        expect(boardId).toMatch(/^[0-9a-f]{24}$/);
+        expect(projectNamed(BROKEN, 'SPWB').ProjectRequiredComponent[1]).toMatchObject({ keyName: 'ProjectKanban', name: 'Board', viewStatus: true });
+        expect(viewIds(BROKEN, 'Local Smoke')).toEqual([LIST_ROW._id, GANTT_ROW._id]);
+        expect(removeCache).toHaveBeenCalledWith(`UserProjectData:${BROKEN}:`, true);
+        expect(mockDbFor(BROKEN).calls.every((call) => call.companyId === BROKEN)).toBe(true);
+    });
+
+    test('takes the id from the company catalogue when it has a row for that view', async () => {
+        const db = seedCompany(BROKEN);
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'SHOP', ProjectRequiredComponent: [{ ...listView }, { ...BOARD }] });
+
+        await migration.up(contextFor([BROKEN]));
+
+        expect(viewIds(BROKEN, 'SHOP')).toEqual([LIST_ROW._id, '6a97261fb28e840202058562']);
+    });
+
+    test('is idempotent: a second run repairs nothing and keeps the ids the first run minted', async () => {
+        const db = seedCompany(BROKEN, { board: false });
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'SPWC', ProjectRequiredComponent: [{ ...listView }, { ...BOARD }] });
+        await migration.up(contextFor([BROKEN]));
+        const after = viewIds(BROKEN, 'SPWC');
+
+        const again = contextFor([BROKEN]);
+        await migration.up(again);
+
+        expect(again.companies[BROKEN]).toEqual({ ok: true, projects: 1, repaired: 0, entries: 0 });
+        expect(viewIds(BROKEN, 'SPWC')).toEqual(after);
+    });
+
+    test('writes nothing to a company whose projects all have ids', async () => {
+        const db = seedCompany(CLEAN);
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'Local Smoke', ProjectRequiredComponent: [{ ...listView }] });
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'Embeds', ProjectRequiredComponent: [{ ...listView }, { name: 'Figma', _id: 'ab12cd', id: 'ab12cd' }] });
+
+        const ctx = contextFor([CLEAN]);
+        await migration.up(ctx);
+
+        expect(ctx.companies[CLEAN]).toEqual({ ok: true, projects: 2, repaired: 0, entries: 0 });
+        expect(mockDbFor(CLEAN).calls.some((call) => call.method === 'updateOne')).toBe(false);
+        expect(removeCache).not.toHaveBeenCalled();
+        expect(viewIds(CLEAN, 'Embeds')).toEqual([LIST_ROW._id, 'ab12cd']);
+    });
+
+    test('a project with no views at all is left as it is', async () => {
+        const db = seedCompany(CLEAN);
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'Bare', ProjectRequiredComponent: [] });
+        db.seed(SCHEMA_TYPE.PROJECTS, { ProjectName: 'Unset' });
+
+        const ctx = contextFor([CLEAN]);
+        await migration.up(ctx);
+
+        expect(ctx.companies[CLEAN]).toEqual({ ok: true, projects: 2, repaired: 0, entries: 0 });
+        expect(projectNamed(CLEAN, 'Unset').ProjectRequiredComponent).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## The bug

Opening certain projects rendered no view bar and no task list, with the empty state
`EmptyState.no_match_title` — "Nothing matches your filters / There is work in this project,
it is just hidden right now" — for a project where no filter was set.

`frontend/src/views/Projects/Projects.vue`, in `getChange()`:

```js
const Tabs2 = projectData.value.ProjectRequiredComponent?.filter((item) => item._id.length > 6);
```

`item._id` is `undefined` for some entries, so this throws
`TypeError: Cannot read properties of undefined (reading 'length')` before `getChange()`
assigns `viewsListArray`. The view bar and the task list therefore never populate. The same
unguarded read appeared twice more: `item._id.length == 6` for the embed menu (not even
optional-chained on `ProjectRequiredComponent`) and `element.id.length` on the member's
private tabs.

The empty state then misattributed it: `ListView.vue`, `BoardView.vue` and `TableView.vue`
all chose between "no tasks yet" and "nothing matches your filters" purely on
`project?.lastTaskId` being non-zero, never checking whether a filter was actually set. A
render crash reached the user as a filter problem.

## Where a view's `_id` comes from, and why Board never got one

Each company's view catalogue lives in `project_tab_components`, seeded row by row at
company creation by `importProjectTabComponents` (`utils/data.js`). `createProject` copies a
catalogue row's `_id` — as a **string** — onto the project's view entry
(`Modules/createProject/controller.js`):

```js
const valueItem = tabComponentsArray.find(value => value.name === item.name);
if (valueItem) {
    return Object.assign({}, { /* … */ _id: valueItem.id ? valueItem.id : JSON.parse(JSON.stringify(valueItem._id)), /* … */ });
}
return item;   // ← no _id
```

So the id is *not* Mongoose-generated per project — `ProjectRequiredComponent` is declared
`type: Array` (untyped), so Mongoose casts and generates nothing. Every project in a company
shares one id per view because they all copy the same catalogue row. That id's **length is
semantically load-bearing**: 24 characters means a real view, 6 means an embed
(`makeUniqueId(6)` in `EmbedView.vue`), which is what the two `.length` comparisons encode.

Board never got one because the lookup misses and the mapper falls through to `return item` —
the raw template entry, which carries no `_id`. Verified against the dev database:

| company | catalogue rows | Board row | `ProjectKanban` entries |
|---|---|---|---|
| `6a8ee973d625fca52e519a12` | 3 (List, Dashboard, Gantt View) | **absent** | 17, all with **no** `_id` |
| `6a8c18fdb6711e95fca888ea` | 20 (full seed) | `6a8c18feb6711e95fca8898f` | 2, both carrying exactly that id |

`6a97261fb28e840202058560` — the shared id on every `ProjectListView` entry in the first
company — is that company's `project_tab_components` "List" row `_id`. The company whose
catalogue still has a Board row stores a perfectly valid Board id. That is the mechanism,
confirmed end to end.

## What changed

**1. The reads are defensive** — `frontend/src/views/Projects/composables/projectViewBar.js`

`splitProjectViews(projectViews, userTabs)` replaces the three inline reads in `getChange()`
and takes every id through `String(...)` with an empty-string fallback. A malformed entry is
**skipped**, not repaired in place on read: the browser cannot mint an id that is stored
anywhere, and a rename, pin or delete matches `_id` with `===` in `arrayFilters` / `$pull`,
so an id invented client-side would make those writes silently target nothing. The server is
the only place that can mint a durable id. One bad entry now costs that one tab; every other
view still lists. The function also tolerates a missing or non-array
`ProjectRequiredComponent`, which line 885 did not.

**2. The writer** — `Modules/createProject/viewEntries.js`, wired into the controller

`withViewIds(entries, catalogue)` runs once after every template branch (category template,
no-category template, and project-as-template) and before the save, so no branch can store an
entry without an id. A missing `_id` is filled from the company's catalogue row for that
entry's **`keyName`** — the stable identifier; `name` is a label an owner can rename — falling
back to `name`, and to a fresh `new mongoose.Types.ObjectId().toString()` when the catalogue
has no such row at all. That keeps the id 24 characters, i.e. still a view and not an embed,
and preserves the existing convention that the id is the catalogue row's whenever one exists.
An entry that already has an id is never renumbered.

**3. The migration** — `migrations/021-project-view-ids.js` (company-scoped, **not applied**)

For each company it reads `project_tab_components`, walks `projects`, and for any project
carrying an entry with no `_id` sets `ProjectRequiredComponent` to the same `withViewIds`
result, then clears `UserProjectData:<companyId>:`. It is idempotent (an entry with an id is
skipped, and a project with no broken entries is never written) and touches only entries
whose `_id` is missing.

**Exact effect if run today**, from the dev database:

* company `6a8ee973d625fca52e519a12`: **17 project documents**, **17 entries** — one
  `ProjectKanban` entry each, given a fresh 24-character id (this company's catalogue has no
  Board row). Documents: AlianHub Redesign, Personal, Sweep Project W2 / W2b / W2c / W2d,
  `[QA projects]` Private / Public / Created by member / Created by guest, `[QA pages]`
  private / import / idor ts8z, `[QA automations]` Private scope, `__probe delete me`,
  Shopify Ecommerce Store for Cloth Brand (SHOP), Counter scratch XT09.
* every other database on the instance: **0 documents, 0 entries** — no other company has an
  entry with a missing `_id`.
* nothing else on any document is touched; no entry that already has an `_id` changes.

It has deliberately **not** been run — the owner decides when to migrate.

**4. The empty state** — `frontend/src/views/Projects/composables/useTaskEmptyState.js`

The three views now ask `useTaskEmptyState(project)`, which consults the task list's own
`searchedTask` flag (`useProjectSearch`, already `provide`d by `Projects.vue`) — true exactly
while a search, an assignee pick, a saved filter or the archive toggle is narrowing the list.
"Nothing matches your filters" is shown only then. With no filter on a project that has held
tasks before, the new copy says so instead:

```
EmptyState.no_visible_tasks_title: "No tasks to show here"
EmptyState.no_visible_tasks_msg:   "This project has had tasks before, but none are visible in this view. They may have been archived or deleted."
```

Both keys are new — no existing string was reworded, so `npm run i18n:backfill` filled all 13
locales (2 keys each, recorded in `<locale>.pending.json`) and `npm run i18n:check` passes.

## Tests

`frontend/tests/unit/projectViewBar.spec.js` (vitest, 9 tests)
* lists the other views and does not throw on an entry with no `_id`
* tolerates a null `_id`, a null entry and a missing array
* keeps the 24-character ids in the tab bar and the 6-character ones in the embeds
* adds a member's private views and drops the ones the project already has
* drops the dead legacy Gantt and Timeline keyNames
* pins sort ahead of the rest
* does not blame a filter when none is applied
* offers to clear the filter while one narrows the list
* says the project has no tasks yet before its first one exists

`tests/create-project-view-ids.test.js` (jest, 8 tests)
* the blank template ships no ids of its own, so the writer has to supply them
* every entry of the blank template gets a view-length id on a catalogue with no Board row
* a catalogued view takes the catalogue row id, matched on keyName not the renamable label
* the id the catalogue cannot supply is a fresh ObjectId, distinct per entry
* an entry that already has an id keeps it, so a later rename or delete still matches
* repeating the repair changes nothing
* the shapes a broken entry actually takes never throw
* the repair runs after every template branch, on the object that is saved

`tests/migration-project-view-ids.test.js` (jest, 6 tests)
* is a valid company-scoped migration listed after 020
* gives the Board entry an id and leaves every other entry alone
* takes the id from the company catalogue when it has a row for that view
* is idempotent: a second run repairs nothing and keeps the ids the first run minted
* writes nothing to a company whose projects all have ids
* a project with no views at all is left as it is

The existing create-project, personal-list, demo-project and migrations-runner suites and the
whole `conventions` project (95 tests, i18n-check included) still pass.

## Still open, not fixed here

Why company `6a8ee973d625fca52e519a12`'s catalogue holds only 3 of the 20 seeded rows. No
application code deletes from `project_tab_components` — the only writes are
`importProjectTabComponents` (delete-all then re-save all 20) and `ensureDashboardTab`, which
self-heals the Dashboard row and nothing else. So nothing will restore Board there, and the
"+ View" menu in that workspace can still only offer List, Dashboard and Gantt View. This PR
makes project creation and rendering robust to the pruned catalogue; repopulating it is a
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
