### PR TITLE
fix(automations): name a rule from the rule it saves and fire once per change

### DIFF
--- a/Modules/Automations/controller.js
+++ b/Modules/Automations/controller.js
@@ -15,6 +15,7 @@ const { canEditProject } = require('../AIProjectGenerator/projectAccess');
 
 const NOT_FOUND = 'Not found.';
 const APPLY_REFUSED = 'You cannot edit every task this automation targets.';
+const V2_NOT_APPLIABLE = 'This automation runs on events and cannot be applied in bulk.';
 
 const companyOf = (req) => req.headers['companyid'];
 const oid = (id) => (/^[0-9a-fA-F]{24}$/.test(String(id || '')) ? new mongoose.Types.ObjectId(String(id)) : null);
@@ -69,8 +70,11 @@ exports.listRules = async (req, res) => {
     try {
         const companyId = companyOf(req);
         if (!companyId) return refuse(res, 400, 'companyId is required.');
+        // v2 rules are excluded: they carry `steps`, not `actions`, so R.describe
+        // reads them as empty and `lastRunCount` — which only the bulk apply below
+        // ever writes — reads as "0 tasks affected" for a rule that has been firing.
         const rows = await MongoDbCrudOpration(companyId, {
-            type: SCHEMA_TYPE.AUTOMATION_RULES, data: [{ deletedStatusKey: { $ne: 1 } }, {}, { sort: { updatedAt: -1 } }],
+            type: SCHEMA_TYPE.AUTOMATION_RULES, data: [{ deletedStatusKey: { $ne: 1 }, version: { $ne: 2 } }, {}, { sort: { updatedAt: -1 } }],
         }, 'find');
         return res.send({ status: true, data: (rows || []).map((r) => ({ ...(r.toObject ? r.toObject() : r), summary: R.describe(r) })) });
     } catch (e) { logger.error(`listRules: ${e.message}`); return res.send({ status: false, statusText: e.message }); }
@@ -144,6 +148,10 @@ exports.applyRule = async (req, res) => {
         const target = await ruleForWrite(req, res, companyId);
         if (!target) return undefined;
         const { id, rule } = target;
+        // A v2 rule keeps its work in `steps`, so this would find no action, touch
+        // nothing, and still answer "Applied to 0 task(s)" while stamping a zero
+        // over the counter.
+        if (Number(rule.version) === 2) return refuse(res, 400, V2_NOT_APPLIABLE);
         const pr = (rule.actions || []).find((a) => a.type === 'set_priority');
         const tasks = pr
             ? await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.TASKS, data: [R.buildMatch(rule.conditions || {}, oid), 'ProjectID Task_Priority'] }, 'find')
@@ -176,9 +184,16 @@ exports.getRegistry = async (req, res) => {
     }
 };
 
+const V1_APPLY_FIELDS = ['lastRunAt', 'lastRunCount'];
+
+/* Those two belong to the v1 bulk apply and are dropped here: the schema default
+ * would otherwise report "never run, 0 tasks" for a rule the engine has been firing
+ * on every matching event. */
 const v2Summary = (r) => {
     const raw = r.toObject ? r.toObject() : r;
-    return { ...raw, summary: V2.describeV2(raw), sentence: sentences.describeRule(raw) };
+    const summarised = { ...raw, summary: V2.describeV2(raw), sentence: sentences.describeRule(raw) };
+    V1_APPLY_FIELDS.forEach((field) => delete summarised[field]);
+    return summarised;
 };
 
 // GET /api/v2/automations
@@ -190,9 +205,19 @@ exports.listRulesV2 = async (req, res) => {
             type: SCHEMA_TYPE.AUTOMATION_RULES,
             data: [{ deletedStatusKey: { $ne: 1 }, version: 2 }, {}, { sort: { updatedAt: -1 } }],
         }, 'find');
+        // Lifetime, every run the rule has ever started, and one run per matched
+        // event whatever its outcome — so it is not the number of comments posted
+        // today, and `failedCount` is what says the difference.
         const fired = await MongoDbCrudOpration(companyId, {
             type: SCHEMA_TYPE.AUTOMATION_RUNS,
-            data: [[{ $group: { _id: '$ruleId', runs: { $sum: 1 }, lastAt: { $max: '$startedAt' } } }]],
+            data: [[{
+                $group: {
+                    _id: '$ruleId',
+                    runs: { $sum: 1 },
+                    failures: { $sum: { $cond: [{ $eq: ['$status', 'failed'] }, 1, 0] } },
+                    lastAt: { $max: '$startedAt' },
+                },
+            }]],
         }, 'aggregate').catch(() => []);
         const byRule = {};
         (fired || []).forEach((f) => { byRule[String(f._id)] = f; });
@@ -200,7 +225,7 @@ exports.listRulesV2 = async (req, res) => {
             status: true,
             data: (rows || []).map((r) => {
                 const stats = byRule[String(r._id)] || {};
-                return { ...v2Summary(r), firedCount: Number(stats.runs || 0), lastFiredAt: stats.lastAt || null };
+                return { ...v2Summary(r), firedCount: Number(stats.runs || 0), failedCount: Number(stats.failures || 0), lastFiredAt: stats.lastAt || null };
             }),
         });
     } catch (e) { logger.error(`listRulesV2: ${e.message}`); return res.send({ status: false, statusText: e.message }); }
