### PR TITLE
fix: read a project's sprints from the sprints collection, not the project doc

### DIFF
--- a/Modules/AIProjectGenerator/controller.js
+++ b/Modules/AIProjectGenerator/controller.js
@@ -860,7 +860,7 @@ async function generateTasksPlanForJob({ jobId, uid, companyId, projectId, addit
             description: projectDoc.description || '',
             taskStatusNames: (projectDoc.taskStatusData || []).map((s) => s.name).filter(Boolean),
             taskTypes: (projectDoc.taskTypeCounts || []).map((t) => ({ key: t.key, name: t.name })),
-            sprintNames: Object.values(projectDoc.sprintsObj || {}).map((s) => s && s.name).filter(Boolean),
+            sprintNames: await orchestrator.loadSprintNamesForProject(companyId, projectId),
         };
         const members = await loadActiveMembers(companyId);
         const memory = await memoryStore.contextFor({ companyId, userId: String(uid), projectId });

--- a/Modules/AIProjectGenerator/orchestrator.js
+++ b/Modules/AIProjectGenerator/orchestrator.js
@@ -1192,6 +1192,19 @@ async function loadProjectForTasks(companyId, projectId) {
     return (Array.isArray(rows) && rows[0]) || null;
 }
 
+// The project's sprint names, for the planning prompt. Read from the SPRINTS
+// collection for the same reason as loadSprintForTasks below: the project doc's
+// sprintsObj is a legacy copy that no sprint write maintains.
+async function loadSprintNamesForProject(companyId, projectId) {
+    let oid;
+    try { oid = new mongoose.Types.ObjectId(String(projectId)); } catch (_e) { return []; }
+    const rows = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.SPRINTS,
+        data: [{ projectId: oid, deletedStatusKey: { $ne: 1 } }],
+    }, 'find').catch(() => []);
+    return (Array.isArray(rows) ? rows : []).map((s) => s && s.name).filter(Boolean);
+}
+
 // Load a single sprint by id (company-scoped, non-deleted) from the SPRINTS
 // collection — the source of truth — rather than the project doc's
 // denormalized `sprintsObj`, which a freshly-loaded project doc may not carry.
