### PR TITLE
fix(company): require the owner and a typed confirmation to delete a company

### DIFF
--- a/Modules/Auth/controller/loginSession.js
+++ b/Modules/Auth/controller/loginSession.js
@@ -18,6 +18,7 @@ const { updateUserFun } = require("../../Users/controller.js");
 
 const { addAndRemoveUserInMongodbNotificationCount, generateTokenV2Fun, verifyAuth } = require('./authHelpers');
 const twoFactorRules = require('../helpers/twoFactorRules');
+const { pinSessionTenant } = require('../../../Config/tenant');
 exports.manageAttempt = (req, res) => {
     const forwarded = req?.headers['x-forwarded-for'] || req.ip;
     const clientIp = forwarded ? forwarded?.split(',')[0] : req?.connection?.remoteAddress;
@@ -38,13 +39,7 @@ exports.manageAttempt = (req, res) => {
  */
 
 exports.removeUserNotification = (req,res) => {
-    if (!(req.body && req.body.companyId)) {
-        res.send({
-            status: false,
-            statusText: "CompanyId is required"
-        })
-        return;
-    }
+    if (!pinSessionTenant(req, res)) return;
     if (!(req.body && req.body.userId)) {
         res.send({
             status: false,

--- a/Modules/Company/controller.js
+++ b/Modules/Company/controller.js
@@ -18,6 +18,8 @@ const { storeRefferalCode, checkAndStoreRefferalCode } = require("../Affiliate/c
 const { handleCreateCompanyDataStorageFunForUpload, handleCreateCompanyDataStorageFun } = require(`../../common-storage/common-${process.env.STORAGE_TYPE}.js`);
 const { seedSampleProject } = require("../createProject/sampleProject.js");
 const { normaliseFocus, FOCUS_LABELS } = require("../createProject/sampleTasks.js");
+const { pinSessionTenant } = require("../../Config/tenant.js");
+const { getRoleType, ROLE_OWNER } = require("../../Config/permissionGuard.js");
 
 const TEAM_SIZES = ["1", "2-15", "16-50", "50+"];
 
@@ -701,61 +703,64 @@ exports.checkFreeCompanyCounts = (userId) => {
     });
 };
 
-exports.deleteCompany = (req, res) => {
+/* A dedicated short-lived connection, built the way mongoConnector builds every other one.
+ * mongoose.connect would instead open the process-wide default connection, which nothing else
+ * in this app uses and which refuses to reopen for a second company once it is active. */
+const dropCompanyDatabase = async (companyId) => {
+    const baseUrl = String(process.env.MONGODB_URL || '').replace(/\/+$/, '');
+    const connStr = baseUrl.startsWith('mongodb+srv') ? `${baseUrl}/${companyId}` : `${baseUrl}/${companyId}?authSource=admin`;
+    const connection = await mongoose.createConnection(connStr).asPromise();
     try {
-        if (!(req.body && req.body.companyId)) {
-            res.send({
-                status: false,
-                statusText: "CompanyId is required"
-            })
-            return;
-        }
-        mongoose.connect(process.env.MONGODB_URL+"/"+req.body.companyId);
-        const connection = mongoose.connection;
-        connection.once('open', () => {
-            logger.info(`MongoDB database connection established successfully ${req.body.companyId}`);
-        });
-        mongoose.connection.dropDatabase().then(() => {
-            try {
-                mongoose.connection.close();
-                let delObj = {
-                    type: SCHEMA_TYPE.COMPANIES,
-                    data: [
-                        {
-                            _id: new mongoose.Types.ObjectId(req.body.companyId)
-                        }
-                    ]
-                }
-                updateCompanyFun(SCHEMA_TYPE.GOLBAL,delObj,"deleteOne",req.body.companyId)
-                .then(() => {
-                    let findObj = {
-                        type: dbCollections.USERS,
-                        data: [
-                            {'AssignCompany': { $in: [req.body.companyId]}},
-                            {
-                                $pull: { 'AssignCompany': req.body.companyId }
-                            }
-                        ]
-                    };
+        await connection.dropDatabase();
+    } finally {
+        await connection.close();
+    }
+};
 
-                    updateUserFun(dbCollections.GLOBAL,findObj,"updateMany",req.body.companyId,'',true)
-                    .then(() => {
-                        res.send({ status: true, statusText: "Done"});
-                    }).catch((error) => {
-                        res.send({ status: false, statusText: error});
-                        console.error(error,"errorerror");
-                    });
-                })
-            } catch (err) {
-                res.send({ status: false, statusText: err});
-                console.error(err,"ERROR IN CLOSE CONNECTION");
-            }
-        }).catch((error) => {
-            res.send({ status: false, statusText: error});
-            console.error(error,"ERROR IN DROP DATABASE");
-        });
+/* Destroys the tenant's whole database, so it is gated harder than any other company write:
+ * the owner of the company the verified session names, who has typed that company's name back.
+ * The role is read against the pinned tenant, not the header, so the company being judged and
+ * the company being dropped cannot be two different ones. */
+exports.deleteCompany = async (req, res) => {
+    const refuse = (code, statusText) => res.status(code).send({ status: false, statusText });
+    try {
+        const companyId = pinSessionTenant(req, res);
+        if (!companyId) return undefined;
+        if (req.apiToken) return refuse(403, "An API token cannot delete a company.");
+
+        const roleType = await getRoleType(companyId, req.uid);
+        if (roleType !== ROLE_OWNER) return refuse(403, "Only the company owner can delete this company.");
+
+        const company = await MongoDbCrudOpration(SCHEMA_TYPE.GOLBAL, {
+            type: SCHEMA_TYPE.COMPANIES,
+            data: [{ _id: new mongoose.Types.ObjectId(companyId) }, { Cst_CompanyName: 1 }],
+        }, "findOne");
+        if (!company) return refuse(404, "No such company.");
+        if (String(req.body.confirm || "") !== String(company.Cst_CompanyName || "")) {
+            return refuse(400, "Type the company name to confirm the deletion.");
+        }
+
+        await dropCompanyDatabase(companyId);
+
+        const delObj = {
+            type: SCHEMA_TYPE.COMPANIES,
+            data: [{ _id: new mongoose.Types.ObjectId(companyId) }],
+        };
+        await updateCompanyFun(SCHEMA_TYPE.GOLBAL, delObj, "deleteOne", companyId);
+
+        const findObj = {
+            type: dbCollections.USERS,
+            data: [
+                { 'AssignCompany': { $in: [companyId] } },
+                { $pull: { 'AssignCompany': companyId } },
+            ],
+        };
+        await updateUserFun(dbCollections.GLOBAL, findObj, "updateMany", companyId, '', true);
+
+        logger.info(`Company ${companyId} deleted by ${req.uid}`);
+        return res.send({ status: true, statusText: "Done" });
     } catch (error) {
-        res.send({ status: false, statusText: error});
-        console.error(error,"ERROR IN DELETE COMPANY:");
+        logger.error(`ERROR in delete company: ${error.message || error}`);
+        return refuse(500, "Could not delete the company.");
     }
 }

--- a/Modules/Company/routes.js
+++ b/Modules/Company/routes.js
@@ -116,7 +116,9 @@ exports.init = (app) => {
      */
 	app.post("/api/v2/company/create", upload.single("file"), ctrl.createCompanyV2);
 	app.get("/api/v1/freeCompanyCount/:userId", ctrl.checkFreeCompanyCountsApi);
-	app.post("/api/v2/company/delete", ctrl.deleteCompany);
+	// The audience is frozen at login, so the membership re-check is what stops a removed
+	// member reaching a handler that drops the whole database.
+	app.post("/api/v2/company/delete", requireLiveCompanyMembership, ctrl.deleteCompany);
     app.get('/company-create/events/:id', (req, res) => {
         res.setHeader('Content-Type', 'text/event-stream');
         res.setHeader('Cache-Control', 'no-cache');

--- a/Modules/Milestone/controller/clientView.js
+++ b/Modules/Milestone/controller/clientView.js
@@ -4,6 +4,7 @@ const { MongoDbCrudOpration } = require('../../../utils/mongo-handler/mongoQueri
 const { SCHEMA_TYPE } = require('../../../Config/schemaType');
 const socketEmitter = require('../../../event/socketEventEmitter');
 const { buildClientView } = require('../helpers/clientProjection');
+const { sessionTenantOf, TenantError } = require('../../../Config/tenant');
 const billing = require('./billing');
 
 // Client view (handoff 19d). The ONE place the guest payload is assembled.
@@ -14,7 +15,7 @@ const billing = require('./billing');
 // added to the schema next.
 
 const MAX_MESSAGE = 2000;
-const { companyOf, actorId, isObjectIdString, toEpoch, DONE_STATUS_TYPE } = billing;
+const { actorId, isObjectIdString, toEpoch, DONE_STATUS_TYPE } = billing;
 
 const signedOff = (milestone) => Boolean(milestone.signOffAt)
     || milestone.billingState === 'paid'
@@ -101,15 +102,16 @@ const buildClientPayload = async (companyId, projectId) => {
  * no richer variant of this endpoint to accidentally serve. */
 exports.getClientView = async (req, res) => {
     try {
-        const companyId = companyOf(req);
+        const companyId = sessionTenantOf(req);
         const projectId = String((req.query && req.query.projectId) || '');
-        if (!companyId || !isObjectIdString(projectId)) {
-            return res.send({ status: false, statusText: 'companyId and a valid projectId are required.' });
+        if (!isObjectIdString(projectId)) {
+            return res.send({ status: false, statusText: 'A valid projectId is required.' });
         }
         const data = await buildClientPayload(companyId, projectId);
         if (!data) return res.send({ status: false, statusText: 'Project not found.' });
         return res.send({ status: true, statusText: 'OK', data });
     } catch (error) {
+        if (error instanceof TenantError) return res.status(error.statusCode).json({ status: false, statusText: error.message });
         logger.error(`ERROR in get client view: ${error.message}`);
         return res.send({ status: false, statusText: error.message });
     }
@@ -119,12 +121,12 @@ exports.getClientView = async (req, res) => {
  * Posts into the project channel, which is where the mock says it goes. */
 exports.postClientMessage = async (req, res) => {
     try {
-        const companyId = companyOf(req);
+        const companyId = sessionTenantOf(req);
         const uid = actorId(req);
         const projectId = String((req.body && req.body.projectId) || '');
         const message = String((req.body && req.body.message) || '').trim();
-        if (!companyId || !isObjectIdString(projectId) || !uid) {
-            return res.send({ status: false, statusText: 'companyId, a valid projectId and an authenticated user are required.' });
+        if (!isObjectIdString(projectId) || !uid) {
+            return res.send({ status: false, statusText: 'A valid projectId and an authenticated user are required.' });
         }
         if (!message) return res.send({ status: false, statusText: 'Write a message first.' });
 
@@ -150,6 +152,7 @@ exports.postClientMessage = async (req, res) => {
         socketEmitter.emit('update', { type: 'add', data: saved, module: 'comments' });
         return res.send({ status: true, statusText: 'Message sent.', data: { _id: String(saved && saved._id) } });
     } catch (error) {
+        if (error instanceof TenantError) return res.status(error.statusCode).json({ status: false, statusText: error.message });
         logger.error(`ERROR in post client message: ${error.message}`);
         return res.send({ status: false, statusText: error.message });
     }

--- a/Modules/notification/prepare-notification-data/controllerV2.js
+++ b/Modules/notification/prepare-notification-data/controllerV2.js
@@ -10,10 +10,14 @@ const { default: axios } = require("axios");
 const config =  require('../../../Config/config.js');
 const socketEmitter = require('../../../event/socketEventEmitter.js');
 const { getUserProfilePresignedUrlCallBackFunction } = require("../../storage/wasabi/controller.js")
+const { pinSessionTenant } = require('../../../Config/tenant');
 
 
 
+// The tenant is pinned here rather than in handleNotificationtFun: every other caller of that
+// is an internal one passing a synthetic { body } and no res, so it has no response to refuse on.
 exports.handleNotification = (req, res) => {
+  if (!pinSessionTenant(req, res)) return;
   exports.handleNotificationtFun(req).then((data) => {
     res.json(data);
   }).catch((error) => {

--- a/Modules/taskIndex/controller.js
+++ b/Modules/taskIndex/controller.js
@@ -6,6 +6,7 @@ const { MongoDbCrudOpration } = require("../../utils/mongo-handler/mongoQueries"
 const { SCHEMA_TYPE } = require("../../Config/schemaType");
 const { getCompanyDataFun } = require("../Company/controller/updateCompany");
 const socketEmitter = require("../../event/socketEventEmitter");
+const { pinSessionTenant } = require("../../Config/tenant");
 
 const projectQueues = {};
 const processingProjects = new Set();
@@ -15,6 +16,8 @@ const processingProjects = new Set();
  */
 exports.updateTaskIndex = (req,res) => {
     try {
+        // Hoisted above the checks below: those answer without returning, so they cannot stop the handler.
+        if (!pinSessionTenant(req, res)) return;
         if (!req.body&& req.body.isFirst === undefined) {
             res.send({
                 status: false,
@@ -31,12 +34,6 @@ exports.updateTaskIndex = (req,res) => {
             res.send({
                 status: false,
                 statusText: `taskId is required`
-            })
-        }
-        if (!(req.body && req.body.companyId)) {
-            res.send({
-                status: false,
-                statusText: `companyId is required`
             })
         }
         if (!(req.body && req.body.projectId)) {
@@ -340,13 +337,7 @@ exports.updateTaskIndexWhenLoad = (req,res) => {
             }))
             return;
         }
-        if(!(req.body && req.body.companyId)) {
-            res.send(({
-                status: false,
-                statusText: `CompanyId Is Required`
-            }))
-            return;
-        }
+        if (!pinSessionTenant(req, res)) return;
         let obj = {
             type: dbCollections.TASKS,
             data: [

--- a/tests/billing-client-view.test.js
+++ b/tests/billing-client-view.test.js
@@ -1,0 +1,101 @@
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn() }));
+jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const { MongoDbCrudOpration } = require('../utils/mongo-handler/mongoQueries');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const billing = require('../Modules/Milestone/controller/billing');
+const clientView = require('../Modules/Milestone/controller/clientView');
+
+const COMPANY = '6a9954186dd786246031e47b';
+const OTHER_COMPANY = '6a9954186dd786246031e47d';
+const USER = '6a9954186dd786246031e47c';
+const PROJECT = '6a9954186dd786246031e47e';
+
+const res = () => {
+    const r = { code: 200, body: null };
+    r.status = (c) => { r.code = c; return r; };
+    r.json = (b) => { r.body = b; return r; };
+    r.send = r.json;
+    return r;
+};
+
+const call = (handler, req) => {
+    const r = res();
+    return Promise.resolve(handler({ headers: { companyid: COMPANY }, query: {}, body: {}, uid: USER, aud: COMPANY, ...req }, r)).then(() => r);
+};
+
+const context = {
+    project: { ProjectName: 'Client Project' },
+    contract: { clientContactIds: [], currency: 'USD' },
+    milestones: [{ id: 'm1', name: 'Kickoff', dueDate: '2026-03-01', percentBp: 10000, signOffAt: '2026-03-02' }],
+    tasks: [],
+    invoices: [],
+};
+
+beforeEach(() => {
+    MongoDbCrudOpration.mockReset();
+    jest.spyOn(billing, 'buildBillingContext').mockResolvedValue(context);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+/* The five names clientView destructures off billing. companyOf was deleted from billing with
+ * the tenancy rewrite and nothing caught it, so both routes threw on every request. */
+describe('the billing module still exports everything the client view destructures', () => {
+    it.each([['actorId'], ['isObjectIdString'], ['toEpoch'], ['DONE_STATUS_TYPE']])('exports %s', (name) => {
+        expect(billing[name]).toBeDefined();
+    });
+
+    it('no longer exports companyOf, so nothing may destructure it', () => {
+        expect(billing.companyOf).toBeUndefined();
+    });
+});
+
+describe('GET /api/v2/billing/client-view', () => {
+    it('answers with the client payload', async () => {
+        const r = await call(clientView.getClientView, { query: { projectId: PROJECT } });
+
+        expect(r.code).toBe(200);
+        expect(r.body.status).toBe(true);
+        expect(r.body.data.project).toMatchObject({ name: 'Client Project' });
+        expect(billing.buildBillingContext).toHaveBeenCalledWith(COMPANY, PROJECT);
+    });
+
+    it('refuses a body that names another company', async () => {
+        const r = await call(clientView.getClientView, { query: { projectId: PROJECT }, body: { companyId: OTHER_COMPANY } });
+
+        expect(r.code).toBe(403);
+        expect(r.body).toMatchObject({ status: false });
+        expect(billing.buildBillingContext).not.toHaveBeenCalled();
+    });
+
+    it('asks for a projectId rather than failing on one', async () => {
+        const r = await call(clientView.getClientView, {});
+
+        expect(r.body).toMatchObject({ status: false, statusText: 'A valid projectId is required.' });
+    });
+});
+
+describe('POST /api/v2/billing/client-view/message', () => {
+    it('saves the message and answers', async () => {
+        MongoDbCrudOpration.mockImplementation(async (db, obj, method) => {
+            if (obj.type === SCHEMA_TYPE.PROJECT_CONTRACTS) return { allowClientMessages: true };
+            if (method === 'save') return { _id: 'c1' };
+            return null;
+        });
+
+        const r = await call(clientView.postClientMessage, { body: { projectId: PROJECT, message: 'Looks good' } });
+
+        expect(r.code).toBe(200);
+        expect(r.body).toMatchObject({ status: true, statusText: 'Message sent.' });
+        expect(MongoDbCrudOpration).toHaveBeenCalledWith(COMPANY, expect.objectContaining({ type: SCHEMA_TYPE.COMMENTS }), 'save');
+    });
+
+    it('refuses a body that names another company, and writes nothing', async () => {
+        const r = await call(clientView.postClientMessage, { body: { companyId: OTHER_COMPANY, projectId: PROJECT, message: 'Looks good' } });
+
+        expect(r.code).toBe(403);
+        expect(MongoDbCrudOpration).not.toHaveBeenCalled();
+    });
+});

--- a/tests/conventions/tenant-scoping.baseline.json
+++ b/tests/conventions/tenant-scoping.baseline.json
@@ -3,10 +3,9 @@
   "Agents/controller.js": 1,
   "Audit/controller.js": 1,
   "Audit/recorder.js": 1,
-  "Auth/controller/loginSession.js": 2,
+  "Auth/controller/loginSession.js": 1,
   "Auth/controller/sendInvitation.js": 2,
   "CloudStorage/controller.js": 2,
-  "Company/controller.js": 8,
   "EmailIn/controller.js": 2,
   "Integrations/controller.js": 2,
   "LogTime/controllerV2/capture.js": 17,
@@ -27,6 +26,6 @@
   "storage/server/controller.js": 6,
   "storage/server/helpers/bucket.helper.js": 1,
   "storage/wasabi/controller.js": 9,
-  "taskIndex/controller.js": 10,
+  "taskIndex/controller.js": 8,
   "trackerUserPermission/controller.js": 1
 }

--- a/tests/integration/body-tenant-writers.int.test.js
+++ b/tests/integration/body-tenant-writers.int.test.js
@@ -1,0 +1,91 @@
+const crypto = require('node:crypto');
+const { MongoClient } = require('mongodb');
+const { resolveMongoUrl } = require('../../e2e/support/env');
+const { loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const COMPANY_B = crypto.randomBytes(12).toString('hex');
+const PROJECT = state.projects.shared;
+const TASK = state.tasks[0];
+
+let client;
+
+const foreignRows = async () => {
+    const db = client.db(COMPANY_B);
+    const names = (await db.listCollections().toArray()).map((c) => c.name);
+    const counts = await Promise.all(names.map((name) => db.collection(name).countDocuments({})));
+    return counts.reduce((sum, n) => sum + n, 0);
+};
+
+const foreignDatabaseExists = async () => {
+    const { databases } = await client.db('admin').admin().listDatabases({ nameOnly: true });
+    return databases.some((db) => db.name === COMPANY_B);
+};
+
+const routes = [
+    ['/api/v1/taskIndex', (session) => ({
+        companyId: COMPANY_B,
+        taskId: TASK._id,
+        projectId: PROJECT._id,
+        sprintId: TASK.sprintId,
+        isFirst: true,
+        isFirstWithRecord: false,
+        updateData: { TaskName: 'Steered' },
+        userId: session.userId,
+    })],
+    ['/api/v1/updateTaskIndexOnload', () => ({
+        companyId: COMPANY_B,
+        taskUpdate: { data: TASK._id },
+    })],
+    ['/api/v2/prepare-notification-data', (session) => ({
+        companyId: COMPANY_B,
+        key: 'TASK_ASSIGNEE',
+        projectId: PROJECT._id,
+        taskId: TASK._id,
+        userId: session.userId,
+    })],
+    ['/api/v1/removeUserNotification', (session) => ({
+        companyId: COMPANY_B,
+        userId: session.userId,
+        type: 'Add',
+    })],
+];
+
+beforeAll(async () => {
+    client = new MongoClient(resolveMongoUrl(), { serverSelectionTimeoutMS: 5000 });
+    await client.connect();
+});
+
+afterAll(async () => {
+    if (!client) return;
+    await client.db(COMPANY_B).dropDatabase();
+    await client.close();
+});
+
+describe('the routes PR #686 left open take the company from the companyid header', () => {
+    it.each(routes)('refuses a member whose body aims %s at another company, and writes nothing there', async (route, body) => {
+        const member = await loginAs('member');
+        const res = await member.api.post(route, body(member));
+
+        expect({
+            route,
+            status: res.status,
+            answered: res.body && res.body.status,
+            rows: await foreignRows(),
+            database: await foreignDatabaseExists(),
+        }).toEqual({ route, status: 403, answered: false, rows: 0, database: false });
+    });
+
+    it('still serves the header company when the body repeats it', async () => {
+        const member = await loginAs('member');
+        const res = await member.api.post('/api/v1/removeUserNotification', {
+            companyId: member.companyId,
+            userId: member.userId,
+            type: 'Add',
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body && res.body.status).not.toBe(false);
+        expect(await foreignDatabaseExists()).toBe(false);
+    });
+});

--- a/tests/integration/company-delete-authorization.int.test.js
+++ b/tests/integration/company-delete-authorization.int.test.js
@@ -1,0 +1,106 @@
+const crypto = require('node:crypto');
+const { MongoClient, ObjectId } = require('mongodb');
+const { resolveMongoUrl } = require('../../e2e/support/env');
+const { loginAs, readState } = require('../../e2e/support/fixtures');
+
+const state = readState();
+const FOREIGN_COMPANY = crypto.randomBytes(12).toString('hex');
+
+let client;
+
+/* The drop is irreversible, so "the database is still there" is the assertion that matters:
+ * a refusal that still dropped would show up here and nowhere else. */
+const databaseExists = async (name) => {
+    const { databases } = await client.db('admin').admin().listDatabases({ nameOnly: true });
+    return databases.some((db) => db.name === name);
+};
+
+const deleteBody = (overrides = {}) => ({ companyId: state.companyId, confirm: state.companyName, ...overrides });
+
+/* A company of its own to destroy, so the success case never touches the harness company
+ * the rest of the integration suite runs against. */
+const seedCompany = async (name, ownerUserId) => {
+    const companyId = crypto.randomBytes(12).toString('hex');
+    await client.db('global').collection('companies').insertOne({ _id: new ObjectId(companyId), Cst_CompanyName: name });
+    await client.db(companyId).collection('company_users').insertOne({ userId: String(ownerUserId), roleType: 1, status: 2, isDelete: false });
+    await client.db('global').collection('users').updateOne({ _id: new ObjectId(String(ownerUserId)) }, { $push: { AssignCompany: companyId } });
+    return companyId;
+};
+
+beforeAll(async () => {
+    client = new MongoClient(resolveMongoUrl(), { serverSelectionTimeoutMS: 5000 });
+    await client.connect();
+});
+
+afterAll(async () => {
+    if (!client) return;
+    await client.db(FOREIGN_COMPANY).dropDatabase();
+    await client.close();
+});
+
+describe('POST /api/v2/company/delete', () => {
+    it.each([['member'], ['admin'], ['guest']])('refuses %s, and the company database still exists', async (role) => {
+        const session = await loginAs(role);
+        const res = await session.api.post('/api/v2/company/delete', deleteBody());
+
+        expect({ role, status: res.status, answered: res.body && res.body.status }).toEqual({ role, status: 403, answered: false });
+        expect(await databaseExists(state.companyId)).toBe(true);
+    });
+
+    it('refuses the owner without the typed company name, and the company database still exists', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.post('/api/v2/company/delete', deleteBody({ confirm: 'not the name' }));
+
+        expect(res.status).toBe(400);
+        expect(res.body.status).toBe(false);
+        expect(await databaseExists(state.companyId)).toBe(true);
+    });
+
+    it('refuses a body company the caller is not in, and never creates its database', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.post('/api/v2/company/delete', deleteBody({ companyId: FOREIGN_COMPANY }));
+
+        expect(res.status).toBe(403);
+        expect(await databaseExists(FOREIGN_COMPANY)).toBe(false);
+        expect(await databaseExists(state.companyId)).toBe(true);
+    });
+
+    it('refuses a body company id that is not a company id, and the global registry survives', async () => {
+        const owner = await loginAs('owner');
+        const res = await owner.api.post('/api/v2/company/delete', deleteBody({ companyId: 'global' }));
+
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect(await databaseExists('global')).toBe(true);
+    });
+
+    /* The whole point of pinning: the role is read against the company the body names, not the
+     * header, so owning some other company cannot buy the right to drop this one. */
+    it('refuses a member who owns another company and aims the body at this one', async () => {
+        const member = state.users.member;
+        const ownedCompany = await seedCompany('Spoof Co', member.userId);
+        const session = await loginAs('member');
+
+        const res = await session.api.withCompany(ownedCompany).post('/api/v2/company/delete', deleteBody());
+
+        expect(res.status).toBe(403);
+        expect(res.body.status).toBe(false);
+        expect(await databaseExists(state.companyId)).toBe(true);
+        expect(await databaseExists(ownedCompany)).toBe(true);
+    });
+
+    it('lets the company owner delete their own company when the name is typed back', async () => {
+        const owner = state.users.owner;
+        const doomed = await seedCompany('Doomed Co', owner.userId);
+        const session = await loginAs('owner');
+
+        expect(await databaseExists(doomed)).toBe(true);
+
+        const res = await session.api.withCompany(doomed).post('/api/v2/company/delete', { companyId: doomed, confirm: 'Doomed Co' });
+
+        expect({ status: res.status, answered: res.body && res.body.status }).toEqual({ status: 200, answered: true });
+        expect(await databaseExists(doomed)).toBe(false);
+        expect(await client.db('global').collection('companies').countDocuments({ _id: new ObjectId(doomed) })).toBe(0);
+        expect(await databaseExists(state.companyId)).toBe(true);
+    });
+});


### PR DESCRIPTION
## ⚠️ Behaviour change: who may delete a company

**Before:** any authenticated user could `POST /api/v2/company/delete` and irreversibly drop a database named by the request body. No role check of any kind.

**After:** the caller must be the **company owner (roleType 1)** of the company the verified session names, must be a live member of it, must not be using an API token, and must type the company name back in a new required `confirm` body field.

`confirm` is a **new required field**. Nothing in the repo called this endpoint (zero callers in `frontend/src`, `tests/`, `e2e/`, `scripts/`, Electron), so no existing caller breaks — but any external client of this API will now get a 400 without it.

---

## 1. P0 — unauthorised, irreversible database drop

`Modules/Company/routes.js:119` registered `ctrl.deleteCompany` bare, and the handler did:

```js
mongoose.connect(process.env.MONGODB_URL + "/" + req.body.companyId);
mongoose.connection.dropDatabase()
```

with a presence check as its only validation.

### Blast radius was wider than one tenant

The route runs `verifyJWTTokenV2` + `requireCompanyAud` (`Config/setMiddleware.js:346`, `:419-425`). `requireCompanyAud` does check `req.body.companyId` against the JWT audience — **but only after filtering candidates through `OBJECT_ID_PATTERN`** (`Config/jwt.js:583`). A non-ObjectId body value is skipped by the audience check entirely and flows straight into the connection string. Since `SCHEMA_TYPE.GOLBAL === "global"`, `{"companyId":"global"}` from *any* authenticated user dropped the instance-wide registry of users, companies and subscriptions — every tenant at once, not just the caller's.

### The role gate: company owner only

Chosen **company owner only**, not owner+admin and not instance-owner-only.

- `requireCompanyAdmin` (`Config/permissionGuard.js:209`) sets the repo's owner+admin bar for *reversible* company **settings** writes. PR #620 set the same owner+admin bar for managing and deleting **agents** — a soft delete that keeps runs, proposals and audit rows.
- Destroying the tenant database is irreversible and takes every other member's data with it, including the owner's. There is no existing precedent in this repo for granting an admin an irreversible whole-tenant destruction, and admins are appointed and removable by the owner — letting one destroy the owner's company inverts that relationship. So this sits one notch below the settings bar, at the owner alone.
- **Not instance-owner-only:** `requireInstanceAdmin` / `isInstanceOwner` (`Modules/Instance/guard.js`) exists and is well adopted, but `/api/v2/company/create` is self-service with no instance gate and a free-company quota, so a company owner must be able to delete the company they created. Routing every tenant deletion through the single `isProductOwner` account contradicts the documented multi-tenant model. The instance owner keeps `/api/v2/instance/*` (backups, restore) for operator-level work.

`requireRole` and `requirePermission` were **not** usable here: both bail out via `isApiTokenRequest` (`permissionGuard.js:188`, `:229`) and so do not enforce for web sessions at all — exactly the caller this bug is about.

### The body tenant

`pinSessionTenant(req, res)` from PR #686 is the first statement of the handler. It refuses when the body names a company other than the verified `companyid` header, enforces the ObjectId shape (which is what closes the `"global"` bypass), and pins `req.body.companyId` to the verified value.

The role is then read **against that pinned tenant**, not against the header. This matters: `requireCompanyAdmin` reads `req.headers["companyid"]`, so a header-based gate combined with a body-driven drop would let someone who owns their own company A set `header=A` (passing the owner check) and `body=B` to drop company B, as long as both are in their audience. There is a regression test for exactly that.

The route also gained `requireLiveCompanyMembership`, matching `Modules/Company/routes.js:133-134` — the audience is frozen at login, so without it a removed member keeps reaching the handler with the token they hold.

An API token is refused outright. `verifyJWTTokenV2` has a PAT branch, so a leaked PAT could otherwise reach this; `requireInstanceAdmin` takes the same stance for instance administration.

### Confirmation: the existing repo pattern, not a new one

`Modules/Instance/backups.js:201` already does typed-name confirmation for the one other destroy-and-refill operation:

```js
if (confirm !== name) throw new Error('Type the backup name to confirm the restore.');
```

Adopted verbatim in shape: `confirm` in the body, `String(req.body.confirm || "")`, strict `!==` against the company's stored `Cst_CompanyName`, refused with 400. A bare id is no longer enough, and because the name is fetched from the *pinned* company, a typo'd or steered id cannot match.

### Verdict on the per-request `mongoose.connect` — real, but narrower than feared

**It cannot disrupt other in-flight requests.** Every tenant query in the app goes through `mongoose.createConnection` in `utils/mongo-handler/mongoConnector.js`; `deleteCompany` was the only caller of `mongoose.connect` anywhere in the repo, so the process-wide default connection it opened and closed is used by nothing else. Closing it breaks no other query.

It is still a genuine bug **within the endpoint**:
- `mongoose.connect(...)` is never awaited, so the `dropDatabase()` on the next line races it and relies on driver buffering.
- `connection.once('open', ...)` leaks one listener per request.
- Mongoose refuses `connect()` on an active default connection with a different connection string, so the *second* company deletion in a process lifetime would throw.

Fixed with a dedicated short-lived connection, awaited and closed in a `finally`, built with the same `?authSource=admin` / `mongodb+srv` handling `mongoConnector.connect` uses so it keeps working against an authenticated or Atlas deployment.

### Deferred drop: judged too large for this PR

There is no soft-delete or reaper infrastructure for companies — no `pendingDeletion` flag, no scheduler, no grace period, no restore path. Building one is a feature (retention policy, reaper job, restore UI, storage-bucket lifecycle), not a security fix. The drop stays inline, now behind the new guards. Flagging it rather than half-changing it.

---

## 2. Broken billing client-view

`companyOf` was deleted from `Modules/Milestone/controller/billing.js` — definition *and* export — by commit `e548c1a8`, which rewrote the five sibling handlers to `sessionTenantOf(req)` but missed `clientView.js`, the only other file destructuring it. Result: a `TypeError` swallowed by the handler's own catch into an HTTP **200** carrying `{"status":false,"statusText":"companyOf is not a function"}`, on every request to both endpoints.

**The other four names were checked and are all genuinely exported** (`billing.js:647-650`): `actorId`, `isObjectIdString`, `toEpoch`, `DONE_STATUS_TYPE`. `companyOf` was the only broken one; there is now a test asserting each of the five.

`companyOf` should have become **`sessionTenantOf(req)`** — not `tenantOf`, which keeps the header-or-query-or-body fallback that commit existed to remove. Both handlers now also carry the `instanceof TenantError` branch its five siblings got, so a tenancy refusal answers 403 instead of being flattened into a 200.

Nothing covered these endpoints: `tests/project-content-isolation.test.js` registers both routes but `jest.mock`s the whole controller, which is why this shipped green.

---

## 3. The three body-tenant writers

All three verified **genuinely exploitable** — none is saved by a route-layer guard. All four routes sit in the `verifyJWTTokenWithCRoute` list, and `requireCompanyAud` is attached **only** to the `verifyJWTToken` list (`Config/setMiddleware.js:424`). The single guard that runs is `verifyJWTTokenWithCV2`, which reads the header and never looks at `req.body.companyId`.

| Route | Sink | Verdict |
|---|---|---|
| `POST /api/v1/taskIndex` | `MongoDbCrudOpration(taskData.companyId, …, "findOneAndUpdate")` with attacker-spread `updateData` | exploitable — arbitrary `$set` in another tenant |
| `POST /api/v1/updateTaskIndexOnload` | cross-tenant read echoed back, plus writes at `:484`/`:535` | exploitable |
| `POST /api/v2/prepare-notification-data` | `MongoDbCrudOpration(objects.companyId, obj, "save")` | exploitable |
| `POST /api/v1/removeUserNotification` | `authHelpers.js:44` `findOneAndDelete` | exploitable |

Two placement notes:

- In `prepare-notification-data`, the guard went in the HTTP wrapper `exports.handleNotification`, **not** in `handleNotificationtFun` — that function has six internal callers (`Comments`, `Tasks/helpers/handleNotification`, `Agents/runs`, `Agents/budget`) that pass a synthetic `{ body }` with no `res`. Its `companyId` presence check therefore stays, and its baseline entry stays at 1.
- In `updateTaskIndex`, the guard is hoisted to the first statement because the surrounding validation blocks call `res.send(...)` without `return` and so never actually stop the handler.

**Baseline `tests/conventions/tenant-scoping.baseline.json`: 186 → 175.** `Company/controller.js` 8 → entry removed (now zero), `taskIndex/controller.js` 10 → 8, `Auth/controller/loginSession.js` 2 → 1.

---

## Testing

Exercised against a throwaway Mongo container on a unique name and port (`agentdrop-mongo-27077`). **The owner's `alianhub-mongo` (27017), port 27018 and the server on 4000 were never touched** — `e2e/support/env.js` also hard-refuses 27017 outside CI.

`tests/integration/company-delete-authorization.int.test.js` — 8 tests, database existence asserted via `listDatabases` exactly as PR #686's tenancy tests do:
- `refuses member|admin|guest, and the company database still exists` (×3)
- `refuses the owner without the typed company name, and the company database still exists`
- `refuses a body company the caller is not in, and never creates its database`
- `refuses a body company id that is not a company id, and the global registry survives`
- `refuses a member who owns another company and aims the body at this one` — the header/body steering case, both databases asserted still present
- `lets the company owner delete their own company when the name is typed back` — seeds a company of its own so the success case never touches the shared harness company

`tests/integration/body-tenant-writers.int.test.js` — 5 tests, one per route plus a positive control that the header company still works.

`tests/billing-client-view.test.js` — 10 tests covering both endpoints and all five destructured exports.

**Negative controls run:** against pre-fix code, 7 of the 8 company-delete tests fail and the member's request really does drop the company database (which is why the later existence assertions return `false`); 5 of the 10 billing tests fail with `companyOf is not a function`.

Full suites green: **4313 unit + conventions**, **961 integration (61 suites)**. `scripts/i18n-check.js` exits 0 with no missing keys; eslint reports 0 errors on every touched file.

### i18n

No keys added and no backfill needed. This PR adds no frontend copy — the endpoint has no UI — and the new `statusText` values follow the established backend convention of English-only refusal strings surfaced raw: PR #620's `REFUSAL.MANAGE`, `Modules/Instance/guard.js`'s `'Only the instance owner can do this.'` and `backups.js`'s `'Type the backup name to confirm the restore.'` all carry no i18n key. If a danger-zone UI is built later, `InstanceBackups.vue` + the `Instance.restore_type` key are the pattern to copy.

### Follow-up not done here

After a successful deletion the `membership:*` and `roleType:*` cache entries for the deleted company are left to expire on their own (60s / TTL). Harmless — the database is gone — but worth invalidating when someone next touches this area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