@@ -217,10 +242,12 @@ exports.createRuleV2 = async (req, res) => {
         if (denied) return refuse(res, denied.code, denied.statusText);
 
         // A rule that mutates tasks the instant it is saved gives the author no chance to look at it first.
+        // No lastRunCount: that counter belongs to the v1 bulk apply, and seeding it
+        // here puts a permanent 0 next to a rule the event engine does fire.
         const data = {
             _id: new mongoose.Types.ObjectId(), ...check.value,
             enabled: req.body.enabled === true,
-            createdBy: String(req.uid || ''), lastRunCount: 0, deletedStatusKey: 0,
+            createdBy: String(req.uid || ''), deletedStatusKey: 0,
         };
         const saved = await MongoDbCrudOpration(companyId, { type: SCHEMA_TYPE.AUTOMATION_RULES, data }, 'save');
         rulesChanged(companyId);

--- a/Modules/Automations/helpers/ruleSchemaV2.js
+++ b/Modules/Automations/helpers/ruleSchemaV2.js
@@ -1,6 +1,7 @@
 const { validate: validateConditions, usesChangeOps } = require('../engine/expression');
 const registry = require('../engine/registry');
 const timeTrigger = require('../../Workflows/timeTrigger');
+const { describeRule } = require('./sentenceRules');
 
 // Validation for v2 (event-triggered, multi-step) rules.
 //
@@ -15,6 +16,10 @@ const MAX_STEPS = 25;
 const MAX_NAME = 120;
 
 const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+/* The one composer of a rule's own words: `sentence` on every read and `name` on
+ * every save come from here, so the two can never describe different rules. */
+const composedName = (rule) => describeRule(rule).slice(0, MAX_NAME);
 
 const validateStep = (step, index, errors) => {
     const at = `steps[${index}]`;
@@ -50,7 +55,6 @@ const validateRuleV2 = (input = {}) => {
     const errors = [];
 
     const name = String(input.name || '').trim();
-    if (!name) errors.push('name: required');
     if (name.length > MAX_NAME) errors.push(`name: must be ${MAX_NAME} characters or fewer`);
 
     const trigger = isPlainObject(input.trigger) ? input.trigger : {};
@@ -79,30 +83,39 @@ const validateRuleV2 = (input = {}) => {
     const ids = steps.map((s) => s && s.id).filter(Boolean);
     if (new Set(ids).size !== ids.length) errors.push('steps: step ids must be unique');
 
-    if (errors.length) return { valid: false, errors, value: null };
+    // Composing the name needs a rule that parses, so an unusable one still has to
+    // carry its own.
+    if (errors.length) {
+        if (!name) errors.push('name: required');
+        return { valid: false, errors, value: null };
+    }
 
     const scope = isPlainObject(input.scope) ? input.scope : {};
-    return {
-        valid: true,
-        errors: [],
-        value: {
-            name,
-            version: 2,
-            trigger: triggerDef.kind === 'time'
-                ? { type: 'time', event: trigger.event, schedule: { ...trigger.schedule, timezone: 'UTC' } }
-                : { type: 'event', event: trigger.event },
-            scope: {
-                allProjects: scope.allProjects !== false,
-                projectIds: Array.isArray(scope.projectIds) ? scope.projectIds.map(String) : [],
-            },
-            conditions: isPlainObject(input.conditions) ? input.conditions : {},
-            steps: steps.map((s) => (s.type === 'condition'
-                ? { id: s.id, type: 'condition', condition: s.condition }
-                : { id: s.id, type: 'action', action: s.action, config: isPlainObject(s.config) ? s.config : {} })),
-            reactToAutomation: input.reactToAutomation === true,
-            limits: { maxRunsPerHour: Number(input.limits?.maxRunsPerHour) > 0 ? Number(input.limits.maxRunsPerHour) : 500 },
+    const value = {
+        name,
+        version: 2,
+        trigger: triggerDef.kind === 'time'
+            ? { type: 'time', event: trigger.event, schedule: { ...trigger.schedule, timezone: 'UTC' } }
+            : { type: 'event', event: trigger.event },
+        scope: {
+            allProjects: scope.allProjects !== false,
+            projectIds: Array.isArray(scope.projectIds) ? scope.projectIds.map(String) : [],
         },
+        conditions: isPlainObject(input.conditions) ? input.conditions : {},
+        steps: steps.map((s) => (s.type === 'condition'
+            ? { id: s.id, type: 'condition', condition: s.condition }
+            : { id: s.id, type: 'action', action: s.action, config: isPlainObject(s.config) ? s.config : {} })),
+        reactToAutomation: input.reactToAutomation === true,
+        limits: { maxRunsPerHour: Number(input.limits?.maxRunsPerHour) > 0 ? Number(input.limits.maxRunsPerHour) : 500 },
     };
+
+    // An unnamed rule is named by the sentence that describes the rule being saved,
+    // composed here rather than by the caller: a name the client derived from an
+    // earlier compile can be a step behind the rule it is attached to, and then the
+    // list, the audit trail and the run log all quote a rule that was never saved.
+    if (!value.name) value.name = composedName(value);
+
+    return { valid: true, errors: [], value };
 };
 
 /* One-line human summary for the rule list — the same sentence the builder shows,
@@ -117,4 +130,4 @@ const describeV2 = (rule = {}) => {
     return `${when} → ${actions.join(', ') || 'no actions'}`;
 };
 
-module.exports = { validateRuleV2, describeV2, validateStep, MAX_STEPS };
+module.exports = { validateRuleV2, describeV2, validateStep, composedName, MAX_STEPS, MAX_NAME };

--- a/event/domainEventBus.js
+++ b/event/domainEventBus.js
@@ -162,6 +162,20 @@ function flush(key) {
     publish(buildEnvelope({ companyId, type, doc, changedFields: changed, previous, actor, depth }));
 }
 
+const fieldValue = (doc, field) => {
+    const value = doc ? doc[field] : undefined;
+    if (value === null || value === undefined) return '';
+    return typeof value === 'object' ? JSON.stringify(value) : String(value);
+};
+
+/* Whether this emit is a second change rather than another echo of the pending one.
+ * The window exists to collapse the several emits ONE write produces, and those all
+ * carry the same values; an emit that reports a NEW value for a field the pending
+ * emit already moved is a separate domain event, and merging the two would publish
+ * one envelope for two changes — an automation that should fire twice fires once. */
+const supersedesPending = (entry, doc, changedNow) => Boolean(entry) && [...changedNow]
+    .some((field) => entry.changed.has(field) && fieldValue(entry.doc, field) !== fieldValue(doc, field));
+
 /* One user action fires several emits (the write, then counter and index updates).
  * Collapsing them within a window means a status+priority change in the same save
  * produces one envelope carrying both fields, not two envelopes that each see half
@@ -174,11 +188,14 @@ function onTaskEvent(emitType) {
 
             const companyId = String(doc.CompanyId);
             const key = `${companyId}:${String(doc._id)}:${emitType}`;
+            const changedNow = normalizeChangedFields(payload?.updatedFields);
             const existing = pending.get(key);
             if (existing) clearTimeout(existing.timer);
+            if (supersedesPending(existing, doc, changedNow)) flush(key);
 
-            const changed = new Set(existing ? existing.changed : []);
-            normalizeChangedFields(payload?.updatedFields).forEach((field) => changed.add(field));
+            const carried = pending.get(key);
+            const changed = new Set(carried ? carried.changed : []);
+            changedNow.forEach((field) => changed.add(field));
 
             pending.set(key, {
                 companyId,
@@ -223,4 +240,5 @@ module.exports = {
     trimTask,
     resolveActor,
     buildEnvelope,
+    supersedesPending,
 };

--- a/frontend/src/views/Automations/AutomationsPage.vue
+++ b/frontend/src/views/Automations/AutomationsPage.vue
@@ -167,7 +167,7 @@ const backtest = ref(null);
 
 const scopeChoice = ref('all');
 const conditions = ref([]);
-const draft = reactive({ name: '', trigger: { type: 'event', event: '' }, steps: [] });
+const draft = reactive({ trigger: { type: 'event', event: '' }, steps: [] });
 
 let stepSeq = 0;
 const nextStepId = () => { stepSeq += 1; return `s${stepSeq}`; };
@@ -248,8 +248,10 @@ const loadConditions = (node) => {
     return list.filter((n) => n && n.field).map((n) => ({ field: n.field, op: n.op, value: n.value ?? '' }));
 };
 
+/* No name: the server composes it from the rule it is saving. A name derived
+ * here would come from the sentence box, which is one compile behind whatever was
+ * typed last. */
 const currentRule = () => ({
-    name: draft.name || sentence.value.slice(0, 120),
     version: 2,
     trigger: { type: 'event', event: draft.trigger.event },
     scope: scopeChoice.value === 'all'
@@ -273,7 +275,7 @@ const applyRule = (rule) => {
 const compileSentence = async () => {
     if (!sentence.value.trim()) return;
     backtest.value = null;
-    const body = (await apiRequest('post', env.AUTOMATIONS_COMPILE, { sentence: sentence.value, name: draft.name }))?.data;
+    const body = (await apiRequest('post', env.AUTOMATIONS_COMPILE, { sentence: sentence.value }))?.data;
     if (!body?.status) { errors.value = [body?.statusText || 'Could not read that sentence.']; return; }
     errors.value = body.data.errors || [];
     ambiguities.value = body.data.ambiguities || [];
@@ -287,7 +289,7 @@ const compileSentence = async () => {
 /* rule → sentence, so editing a slot rewrites the sentence above it. */
 const onRuleEdit = async () => {
     backtest.value = null;
-    const body = (await apiRequest('post', env.AUTOMATIONS_COMPILE, { rule: currentRule(), name: draft.name }))?.data;
+    const body = (await apiRequest('post', env.AUTOMATIONS_COMPILE, { rule: currentRule() }))?.data;
     if (!body?.status) return;
     errors.value = body.data.errors || [];
     sentence.value = body.data.sentence;
@@ -314,7 +316,6 @@ const startNew = async () => {
     ambiguities.value = [];
     backtest.value = null;
     editingId.value = null;
-    draft.name = '';
     draft.trigger = { type: 'event', event: manifest.triggers[0]?.key || '' };
     draft.steps = [];
     conditions.value = [];
@@ -333,7 +334,6 @@ const edit = (rule) => {
     ambiguities.value = [];
     backtest.value = null;
     editingId.value = rule._id;
-    draft.name = rule.name || '';
     applyRule(rule);
     sentence.value = rule.sentence || '';
     building.value = true;
@@ -345,8 +345,7 @@ const save = async (enabled) => {
     saving.value = true;
     errors.value = [];
     try {
-        if (!draft.name) await onRuleEdit();
-        const body = { ...currentRule(), name: draft.name || sentence.value.slice(0, 120), enabled };
+        const body = { ...currentRule(), enabled };
         const res = editingId.value
             ? await apiRequest('put', `${env.AUTOMATIONS_V2}/${editingId.value}`, body)
             : await apiRequest('post', env.AUTOMATIONS_V2, body);

--- a/migrations/021-automation-rule-name-sentence.js
+++ b/migrations/021-automation-rule-name-sentence.js
@@ -1,0 +1,43 @@
+/* A v2 rule's `name` used to be composed by the builder from whatever the sentence
+ * box held at save time, which could be a compile behind the rule being saved. The
+ * result is a stored name that describes a different rule than the one that runs —
+ * seen in the wild as `post a comment saying ""` on a rule whose step carries a
+ * body. The name is quoted in the rule list, in every run row and as the actor on
+ * every audit entry the rule writes, so leaving it wrong keeps showing people a
+ * rule nobody saved.
+ *
+ * Only machine-composed names are repaired. A name that does not read as a
+ * generated sentence was typed by somebody and is left exactly as it is; one that
+ * does and already matches the rule is left alone too, which is what makes this
+ * idempotent — after it runs every rewritten name equals describeRule(rule), so a
+ * second run matches nothing.
+ *
+ * Run rows and audit entries keep the name they were written with: they record what
+ * was shown at the time, and rewriting history to match the present would make the
+ * log a worse record than it is.
+ */
+
+const { composedName } = require('../Modules/Automations/helpers/ruleSchemaV2');
+
+const GENERATED = /^When .*\.$/s;
+
+module.exports = {
+    id: '021-automation-rule-name-sentence',
+    scope: 'company',
+    async up(ctx) {
+        await ctx.forEachCompany(async (companyId) => {
+            const type = ctx.SCHEMA_TYPE.AUTOMATION_RULES;
+            const rules = (await ctx.company(companyId, { type, data: [{ version: 2 }] }, 'find')) || [];
+            const stale = rules
+                .map((rule) => (rule.toObject ? rule.toObject() : rule))
+                .map((rule) => ({ _id: rule._id, name: composedName(rule), was: String(rule.name || '').trim() }))
+                .filter((r) => GENERATED.test(r.was) && r.was !== r.name);
+            for (const rule of stale) {
+                // eslint-disable-next-line no-await-in-loop
+                await ctx.company(companyId, { type, data: [{ _id: rule._id }, { $set: { name: rule.name } }] }, 'updateOne');
+            }
+            ctx.logger.info(`[migrations] 021 ${companyId}: ${stale.length} of ${rules.length} v2 rule name(s) rewritten from the rule`);
+            return { rules: rules.length, renamed: stale.length };
+        });
+    },
+};

--- a/tests/automation-rule-v2.test.js
+++ b/tests/automation-rule-v2.test.js
@@ -1,4 +1,4 @@
-const { validateRuleV2, describeV2 } = require('../Modules/Automations/helpers/ruleSchemaV2');
+const { validateRuleV2, describeV2, MAX_NAME } = require('../Modules/Automations/helpers/ruleSchemaV2');
 
 const valid = () => ({
     name: 'Escalate closed stories',
@@ -71,5 +71,40 @@ describe('v2 rule validation', () => {
 
     it('describes a rule as the same sentence the builder shows', () => {
         expect(describeV2(valid())).toBe('Task status changes → Change priority');
+    });
+});
+
+describe('v2 rule name', () => {
+    const commenter = (body) => ({
+        trigger: { type: 'event', event: 'task.priority_changed' },
+        scope: { allProjects: true },
+        steps: [{ id: 's1', type: 'action', action: 'add_comment', config: { body } }],
+    });
+
+    it('names an unnamed rule after the rule itself, body and all', () => {
+        const r = validateRuleV2(commenter('Sweep automation fired'));
+        expect(r.valid).toBe(true);
+        expect(r.value.name).toBe('When a task priority changes, post a comment saying "Sweep automation fired".');
+    });
+
+    it('never keeps a name that describes a different rule than the one being saved', () => {
+        const stale = 'When a task priority changes, post a comment saying "".';
+        const r = validateRuleV2({ ...commenter('Sweep automation fired'), name: '' });
+        expect(r.value.name).not.toBe(stale);
+        expect(r.value.name).toContain('Sweep automation fired');
+    });
+
+    it('leaves a name somebody typed alone', () => {
+        expect(validateRuleV2({ ...commenter('hi'), name: 'Nudge the reporter' }).value.name).toBe('Nudge the reporter');
+    });
+
+    it('keeps the composed name inside the stored length', () => {
+        const r = validateRuleV2(commenter('x'.repeat(400)));
+        expect(r.valid).toBe(true);
+        expect(r.value.name.length).toBe(MAX_NAME);
+    });
+
+    it('still asks for a name on a rule it cannot describe', () => {
+        expect(validateRuleV2({ name: '', steps: [] }).errors).toEqual(expect.arrayContaining(['name: required', 'steps: at least one action is required']));
     });
 });

--- a/tests/domain-event-bus.test.js
+++ b/tests/domain-event-bus.test.js
@@ -3,6 +3,7 @@ const {
     trimTask,
     resolveActor,
     buildEnvelope,
+    supersedesPending,
     MAX_DEPTH,
 } = require('../event/domainEventBus');
 
@@ -104,6 +105,43 @@ describe('domainEventBus', () => {
 
         it('exposes the depth ceiling the publisher enforces', () => {
             expect(MAX_DEPTH).toBe(3);
+        });
+    });
+
+    describe('supersedesPending', () => {
+        const waiting = (doc, ...changed) => ({ doc, changed: new Set(changed) });
+
+        it('merges the echo emits one write produces — same values, nothing superseded', () => {
+            const doc = { Task_Priority: 'HIGH', statusType: 'open' };
+            expect(supersedesPending(waiting(doc, 'Task_Priority'), doc, fields('Task_Priority'))).toBe(false);
+        });
+
+        it('merges an emit that touches a field the pending one never claimed', () => {
+            const pendingDoc = { Task_Priority: 'HIGH', groupByPriorityIndex: 1 };
+            const next = { Task_Priority: 'HIGH', groupByPriorityIndex: 2 };
+            expect(supersedesPending(waiting(pendingDoc, 'Task_Priority'), next, fields('groupByPriorityIndex'))).toBe(false);
+        });
+
+        it('publishes the pending change when the same field moves again — three changes are three events', () => {
+            const urgent = waiting({ Task_Priority: 'URGENT' }, 'Task_Priority');
+            expect(supersedesPending(urgent, { Task_Priority: 'BANANA' }, fields('Task_Priority'))).toBe(true);
+        });
+
+        it('compares arrays and subdocuments by value, not by reference', () => {
+            const entry = waiting({ AssigneeUserId: ['u1'], status: { text: 'To do' } }, 'AssigneeUserId', 'status');
+            expect(supersedesPending(entry, { AssigneeUserId: ['u1'], status: { text: 'To do' } }, fields('AssigneeUserId'))).toBe(false);
+            expect(supersedesPending(entry, { AssigneeUserId: ['u1', 'u2'], status: { text: 'To do' } }, fields('AssigneeUserId'))).toBe(true);
+            expect(supersedesPending(entry, { AssigneeUserId: ['u1'], status: { text: 'Done' } }, fields('status'))).toBe(true);
+        });
+
+        it('treats a cleared field as a change rather than as an absent one', () => {
+            const entry = waiting({ Task_Leader: 'u1' }, 'Task_Leader');
+            expect(supersedesPending(entry, { Task_Leader: null }, fields('Task_Leader'))).toBe(true);
+            expect(supersedesPending(waiting({}, 'Task_Leader'), { Task_Leader: undefined }, fields('Task_Leader'))).toBe(false);
+        });
+
+        it('has nothing to supersede when no emit is waiting', () => {
+            expect(supersedesPending(undefined, { Task_Priority: 'HIGH' }, fields('Task_Priority'))).toBe(false);
         });
     });
 });

--- a/tests/integration/automations.int.test.js
+++ b/tests/integration/automations.int.test.js
@@ -48,11 +48,47 @@ async function createRule(api, rule) {
 
 const removeRule = (api, id) => (id ? api.delete(`/api/v2/automations/${id}`) : null);
 
-const finishedRuns = (api, ruleId) => waitFor(async () => {
+const finishedRuns = (api, ruleId, atLeast = 1) => waitFor(async () => {
     const res = await api.get(`/api/v2/automations/${ruleId}/runs`);
     const rows = res.body.data || [];
-    return rows.length && rows.every((run) => FINISHED_RUN.includes(run.status)) ? rows : null;
-}, { timeout: 15000 });
+    return rows.length >= atLeast && rows.every((run) => FINISHED_RUN.includes(run.status)) ? rows : null;
+}, { timeout: 20000 });
+
+const commenterFor = (projectId, body) => ruleFor(projectId, {
+    steps: [{ id: 's1', type: 'action', action: 'add_comment', config: { body } }],
+});
+
+/* The shape the builder saves: no name, because the server composes it from the
+ * rule. Everything below drops it the same way. */
+const unnamed = (rule) => ({ ...rule, name: undefined });
+
+const setPriority = (api, { project, task, user, priority }) => api.patch('/api/v2/tasks', {
+    action: 'updatePriority',
+    firebaseObj: { Task_Priority: priority },
+    projectData: { _id: String(project._id), ProjectName: project.ProjectName, CompanyId: api.companyId },
+    taskData: { _id: String(task._id), ProjectID: String(project._id), sprintId: task.sprintId },
+    priorityObj: { taskId: String(task._id), taskName: task.name || '', priorityName: 'MEDIUM', newPriorityName: priority },
+    userData: { Employee_Name: 'E2E', id: user.userId, companyOwnerId: user.userId },
+    isUpdateTask: true,
+});
+
+const commentsSaying = async (api, { project, task, body }) => {
+    const res = await api.get('/api/v1/comments/get-paginated-messages', {
+        query: { projectId: String(project._id), taskId: String(task._id), isDefault: 'true', batchLimit: 100 },
+    });
+    return (res.body.data || []).filter((c) => c.message === body);
+};
+
+const listedRule = async (api, ruleId) => {
+    const res = await api.get('/api/v2/automations');
+    return (res.body.data || []).find((r) => r._id === ruleId);
+};
+
+async function projectWithTask(owner) {
+    const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+    const task = await createTask(owner.api, { project, user: state.users.owner, companyOwnerId: owner.uid });
+    return { project, task };
+}
 
 async function mcpCall(pat, method, params = {}) {
     const client = createApiClient({ baseURL: state.baseURL, accessToken: pat, companyId: state.companyId });
@@ -229,6 +265,87 @@ describe('automation rules (v2)', () => {
         expect(patch.body.status).toBe(false);
     });
 
+    it('AUT-10 names a saved rule after the rule it saved, action body and all', async () => {
+        const { api } = await loginAs('owner');
+        const body = `E2E body ${uniqueSuffix()}`;
+        const rule = await createRule(api, unnamed(commenterFor(state.projects.shared._id, body)));
+        try {
+            expect(rule.name).toContain(body);
+            expect(rule.name).toBe(rule.sentence);
+            expect((await listedRule(api, rule._id)).name).toContain(body);
+        } finally {
+            await removeRule(api, rule._id);
+        }
+    });
+
+    it('AUT-10 renames a rule when its action body is edited, rather than keeping the old sentence', async () => {
+        const { api } = await loginAs('owner');
+        const rule = await createRule(api, unnamed(commenterFor(state.projects.shared._id, 'E2E before')));
+        try {
+            const body = `E2E after ${uniqueSuffix()}`;
+            const updated = await api.put(`/api/v2/automations/${rule._id}`, unnamed(commenterFor(state.projects.shared._id, body)));
+            expect(updated.body.data.name).toContain(body);
+            expect(updated.body.data.name).not.toContain('E2E before');
+        } finally {
+            await removeRule(api, rule._id);
+        }
+    });
+
+    it('AUT-11 counts one run per firing and posts one comment for each run that worked', async () => {
+        const owner = await loginAs('owner');
+        const { project, task } = await projectWithTask(owner);
+        const body = `E2E counted ${uniqueSuffix()}`;
+        const commenter = await createRule(owner.api, unnamed(commenterFor(project._id, body)));
+        const broken = await createRule(owner.api, unnamed(ruleFor(project._id, {
+            steps: [{ id: 's1', type: 'action', action: 'set_status', config: { status: 'No such status' } }],
+        })));
+        try {
+            for (const rule of [commenter, broken]) {
+                await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: true });
+            }
+            expect((await setPriority(owner.api, { project, task, user: state.users.owner, priority: 'HIGH' })).body.status).toBe(true);
+
+            const [worked, failed] = [await finishedRuns(owner.api, commenter._id), await finishedRuns(owner.api, broken._id)];
+            expect(worked.map((r) => r.status)).toEqual(['success']);
+            expect(failed.map((r) => r.status)).toEqual(['failed']);
+
+            const counted = await Promise.all([commenter, broken].map((r) => listedRule(owner.api, r._id)));
+            expect(counted.map((r) => [r.firedCount, r.failedCount])).toEqual([[1, 0], [1, 1]]);
+            // The number people actually care about: a fire that did its work left a
+            // comment, and a fire that did not is the one `failedCount` names.
+            expect(await commentsSaying(owner.api, { project, task, body })).toHaveLength(counted[0].firedCount - counted[0].failedCount);
+            expect(counted.every((r) => r.lastRunCount === undefined)).toBe(true);
+        } finally {
+            for (const rule of [commenter, broken]) {
+                await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: false });
+                await removeRule(owner.api, rule._id);
+            }
+        }
+    });
+
+    it('AUT-11 fires once for every priority change, including ones inside the same debounce window', async () => {
+        const owner = await loginAs('owner');
+        const { project, task } = await projectWithTask(owner);
+        const body = `E2E every change ${uniqueSuffix()}`;
+        const rule = await createRule(owner.api, unnamed(commenterFor(project._id, body)));
+        const priorities = ['HIGH', 'LOW', 'MEDIUM'];
+        try {
+            await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: true });
+            for (const priority of priorities) {
+                await setPriority(owner.api, { project, task, user: state.users.owner, priority });
+            }
+
+            const runs = await finishedRuns(owner.api, rule._id, priorities.length);
+            expect(runs.map((r) => r.status)).toEqual(priorities.map(() => 'success'));
+            expect(runs.map((r) => r.envelope.data.Task_Priority).sort()).toEqual([...priorities].sort());
+            expect(await commentsSaying(owner.api, { project, task, body })).toHaveLength(priorities.length);
+            expect((await listedRule(owner.api, rule._id)).firedCount).toBe(priorities.length);
+        } finally {
+            await owner.api.patch(`/api/v2/automations/${rule._id}/enabled`, { enabled: false });
+            await removeRule(owner.api, rule._id);
+        }
+    });
+
     it('AUT-03 keeps private-project tasks out of a guest backtest', async () => {
         const owner = await loginAs('owner');
         const guest = await loginAs('guest');
@@ -275,6 +392,18 @@ describe('automation rules (v1)', () => {
             expect(preview.body.data.sample).toEqual([expect.objectContaining({ id: task._id, priority: 'HIGH' })]);
         } finally {
             await owner.api.delete(`/api/v1/automations/${id}`);
+        }
+    });
+
+    it('AUT-11 keeps event-driven rules out of the bulk-apply list and refuses to apply one', async () => {
+        const { api } = await loginAs('owner');
+        const rule = await createRule(api, unnamed(commenterFor(state.projects.shared._id, 'E2E v1 leak')));
+        try {
+            expect((await api.get('/api/v1/automations')).body.data.map((r) => r._id)).not.toContain(rule._id);
+            const applied = await api.post(`/api/v1/automations/${rule._id}/apply`, {});
+            expect(refused(applied)).toBe(true);
+        } finally {
+            await removeRule(api, rule._id);
         }
     });
 

--- a/tests/migration-automation-rule-name.test.js
+++ b/tests/migration-automation-rule-name.test.js
@@ -1,0 +1,74 @@
+const mockDbs = {};
+const mockDbFor = (companyId) => { mockDbs[companyId] = mockDbs[companyId] || require('./fixtures/fakeMongo').create(); return mockDbs[companyId]; };
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: (companyId, q, method) => mockDbFor(String(companyId)).crud(companyId, q, method) }));
+jest.mock('../Config/config', () => ({ myCache: { get: () => undefined, set: () => {}, del: () => {}, getTtl: () => 0 } }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const { buildContext, validateMigration, listMigrations } = require('../migrations');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const { settingsCollectionDocs } = require('../Config/collections');
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const migration = require('../migrations/021-automation-rule-name-sentence');
+
+const COMPANY = '6f0000000000000000000d01';
+const STALE = 'When a task priority changes, post a comment saying "".';
+const REPAIRED = 'When a task priority changes, post a comment saying "Sweep automation fired".';
+
+const logger = { info: jest.fn(), error: jest.fn() };
+const context = () => buildContext({ MongoDbCrudOpration, SCHEMA_TYPE, settingsCollectionDocs, logger, listCompanies: async () => [{ _id: COMPANY }] });
+const rules = () => mockDbFor(COMPANY).store[SCHEMA_TYPE.AUTOMATION_RULES] || [];
+const named = (name) => rules().find((r) => r.marker === name);
+
+const commenter = (marker, name, body = 'Sweep automation fired') => ({
+    marker,
+    name,
+    version: 2,
+    trigger: { type: 'event', event: 'task.priority_changed' },
+    scope: { allProjects: true, projectIds: [] },
+    steps: [{ id: 's1', type: 'action', action: 'add_comment', config: { body } }],
+    enabled: true,
+    deletedStatusKey: 0,
+});
+
+beforeEach(() => {
+    Object.keys(mockDbs).forEach((k) => { delete mockDbs[k]; });
+    jest.clearAllMocks();
+    const db = mockDbFor(COMPANY);
+    db.seed(SCHEMA_TYPE.AUTOMATION_RULES, commenter('stale', STALE));
+    db.seed(SCHEMA_TYPE.AUTOMATION_RULES, commenter('current', REPAIRED));
+    db.seed(SCHEMA_TYPE.AUTOMATION_RULES, commenter('authored', 'Sweep watcher'));
+    db.seed(SCHEMA_TYPE.AUTOMATION_RULES, { ...commenter('v1', STALE), version: 1 });
+});
+
+describe('021-automation-rule-name-sentence', () => {
+    test('is a valid company-scoped migration listed after 020', () => {
+        expect(() => validateMigration(migration, '021-automation-rule-name-sentence')).not.toThrow();
+        expect(migration.scope).toBe('company');
+        const ids = listMigrations().map((m) => m.id);
+        expect(ids.indexOf('021-automation-rule-name-sentence')).toBeGreaterThan(ids.indexOf('020-workflow-definitions'));
+    });
+
+    test('rewrites a generated name that lost the action body', async () => {
+        await migration.up(context());
+        expect(named('stale').name).toBe(REPAIRED);
+    });
+
+    test('leaves a name somebody typed, a name already correct, and a v1 rule alone', async () => {
+        await migration.up(context());
+        expect(named('authored').name).toBe('Sweep watcher');
+        expect(named('current').name).toBe(REPAIRED);
+        expect(named('v1').name).toBe(STALE);
+    });
+
+    test('is idempotent — a second run finds nothing left to rewrite', async () => {
+        const first = context();
+        await migration.up(first);
+        expect(first.companies[COMPANY]).toMatchObject({ ok: true, renamed: 1 });
+
+        const second = context();
+        await migration.up(second);
+        expect(second.companies[COMPANY]).toMatchObject({ ok: true, renamed: 0 });
+        expect(named('stale').name).toBe(REPAIRED);
+    });
+});

--- a/utils/mongo-handler/schema.js
+++ b/utils/mongo-handler/schema.js
@@ -733,6 +733,9 @@ const schema = {
         // is the switch that stops rule A and rule B triggering each other forever.
         reactToAutomation: { type: Boolean, default: false, required: false },
         enabled: { type: Boolean, default: true, required: false },
+        // The v1 on-demand bulk apply only: when it last ran and how many tasks it
+        // changed. A v2 rule is fired by events, never applied, so these stay unset
+        // on one — how often it fired is counted from its automationRuns.
         lastRunAt: { type: Date, required: false },
         lastRunCount: { type: Number, default: 0, required: false },
         createdBy: { type: String, required: false },


### PR DESCRIPTION
Two defects found while seeding a demo project through the real API, on automation rule `6a9aa66c69b6a2b96f1ecc46`. That rule was read, never written — the repair for it ships as migration 021.

## Defect 1 — the stored name lost the action's body

**Root cause: `name` and `sentence` are two independent derivations of the same words, and only one of them is computed from the rule being saved.**

- `sentence` is composed on the server on every read, in `v2Summary` → `sentenceRules.describeRule(storedRule)`. It cannot drift.
- `name` was composed in the browser: `AutomationsPage.save()` sent `name: draft.name || sentence.value.slice(0, 120)`. There is no name field anywhere in that screen, so `draft.name` is always empty for a new rule and the name was always the sentence box's current text. That text is filled in by `onRuleEdit()` / `compileSentence()` — separate, unawaited `POST /compile` calls fired from `@change` handlers, from `resetConfig()` (which blanks every config field), and from `startNew()` (twice, once through `addStep()` before the step is pushed). Whichever response lands last wins, so the box can hold a sentence for an earlier state of the rule while `draft.steps` already carries the typed body.

Evidence: the stored document has `createdAt === updatedAt === 2026-09-04T11:07:24.298Z`, so the wrong name arrived on the create call and was never an update. `steps[0].config.body` is `"Sweep automation fired"`, and the read-time `sentence` renders it correctly — the same `describeRule` that produced the name, given the stored rule, produces the right sentence. So the input to the name composer was stale, not the composer.

**Fix — one composer, server-side.** `validateRuleV2` composes the name from the rule it has just validated (`composedName` → `describeRule`, truncated to `MAX_NAME`) when the caller sends none, and the builder now sends none. An unusable rule cannot be described, so `name: required` is still reported there, which keeps the existing field-level error contract. A name a caller does type is kept untouched.

Two notes:
- The name is user-visible in more places than the rule list, which renders `sentence || summary`: it is the `ruleName` on every run row and the `actorName` on every audit entry the rule writes. The audit log for the seeding run shows 11 entries attributed to `When a task priority changes, post a comment saying ""`.
- Saving from the builder now renames a rule that was named through the API, because the builder is a sentence-authoring surface with no name input. If a rule should be able to carry a hand-written name, that screen needs a name field first.

**i18n tension (Rule 3), stated rather than resolved.** `describeRule` composes English prose on the server, and the grammar is also the *parser's* vocabulary — `parseSentence` and `describeRule` have to stay inverses, which is what makes the compile step deterministic and offline. This PR does not make that worse: the same English string was already shown to every user as `sentence`; it removes a second, divergent copy of it rather than adding one. Localising it means localising the grammar on both sides and is a piece of work of its own. No new template strings, so no `en.js` keys and no backfill; `npm run i18n:check` is clean.

## Defect 2 — the counters

Three numbers, three different answers, and only one of them was a bug.

**`firedCount: 12` vs 11 comments — not a divergence.** `firedCount` is computed at read time in `listRulesV2` by counting `automation_runs` documents for the rule: lifetime, one per matched event, whatever the outcome. The run log holds 12 runs, **all with status `success` and all recording a `commentId`** — 11 of them between 10:27:25 and 10:27:30 today on SHOP tasks, and one from **2026-09-04** on `AR-2` in the earlier sweep project. The audit log has exactly 11 `automation.task.comment` rows today. So today's runs and today's comments agree exactly; the 12th is eight days old. No action was lost and nothing silently no-opped.

Fixed as naming and reporting only: `firedCount` now travels with a `failedCount` from the same aggregate, and the field is documented as a lifetime count of runs whatever their outcome. (Not surfaced in the UI — that needs an i18n key and was left for a follow-up.)

**`lastRunCount: 0` — a dead field.** It is the v1 bulk apply's counter ("tasks changed by the last `POST /api/v1/automations/:id/apply`"). The v2 event runner never writes it; `createRuleV2` seeded it to `0`, and the Mongoose default re-materialises `0` on every read, so a v2 rule shows a permanent zero. Worse, `listRules` (v1) returns *every* rule, so this v2 rule appeared in the Integrations rule list rendering `lastRunCount || 0` as "0 auto-affected" with an empty `summary` ("any task → ", because `R.describe` reads `actions`, which a v2 rule does not have) and an Apply button that would have run the v1 bulk apply on it — finding no action, touching nothing, answering "Applied to 0 task(s)" and stamping the zero.

Fixed: not seeded on create, stripped from the v2 payload, v2 rules excluded from the v1 list, and `apply` refuses a v2 rule instead of reporting success for doing nothing.

**13 `updatePriority` calls vs 11 firings — the real bug, in the event bus.**

Evidence, from the task activity log of every SHOP task:

```
10:27:23.403 SHOP-4  → MEDIUM        10:27:28.821 SHOP-24 → LOW
10:27:24.701 SHOP-10 → MEDIUM        10:27:28.843 SHOP-29 → LOW
10:27:24.735 SHOP-23 → MEDIUM        10:27:28.875 SHOP-16 → LOW
10:27:26.030 SHOP-25 → MEDIUM        10:27:28.905 SHOP-31 → URGENT
10:27:26.058 SHOP-27 → MEDIUM        10:27:28.944 SHOP-31 → BANANA
10:27:27.378 SHOP-32 → MEDIUM        10:27:28.979 SHOP-31 → HIGH
10:27:27.402 SHOP-34 → MEDIUM
```

13 priority changes, and **SHOP-31 was changed three times in 74ms**. The run log has 11 runs, one per task, and the SHOP-31 run carries `Task_Priority: HIGH` — the last of the three. `event/domainEventBus.js` keys a pending emit on `${companyId}:${taskId}:${emitType}` and **resets the 2000ms timer on every subsequent emit**, so the three writes merged into one envelope carrying only the final value. 13 − 2 swallowed = 11 events = 11 runs = 11 comments. Every number is now accounted for.

The window is there for a real reason — one write fires several emits (the write, then the counter and index updates) and merging them is what makes "status and priority changed in one save" a single envelope carrying both fields. But those echoes all carry the *same* values. A second write that moves a field the pending emit already moved is a different domain event.

Fixed: `supersedesPending` publishes the pending envelope immediately when a new emit reports a different value for a field the pending emit already claimed to have changed. Echo emits (same values, or a field the pending emit never claimed) still merge, and task inserts emit no `updatedFields` at all so `task.created` is untouched.

## Backfilling existing rows — yes, migration `021-automation-rule-name-sentence`

A code fix leaves every already-saved name wrong, and that name is quoted in the rule list, in every run row and as the actor on every audit entry the rule writes. So it is worth repairing.

Narrowly, though: only a name that *reads as a generated sentence* (`/^When .*\.$/`) **and** does not match `describeRule(rule)` is rewritten. A name somebody typed is left exactly as it is — the migration cannot tell an authored name from a machine-composed one except by its shape, so anything that does not look generated is not touched. Idempotent by construction: after it runs every rewritten name equals `describeRule(rule)`, so a second pass matches nothing (asserted in the test).

Run rows and audit entries keep the names they were written with. They record what was shown at the time; rewriting them would make the log a worse record than it is.

Verified offline against the real document without writing to it:

```
stored name  : When a task priority changes, post a comment saying "".
would become : When a task priority changes, post a comment saying "Sweep automation fired".
```

## Tests

New:
- `tests/automation-rule-v2.test.js` → `v2 rule name`: names an unnamed rule after the rule itself, body and all / never keeps a name that describes a different rule than the one being saved / leaves a name somebody typed alone / keeps the composed name inside the stored length / still asks for a name on a rule it cannot describe.
- `tests/domain-event-bus.test.js` → `supersedesPending`: merges the echo emits one write produces / merges an emit that touches a field the pending one never claimed / publishes the pending change when the same field moves again / compares arrays and subdocuments by value / treats a cleared field as a change / has nothing to supersede when no emit is waiting.
- `tests/migration-automation-rule-name.test.js`: valid company-scoped migration listed after 020 / rewrites a generated name that lost the action body / leaves an authored name, an already-correct name and a v1 rule alone / is idempotent.
- `tests/integration/automations.int.test.js`: `AUT-10 names a saved rule after the rule it saved, action body and all`, `AUT-10 renames a rule when its action body is edited`, `AUT-11 counts one run per firing and posts one comment for each run that worked` (one rule succeeds, one fails deterministically on a status the project does not define; asserts `firedCount`/`failedCount` of `[1,0]` and `[1,1]`, that comments written equals `firedCount - failedCount`, and that `lastRunCount` is gone), `AUT-11 fires once for every priority change, including ones inside the same debounce window`, `AUT-11 keeps event-driven rules out of the bulk-apply list and refuses to apply one`.

Both regression tests were confirmed to bite: with `supersedesPending` disabled the debounce test fails, and before the validator change an unnamed rule is refused with `name: required` so the name tests cannot pass.

Full runs on a dedicated Mongo container: unit + conventions **4313 passed**, integration **921 passed** (56 suites), `eslint` clean on the touched files, `npm run i18n:check` exit 0, `frontend` vitest `automationsPage.spec.js` 5 passed.

## Not determined

- Why the seeder changed SHOP-31's priority three times, and why `BANANA` was accepted and written as a priority — `updatePriority` does not validate the value against `PRIORITIES` anywhere on the write path. Out of scope here, flagged separately.
- `Modules/Webhooks/dispatcher.js` has the same sliding-window merge on the same key shape, so webhook deliveries almost certainly coalesce distinct writes the same way. Not touched: this PR is about the automation engine, and webhook delivery has its own semantics to think about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