@@ -1547,6 +1560,7 @@ module.exports = {
     executePlan,
     executeTasksIntoProject,
     loadProjectForTasks,
+    loadSprintNamesForProject,
     normalizePlanColors,
     // Exported for tests / debugging.
     buildProjectDoc,

--- a/Modules/EmailIn/controller.js
+++ b/Modules/EmailIn/controller.js
@@ -40,34 +40,32 @@ const buildTemplate = (b, companyId) => {
 };
 
 // Pick the project's first usable sprint (top-level first, then inside folders) so
-// the inbound task has a real target. Projects embed sprintsObj / sprintsfolders.
-const resolveDefaultSprint = (project) => {
-    if (!project) return null;
-    const pick = (obj, folder) => {
-        for (const k of Object.keys(obj || {})) {
-            const s = obj[k];
-            if (s && s.deletedStatusKey !== 1) {
-                const sid = String(s.id || s._id || k);
-                const out = { sprintId: sid, sprintArray: { id: sid, name: s.name || 'Sprint' } };
-                if (folder) {
-                    out.sprintArray.folderId = folder.folderId;
-                    out.sprintArray.folderName = folder.folderName || '';
-                    out.folderObjId = folder.folderId;
-                }
-                return out;
-            }
-        }
-        return null;
-    };
-    const top = pick(project.sprintsObj);
-    if (top) return top;
-    const folders = project.sprintsfolders || {};
-    for (const fk of Object.keys(folders)) {
-        const f = folders[fk];
-        const inFolder = pick(f && f.sprintsObj, { folderId: (f && (f.folderId || fk)), folderName: f && f.folderName });
-        if (inFolder) return inFolder;
+// the inbound task has a real target. Read from the sprints collection: a project
+// document's sprintsObj is a legacy copy that no sprint write maintains, so a
+// project whose sprints were created through the API embeds none of them.
+const resolveDefaultSprint = async (companyId, projectId) => {
+    const pid = oid(projectId);
+    if (!pid) return null;
+    const rows = await MongoDbCrudOpration(companyId, {
+        type: SCHEMA_TYPE.SPRINTS,
+        data: [{ projectId: pid, deletedStatusKey: { $ne: 1 } }],
+    }, 'find').catch(() => []);
+    const sprints = Array.isArray(rows) ? rows : [];
+    const sprint = sprints.find((s) => s && !s.folderId) || sprints[0];
+    if (!sprint) return null;
+
+    const sid = String(sprint._id);
+    const out = { sprintId: sid, sprintArray: { id: sid, name: sprint.name || 'Sprint' } };
+    if (sprint.folderId) {
+        const folder = await MongoDbCrudOpration(companyId, {
+            type: SCHEMA_TYPE.FOLDERS,
+            data: [{ _id: sprint.folderId }],
+        }, 'findOne').catch(() => null);
+        out.folderObjId = String(sprint.folderId);
+        out.sprintArray.folderId = out.folderObjId;
+        out.sprintArray.folderName = (folder && folder.name) || '';
     }
-    return null;
+    return out;
 };
 
 // POST /api/v1/email-in/inboxes  { projectId | projectData:{_id}, userData, name? }
@@ -90,7 +88,7 @@ exports.createInbox = async (req, res) => {
         let sprintArray = (b.sprintArray && (b.sprintArray.id || b.sprintArray._id)) ? b.sprintArray : null;
         let folderObjId = '';
         if (!sprintId || !sprintArray) {
-            const def = resolveDefaultSprint(projObj);
+            const def = await resolveDefaultSprint(companyId, projectId);
             if (!def) return res.send({ status: false, statusText: 'This project has no sprint to receive tasks — create a sprint first.' });
             sprintId = def.sprintId; sprintArray = def.sprintArray; folderObjId = def.folderObjId || '';
         }

--- a/Modules/Forms/controller.js
+++ b/Modules/Forms/controller.js
@@ -89,9 +89,9 @@ async function buildSnapshots(companyId, form, req) {
     }, 'findOne');
     if (!project) return { ok: false, reason: 'Project not found.' };
 
-    // Read the sprint from the sprints collection, not from anything embedded on
-    // the project: a project document does not reliably carry sprintsObj (the ones
-    // checked were empty), so scanning it rejected sprints that plainly exist.
+    // Read the sprint from the sprints collection, the one source of truth: a
+    // project document's sprintsObj is a legacy copy that no sprint write
+    // maintains, so scanning it rejected sprints that plainly exist.
     //
     // Naming the project in the FILTER is what keeps this a check rather than a
     // lookup — a sprint id from another project simply does not match, so a form

--- a/frontend/src/views/Projects/composables/useProjectTree.js
+++ b/frontend/src/views/Projects/composables/useProjectTree.js
@@ -16,7 +16,11 @@ const defaultTab = (project, current) => {
 
 /* The sprint/folder tree of the open project. Sprints and folders are fetched once
    per project into the store (projectData/sprints|folders) and folded into the
-   project document so every view reads project.sprintsObj / sprintsfolders. */
+   project document so every view reads project.sprintsObj / sprintsfolders.
+   The fetch is unconditional because the project document's own sprintsObj is a
+   legacy copy that no sprint write maintains: POST /api/v1/sprint only writes the
+   sprints collection, so a project whose sprints were created through the API
+   carries an empty (or absent) sprintsObj and would render an empty board. */
 export function useProjectTree(projectData) {
     const { getters, commit, dispatch } = useStore();
     const route = useRoute();
@@ -73,9 +77,6 @@ export function useProjectTree(projectData) {
         }
     }
 
-    // Folder routes read the folder tree straight from the project, and nothing else loads it for a global-permission project.
-    const needsSprintTree = (project) => project.isGlobalPermission === false || Boolean(route.params?.folderId);
-
     function selectProject(data, updateRoute = false) {
         const project = byId(projects.value, data?._id) || data;
         if (!project?._id) return;
@@ -84,7 +85,7 @@ export function useProjectTree(projectData) {
         }
         commit('projectData/mutateCurrentProjectDetails', project);
         projectData.value = project;
-        if (needsSprintTree(project)) loadSprintFolderData(project._id);
+        loadSprintFolderData(project._id);
     }
 
     // A project created seconds ago is in the store before it reaches the list.

--- a/frontend/tests/useProjectTree.spec.js
+++ b/frontend/tests/useProjectTree.spec.js
@@ -97,12 +97,44 @@ describe('useProjectTree', () => {
         expect(setFolders).toHaveBeenCalledWith({ projectId: 'p1' });
     });
 
-    it('leaves the tree to the views for a global-permission project opened without a folder', async () => {
+    it('loads the tree for a global-permission project opened without a folder', async () => {
         projects.value = [alpha, beta];
         routeParams.id = 'p1';
         mountTree();
         await flushPromises();
-        expect(setSprints).not.toHaveBeenCalled();
-        expect(setFolders).not.toHaveBeenCalled();
+        expect(setSprints).toHaveBeenCalledWith({ projectId: 'p1' });
+        expect(setFolders).toHaveBeenCalledWith({ projectId: 'p1' });
+    });
+
+    /* The board hangs its tasks off project.sprintsObj, and a sprint created through
+       POST /api/v1/sprint is written only to the sprints collection — so a project
+       document that embeds no sprintsObj must still end up with one to render. */
+    it('makes a sprint that exists only in the sprints collection visible on the project', async () => {
+        const project = { _id: 'p3', ProjectName: 'Gamma', isGlobalPermission: true, ProjectRequiredComponent: [{ keyName: 'ProjectListView' }] };
+        const sprint = { _id: 's9', name: 'Sprint from the API', projectId: 'p3', deletedStatusKey: 0 };
+        setSprints.mockResolvedValueOnce([sprint]);
+        setFolders.mockResolvedValueOnce([]);
+
+        projects.value = [project];
+        routeParams.id = 'p3';
+        mountTree();
+        await flushPromises();
+
+        expect(project.sprintsObj).toEqual({ s9: { ...sprint, id: 's9' } });
+    });
+
+    it('files a sprint that lives in a folder under that folder rather than the project root', async () => {
+        const project = { _id: 'p4', ProjectName: 'Delta', isGlobalPermission: true, ProjectRequiredComponent: [{ keyName: 'ProjectListView' }] };
+        const sprint = { _id: 's10', name: 'Foldered', projectId: 'p4', folderId: 'f9', deletedStatusKey: 0 };
+        setSprints.mockResolvedValueOnce([sprint]);
+        setFolders.mockResolvedValueOnce([{ _id: 'f9', name: 'Folder', projectId: 'p4', deletedStatusKey: 0 }]);
+
+        projects.value = [project];
+        routeParams.id = 'p4';
+        mountTree();
+        await flushPromises();
+
+        expect(project.sprintsObj).toEqual({});
+        expect(project.sprintsfolders.f9.sprintsObj.s10).toMatchObject({ _id: 's10', id: 's10', folderName: 'Folder' });
     });
 });

--- a/tests/ai-project-memory.test.js
+++ b/tests/ai-project-memory.test.js
@@ -5,7 +5,7 @@ jest.mock('../Modules/AICore/llmProvider', () => ({
 }));
 jest.mock('../utils/mongo-handler/mongoQueries', () => ({ MongoDbCrudOpration: jest.fn(async () => []) }));
 jest.mock('../Modules/settings/ProjectSkills/helper', () => ({ resolveProjectSkills: jest.fn(async () => []), getActiveSkillSlugs: jest.fn(async () => []) }));
-jest.mock('../Modules/AIProjectGenerator/orchestrator', () => ({ normalizePlanColors: (p) => p, executePlan: jest.fn(async () => ({ ok: true })), loadProjectForTasks: jest.fn(async () => null) }));
+jest.mock('../Modules/AIProjectGenerator/orchestrator', () => ({ normalizePlanColors: (p) => p, executePlan: jest.fn(async () => ({ ok: true })), loadProjectForTasks: jest.fn(async () => null), loadSprintNamesForProject: jest.fn(async () => []) }));
 jest.mock('../Modules/AIProjectGenerator/sseEmitter', () => ({ emit: jest.fn(), handleEvents: jest.fn(), COMPLETE_EVENT: 'complete' }));
 jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
 jest.mock('../event/socketEventEmitter', () => ({ emit: jest.fn() }));
@@ -254,7 +254,7 @@ describe('/plan', () => {
 
 describe('/tasks-plan for an existing project', () => {
     it('carries the project\'s own rows in the DATA fence after the clarifications, with the partial in the system prompt', async () => {
-        orchestrator.loadProjectForTasks.mockResolvedValue({ _id: P, ProjectName: 'Bike shop', description: 'Bikes for commuters', taskStatusData: [{ name: 'To Do' }], taskTypeCounts: [{ key: 'task', name: 'Task' }], sprintsObj: {} });
+        orchestrator.loadProjectForTasks.mockResolvedValue({ _id: P, ProjectName: 'Bike shop', description: 'Bikes for commuters', taskStatusData: [{ name: 'To Do' }], taskTypeCounts: [{ key: 'task', name: 'Task' }] });
         primeProvider({ coverage: cov(POINTS) });
         const spy = jest.spyOn(memory, 'contextFor');
         const r = res();

--- a/tests/email-in-default-sprint.test.js
+++ b/tests/email-in-default-sprint.test.js
@@ -1,0 +1,96 @@
+const mockDbs = {};
+const mockDbFor = (companyId) => {
+    mockDbs[companyId] = mockDbs[companyId] || require('./fixtures/fakeMongo').create();
+    return mockDbs[companyId];
+};
+
+jest.mock('../utils/mongo-handler/mongoQueries', () => ({
+    MongoDbCrudOpration: (companyId, q, method) => mockDbFor(String(companyId)).crud(companyId, q, method),
+    validateObjectId: () => true,
+}));
+jest.mock('../utils/commonFunctions', () => ({ removeCache: jest.fn() }));
+jest.mock('../Config/loggerConfig', () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+jest.mock('../Modules/Tasks/helpers/task_class_Mongo', () => ({ taskMongo: { create: jest.fn() } }));
+
+const mongoose = require('mongoose');
+const { SCHEMA_TYPE } = require('../Config/schemaType');
+const controller = require('../Modules/EmailIn/controller');
+
+const COMPANY = '6f0000000000000000000c01';
+const PROJECT = '6f0000000000000000000701';
+const oid = (hex) => new mongoose.Types.ObjectId(hex);
+
+const seedProject = () => mockDbFor(COMPANY).crud(COMPANY, {
+    type: SCHEMA_TYPE.PROJECTS,
+    data: { _id: oid(PROJECT), ProjectName: 'Shop', ProjectCode: 'SHP', deletedStatusKey: 0 },
+}, 'save');
+
+const seedSprint = (hex, extra = {}) => mockDbFor(COMPANY).crud(COMPANY, {
+    type: SCHEMA_TYPE.SPRINTS,
+    data: { _id: oid(hex), name: `Sprint ${hex.slice(-2)}`, projectId: oid(PROJECT), deletedStatusKey: 0, ...extra },
+}, 'save');
+
+const createInbox = async (body) => {
+    const sent = {};
+    await controller.createInbox(
+        { headers: { companyid: COMPANY }, body },
+        { send: (payload) => { sent.payload = payload; } },
+    );
+    return sent.payload;
+};
+
+const body = { projectId: PROJECT, userData: { id: 'u1', Employee_Name: 'Owner' } };
+
+/* The project document's sprintsObj is a legacy copy no sprint write maintains, so an
+ * inbox resolving its target sprint from it refused every project whose sprints were
+ * created through the API. */
+describe('POST /api/v1/email-in/inboxes default sprint', () => {
+    beforeEach(() => { Object.keys(mockDbs).forEach((k) => delete mockDbs[k]); });
+
+    it('takes the sprint from the sprints collection when the project embeds none', async () => {
+        await seedProject();
+        await seedSprint('6f0000000000000000000801');
+
+        const res = await createInbox(body);
+
+        expect(res.status).toBe(true);
+        expect(res.data.sprintId).toBe('6f0000000000000000000801');
+        expect(res.data.sprintArray).toMatchObject({ id: '6f0000000000000000000801', name: 'Sprint 01' });
+    });
+
+    it('prefers a top-level sprint over one inside a folder', async () => {
+        await seedProject();
+        await seedSprint('6f0000000000000000000802', { folderId: oid('6f0000000000000000000901') });
+        await seedSprint('6f0000000000000000000803');
+
+        expect((await createInbox(body)).data.sprintId).toBe('6f0000000000000000000803');
+    });
+
+    it('carries the folder when the only sprint lives in one', async () => {
+        await seedProject();
+        await seedSprint('6f0000000000000000000804', { folderId: oid('6f0000000000000000000901') });
+        await mockDbFor(COMPANY).crud(COMPANY, {
+            type: SCHEMA_TYPE.FOLDERS,
+            data: { _id: oid('6f0000000000000000000901'), name: 'Inbound', projectId: oid(PROJECT), deletedStatusKey: 0 },
+        }, 'save');
+
+        const res = await createInbox(body);
+
+        expect(res.data.sprintId).toBe('6f0000000000000000000804');
+        expect(res.data.sprintArray).toMatchObject({ folderId: '6f0000000000000000000901', folderName: 'Inbound' });
+    });
+
+    it('skips a deleted sprint', async () => {
+        await seedProject();
+        await seedSprint('6f0000000000000000000805', { deletedStatusKey: 1 });
+        await seedSprint('6f0000000000000000000806');
+
+        expect((await createInbox(body)).data.sprintId).toBe('6f0000000000000000000806');
+    });
+
+    it('still refuses a project that genuinely has no sprint', async () => {
+        await seedProject();
+
+        expect(await createInbox(body)).toMatchObject({ status: false });
+    });
+});

--- a/tests/integration/sprint-board-visibility.int.test.js
+++ b/tests/integration/sprint-board-visibility.int.test.js
@@ -1,0 +1,56 @@
+const { assertOk, createProject, listSprints, loginAs, uniqueSuffix } = require('../../e2e/support/fixtures');
+
+/* The board hangs its tasks off the sprints it can see, so a sprint that exists only
+ * in the sprints collection renders nothing unless the read path returns it. These
+ * assert the whole round trip — create through the API, read back the way the board
+ * reads — rather than that the row landed in the collection. */
+
+/* addSprintFun reads companyId off the body, not the companyid header, and the
+ * per-project quota check silently refuses with "Upgrade your plan" when it is absent. */
+const addSprint = (api, { companyId, projectId, projectName, sprintName, user }) => api.post('/api/v1/sprint', {
+    companyId,
+    projectId,
+    projectName,
+    sprintName,
+    userData: { id: user.uid, Employee_Name: user.Employee_Name || 'Owner', companyOwnerId: user.companyOwnerId || user.uid },
+    folder: {},
+});
+
+const sprintNames = (sprints) => sprints.map((sprint) => sprint.name).sort();
+
+describe('a sprint is visible to the board wherever it was created', () => {
+    it('shows a sprint created through POST /api/v1/sprint', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const name = `Board visible ${uniqueSuffix()}`;
+
+        const created = await addSprint(owner.api, { companyId: owner.companyId, projectId: project._id, projectName: project.ProjectName, sprintName: name, user: owner });
+        assertOk(created, 'create sprint');
+        expect(created.body.status).toBe(true);
+
+        const sprints = await listSprints(owner.api, project._id);
+        expect(sprintNames(sprints)).toEqual(['List', name].sort());
+    });
+
+    it('shows the default sprint POST /api/v1/createproject makes', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+
+        expect(sprintNames(await listSprints(owner.api, project._id))).toEqual(['List']);
+    });
+
+    /* Pins the reason the board must not read the project document: no sprint write
+     * maintains its sprintsObj, so a reader that trusts it sees an empty board. */
+    it('does not put either sprint on the project document', async () => {
+        const owner = await loginAs('owner');
+        const project = await createProject(owner.api, { assigneeIds: [owner.uid], createdBy: owner.uid });
+        const name = `Not embedded ${uniqueSuffix()}`;
+        assertOk(await addSprint(owner.api, { companyId: owner.companyId, projectId: project._id, projectName: project.ProjectName, sprintName: name, user: owner }), 'create sprint');
+
+        const res = await owner.api.get(`/api/v1/project/${project._id}`);
+        assertOk(res, 'read project');
+
+        expect(Object.values(res.body.sprintsObj || {}).map((sprint) => sprint && sprint.name)).not.toContain(name);
+        expect(sprintNames(await listSprints(owner.api, project._id))).toContain(name);
+    });
+});


### PR DESCRIPTION
Second root cause of the blank project board. PR #689 stopped the crash in this view; this one gives the board a sprint to hang tasks under.

## Confirmed, and narrower than first diagnosed

`addSprintFun` (`Modules/Sprints/controller.js:100`) writes the sprints collection and never touches the projects collection, so a project's denormalised `sprintsObj` is never maintained. That much was right.

The board, though, already has a correct loader. `loadSprintFolderData` in `useProjectTree.js` builds `sprintsObj`/`sprintsfolders` from `GET /api/v1/project/sprintFolder/:id` — the endpoint that was returning all six of SHOP's sprints correctly all along. It was simply not being called:

```js
const needsSprintTree = (project) => project.isGlobalPermission === false || Boolean(route.params?.folderId);
if (needsSprintTree(project)) loadSprintFolderData(project._id);
```

SHOP has `isGlobalPermission: true`, so the tree was never fetched and the board fell back to the embedded copy, which is absent. No sprintId, no task query, empty board — matching the captured XHR traffic exactly.

Local Smoke has `isGlobalPermission: undefined`, which does not equal `false` either, so **its tree was never fetched either**. It renders only because it happens to carry a stored `sprintsObj`. It was luck, not a working code path.

The embedded copy is dead data, not merely unreliable:

- **1 of 21 projects** in the dev company has a non-empty `sprintsObj`. Twenty are broken; SHOP is not special.
- Where it exists it is already stale — Local Smoke's copy says `tasks: 4`, its sprint document says `tasks: 7`, and it lists 1 of that project's 2 sprints.
- No backend writer ever populates it. Every one only initialises `sprintsObj: {}` (`Setup/demoProject.js:133`, `PersonalList/controller.js:70`, `AIProjectGenerator/orchestrator.js:580`).
- `projectSetting/controller.js:352` `migrateProject` reads the embedded copy and writes it **into** the sprints collection. The architecture's own direction is embedded → collections; the embedded copy is the legacy side.
- The last frontend test asserted the bug as intended behaviour: *"leaves the tree to the views for a global-permission project opened without a folder"*.

## Option (b), and it turned out to be the small change

I took **(b), delete the second source of truth** — and it needed neither the frontend rewrite nor the migration, because the reader that mattered already existed and only had to stop being gated. `sprintsObj` becomes a per-read projection of the sprints collection rather than a stored duplicate.

(a) was the wrong trade: four write paths would have had to remember to maintain a copy that 20 of 21 projects do not have and that is stale where it does, and it would have needed a migration to repair them.

**No migration.** The tree is computed when a project is opened, so SHOP and the other nineteen repair themselves on the next open. Nothing to run against the owner's database.

## Every `sprintsObj` reader, and what happened to each

~200 references across ~50 files. All but three are unchanged **and correct**, because they read `project.sprintsObj` and that object is now always built from the sprints collection before they see it.

| Reader | Disposition |
|---|---|
| `views/Projects/composables/useProjectTree.js` | **Fixed.** Gate removed; builds the tree from the sprints collection on every project open. |
| `store/ProjectData/mutations.js` (17), `views/Projects/helper.js` (18), `ConvertToSubTaskSidebar` (15+6), `Projects.vue` (11), `SubItem` (11), `Comments.vue` (9), `SideBarSprintFolderData` (7), `TaskDetailPanel` (6), `BulkActionBar` (6), + ~30 more frontend files | Unchanged, now correct — all consume the freshly built object. `mutations.js:974-1004` and `helper.js:200-260` already built it from a sprint list for the search and archived-project paths. |
| `components/organisms/Item/Item.vue` | Unchanged. Already merged the live `sprintData` prop over the embedded copy. |
| `Modules/EmailIn/controller.js:43-67` | **Migrated.** `resolveDefaultSprint` now queries the sprints collection. It was refusing inbox creation with "This project has no sprint to receive tasks" for 20 of 21 projects. |
| `Modules/AIProjectGenerator/controller.js:863` | **Migrated** to a new `orchestrator.loadSprintNamesForProject`. `sprintNames` in the planning prompt was always empty, so the AI never knew which sprints existed. |
| `Modules/Forms/controller.js:90` | Already on the sprints collection. Comment reworded to cite the general rule rather than a local observation. |
| `Modules/AIProjectGenerator/orchestrator.js:1195` | Already on the sprints collection. |
| `Modules/projectSetting/controller.js:352,356` | **Deliberately unchanged.** This is `migrateProject`, the legacy embedded → collections drain. It *must* keep reading the embedded copy. |
| `Modules/Tasks/helpers/handleNotification.js:68,78` | **Left, and it is a different bug** — see below. |
| `utils/mongo-handler/schema.js:2525,2768` | Field left declared. `migrateProject` still needs to read it off old documents. |

No reader is left split across the two sources.

## The create path was broken too

`POST /api/v1/createproject` creates its default `List` sprint through the same `addSprintFun`, so it also landed only in the sprints collection — which is why SHOP had no `sprintsObj` at all rather than a partial one. Fixed by the same read path, and asserted.

## Tests

`frontend/tests/useProjectTree.spec.js`
- `loads the tree for a global-permission project opened without a folder` — the inverted test that used to assert the bug.
- **`makes a sprint that exists only in the sprints collection visible on the project`** — the end-to-end frontend assertion: a sprint present only in the collection lands in `project.sprintsObj`.
- `files a sprint that lives in a folder under that folder rather than the project root`.

Verified non-vacuous: with the gate restored, exactly these three fail (`expected undefined to deeply equal { s9: … }`).

`tests/integration/sprint-board-visibility.int.test.js` (new, real Mongo + real server)
- **`shows a sprint created through POST /api/v1/sprint`** — the whole bug, end to end: create through the real endpoint, read back the way the board reads. This is the assertion that was missing.
- `shows the default sprint POST /api/v1/createproject makes` — the create path.
- `does not put either sprint on the project document` — pins *why* the board must not read the project doc, so a future change that re-introduces the dependency fails here.

`tests/email-in-default-sprint.test.js` (new, 5 cases) — inbox sprint resolution from the collection: top-level preferred over foldered, folder name carried, deleted sprint skipped, genuinely sprintless project still refused.

Full suites green: backend 4332/4332 (unit + conventions), frontend 319/319, and the 7 sprint/project integration suites 62/62. `npm run i18n:check` exits 0 — no user-visible strings added.

## Adjacent, deliberately not in this PR

- **No sprint mutation emits a socket event.** Confirmed: `Modules/Sprints/controller.js` never imports `event/socketEventEmitter`, while ~20 other modules do. Not trivially adjacent to a read-path fix — it needs an event name under the `<module>:<event>` convention, a socket handler, and a frontend listener to commit `mutateSprints`. Listing it, not fixing it. Sprint changes still reach other clients on the next project open.
- **`handleNotification.js:68,78` reads `sprintsObj` off a task document**, which has never had that field (verified against the live database). `Object.values(undefined || {})` yields `[]`, so sprint-level watcher notifications silently never fire. A separate bug that needs an async sprint lookup inside a synchronous `filter`.
- **`addSprintFun` takes `companyId` from `req.body`**, not the `companyid` header. When it is absent the quota check rejects internally and the endpoint answers `{status: false, statusText: "Upgrade your plan"}` — a misleading error, and worth a look next to the tenant-scoping baseline.

## Not verified

The fix is not confirmed in a live browser. Doing so would mean rebuilding the frontend in the owner's running checkout, which I was asked to leave untouched. The evidence is the test proven to fail without the change plus the end-to-end integration test.
