### PR TITLE
fix(list): count closed subtasks on collapsed parent rows

### DIFF
--- a/frontend/src/locales/ar.js
+++ b/frontend/src/locales/ar.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/ar.pending.json
+++ b/frontend/src/locales/ar.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ar",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.426Z",
+  "updatedAt": "2026-09-12T13:04:37.351Z",
   "keys": {
     "Scrum.stranded_head": "These {count} will stay in this sprint",
     "Scrum.stranded_hint": "They are unfinished, but their parent task is done — and a subtask moves with its parent. Finish them, or reopen the parent task, before completing the sprint.",
@@ -7865,6 +7865,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/ch.js
+++ b/frontend/src/locales/ch.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/ch.pending.json
+++ b/frontend/src/locales/ch.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ch",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.454Z",
+  "updatedAt": "2026-09-12T13:04:37.382Z",
   "keys": {
     "errorPage.card_name": "card name",
     "Auth.welcome_back": "Welcome back",
@@ -5723,6 +5723,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/en.js
+++ b/frontend/src/locales/en.js
@@ -1907,6 +1907,7 @@ export default {
         tracking_now: "Tracking now",
         agent_working: "working on this",
         wip: "WIP {used}/{limit}",
+        sprint_total_hint: "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         add_task_to: "Add task to {group}…",
         group_empty: "Nothing in this group yet.",
         select_group: "Select every task in this group",

--- a/frontend/src/locales/fr.js
+++ b/frontend/src/locales/fr.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/fr.pending.json
+++ b/frontend/src/locales/fr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "fr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.483Z",
+  "updatedAt": "2026-09-12T13:04:37.409Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5732,6 +5732,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/ge.js
+++ b/frontend/src/locales/ge.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/ge.pending.json
+++ b/frontend/src/locales/ge.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ge",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.509Z",
+  "updatedAt": "2026-09-12T13:04:37.435Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5804,6 +5804,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/gr.js
+++ b/frontend/src/locales/gr.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/gr.pending.json
+++ b/frontend/src/locales/gr.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gr",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.541Z",
+  "updatedAt": "2026-09-12T13:04:37.465Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5725,6 +5725,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/gu.js
+++ b/frontend/src/locales/gu.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/gu.pending.json
+++ b/frontend/src/locales/gu.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "gu",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.577Z",
+  "updatedAt": "2026-09-12T13:04:37.493Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5723,6 +5723,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/hi.js
+++ b/frontend/src/locales/hi.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/hi.pending.json
+++ b/frontend/src/locales/hi.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "hi",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.604Z",
+  "updatedAt": "2026-09-12T13:04:37.520Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5724,6 +5724,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/it.js
+++ b/frontend/src/locales/it.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/it.pending.json
+++ b/frontend/src/locales/it.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "it",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.635Z",
+  "updatedAt": "2026-09-12T13:04:37.547Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5723,6 +5723,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/ru.js
+++ b/frontend/src/locales/ru.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/ru.pending.json
+++ b/frontend/src/locales/ru.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "ru",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.663Z",
+  "updatedAt": "2026-09-12T13:04:37.575Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5722,6 +5722,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/locales/spa.js
+++ b/frontend/src/locales/spa.js
@@ -1884,6 +1884,7 @@ export default {
         "tracking_now": "Tracking now",
         "agent_working": "working on this",
         "wip": "WIP {used}/{limit}",
+        "sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only.",
         "add_task_to": "Add task to {group}…",
         "group_empty": "Nothing in this group yet.",
         "select_group": "Select every task in this group",

--- a/frontend/src/locales/spa.pending.json
+++ b/frontend/src/locales/spa.pending.json
@@ -1,7 +1,7 @@
 {
   "locale": "spa",
   "machineTranslated": false,
-  "updatedAt": "2026-09-12T11:04:20.690Z",
+  "updatedAt": "2026-09-12T13:04:37.603Z",
   "keys": {
     "Auth.welcome_back": "Welcome back",
     "Auth.login_to_workspace": "Log in to your workspace.",
@@ -5722,6 +5722,7 @@
     "Workflows.lineage_somebody": "somebody",
     "EmptyState.no_visible_tasks_title": "No tasks to show here",
     "EmptyState.no_visible_tasks_msg": "This project has had tasks before, but none are visible in this view. They may have been archived or deleted.",
-    "Toast.Sprint_not_found": "Sprint not found"
+    "Toast.Sprint_not_found": "Sprint not found",
+    "List.sprint_total_hint": "Every task in this sprint, subtasks included. Reports and the burndown count parent tasks only."
   }
 }

--- a/frontend/src/views/Projects/ListView/ListGroup.vue
+++ b/frontend/src/views/Projects/ListView/ListGroup.vue
@@ -25,6 +25,7 @@
                             :data="task"
                             :selected="selection.isSelected(task._id)"
                             :expanded="isExpanded(task._id)"
+                            :progress="progressFor(task._id)"
                             :can-select="canSelect"
                             :can-set-status="canSetStatus"
                             :run="agents.runFor(task._id)"
@@ -80,6 +81,9 @@ import { taskListHelper, useUpdateTasks } from "@/views/Projects/helper.js";
 import { useTaskSelection } from "@/composable/useTaskSelection.js";
 import { useListDragDrop } from "./useListDragDrop.js";
 import { useProjectAgentActivity } from "./useProjectAgentActivity.js";
+import { hasSubtasks, indexProgress, pendingExpandIds, progressQuery, progressSignature } from "./subtaskProgress";
+import { apiRequest } from "@/services";
+import * as env from "@/config/env";
 
 defineOptions({ name: "ListGroup" });
 
@@ -165,7 +169,18 @@ const wip = computed(() => {
 });
 
 const isExpanded = (taskId) => expandedIds.value.includes(String(taskId));
-const hasSubtasks = (task) => Boolean(task.isParentTask && (task.subtaskArray?.length || Number(task.subTasks)));
+
+const subtaskCounts = ref({});
+const progressFor = (taskId) => subtaskCounts.value[String(taskId)] || null;
+
+function loadSubtaskCounts() {
+    const ids = rows.value.filter(hasSubtasks).map((task) => String(task._id));
+    if (!ids.length) return;
+    apiRequest("post", `${env.TASK}/find`, { findQuery: progressQuery(ids) })
+        .then((response) => { subtaskCounts.value = { ...subtaskCounts.value, ...indexProgress(response?.data) }; })
+        .catch((error) => console.error("ERROR in list subtask progress: ", error));
+}
+watch(() => progressSignature(rows.value), loadSubtaskCounts, { immediate: true });
 
 function loadSubtasks(task) {
     if (task.subtaskArray?.length) return;
@@ -189,17 +204,23 @@ function toggleSubtasks(task) {
     loadSubtasks(task);
 }
 
-/* The toolbar's expand / collapse control drives every row at once. */
-watch(taskCollapsed, (collapsed) => {
+/* The toolbar's expand / collapse control drives every row at once, and has to keep doing
+ * so for rows that arrive later -- a group opened after the toggle was flipped loads its
+ * tasks only then. */
+const autoExpandedIds = ref([]);
+watch([taskCollapsed, rows], () => {
     if (searchedTask.value) return;
-    if (collapsed) {
+    if (taskCollapsed.value) {
         expandedIds.value = [];
+        autoExpandedIds.value = [];
         return;
     }
-    const parents = rows.value.filter(hasSubtasks);
-    expandedIds.value = parents.map((task) => String(task._id));
-    parents.forEach(loadSubtasks);
-});
+    const pending = pendingExpandIds(rows.value, autoExpandedIds.value);
+    if (!pending.length) return;
+    autoExpandedIds.value = [...autoExpandedIds.value, ...pending];
+    expandedIds.value = [...new Set([...expandedIds.value, ...pending])];
+    rows.value.filter((task) => pending.includes(String(task._id))).forEach(loadSubtasks);
+}, { immediate: true });
 
 function visibleSubtasks(task) {
     return (task.subtaskArray || []).filter((sub) => (showArchived.value ? sub.deletedStatusKey === 2 : !sub.deletedStatusKey));

--- a/frontend/src/views/Projects/ListView/ListRow.vue
+++ b/frontend/src/views/Projects/ListView/ListRow.vue
@@ -79,6 +79,7 @@ import { useGetterFunctions } from "@/composable";
 import { dueBucket, dueLabel, fmtEstimate, priorityMeta } from "@/components/molecules/Home/homeFormat";
 import { timerState, isTimerFor, elapsedSeconds } from "@/components/organisms/TaskDetailOverlay/useTaskTimer";
 import { taskRisk } from "@/views/Projects/composables/taskRisk";
+import { isClosedTask, subtaskProgress, subtaskTotal } from "./subtaskProgress";
 
 defineOptions({ name: "ListRow" });
 
@@ -90,22 +91,23 @@ const props = defineProps({
     canSelect: { type: Boolean, default: false },
     canSetStatus: { type: Boolean, default: false },
     run: { type: Object, default: null },
-    proposal: { type: Object, default: null }
+    proposal: { type: Object, default: null },
+    progress: { type: Object, default: null }
 });
 const emit = defineEmits(["open", "select", "toggle-subtasks", "toggle-done", "review-agent"]);
 
 const { t } = useI18n();
 const { getUser } = useGetterFunctions();
 
-const done = computed(() => (props.data.status?.type || props.data.statusType) === "close");
-const subtaskCount = computed(() => (Array.isArray(props.data.subtaskArray) ? props.data.subtaskArray.length : 0) || Number(props.data.subTasks) || 0);
-const subtaskDone = computed(() => (props.data.subtaskArray || []).filter((s) => (s?.status?.type || s?.statusType) === "close").length);
+const done = computed(() => isClosedTask(props.data));
+const subtaskCount = computed(() => subtaskTotal(props.data, props.progress));
+const progress = computed(() => subtaskProgress(props.data, props.progress));
 
 const metaText = computed(() => {
     const key = props.data.TaskKey && props.data.TaskKey !== "--" ? props.data.TaskKey : "";
-    if (!subtaskCount.value) return key;
-    const progress = `${subtaskDone.value}/${subtaskCount.value}`;
-    return key ? `${key} · ${progress}` : progress;
+    if (!progress.value) return key;
+    const text = `${progress.value.done}/${progress.value.total}`;
+    return key ? `${key} · ${text}` : text;
 });
 
 const assignee = computed(() => {

--- a/frontend/src/views/Projects/ListView/ListView.vue
+++ b/frontend/src/views/Projects/ListView/ListView.vue
@@ -56,7 +56,7 @@
                         <button v-if="groupedTasks.length > 1 || !sprint.isExpanded" type="button" class="lv2__sprint-head" @click="toggleSprints(sprint?.id)">
                             <span class="lv2__caret" :class="{ 'lv2__caret--open': sprint.isExpanded }">▸</span>
                             <span class="lv2__sprint-name">{{ sprint.name }}</span>
-                            <span class="lv2__sprint-meta">{{ sprint.tasks || 0 }}</span>
+                            <span class="lv2__sprint-meta" :title="$t('List.sprint_total_hint')">{{ sprint.tasks || 0 }}</span>
                         </button>
 
                         <template v-if="sprint.isExpanded">

--- a/frontend/src/views/Projects/ListView/subtaskProgress.js
+++ b/frontend/src/views/Projects/ListView/subtaskProgress.js
@@ -1,0 +1,74 @@
+/* Subtask progress ("7/9") for a parent row in the List view.
+ *
+ * The list query fetches parents only, so a collapsed row has no subtaskArray and cannot
+ * count its own closed children. The closed count therefore comes from one aggregate per
+ * group, keyed by parent id, over the same subtask documents the expanded rows render --
+ * which is what keeps a collapsed row, an expanded row and the detail panel's pill from
+ * disagreeing. CommonJS so tests/list-subtask-progress.test.js can require it directly,
+ * like composables/taskRisk.js. */
+
+const CLOSED = "close";
+
+const isClosedTask = (task) => (task?.status?.type || task?.statusType) === CLOSED;
+
+const liveSubtasks = (task) => (Array.isArray(task?.subtaskArray) ? task.subtaskArray : []).filter((sub) => sub && !sub.deletedStatusKey);
+
+const hasSubtasks = (task) => Boolean(task?.isParentTask && ((task.subtaskArray || []).length || Number(task.subTasks)));
+
+/* subTasks is a denormalized counter maintained by a chain of $inc calls, so it is the
+ * last resort: an aggregate of the real children outranks it whenever we have one. */
+const subtaskTotal = (task, counts) => Number(counts?.total) || liveSubtasks(task).length || Number(task?.subTasks) || 0;
+
+const subtaskProgress = (task, counts) => {
+    const total = subtaskTotal(task, counts);
+    if (!total) return null;
+    const loaded = liveSubtasks(task);
+    if (loaded.length >= total) return { done: loaded.filter(isClosedTask).length, total };
+    const completed = Number(counts?.completed);
+    return Number.isInteger(completed) ? { done: completed, total } : null;
+};
+
+const progressQuery = (parentIds) => [
+    { $match: { ParentTaskId: { $in: (parentIds || []).map(String) }, deletedStatusKey: { $in: [0, undefined] } } },
+    {
+        $group: {
+            _id: "$ParentTaskId",
+            total: { $sum: 1 },
+            completed: { $sum: { $cond: [{ $eq: ["$statusType", CLOSED] }, 1, 0] } }
+        }
+    }
+];
+
+const indexProgress = (rows) => (Array.isArray(rows) ? rows : []).reduce((out, row) => {
+    if (!row || !row._id) return out;
+    out[String(row._id)] = { total: Number(row.total) || 0, completed: Number(row.completed) || 0 };
+    return out;
+}, {});
+
+const progressSignature = (rows) => (Array.isArray(rows) ? rows : [])
+    .filter(hasSubtasks)
+    .map((task) => `${task._id}:${Number(task.subTasks) || 0}:${(task.subtaskArray || []).length}`)
+    .sort()
+    .join(",");
+
+/* Rows arrive after their group is opened, so the toolbar's expand state has to be applied
+ * again as they land -- but only to parents it has not already been applied to, or it would
+ * keep reopening rows the user collapsed by hand. */
+const pendingExpandIds = (rows, appliedIds) => {
+    const applied = new Set((appliedIds || []).map(String));
+    return (Array.isArray(rows) ? rows : [])
+        .filter((task) => hasSubtasks(task) && !applied.has(String(task._id)))
+        .map((task) => String(task._id));
+};
+
+module.exports = {
+    CLOSED,
+    isClosedTask,
+    hasSubtasks,
+    subtaskTotal,
+    subtaskProgress,
+    progressQuery,
+    indexProgress,
+    progressSignature,
+    pendingExpandIds,
+};

--- a/tests/list-subtask-progress.test.js
+++ b/tests/list-subtask-progress.test.js
@@ -1,0 +1,202 @@
+/* The List view's parent rows used to read "0/N" until they were expanded, because the
+   closed count only ever looked at subtaskArray, which the list query never returns. */
+const fs = require('fs');
+const path = require('path');
+const P = require('../frontend/src/views/Projects/ListView/subtaskProgress');
+const { validatePipeline, QueryRefused } = require('../Modules/Tasks/helpers/taskQueryGuard');
+
+const parent = (overrides) => Object.assign({
+    _id: 'p1',
+    TaskKey: 'AP-410',
+    isParentTask: true,
+    statusType: 'active',
+    subTasks: 13,
+}, overrides);
+
+const sub = (statusType) => ({ _id: Math.random().toString(36).slice(2), statusType, deletedStatusKey: 0 });
+const subs = (closed, open) => [...Array(closed).fill(0).map(() => sub('close')), ...Array(open).fill(0).map(() => sub('active'))];
+
+/* The pill in TaskDetailPanel.vue (subtaskCompletion) is the number the row may never
+   contradict, so its math is mirrored here as the reference. */
+const detailPanelPill = (task, counts) => {
+    const valid = (task.subtaskArray || []).filter((s) => s && (s.deletedStatusKey === 0 || s.deletedStatusKey === undefined));
+    const loadedCompleted = valid.filter((s) => (s?.status?.type || s?.statusType) === 'close').length;
+    const trueTotal = Math.max(valid.length, Number(task.subTasks) || 0, (counts && counts.total) || 0);
+    if (valid.length >= trueTotal) return { total: valid.length, completed: loadedCompleted };
+    if (counts && counts.total) return { total: counts.total, completed: counts.completed };
+    return { total: trueTotal, completed: loadedCompleted };
+};
+
+describe('a collapsed parent reports the true closed count', () => {
+    test('AP-410: 13 of 13 closed reads 13/13 with no subtaskArray loaded', () => {
+        const row = parent();
+        expect(P.subtaskProgress(row, { total: 13, completed: 13 })).toEqual({ done: 13, total: 13 });
+    });
+
+    test('a partly finished parent reads its real numerator, not 0', () => {
+        expect(P.subtaskProgress(parent({ subTasks: 9 }), { total: 9, completed: 7 })).toEqual({ done: 7, total: 9 });
+    });
+
+    test('no fraction is shown at all until the aggregate lands, so 0/N is never rendered', () => {
+        expect(P.subtaskProgress(parent(), null)).toBeNull();
+        expect(P.subtaskTotal(parent(), null)).toBe(13);
+    });
+
+    test('a genuinely unfinished parent still reads 0/N once counted', () => {
+        expect(P.subtaskProgress(parent({ subTasks: 4 }), { total: 4, completed: 0 })).toEqual({ done: 0, total: 4 });
+    });
+});
+
+describe('collapsed, expanded and the detail panel agree', () => {
+    const cases = [
+        ['all closed', 13, 13, 0],
+        ['none closed', 5, 0, 5],
+        ['partly closed', 9, 7, 2],
+        ['single subtask', 1, 1, 0],
+    ];
+
+    test.each(cases)('%s: the same parent reads alike collapsed and expanded', (_name, total, closed, open) => {
+        const counts = { total, completed: closed };
+        const collapsed = P.subtaskProgress(parent({ subTasks: total }), counts);
+        const expanded = P.subtaskProgress(parent({ subTasks: total, subtaskArray: subs(closed, open) }), counts);
+        expect(collapsed).toEqual({ done: closed, total });
+        expect(expanded).toEqual(collapsed);
+    });
+
+    test.each(cases)('%s: neither disagrees with the detail panel pill', (_name, total, closed, open) => {
+        const counts = { total, completed: closed };
+        const loaded = parent({ subTasks: total, subtaskArray: subs(closed, open) });
+        const pill = detailPanelPill(loaded, counts);
+        expect(P.subtaskProgress(parent({ subTasks: total }), counts)).toEqual({ done: pill.completed, total: pill.total });
+        expect(P.subtaskProgress(loaded, counts)).toEqual({ done: pill.completed, total: pill.total });
+    });
+
+    test('closing a subtask in an expanded row moves the numerator live', () => {
+        const stale = { total: 13, completed: 12 };
+        const row = parent({ subtaskArray: subs(13, 0) });
+        expect(P.subtaskProgress(row, stale)).toEqual({ done: 13, total: 13 });
+    });
+
+    test('a truncated expand keeps the aggregate, so the fraction never shrinks to the page size', () => {
+        const row = parent({ subTasks: 40, subtaskArray: subs(30, 5) });
+        expect(P.subtaskProgress(row, { total: 40, completed: 38 })).toEqual({ done: 38, total: 40 });
+        expect(detailPanelPill(row, { total: 40, completed: 38 })).toEqual({ total: 40, completed: 38 });
+    });
+
+    test('the aggregate outranks a drifted subTasks counter', () => {
+        expect(P.subtaskProgress(parent({ subTasks: 15 }), { total: 13, completed: 13 })).toEqual({ done: 13, total: 13 });
+    });
+
+    test('archived subtasks are left out of both halves of the fraction', () => {
+        const row = parent({ subTasks: 2, subtaskArray: [sub('close'), { _id: 'x', statusType: 'close', deletedStatusKey: 2 }] });
+        expect(P.subtaskProgress(row, { total: 1, completed: 1 })).toEqual({ done: 1, total: 1 });
+    });
+
+    test('a parent with no subtasks shows nothing', () => {
+        expect(P.subtaskProgress(parent({ subTasks: 0 }), null)).toBeNull();
+        expect(P.subtaskProgress({ _id: 'p', isParentTask: true }, null)).toBeNull();
+    });
+});
+
+describe('the progress aggregate the rows are counted from', () => {
+    const query = P.progressQuery(['p1', 'p2']);
+
+    test('it groups closed children by parent id', () => {
+        expect(query[0].$match.ParentTaskId).toEqual({ $in: ['p1', 'p2'] });
+        expect(query[0].$match.deletedStatusKey).toEqual({ $in: [0, undefined] });
+        expect(query[1].$group._id).toBe('$ParentTaskId');
+        expect(query[1].$group.completed.$sum.$cond[0]).toEqual({ $eq: ['$statusType', 'close'] });
+    });
+
+    test('the backend task-query guard accepts it', () => {
+        expect(() => validatePipeline(JSON.parse(JSON.stringify(query)))).not.toThrow();
+    });
+
+    test('a $lookup into tasks would have been refused, which is why it is a $group', () => {
+        const join = [{ $lookup: { from: 'tasks', localField: '_id', foreignField: 'ParentTaskId', as: 'subs' } }];
+        expect(() => validatePipeline(join)).toThrow(QueryRefused);
+    });
+
+    test('aggregate rows index by parent id', () => {
+        expect(P.indexProgress([{ _id: 'p1', total: 13, completed: 13 }, { _id: 'p2', total: 4, completed: 1 }]))
+            .toEqual({ p1: { total: 13, completed: 13 }, p2: { total: 4, completed: 1 } });
+        expect(P.indexProgress(null)).toEqual({});
+    });
+
+    test('the fetch re-runs when a group gains parents, not when rows are merely reordered', () => {
+        const a = parent({ _id: 'p1' });
+        const b = parent({ _id: 'p2', subTasks: 4 });
+        expect(P.progressSignature([a, b])).toBe(P.progressSignature([b, a]));
+        expect(P.progressSignature([a])).not.toBe(P.progressSignature([a, b]));
+        expect(P.progressSignature([parent({ subTasks: 13 })])).not.toBe(P.progressSignature([parent({ subTasks: 14 })]));
+    });
+});
+
+describe('the expand toggle reaches groups opened after it was flipped', () => {
+    const rows = [parent({ _id: 'p1' }), parent({ _id: 'p2', subTasks: 4 }), { _id: 'p3', isParentTask: true, subTasks: 0 }];
+
+    test('rows that land after the toggle are expanded', () => {
+        expect(P.pendingExpandIds(rows, [])).toEqual(['p1', 'p2']);
+    });
+
+    test('a parent with no subtasks is never expanded', () => {
+        expect(P.pendingExpandIds(rows, [])).not.toContain('p3');
+    });
+
+    test('a row the user collapsed by hand is not reopened when the group reloads', () => {
+        expect(P.pendingExpandIds(rows, ['p1', 'p2'])).toEqual([]);
+        expect(P.pendingExpandIds([...rows, parent({ _id: 'p4', subTasks: 2 })], ['p1', 'p2'])).toEqual(['p4']);
+    });
+
+    test('an empty group asks for nothing', () => {
+        expect(P.pendingExpandIds([], [])).toEqual([]);
+        expect(P.pendingExpandIds(null, null)).toEqual([]);
+    });
+});
+
+describe('the List view is wired to all of this', () => {
+    const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+    const group = read('frontend/src/views/Projects/ListView/ListGroup.vue');
+    const row = read('frontend/src/views/Projects/ListView/ListRow.vue');
+
+    test('the expand toggle watches rows as well, and runs immediately', () => {
+        const watcher = group.match(/watch\(\[taskCollapsed, rows\][\s\S]*?\{ immediate: true \}\);/);
+        expect(watcher).not.toBeNull();
+        expect(watcher[0]).toContain('pendingExpandIds(rows.value, autoExpandedIds.value)');
+    });
+
+    test('each group loads the progress aggregate and hands it to its rows', () => {
+        expect(group).toMatch(/watch\(\(\) => progressSignature\(rows\.value\), loadSubtaskCounts, \{ immediate: true \}\)/);
+        expect(group).toContain('findQuery: progressQuery(ids)');
+        expect(group).toContain(':progress="progressFor(task._id)"');
+    });
+
+    test('the row takes its fraction from the shared helper, never from subtaskArray alone', () => {
+        expect(row).toContain('subtaskProgress(props.data, props.progress)');
+        expect(row).not.toMatch(/subtaskArray \|\| \[\]\)\.filter/);
+    });
+});
+
+describe('the sprint header count says what it counts', () => {
+    const read = (file) => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+    /* The header (sprints.tasks) counts parents + subtasks; the burndown counts parents.
+       Both are right for their own definition, so the header is labelled, not changed. */
+    test('the header number carries the hint', () => {
+        const view = read('frontend/src/views/Projects/ListView/ListView.vue');
+        const meta = view.split('\n').find((line) => line.includes('lv2__sprint-meta'));
+        expect(meta).toMatch(/:title="\$t\('List\.sprint_total_hint'\)"/);
+        expect(meta).toContain('sprint.tasks');
+    });
+
+    test('the hint is keyed in en.js and names both definitions', () => {
+        const hint = read('frontend/src/locales/en.js').match(/sprint_total_hint: "([^"]+)"/);
+        expect(hint).not.toBeNull();
+        expect(hint[1]).toMatch(/subtask/i);
+        expect(hint[1]).toMatch(/burndown|parent/i);
+    });
+
+    test('the burndown still counts parent tasks only', () => {
+        expect(read('Modules/Sprints/burndown.js')).toContain('isParentTask: true');
+    });
+});


### PR DESCRIPTION
## The bug

A parent row on the project List view read `0/N` until you expanded it. `AP-410` showed `0/13` collapsed and `13/13` expanded; all 20 parents of the `Delivered` sprint read `0/N` on load. The default view said nothing was done.

The denominator fell back to the persisted `subTasks` counter, so it was right on load. The numerator had no fallback and counted only `subtaskArray` — and the list query never returns subtasks: it matches `isParentTask: true` and children are fetched only when a row is expanded (`store/ProjectData/actions.js:147-152`).

## The numerator: derived, not persisted

**Chosen: one `$match` + `$group` aggregate per group, keyed by parent id.** No backend change, no schema field.

I checked what the server persists first. `subTasks` is declared at `utils/mongo-handler/schema.js:141`; there is **no** completed-subtask counter anywhere. So the two options were a second persisted counter or deriving the count.

A persisted `subTasksDone` loses on two counts:

- **It would start life wrong on every existing document.** A new field is absent until written, so `AP-410` would still have read `0/13` after the fix — a backfill migration would be part of the "small schema field", and the fix would be wrong for anyone who had not run it.
- **It would drift.** `subTasks` is maintained by twelve independent `$inc` sites (`taskMongo/create.js:58`, `structural.js:415`, `mongo_helper.js:280-303`, `mergeDuplicate.js:119`, `Automations/engine/tools.js:236`, `Agents/undo.js:75`, …) with no reconcile job, and a closed-subtask counter needs a superset of those plus every status transition, bulk status write and automation. A counter that drifts is a wrong number, which is the thing being fixed.

Deriving needs nothing new on the server. `TaskDetailPanel.vue:640-655` already sends exactly this shape to `POST /api/v1/task/find`, so it is an established, guard-approved query — `taskQueryGuard.js` allows `$match` and `$group`, and refuses `$lookup` into `tasks` (a test asserts it), which is why this groups rather than joins. `ParentTaskId` is indexed (`createSchema.js:322`) and it is one request per group of ≤35 parents.

**Why collapsed, expanded and the pill cannot disagree:** all three now count the same subtask documents. The row prefers the aggregate over `subTasks` (an aggregate of real children outranks a denormalized counter), and prefers the loaded `subtaskArray` once it covers the total, so toggling a subtask moves the numerator live. When an expand is truncated at the page size the aggregate still wins, which is what `subtaskCompletion` in the detail panel does — the test mirrors that function's math as the reference and asserts agreement across a matrix of cases.

**Until the aggregate lands the row shows no fraction at all** rather than `0/N`. The disclosure triangle still comes from `subTasks`, so expanding works immediately.

## The watcher

`ListGroup.vue` watched `taskCollapsed` alone with no immediate run, so a group whose tasks loaded after the toggle was flipped came up collapsed. It now watches rows too and applies the toggle to each parent as it lands, tracking which ones it has already applied so a row the user collapsed by hand is not reopened when the group reloads.

## Header vs burndown: they measure different things, so the header is labelled

Verified against the real dataset — `sprints.tasks` equals parents + subtasks **exactly** for all 11 sprints (`Delivered` 217 = 20 + 197; `In flight` 107 = 8 + 99), and burndown equals the parent count. Neither is broken:

| | counts | where |
|---|---|---|
| Sprint header `107` | parents + subtasks, live only | `sprints.tasks`, `$inc` at `taskMongo/create.js:32` |
| Burndown `8` | parents only, archived included | `Modules/Sprints/burndown.js:68` |

Forcing them equal means changing one. The burndown's parents-only filter is deliberate and shared by nine report call sites (`scrum.js` refuses to redefine done-ness precisely so charts cannot disagree), and the header is the only total-work-in-sprint figure in the product. The real defect was that **neither number said which it was**. So the header count now carries a hint naming both definitions, matching the existing `sprint_planned_hint` precedent on the sprint hours chip — one new i18n key, backfilled across 13 locales, `i18n:check` clean.

## Verification

Against company `6a8ee973d625fca52e519a12`, project **AlianHub Platform** (read-only; nothing in that data was modified). Replayed the exact aggregate the code sends through the running API with a real token:

- `AP-410` → `{total: 13, completed: 13}`. **Before `0/13`, after `13/13`.**
- All 20 `Delivered` parents in one request → 197 subtasks, 185 closed, **zero rows with a zero numerator** (was 20 of 20).

One correction to the brief: `Delivered` is not 100% closed. 185 of 197 subtasks are closed and 12 of the 20 parents are fully closed — `AP-207` is genuinely `7/9`, `AP-303` `33/35`. Those rows now read their true fraction rather than `N/N`. `subTasks` matched the real child count on all 20 parents, so no drift is visible in this dataset.

## Tests

`tests/list-subtask-progress.test.js`, 32 tests. Every fix was reverted in turn and the tests watched to fail:

- **numerator reverted to the old semantics → 11 fail**, including `AP-410: 13 of 13 closed reads 13/13 with no subtaskArray loaded` with `done: 0, total: 13` — the exact reported bug.
- **watcher reverted → 1 fails** (`the expand toggle watches rows as well, and runs immediately`).
- **header label removed → 1 fails** (`the header number carries the hint`).

Also green: `conventions` (95), `task-query-guard`, `task-risk`, `scrum-rules` (136). The three touched SFCs compile under `@vue/compiler-sfc`.

## Known limitation

If someone else closes a subtask under a row that is collapsed in your window, that row's fraction stays stale until its group reloads or you expand it (expanding refetches and corrects). Live-syncing the aggregate would mean a socket handler for subtask status on unloaded children — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
