### PR TITLE
fix(projects): repair the list grid, the sticky table head and dark-mode contrast

### DIFF
--- a/frontend/src/assets/css/button.css
+++ b/frontend/src/assets/css/button.css
@@ -127,12 +127,8 @@
     font-weight: 400;
     font-size: 16px;
     line-height: 24px;
-    font-family: 'Roboto', sans-serif !important;
+    font-family: 'Roboto', sans-serif;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-family: 'Roboto', sans-serif;
-}
-button{
-    font-family: 'Roboto', sans-serif !important;
 }

--- a/frontend/src/components/atom/EmptyState/EmptyState.vue
+++ b/frontend/src/components/atom/EmptyState/EmptyState.vue
@@ -58,17 +58,13 @@ const resolvedHelpHref = computed(() => {
     max-width: 180px;
 }
 .empty-state__title {
-    font-family: Roboto, sans-serif;
-    font-size: 18px;
-    font-weight: 500;
-    color: #172b4d;
+    font: var(--text-h3);
+    color: var(--ink);
     margin-bottom: 6px;
 }
 .empty-state__msg {
-    font-family: Roboto, sans-serif;
-    font-size: 13.5px;
-    line-height: 1.5;
-    color: #8c8c8c;
+    font: var(--text-small);
+    color: var(--ink-2);
     max-width: 380px;
     margin: 0 0 16px;
 }
@@ -78,9 +74,8 @@ const resolvedHelpHref = computed(() => {
 .empty-state__help {
     display: inline-block;
     margin-top: 12px;
-    font-family: Roboto, sans-serif;
-    font-size: 13px;
-    color: #2f6fdb;
+    font: var(--text-small);
+    color: var(--brand);
     text-decoration: none;
 }
 .empty-state__help:hover {

--- a/frontend/src/views/Projects/Kanban/BoardViewDisplayCardComponent.vue
+++ b/frontend/src/views/Projects/Kanban/BoardViewDisplayCardComponent.vue
@@ -20,7 +20,7 @@
                                 aria-label="Select task"
                             />
                         </label>
-                        <div class="list-group-kanban-item__taskName text-ellipsis font-weight-500 font-size-14 ml-5px black" :title="element.TaskName">
+                        <div class="list-group-kanban-item__taskName card-title text-ellipsis font-weight-500 ml-5px" :title="element.TaskName">
                             <img v-if="element.deletedStatusKey === 2" :src="inventoryIcon" alt="inventory" class="ml-5px" />
                             <img v-if="element.deletedStatusKey === 1" :src="deleteIcon" alt="delete" class="ml-5px" />
                             {{ element.TaskName }}

--- a/frontend/src/views/Projects/Kanban/KanbanBoard.vue
+++ b/frontend/src/views/Projects/Kanban/KanbanBoard.vue
@@ -47,7 +47,7 @@
                 >
                     <template #item="{ element }">
                         <div
-                            class="kanban-card hover-bg-light-lavender"
+                            class="kanban-card"
                             :class="{ 'is-agent-run': !!runFor(element._id) }"
                             draggable="true"
                             @dragstart="(e) => onManualDragStart(cardData, e)"

--- a/frontend/src/views/Projects/Kanban/new-style.css
+++ b/frontend/src/views/Projects/Kanban/new-style.css
@@ -118,10 +118,13 @@
     background: none;
 }
 
+/* An empty column's drop container was 0px tall, leaving Sortable's 5px
+   emptyInsertThreshold as the only catchment. */
 .kanban-board .kanban-cards {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    min-height: 88px;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
 }
@@ -139,6 +142,7 @@
     transition: border-color var(--t-state) var(--ease), box-shadow var(--t-state) var(--ease);
 }
 .kanban-board .kanban-card:hover { border-color: var(--border); }
+.kanban-board .kanban-card .card-title { color: var(--ink); font: 500 13px/1.35 var(--font-ui); }
 
 /* Blocked columns tint their cards' border, as in the mock. */
 .kanban-board .kanban-column--danger .kanban-card { border-color: rgba(193, 18, 31, .3); }
@@ -189,7 +193,7 @@
     margin-top: 7px;
 }
 .kanban-board .card-key { font: 600 9.5px/1 var(--font-mono); color: var(--ink-3); }
-.kanban-board .card-timer { font: 500 10px/1 var(--font-mono); color: var(--ok); white-space: nowrap; }
+.kanban-board .card-timer { font: 500 10px/1 var(--font-mono); color: var(--ok-ink); white-space: nowrap; }
 .kanban-board .card-progress { height: 4px; border-radius: 99px; background: rgba(0, 0, 0, .07); margin-top: 7px; overflow: hidden; }
 .kanban-board .card-progress > span { display: block; height: 100%; border-radius: 99px; background: var(--brand); }
 

--- a/frontend/src/views/Projects/ListView/ListBulkBar.vue
+++ b/frontend/src/views/Projects/ListView/ListBulkBar.vue
@@ -224,10 +224,10 @@ onBeforeUnmount(() => {
 </script>
 
 <style>
-/* Bulk bar (14a) */
+/* Out of flow: in flow its 40px came out of the list's height, so the first checkbox
+   click moved every row out from under the pointer. */
 .lv2-bulk {
     height: 40px;
-    flex: none;
     background: var(--rail);
     color: #fff;
     display: flex;
@@ -235,9 +235,13 @@ onBeforeUnmount(() => {
     padding: 0 20px;
     gap: 14px;
     font-size: 12.5px;
-    position: relative;
-    z-index: 4;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 3;
 }
+.lv2-bulk ~ .lv2__scroll { padding-bottom: 48px; }
 .lv2-bulk__count { font-weight: 600; }
 .lv2-bulk__btn {
     background: none; border: 0; padding: 0;
@@ -254,7 +258,7 @@ onBeforeUnmount(() => {
 .lv2-bulk__menu-wrap { position: relative; }
 .lv2-bulk__menu {
     position: absolute;
-    top: calc(100% + 8px);
+    bottom: calc(100% + 8px);
     left: 0;
     min-width: 200px;
     max-height: 280px;

--- a/frontend/src/views/Projects/ListView/ListBulkBar.vue
+++ b/frontend/src/views/Projects/ListView/ListBulkBar.vue
@@ -224,10 +224,9 @@ onBeforeUnmount(() => {
 </script>
 
 <style>
-/* Out of flow: in flow its 40px came out of the list's height, so the first checkbox
-   click moved every row out from under the pointer. */
 .lv2-bulk {
     height: 40px;
+    flex: none;
     background: var(--rail);
     color: #fff;
     display: flex;
@@ -235,13 +234,20 @@ onBeforeUnmount(() => {
     padding: 0 20px;
     gap: 14px;
     font-size: 12.5px;
+    position: relative;
+    z-index: 4;
+}
+/* In flow the bar's 40px came out of the list's height, so the first checkbox click
+   moved every row out from under the pointer. Table and Board mount this same bar in
+   containers that are not positioned, so only the list takes it out of flow. */
+.lv2 > .lv2-bulk {
     position: absolute;
     left: 0;
     right: 0;
     bottom: 0;
     z-index: 3;
 }
-.lv2-bulk ~ .lv2__scroll { padding-bottom: 48px; }
+.lv2 > .lv2-bulk ~ .lv2__scroll { padding-bottom: 48px; }
 .lv2-bulk__count { font-weight: 600; }
 .lv2-bulk__btn {
     background: none; border: 0; padding: 0;
@@ -258,7 +264,7 @@ onBeforeUnmount(() => {
 .lv2-bulk__menu-wrap { position: relative; }
 .lv2-bulk__menu {
     position: absolute;
-    bottom: calc(100% + 8px);
+    top: calc(100% + 8px);
     left: 0;
     min-width: 200px;
     max-height: 280px;
@@ -284,6 +290,9 @@ onBeforeUnmount(() => {
 .lv2-bulk__note { padding: 7px 8px; color: var(--ink-2); font: var(--text-small); }
 
 .lv2-bulk__dot { width: 8px; height: 8px; border-radius: 2px; flex: none; background: var(--ink-3); }
+
+/* In the list the bar sits at the foot of the view, so its menus open upward. */
+.lv2 > .lv2-bulk .lv2-bulk__menu { top: auto; bottom: calc(100% + 8px); }
 
 @media (max-width: 767px) {
     .lv2-bulk { padding: 0 16px; gap: 10px; overflow-x: auto; }

--- a/frontend/src/views/Projects/ListView/style.css
+++ b/frontend/src/views/Projects/ListView/style.css
@@ -6,6 +6,7 @@
     flex-direction: column;
     min-height: 0;
     background: var(--canvas);
+    position: relative;
 }
 
 .lv2__scroll {
@@ -29,7 +30,7 @@
     text-transform: uppercase;
     color: var(--ink-label);
 }
-.lv2__cols span:last-child { color: var(--brand); }
+.lv2__cols .lv2__c-risk { color: var(--brand); }
 
 .lv2__sprint { display: flex; flex-direction: column; gap: 12px; }
 .lv2__sprint-head {
@@ -120,7 +121,7 @@
 .lv2__row.is-sub .lv2__name { font-weight: 400; }
 .lv2__row.is-sub.is-done .lv2__name { text-decoration: line-through; color: var(--ink-3); }
 .lv2__key { font: 500 10px/1 var(--font-mono); color: var(--ink-label); flex: none; }
-.lv2__timer { font: 500 10px/1 var(--font-mono); color: var(--ok); display: inline-flex; align-items: center; gap: 4px; flex: none; }
+.lv2__timer { font: 500 10px/1 var(--font-mono); color: var(--ok-ink); display: inline-flex; align-items: center; gap: 4px; flex: none; }
 .lv2__agent-line {
     font: 500 10px/1.3 var(--font-ui);
     color: var(--brand);
@@ -188,11 +189,11 @@
 }
 .lv2__collapsed-count { font: var(--text-data); color: var(--ink-label); }
 
-.lv2__empty-group { padding: 10px 12px; color: var(--ink-3); font-size: 12px; }
+.lv2__empty-group { margin: 0; padding: 10px 12px; color: var(--ink-3); font-size: 12px; }
 .lv2__skeleton { height: 44px; border-radius: var(--r-card); }
 
 @media (max-width: 1279px) {
-    .lv2 { --lv2-cols: 28px minmax(0, 1fr) 80px 90px 76px 60px 56px; }
+    .lv2 { --lv2-cols: 28px minmax(0, 1fr) 80px 90px 76px 60px 56px 104px; }
 }
 @media (max-width: 767px) {
     .lv2 { --lv2-cols: 28px minmax(0, 1fr) 60px 56px; }
@@ -218,5 +219,5 @@
 
 /* Declared last so it wins over the tablet rule above: at phone width the name keeps the row. */
 @media (max-width: 767px) {
-    .lv2 { --lv2-cols: 28px minmax(0, 1fr) 60px 56px; }
+    .lv2 { --lv2-cols: 28px minmax(0, 1fr); }
 }

--- a/frontend/src/views/Projects/Projects.vue
+++ b/frontend/src/views/Projects/Projects.vue
@@ -12,6 +12,7 @@
                             :activeView="activeTab"
                             :favourite="isProjectFavourite"
                             :agentSummary="agentSummary"
+                            :showFilter="false"
                             :showAiAssist="canAiAssist"
                             :showAddTask="canAddTask"
                             @toggle-favourite="markProjectFavourite()"

--- a/frontend/src/views/Projects/TableView/style.css
+++ b/frontend/src/views/Projects/TableView/style.css
@@ -35,11 +35,12 @@
     font-size: 12.5px;
 }
 
+/* No non-visible overflow here: it would capture .tv2__head's sticky positioning,
+   so the corners are rounded on the head and the last row instead. */
 .tv2__grid {
     background: var(--surface);
     border: 1px solid var(--hairline);
     border-radius: var(--r-card);
-    overflow: hidden;
     min-width: 900px;
 }
 
@@ -54,6 +55,7 @@
     color: var(--ink-label);
     border-bottom: 1px solid var(--hairline);
     background: var(--surface-2);
+    border-radius: var(--r-card) var(--r-card) 0 0;
     position: sticky;
     top: 0;
     z-index: 2;
@@ -92,7 +94,7 @@
 }
 .tv2__row:hover { background: var(--surface-hover); }
 .tv2__row.is-selected { background: var(--brand-tint); }
-.tv2__row:last-child { border-bottom: 0; }
+.tv2__row:last-child { border-bottom: 0; border-radius: 0 0 var(--r-card) var(--r-card); }
 
 .tv2__name {
     background: none; border: 0; padding: 0;


### PR DESCRIPTION
PR 0 of the project-screens fix plan: thirteen one-line-ish corrections, no new copy, no markup restructuring. **This merges before the other UI batches** — it touches the same files they restructure.

## The thirteen

| # | File | What changed |
|---|---|---|
| 1 | `assets/css/button.css` | Deleted the app-wide `button { font-family: 'Roboto' !important }`; dropped `!important` and the duplicate declaration from `.btn`. Every button now renders the family its own rule asks for. |
| 2 | `ListView/style.css` | The 1279px template declared 7 tracks for 8 cells; appended the 8th (`104px`). |
| 3 | `ListView/style.css` | At ≤767px only the checkbox and the title are visible; the template now declares two tracks, not four. |
| 4 | `ListView/style.css` | `.lv2__cols span:last-child` → `.lv2__cols .lv2__c-risk`, so the brand "generated" colour marks the RISK column rather than DONE BY. |
| 5 | `ListView/style.css` | `margin: 0` on `.lv2__empty-group` (it is a `<p>`; no UA reset exists). |
| 6 | `ListView/style.css`, `Kanban/new-style.css` | Running-timer readouts `var(--ok)` → `var(--ok-ink)`, the text tier. |
| 7 | `ListBulkBar.vue` (+ `.lv2` / `.lv2__scroll`) | The list's bulk bar leaves the flow (`.lv2 > .lv2-bulk`, pinned to the foot of the view); the scroll keeps 48px of bottom padding while it is up, and its menus open upward. Table and Board mount the same component in containers that are not positioned, so their bar stays in flow — unscoping this would have sent it to the bottom of the whole project section. |
| 8 | `TableView/style.css` | Removed `overflow: hidden` from `.tv2__grid` so `.tv2__head` can pin; the rounding moved to the head and the last row. |
| 9 | `Kanban/KanbanBoard.vue` | Dropped `hover-bg-light-lavender` from the card. |
| 10 | `BoardViewDisplayCardComponent.vue`, `Kanban/new-style.css` | Card title loses `black` and `font-size-14`; a token-based rule gives it `var(--ink)` and `var(--font-ui)`. |
| 11 | `Kanban/new-style.css` | `min-height: 88px` on `.kanban-cards`, so an empty column has a drop target. |
| 12 | `EmptyState.vue` | Title, message and help link take `--text-h3` / `--text-small` and `--ink` / `--ink-2` / `--brand`; all three Roboto stacks and all three literal hex values are gone. |
| 13 | `Projects.vue` | `:showFilter="false"` — the header's word-button "Filter" duplicated the toolbar icon and was a silent no-op on a dozen views. |

## Measured

Verified by reading computed CSS in a headless run against the real stylesheets (the dev server belongs to the owner).

- **1101–1279px:** row height 75px → **43px**, header 47.8px → **12.6px**, 8 tracks. Single-height at 1101, 1200, 1279 and 1280.
- **375px:** title column 151px → **283px**; the task-name button 30px → **162px**.
- **Checkbox click:** first selection used to move every row **40px**; now **0px**. The bar pins to the bottom of the view and the last row clears it by 8px.
- **Table head:** after scrolling 300px it stays **14px** from the top of the scroll box (it used to leave at −285px).
- **Dark theme contrast:** board card title **15.75:1** (was `#000` on `#18181c` = 1.19:1); empty-state heading **16.77:1** (was 1.34:1), message **7.62:1**, help link **7.38:1** (was 3.97:1); timer readout **11.81:1**. Light theme: timer **6.05:1** (was 3.33:1), empty-state heading 16.64:1, message 4.67:1.
- **Type:** `.lv2__name` → `"Inter Tight"`, `.task-count` → `"JetBrains Mono"`.
- **Empty column:** drop container 0px → **88px**. Empty group: 95px → **71px**.

## Blast radius of #1 and #12

Every button on the redesigned screens declares its own font (`.ah-btn`, `.ah-tbtn`, `.ah-pop__item`, `.auth__links button`, `.av2-*`), so they move from Roboto to Inter Tight with **no change in height or padding** — heights are fixed px. Content-driven widths shrink 2–9px because Inter Tight is narrower. Legacy `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-white` and anything carrying `font-roboto-sans` still declare Roboto explicitly. A sweep of Login, Home and Settings found no text-bearing button without a font-declaring rule.

`EmptyState.vue` is imported by 17 screens; the new type and colour resolve from tokens in both themes.

## Checks

`npm run i18n:check` passes and is a no-op (no strings touched). Frontend vitest: **44 files, 319 tests, all passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
